### PR TITLE
Skeleton

### DIFF
--- a/packages/gatsby-theme-vtex/package.json
+++ b/packages/gatsby-theme-vtex/package.json
@@ -51,7 +51,6 @@
     "p-queue": "^6.5.0",
     "react-helmet": "^6.1.0",
     "react-hook-inview": "^4.3.0",
-    "react-loading-skeleton": "^2.1.1",
     "requestidlecallback-polyfill": "^1.0.2",
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0",

--- a/packages/gatsby-theme-vtex/src/components/ProductPage/AboveTheFoldPreview.tsx
+++ b/packages/gatsby-theme-vtex/src/components/ProductPage/AboveTheFoldPreview.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react'
-import Skeleton from '@vtex/store-ui/src/Skeleton'
-import { Grid, Flex, Card } from '@vtex/store-ui'
+import { Grid, Flex, Card, Skeleton } from '@vtex/store-ui'
 
 import Container from '../Container'
 

--- a/packages/gatsby-theme-vtex/src/components/ProductPage/AboveTheFoldPreview.tsx
+++ b/packages/gatsby-theme-vtex/src/components/ProductPage/AboveTheFoldPreview.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import Skeleton from 'react-loading-skeleton'
+import Skeleton from '@vtex/store-ui/src/Skeleton'
 import { Grid, Flex, Card } from '@vtex/store-ui'
 
 import Container from '../Container'
