### PR TITLE
Types from provider in search sdk

### DIFF
--- a/packages/gatsby-theme-vtex/src/sdk/search/Provider.tsx
+++ b/packages/gatsby-theme-vtex/src/sdk/search/Provider.tsx
@@ -8,18 +8,20 @@ export interface SearchFilters {
   orderBy: Maybe<string>
 }
 
-interface SearchContext {
+interface SearchContextType {
   data: SearchPageQueryQuery
   filters: SearchFilters
 }
 
-export const SearchContext = createContext<SearchContext>(undefined as any)
+export const SearchContext = createContext<SearchContextType>(undefined as any)
 
 SearchContext.displayName = 'SearchContext'
 
-type Props = SearchContext
-
-export const SearchProvider: FC<Props> = ({ children, filters, data }) => (
+export const SearchProvider: FC<SearchContextType> = ({
+  children,
+  filters,
+  data,
+}) => (
   <SearchContext.Provider value={{ filters, data }}>
     {children}
   </SearchContext.Provider>


### PR DESCRIPTION
The name of the interface was the name of the context, so the FunctionComponent would blink as to whether it should import the context or the interface.

In this PR I rename the interface to fix that.