### PR TITLE
remove lint config from store-ui

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 package.json
 node_modules/
 public/
+dist/
 coverage/
 .vscode/
 .cache/

--- a/packages/gatsby-theme-vtex/src/components/Shelf/index.tsx
+++ b/packages/gatsby-theme-vtex/src/components/Shelf/index.tsx
@@ -53,7 +53,7 @@ const Shelf: FC<Props> = ({ syncProducts }) => {
             <Button
               backgroundColor="transparent"
               onClick={() => setPage(page - 1)}
-              aria-label={'See shelf previous page'}
+              aria-label="See shelf previous page"
             >
               <ArrowLeft size={arrowSize} />
             </Button>
@@ -79,7 +79,7 @@ const Shelf: FC<Props> = ({ syncProducts }) => {
                   onClick={() => {
                     setPage(page + 1)
                   }}
-                  aria-label={'See shelf next page'}
+                  aria-label="See shelf next page"
                 >
                   <ArrowRight size={arrowSize} />
                 </Button>

--- a/packages/store-ui/.eslintignore
+++ b/packages/store-ui/.eslintignore
@@ -1,6 +1,0 @@
-build/
-dist/
-node_modules/
-.snapshots/
-storybook-static/
-*.min.js

--- a/packages/store-ui/.eslintrc
+++ b/packages/store-ui/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": ["vtex-react"]
-}

--- a/packages/store-ui/.prettierrc
+++ b/packages/store-ui/.prettierrc
@@ -1,1 +1,0 @@
-"@vtex/prettier-config"

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -19,7 +19,6 @@
     "develop": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test --passWithNoTests",
-    "lint": "eslint src/ --ext .tsx,.ts",
     "prepare": "tsdx build",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
@@ -45,8 +44,6 @@
     "@types/theme-ui": "^0.3.5",
     "@vtex/prettier-config": "^0.3.1",
     "@vtex/tsconfig": "^0.5.0",
-    "eslint-config-vtex-react": "^6.7.0",
-    "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.1",

--- a/packages/store-ui/tsconfig.eslint.json
+++ b/packages/store-ui/tsconfig.eslint.json
@@ -1,5 +1,0 @@
-{
-    "extends": "@vtex/tsconfig",
-    "include": ["src", "stories"],
-    "exclude": ["node_modules", "dist"]
-  }

--- a/packages/store-ui/tsconfig.json
+++ b/packages/store-ui/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "@vtex/tsconfig",
-  "compilerOptions": {
-    "rootDirs": ["src", "stories"],
-    "baseUrl": "src",
-  },
-  "exclude": ["node_modules", "dist", "stories"]
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8277,16 +8277,6 @@ eslint-config-vtex-react@^6.5.0:
     eslint-plugin-react "^7.18.0"
     eslint-plugin-react-hooks "^2.3.0"
 
-eslint-config-vtex-react@^6.7.0:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-vtex-react/-/eslint-config-vtex-react-6.7.1.tgz#21633a61f0bafdbf14277985d957d0f198331d0c"
-  integrity sha512-bLafJrDe9rmJeNMAG3PIdf0BWZe93qLYkMVmNPsNFx45SfK5vo6wS4n4/en3lHXhs4eBGungisP8oklHAyE8Wg==
-  dependencies:
-    eslint-config-vtex "^12.7.1"
-    eslint-plugin-jsx-a11y "^6.2.3"
-    eslint-plugin-react "^7.18.0"
-    eslint-plugin-react-hooks "^2.3.0"
-
 eslint-config-vtex@^12.5.0, eslint-config-vtex@^12.7.0:
   version "12.7.0"
   resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-12.7.0.tgz#8a128012bcfffc1d0ca255bb3049950578d5c36b"
@@ -8301,21 +8291,6 @@ eslint-config-vtex@^12.5.0, eslint-config-vtex@^12.7.0:
     eslint-plugin-jest "^23.7.0"
     eslint-plugin-prettier "^3.1.2"
     eslint-plugin-vtex "^1.2.0"
-
-eslint-config-vtex@^12.7.1:
-  version "12.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-12.7.1.tgz#0110e85207b81aacd253cacd9b5574657605c4b7"
-  integrity sha512-rvGOYXhCXoGwBcRmZZueB9VIo1AaxY6ICMqz4DYIHD/Yl/iA4GRetKY9ld4R6eW2TURlWE8OxkcC4FGteUlIYQ==
-  dependencies:
-    "@typescript-eslint/eslint-plugin" "^2.17.0"
-    "@typescript-eslint/parser" "^2.17.0"
-    confusing-browser-globals "^1.0.9"
-    eslint-config-prettier "^6.9.0"
-    eslint-plugin-cypress "^2.9.0"
-    eslint-plugin-import "^2.20.0"
-    eslint-plugin-jest "^23.7.0"
-    eslint-plugin-prettier "^3.1.2"
-    eslint-plugin-vtex "^1.2.1"
 
 eslint-import-resolver-node@^0.3.2, eslint-import-resolver-node@^0.3.3:
   version "0.3.4"
@@ -8533,11 +8508,6 @@ eslint-plugin-vtex@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-vtex/-/eslint-plugin-vtex-1.2.0.tgz#c2423800960ff4c6c610e6189dcb7d8177c9f4cc"
   integrity sha512-bDUCan8fC1Q81XOUOnLJwGupHZjDQM98CMn9cRvHpdDuzpQrdbaat38RgoQk1DaAlBrt0tLymHlNndY7BHpgew==
-
-eslint-plugin-vtex@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-vtex/-/eslint-plugin-vtex-1.2.1.tgz#4cb26d5844a50250c0d65f1d1444db85fdf1c406"
-  integrity sha512-YJ07HC0vXtl2VXn0gRIutNww1uuMWmyV/8ERsLfB6AqLRwWF8+6vran84RuPXtV5u4aqhtOejw2XAn2Omtk7IA==
 
 eslint-scope@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
Currently, we have 2 eslint config, one in the monorepo root and other in store-ui package, so this PR remove eslint config from store-ui in order to use the monorepo eslint config 