### PR TITLE
add store ui as a dev dependency of gatsby theme

### DIFF
--- a/packages/gatsby-theme-vtex/package.json
+++ b/packages/gatsby-theme-vtex/package.json
@@ -26,6 +26,7 @@
     "@types/react": "^16.9.41",
     "@types/react-dom": "^16.9.8",
     "@types/react-helmet": "^6.0.0",
+    "@vtex/store-ui": "^0.13.1-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^3.9.5"


### PR DESCRIPTION
when we run yarn build, lerna tries to build by topology, but store-ui is a peer dependency of gatsby-theme-vtex and he ends up not doing the build. I added it as dev dependcy so that it doesn't break the build script.
