### PR TITLE
slugify pagetype queries

### DIFF
--- a/packages/gatsby-source-vtex/src/api.ts
+++ b/packages/gatsby-source-vtex/src/api.ts
@@ -101,6 +101,34 @@ const search = (
   return `${SEARCH_ROOT}?${querystring}`
 }
 
+const slugifySpecialCharacters = (str: string) => {
+  return str.replace(/[·/_,:]/, '-')
+}
+
+const from =
+  'ÁÄÂÀÃÅČÇĆĎÉĚËÈÊẼĔȆÍÌÎÏŇÑÓÖÒÔÕØŘŔŠŤÚŮÜÙÛÝŸŽáäâàãåčçćďéěëèêẽĕȇíìîïňñóöòôõøðřŕšťúůüùûýÿžþÞĐđßÆa'
+
+const to =
+  'AAAAAACCCDEEEEEEEEIIIINNOOOOOORRSTUUUUUYYZaaaaaacccdeeeeeeeeiiiinnooooooorrstuuuuuyyzbBDdBAa'
+
+const removeAccents = (str: string) => {
+  let newStr = str.slice(0)
+
+  for (let i = 0; i < from.length; i++) {
+    newStr = newStr.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i))
+  }
+
+  return newStr
+}
+
+const slugify = (str: string) => {
+  const noCommas = str.replace(/,/g, '')
+  // eslint-disable-next-line no-useless-escape
+  const replaced = noCommas.replace(/[*+~.()'"!:@&\[\]`/ %$#?{}|><=_^]/g, '-')
+
+  return slugifySpecialCharacters(removeAccents(replaced)).toLowerCase()
+}
+
 const nonNull = <T>(x: T | null): x is T => !!x
 
 const facets = ({
@@ -120,7 +148,7 @@ export const api = {
   search,
   facets,
   pageType: (query: string) =>
-    `/api/catalog_system/pub/portal/pagetype/${query}`,
+    `/api/catalog_system/pub/portal/pagetype/${slugify(query)}`,
   catalog: {
     category: {
       tree: (depth: number) => `/api/catalog_system/pub/category/tree/${depth}`,


### PR DESCRIPTION
Fix this error:
```
FetchError: invalid json response body at https://exitocol.vtexcommercestable.com.br/api/catalog_system/pub/portal/pagetype/ENSUEÑO-HOGAR reason: Unexpected end of JSON input
    at /Users/viniciusagostini/workspace/exito.store/node_modules/node-fetch/lib/index.js:272:32
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5) {
  message: 'invalid json response body at https://exitocol.vtexcommercestable.com.br/api/catalog_system/pub/portal/pagetype/ENSUEÑO-HOGAR reason: Unexpected end of JSON input',
  type: 'invalid-json'
}
 ERROR #11321  PLUGIN
"@vtex/gatsby-source-vtex" threw an error while running the sourceNodes lifecycle:
invalid json response body at https://exitocol.vtexcommercestable.com.br/api/catalog_system/pub/portal/pagetype/ENSUEÑO-HOGAR reason: Unexpected end of JSON input
  FetchError: invalid json response body at https://exitocol.vtexcommercestable.com.br/api/catalog_system/pub/portal/pagetype/ENSUEÑO-H  OGAR reason: Unexpected end of JSON input
  - index.js:272
    [exito.store]/[node-fetch]/lib/index.js:272:32
  - runMicrotasks
  - task_queues.js:97 processTicksAndRejections
    internal/process/task_queues.js:97:5
not finished source and transform nodes - 47.755s
```