### PR TITLE
Fix Versions

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.70.2",
+  "version": "0.70.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.70.0",
+  "version": "0.70.3",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.70.0",
+  "version": "0.70.3",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.70.0",
+  "version": "0.70.3",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-plugin-vtex-nginx/package.json
+++ b/packages/gatsby-plugin-vtex-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-vtex-nginx",
-  "version": "0.70.0",
+  "version": "0.70.3",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.70.0",
+  "version": "0.70.3",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-vtex/package.json
+++ b/packages/gatsby-theme-vtex/package.json
@@ -55,6 +55,5 @@
     "requestidlecallback-polyfill": "^1.0.2",
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0"
-  },
-  "gitHead": "10991ef0abcf9da85387fd564d670225e7cdf944"
+  }
 }

--- a/packages/gatsby-theme-vtex/package.json
+++ b/packages/gatsby-theme-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-vtex",
-  "version": "0.70.2",
+  "version": "0.70.3",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {
@@ -27,18 +27,18 @@
     "@types/react": "^16.9.41",
     "@types/react-dom": "^16.9.8",
     "@types/react-helmet": "^6.0.0",
-    "@vtex/store-ui": "^0.70.2",
+    "@vtex/store-ui": "^0.70.3",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.43",
     "typescript": "^3.9.5"
   },
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
-    "@vtex/gatsby-plugin-graphql": "^0.70.0",
-    "@vtex/gatsby-plugin-i18n": "^0.70.0",
-    "@vtex/gatsby-plugin-theme-ui": "^0.70.0",
-    "@vtex/gatsby-source-vtex": "^0.70.0",
-    "@vtex/gatsby-transformer-vtex-cms": "^0.70.0",
+    "@vtex/gatsby-plugin-graphql": "^0.70.3",
+    "@vtex/gatsby-plugin-i18n": "^0.70.3",
+    "@vtex/gatsby-plugin-theme-ui": "^0.70.3",
+    "@vtex/gatsby-source-vtex": "^0.70.3",
+    "@vtex/gatsby-transformer-vtex-cms": "^0.70.3",
     "babel-gql": "^0.1.3",
     "common-tags": "^1.8.0",
     "dotenv": "^8.2.0",

--- a/packages/gatsby-transformer-vtex-cms/package.json
+++ b/packages/gatsby-transformer-vtex-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-transformer-vtex-cms",
-  "version": "0.70.0",
+  "version": "0.70.3",
   "description": "Gatsby transformer plugin for building pages from VTEX CMS.",
   "main": "index.js",
   "scripts": {

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.70.0",
+  "version": "0.70.3",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.70.2",
+  "version": "0.70.3",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -30,7 +30,7 @@
     "@theme-ui/preset-base": "^0.3.0",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.70.0",
+    "@vtex/gatsby-plugin-i18n": "^0.70.3",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "reakit": "^1.1.2",


### PR DESCRIPTION
In this PR I fixed the versions of all packages. 

@cezarguimaraes released the 0.70.0 but for some reason, the versions were not published in npm. Other versions were created above and this ended up creating a problem similar to this:

<img width="696" alt="Screen Shot 2020-10-01 at 17 57 28" src="https://user-images.githubusercontent.com/10627086/94862574-940f8e00-040f-11eb-9a9d-1d94477d6364.png">

But @vtex/gatsby-transformer-vtex-cms not is a marinbrasil package
