### PR TITLE
Fix/theme ui components type

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.197.0",
+  "version": "0.197.1-kiwi.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.197.1-kiwi.0",
+  "version": "0.197.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.196.0",
+  "version": "0.197.1-kiwi.0",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.197.1-kiwi.0",
+  "version": "0.197.1",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.196.0",
+  "version": "0.197.1-kiwi.0",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.197.1-kiwi.0",
+  "version": "0.197.1",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.196.0",
+  "version": "0.197.1-kiwi.0",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.197.1-kiwi.0",
+  "version": "0.197.1",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-plugin-vtex-nginx/package.json
+++ b/packages/gatsby-plugin-vtex-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-vtex-nginx",
-  "version": "0.196.0",
+  "version": "0.197.1-kiwi.0",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-vtex-nginx/package.json
+++ b/packages/gatsby-plugin-vtex-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-vtex-nginx",
-  "version": "0.197.1-kiwi.0",
+  "version": "0.197.1",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.196.0",
+  "version": "0.197.1-kiwi.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.197.1-kiwi.0",
+  "version": "0.197.1",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-vtex/package.json
+++ b/packages/gatsby-theme-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-vtex",
-  "version": "0.197.0",
+  "version": "0.197.1-kiwi.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {
@@ -37,7 +37,7 @@
     "@vtex/gatsby-plugin-theme-ui": "^0.120.1",
     "@vtex/gatsby-source-vtex": "^0.120.0",
     "@vtex/gatsby-transformer-vtex-cms": "^0.120.0",
-    "@vtex/store-ui": "^0.197.0",
+    "@vtex/store-ui": "^0.197.1-kiwi.0",
     "babel-gql": "^0.1.3",
     "common-tags": "^1.8.0",
     "dotenv": "^8.2.0",

--- a/packages/gatsby-theme-vtex/package.json
+++ b/packages/gatsby-theme-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-vtex",
-  "version": "0.197.1-kiwi.0",
+  "version": "0.197.1",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {
@@ -37,7 +37,7 @@
     "@vtex/gatsby-plugin-theme-ui": "^0.120.1",
     "@vtex/gatsby-source-vtex": "^0.120.0",
     "@vtex/gatsby-transformer-vtex-cms": "^0.120.0",
-    "@vtex/store-ui": "^0.197.1-kiwi.0",
+    "@vtex/store-ui": "^0.197.1",
     "babel-gql": "^0.1.3",
     "common-tags": "^1.8.0",
     "dotenv": "^8.2.0",

--- a/packages/gatsby-transformer-vtex-cms/package.json
+++ b/packages/gatsby-transformer-vtex-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-transformer-vtex-cms",
-  "version": "0.196.0",
+  "version": "0.197.1-kiwi.0",
   "description": "Gatsby transformer plugin for building pages from VTEX CMS.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-transformer-vtex-cms/package.json
+++ b/packages/gatsby-transformer-vtex-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-transformer-vtex-cms",
-  "version": "0.197.1-kiwi.0",
+  "version": "0.197.1",
   "description": "Gatsby transformer plugin for building pages from VTEX CMS.",
   "main": "index.js",
   "scripts": {

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.196.0",
+  "version": "0.197.1-kiwi.0",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.197.1-kiwi.0",
+  "version": "0.197.1",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
     "@theme-ui/preset-base": "^0.3.0",
+    "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
     "@vtex/gatsby-plugin-i18n": "^0.196.0",
@@ -49,7 +50,6 @@
     "@storybook/react": "^5.3.19",
     "@types/react": "^16.9.27",
     "@types/react-dom": "^16.9.7",
-    "@types/theme-ui": "^0.3.5",
     "@types/unorm": "^1.3.28",
     "@vtex/tsconfig": "^0.5.0",
     "react": "^0.0.0-experimental-7f28234f8",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.197.0",
+  "version": "0.197.1-kiwi.0",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.196.0",
+    "@vtex/gatsby-plugin-i18n": "^0.197.1-kiwi.0",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.197.1-kiwi.0",
+  "version": "0.197.1",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.197.1-kiwi.0",
+    "@vtex/gatsby-plugin-i18n": "^0.197.1",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4447,7 +4447,7 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
 
-"@types/theme-ui@*", "@types/theme-ui@^0.3.5":
+"@types/theme-ui@*":
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/@types/theme-ui/-/theme-ui-0.3.7.tgz#67346df27d02045c7f06f9684c88e3a5622a456d"
   integrity sha512-4hzDlDhlFYmOdXBLZTbO4N2hWfuGo1N77AcIMaSyDGEyFbdZSpelMLTkEtNzYT8yQWIl3x0WITiBzjqkfc6dUg==
@@ -4459,7 +4459,7 @@
     "@types/theme-ui__components" "*"
     csstype "^3.0.2"
 
-"@types/theme-ui__components@*":
+"@types/theme-ui__components@*", "@types/theme-ui__components@^0.2.6":
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/@types/theme-ui__components/-/theme-ui__components-0.2.6.tgz#91ae441bdb201acce8daf088717d96a5d8c1048d"
   integrity sha512-i/tz/trP4iPcdokOJBSkI/KNR/0YkwLSuJZzEHdrWRtmCKa4MyY+hKcoN9YALq09Z/vYI2JYSEyBz3+N/zNwvg==


### PR DESCRIPTION
## What's the purpose of this pull request?
The `@theme-ui/components` package doesn't have its own type definitions, so we need to also add `@types/theme-ui__components` as a dependency of our `@vtex/store-ui` package. This makes the TypeScript compiler stop complaining about importing `Box` and other components from our package.

Before:
![image](https://user-images.githubusercontent.com/12702016/99680297-a8f5be80-2a5b-11eb-85ab-e8aea890d3e5.png)

After:
![image](https://user-images.githubusercontent.com/12702016/99680355-bca12500-2a5b-11eb-8de3-92571f61cd98.png)

## How to test it?
n/a

## References
n/a