### PR TITLE
Fix cms-transformer to render beforeBlocks, afterBlocks and extraBlocks

### DIFF
--- a/packages/gatsby-theme-vtex/src/components/cms/components.ts
+++ b/packages/gatsby-theme-vtex/src/components/cms/components.ts
@@ -5,4 +5,5 @@ export const components: Record<string, LazyExoticComponent<any>> = {
   Shelf: lazy(() => import('../Shelf')),
   RichText: lazy(() => import('../RichText')),
   Header: lazy(() => import('../Header')),
+  Footer: lazy(() => import('../Footer')),
 }

--- a/packages/gatsby-theme-vtex/src/pages/preview.tsx
+++ b/packages/gatsby-theme-vtex/src/pages/preview.tsx
@@ -23,7 +23,7 @@ const Preview: FC = () => {
     return <div>No Preview found. Waiting for input</div>
   }
 
-  const { blocks } = content
+  const { beforeBlocks, blocks, afterBlocks } = content
 
   const { title, slug } = getMeta(content) as any
 
@@ -33,7 +33,17 @@ const Preview: FC = () => {
         <title>{title}</title>
       </Helmet>
       <div>slug: {slug}</div>
+      {beforeBlocks?.map((block, index) => (
+        <Suspense key={`block-${index}`} fallback={<div>Loading...</div>}>
+          <Block block={block} />
+        </Suspense>
+      ))}
       {blocks.map((block, index) => (
+        <Suspense key={`block-${index}`} fallback={<div>Loading...</div>}>
+          <Block block={block} />
+        </Suspense>
+      ))}
+      {afterBlocks?.map((block, index) => (
         <Suspense key={`block-${index}`} fallback={<div>Loading...</div>}>
           <Block block={block} />
         </Suspense>

--- a/packages/gatsby-theme-vtex/src/pages/preview.tsx
+++ b/packages/gatsby-theme-vtex/src/pages/preview.tsx
@@ -25,7 +25,7 @@ const Preview: FC = () => {
 
   const { blocks } = content
 
-  const { title, slug } = getMeta(content)
+  const { title, slug } = getMeta(content) as any
 
   return (
     <>

--- a/packages/gatsby-theme-vtex/src/pages/preview.tsx
+++ b/packages/gatsby-theme-vtex/src/pages/preview.tsx
@@ -23,9 +23,9 @@ const Preview: FC = () => {
     return <div>No Preview found. Waiting for input</div>
   }
 
-  const { beforeBlocks, blocks, afterBlocks } = content
+  const { beforeBlocks, blocks, afterBlocks, extraBlocks } = content
 
-  const { title, slug } = getMeta(content) as any
+  const { title, slug } = getMeta(extraBlocks) as any
 
   return (
     <>

--- a/packages/gatsby-theme-vtex/src/pages/preview.tsx
+++ b/packages/gatsby-theme-vtex/src/pages/preview.tsx
@@ -1,6 +1,7 @@
 import {
   Content as ContentType,
   isContent as isContentType,
+  getMeta,
 } from '@vtex/gatsby-transformer-vtex-cms'
 import React, { FC, Suspense } from 'react'
 import { Helmet } from 'react-helmet'
@@ -22,10 +23,9 @@ const Preview: FC = () => {
     return <div>No Preview found. Waiting for input</div>
   }
 
-  const {
-    meta: { title, slug },
-    blocks,
-  } = content
+  const { blocks } = content
+
+  const { title, slug } = getMeta(content)
 
   return (
     <>

--- a/packages/gatsby-transformer-vtex-cms/src/cms.ts
+++ b/packages/gatsby-transformer-vtex-cms/src/cms.ts
@@ -8,10 +8,37 @@ export interface Block {
   props: Record<string, unknown | undefined>
 }
 
+export interface BlockGroup {
+  name: string
+  blocks?: Block[]
+}
+
 export interface Content {
-  meta: Meta
+  afterBlocks?: Block[]
+  beforeBlocks?: Block[]
+  extraBlocks?: BlockGroup[]
   blocks: Block[]
   lastUpdatedAt: string
+}
+
+export const getMeta = (c: Content) => {
+  if (!c?.extraBlocks) {
+    return {}
+  }
+
+  const visibilityExtraBlock = c?.extraBlocks?.find(
+    (block) => block?.name === 'admin/visibilityTitle'
+  )
+
+  if (!visibilityExtraBlock || !visibilityExtraBlock?.blocks) {
+    return {}
+  }
+
+  const meta = visibilityExtraBlock?.blocks?.find(
+    (block) => block.name === 'informations'
+  )
+
+  return meta?.props
 }
 
 export const isBlock = (b: any): b is Block =>
@@ -19,6 +46,6 @@ export const isBlock = (b: any): b is Block =>
 
 export const isContent = (c: any): c is Content =>
   !!c &&
-  typeof c.meta?.slug === 'string' &&
+  typeof getMeta(c)?.slug === 'string' &&
   Array.isArray(c.blocks) &&
   (c.blocks.length === 0 || c.blocks.every(isBlock))

--- a/packages/gatsby-transformer-vtex-cms/src/cms.ts
+++ b/packages/gatsby-transformer-vtex-cms/src/cms.ts
@@ -1,6 +1,7 @@
 export interface Meta {
   slug: string
   title?: string
+  description?: string
 }
 
 export interface Block {
@@ -21,20 +22,20 @@ export interface Content {
   lastUpdatedAt: string
 }
 
-export const getMeta = (c: Content) => {
-  if (!c?.extraBlocks) {
+export const getMeta = (extraBlocks: BlockGroup[] | undefined) => {
+  if (!extraBlocks) {
     return {}
   }
 
-  const visibilityExtraBlock = c?.extraBlocks?.find(
+  const visibilityExtraBlock = extraBlocks.find(
     (block) => block?.name === 'admin/visibilityTitle'
   )
 
-  if (!visibilityExtraBlock || !visibilityExtraBlock?.blocks) {
+  if (!visibilityExtraBlock || !visibilityExtraBlock.blocks) {
     return {}
   }
 
-  const meta = visibilityExtraBlock?.blocks?.find(
+  const meta = visibilityExtraBlock.blocks?.find(
     (block) => block.name === 'informations'
   )
 
@@ -46,6 +47,6 @@ export const isBlock = (b: any): b is Block =>
 
 export const isContent = (c: any): c is Content =>
   !!c &&
-  typeof getMeta(c)?.slug === 'string' &&
+  typeof getMeta(c.extraBlocks)?.slug === 'string' &&
   Array.isArray(c.blocks) &&
   (c.blocks.length === 0 || c.blocks.every(isBlock))

--- a/packages/gatsby-transformer-vtex-cms/src/compiler.ts
+++ b/packages/gatsby-transformer-vtex-cms/src/compiler.ts
@@ -25,15 +25,20 @@ const parseBlockName = (name: string) => {
 export class BlockDOM {
   protected meta: RenderMetaInfo
 
-  constructor(protected blocks: Block[]) {
+  constructor(protected blocks: Block[] | undefined) {
     this.meta = {
       imports: new Map(),
     }
   }
 
   public renderToString = (): string => {
-    const blocksStr = this.renderBlocksToString(this.blocks)
-    const imports = this.renderImportsToString()
+    let blocksStr = '<></>'
+    let imports
+
+    if (this.blocks) {
+      blocksStr = this.renderBlocksToString(this.blocks)
+      imports = this.renderImportsToString()
+    }
 
     return `
 import React, { FC } from 'react'
@@ -43,6 +48,7 @@ ${imports}
 const CMSAutogenPage: FC = () => (
   ${blocksStr}
 )
+
 
 export default CMSAutogenPage
 `

--- a/packages/gatsby-transformer-vtex-cms/src/gatsby-node.ts
+++ b/packages/gatsby-transformer-vtex-cms/src/gatsby-node.ts
@@ -1,6 +1,6 @@
 import { CreateNodeArgs, GatsbyNode } from 'gatsby'
 
-import { isContent } from './cms'
+import { getMeta, isContent } from './cms'
 import { BlockDOM } from './compiler'
 
 const TYPE = 'CMSPage'
@@ -29,7 +29,7 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
 
   const obj = {
     src: dom.renderToString(),
-    slug: content.meta.slug,
+    slug: getMeta(content)?.slug,
     name: node.name,
   }
 

--- a/packages/gatsby-transformer-vtex-cms/src/gatsby-node.ts
+++ b/packages/gatsby-transformer-vtex-cms/src/gatsby-node.ts
@@ -25,11 +25,13 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
     return
   }
 
-  const dom = new BlockDOM(content.blocks)
+  const { blocks, extraBlocks } = content
+
+  const dom = new BlockDOM(blocks)
 
   const obj = {
     src: dom.renderToString(),
-    slug: getMeta(content)?.slug,
+    slug: getMeta(extraBlocks)?.slug,
     name: node.name,
   }
 

--- a/packages/gatsby-transformer-vtex-cms/src/gatsby-node.ts
+++ b/packages/gatsby-transformer-vtex-cms/src/gatsby-node.ts
@@ -1,7 +1,7 @@
 import { CreateNodeArgs, GatsbyNode } from 'gatsby'
 
 import { getMeta, isContent } from './cms'
-import { BlockDOM } from './compiler'
+import { ContentDOM } from './compiler'
 
 const TYPE = 'CMSPage'
 
@@ -25,13 +25,11 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
     return
   }
 
-  const { blocks, extraBlocks } = content
-
-  const dom = new BlockDOM(blocks)
+  const dom = new ContentDOM(content)
 
   const obj = {
     src: dom.renderToString(),
-    slug: getMeta(extraBlocks)?.slug,
+    slug: getMeta(content.extraBlocks)?.slug,
     name: node.name,
   }
 


### PR DESCRIPTION
CMS has changed the location of the meta and title information.

This PR updates the logic so that it can accept this type of page:

```
{
  "lastUpdatedAt": "2020-09-24T17:34:56.493Z",
  "afterBlocks": [],
  "beforeBlocks": [],
  "extraBlocks": [
    {
      "name": "admin/visibilityTitle",
      "blocks": [
        {
          "name": "informations",
          "props": {
            "title": "Page comming from VTEX CMS",
            "slug": "/about"
          }
        }
      ]
    }
  ],
  "blocks": [
    {
      "name": "img",
      "props": {
        "src": "https://content.vtexassets.com/assets/vtex.file-manager-graphql/images/chile-bike-2318___52930c4e532472f5263a0fbfdb067a1e.jpg"
      }
    }
  ]
}
```

## Screenshots

 - Preview
<img src="https://user-images.githubusercontent.com/342161/94867544-d210b000-0417-11eb-8454-0d99e3219a14.png" width="500" />

- Landing Page
<img src="https://user-images.githubusercontent.com/342161/94867643-fec4c780-0417-11eb-8b29-2cd837204bd2.png" width="500" />