@@ -9,12 +9,12 @@ const AboveTheFoldPreview: FC = () => (
     <Flex variant="productPage.container">
       <Skeleton width="500px" height="45px" />
       <Grid my={4} mx="auto" gap={[0, 3]} columns={[1, 2]}>
-        <Skeleton width={500} height={500} />
+        <Skeleton width="500px" height="500px" />
         <Card>
-          <Skeleton width={500} height={20} />
-          <Skeleton width={500} height={20} />
-          <Skeleton width={500} height={20} />
-          <Skeleton width={500} height={20} />
+          <Skeleton width="500px" height="20px" />
+          <Skeleton width="500px" height="20px" />
+          <Skeleton width="500px" height="20px" />
+          <Skeleton width="500px" height="20px" />
         </Card>
       </Grid>
     </Flex>

--- a/packages/gatsby-theme-vtex/src/components/SearchPage/AboveTheFoldPreview.tsx
+++ b/packages/gatsby-theme-vtex/src/components/SearchPage/AboveTheFoldPreview.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
-import Skeleton from 'react-loading-skeleton'
-import { Grid, Flex, Box } from '@vtex/store-ui'
+import Skeleton from '@vtex/store-ui/src/Skeleton'
+import { Grid, Box } from '@vtex/store-ui'
 
 import Container from '../Container'
 import SuspenseDevice from '../Suspense/Device'

--- a/packages/gatsby-theme-vtex/src/components/SearchPage/AboveTheFoldPreview.tsx
+++ b/packages/gatsby-theme-vtex/src/components/SearchPage/AboveTheFoldPreview.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react'
-import Skeleton from '@vtex/store-ui/src/Skeleton'
-import { Grid, Box } from '@vtex/store-ui'
+import { Grid, Box, Skeleton } from '@vtex/store-ui'
 
 import Container from '../Container'
 import SuspenseDevice from '../Suspense/Device'

--- a/packages/gatsby-theme-vtex/src/components/ShippingSimulator/Preview.tsx
+++ b/packages/gatsby-theme-vtex/src/components/ShippingSimulator/Preview.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
-import Skeleton from 'react-loading-skeleton'
 import { Box } from '@vtex/store-ui'
+import Skeleton from '@vtex/store-ui/src/Skeleton'
 
 interface Props {
   variant: string
@@ -8,7 +8,7 @@ interface Props {
 
 const ShippingSimulatorPreview: FC<Props> = ({ variant }) => (
   <Box variant={variant} sx={{ marginX: 10 }}>
-    <Skeleton height={20} />
+    <Skeleton height="20px" />
   </Box>
 )
 

--- a/packages/gatsby-theme-vtex/src/components/ShippingSimulator/Preview.tsx
+++ b/packages/gatsby-theme-vtex/src/components/ShippingSimulator/Preview.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react'
-import { Box } from '@vtex/store-ui'
-import Skeleton from '@vtex/store-ui/src/Skeleton'
+import { Box, Skeleton } from '@vtex/store-ui'
 
 interface Props {
   variant: string

--- a/packages/store-ui/src/Skeleton/index.tsx
+++ b/packages/store-ui/src/Skeleton/index.tsx
@@ -1,0 +1,49 @@
+/** @jsx jsx */
+import { jsx, css, keyframes } from '@emotion/core'
+import { FC } from 'react'
+
+const baseColor = '#eee'
+
+interface Props {
+  width?: string
+  height?: string
+}
+
+const Skeleton: FC<Props> = ({ width = '100%', height = '50px' }) => (
+  <div
+    css={css`
+      background-color: ${baseColor};
+      border-radius: 4px;
+      display: block;
+      line-height: 1;
+      width: ${width};
+      height: ${height};
+      position: relative;
+      overflow: hidden;
+      margin-top: 4px;
+
+      ::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(to left, #eee, #ddd, #eee);
+        animation: ${keyframes`
+    0% {
+      transform: translateX(0);
+    }
+    50% {
+      transform: translateX(calc(${width} - 100px));
+    }
+    0% {
+      transform: translateX(0);
+    }
+  `} 1.2s infinite;
+      }
+    `}
+  />
+)
+
+export default Skeleton

--- a/packages/store-ui/src/index.tsx
+++ b/packages/store-ui/src/index.tsx
@@ -99,3 +99,5 @@ export { default as floatingActionButtonTheme } from './FloatingActionButton/the
 export { default as GiftList } from './GiftList/index'
 export { default as GiftListTitle } from './GiftList/Title'
 export { default as GiftListList } from './GiftList/List'
+// Skeleton
+export { default as Skeleton } from './Skeleton'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,7 +1486,7 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@^10.0.0", "@emotion/core@^10.0.14", "@emotion/core@^10.0.20", "@emotion/core@^10.0.22":
+"@emotion/core@^10.0.0", "@emotion/core@^10.0.14", "@emotion/core@^10.0.20":
   version "10.0.34"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.34.tgz#a643889dc32bdde829482539c9438a026631187c"
   integrity sha512-Kcs8WHZG1NgaVFQsSpgN07G0xpfPAKUclwKvUqKrYrJovezl9uTz++1M4JfXHrgFVEiJ5QO46hMo1ZDDfvY/tw==
@@ -19247,13 +19247,6 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
-react-loading-skeleton@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/react-loading-skeleton/-/react-loading-skeleton-2.1.1.tgz#2c075ea9683587c163408c8eec0703047c4203b1"
-  integrity sha512-+fGvgG9ieUw4D5QVgpqJkJ75jhzUdz96GRsA0HjTlR0Mpj9DJUEFc0AKELs7ZkqWVH8/DiroaaufSrOPld1kGA==
-  dependencies:
-    "@emotion/core" "^10.0.22"
 
 react-popper-tooltip@^2.8.3:
   version "2.11.1"


### PR DESCRIPTION
## What's the purpose of this pull request?
Fix the following failure that was occurring due to the usage of `Skeleton` from `react-loading-skeleton` lib

> `non-composited-animations` failure for `minScore` assertion (Avoid non-composited animations: https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count)


## How it works? 
This new Skeleton component created uses only CSS “compositor-only” properties: `transform`. This way we avoid non-composited animations.

## How to test it?
Go to the product page and watch the skeleton animation before the info is rendered.
Example: https://vtex-sites-marinbrasil-store-123.vtex.app/tanque-tramontina-hera-30-l-em-aco-inox-acetinado-50-x-40-cm-com-valvula-94400107-/p

## References
Article: [stick to compositor-only properties](https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count)
Lib: [react-loading-skeleton](https://github.com/dvtng/react-loading-skeleton
)