### PR TITLE
Uses product from vtex

### DIFF
--- a/packages/gatsby-theme-vtex/src/components/Search/List/index.tsx
+++ b/packages/gatsby-theme-vtex/src/components/Search/List/index.tsx
@@ -64,6 +64,7 @@ export const query = gql`
   ) {
     vtex {
       productSearch(
+        productOriginVtex: true
         hideUnavailableItems: true
         selectedFacets: $selectedFacets
         fullText: $fullText

--- a/packages/gatsby-theme-vtex/src/templates/search.tsx
+++ b/packages/gatsby-theme-vtex/src/templates/search.tsx
@@ -94,15 +94,16 @@ export const query = graphql`
   ) {
     vtex {
       productSearch(
+        from: 0
+        to: 9
+        hideUnavailableItems: true
+        productOriginVtex: true
+        simulationBehavior: skip
         orderBy: $orderBy
         query: $query
         map: $map
         fullText: $fullText
         selectedFacets: $selectedFacets
-        hideUnavailableItems: true
-        simulationBehavior: skip
-        from: 0
-        to: 9
       ) @include(if: $staticPath) {
         products {
           ...ProductSummary_syncProduct


### PR DESCRIPTION
Currently, biggy search does not return all data that Portal returns. This is addressed by using origin-vtex in search queries