### PR TITLE
Fix Home Redirect

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.107.0",
+  "version": "0.108.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.108.0-alpha.0",
+  "version": "0.108.1-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-theme-vtex/package.json
+++ b/packages/gatsby-theme-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-vtex",
-  "version": "0.107.0",
+  "version": "0.108.0-alpha.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-vtex/package.json
+++ b/packages/gatsby-theme-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-vtex",
-  "version": "0.108.0-alpha.0",
+  "version": "0.108.1-alpha.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-vtex/src/sdk/search/controller.ts
+++ b/packages/gatsby-theme-vtex/src/sdk/search/controller.ts
@@ -53,9 +53,16 @@ export const toggleItem = (item: SearchFilterItem, filters: SearchFilters) => {
 
     const index = splittedQuery?.findIndex((s) => s === value)
 
+    // Unselecting the base path. This is not allowed since it would redirect
+    // the user to the home page. In the future we should return a visual
+    // feedback for the user
+    if (index === 0) {
+      return
+    }
+
     // eslint-disable-next-line no-console
     console.assert(
-      index && index > -1,
+      index !== undefined && index > -1,
       `${value} is marked as selected but does not exist in ${query}`
     )
 


### PR DESCRIPTION
## What's the purpose of this pull request?
As mentioned by our customers, when the user is in a department page and removes the last search filter, the user is redirected to the home page. This happens because a department page follows the pattern `/:department`, and when the user removes this filter, the search controller removes the filter, having the url `/`, thus redirecting the user to the home page

## How it works? 
To solve the aforementioned problem, the simple solution of not being able to remove the first filter was implemented in this PR. So, for example, if the user is in the `/banana` and tries to remove the filter `banana`, nothing will happen. Also, if the user is in `/banana/pera` and the user tries to remove `banana` filter, nothing will also happen, since, at least for me, it makes no sense to remove the department filter in a search page.

## How to test it?
Just go to a deploy preview on any of the PRs bellow, enter in a department page and tries to remove the filter. Nothing should happen.

[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/139)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/336)

## References

