### PR TITLE
Run react-preset over hook and theme files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,24 @@
 module.exports = {
   extends: ['vtex'],
   overrides: [
-    // Use vtex-react preset for .tsx files
     {
-      files: '*.tsx',
-      extends: ['vtex-react'],
+      files: [
+        // all tsx files
+        '*.tsx',
+        // gatsby config files (gatsby preset takes care of each variant)
+        'gatsby-*.*',
+        // generic components/hooks path
+        'components/**/*',
+        'hooks/**/*',
+        // hooks
+        'use*.ts',
+        'hooks.ts',
+        // themes
+        'theme.ts',
+        // store-ui is browser-only
+        'packages/store-ui/**/*',
+      ],
+      extends: ['vtex-react/gatsby'],
     },
     // General overrides
     {
@@ -13,7 +27,7 @@ module.exports = {
         'no-console': [
           'error',
           {
-            allow: ['warn', 'error', 'info', 'time', 'timeEnd'],
+            allow: ['warn', 'error', 'info', 'time', 'timeEnd', 'assert'],
           },
         ],
         '@typescript-eslint/no-explicit-any': 'off',
@@ -21,13 +35,11 @@ module.exports = {
         'no-await-in-loop': 'off',
       },
     },
-    // Gatsby configuration files
+    // stories overrides
     {
-      files: ['gatsby-{ssr,browser,node,config}.{ts,tsx}'],
+      files: '*.stories.tsx',
       rules: {
-        'global-require': 'off',
-        '@typescript-eslint/no-require-imports': 'off',
-        '@typescript-eslint/no-var-requires': 'off',
+        'no-console': 'off',
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   },
   "devDependencies": {
     "@vtex/prettier-config": "^0.3.5",
-    "eslint": "^7.2.0",
+    "eslint": "^7.13.0",
     "eslint-config-vtex": "^12.8.10",
-    "eslint-config-vtex-react": "^6.7.12",
-    "husky": "^4.2.5",
+    "eslint-config-vtex-react": "^6.8.2",
+    "husky": "^4.3.0",
     "lerna": "^3.22.1",
-    "lint-staged": "^10.2.11",
-    "prettier": "^2.0.5",
+    "lint-staged": "^10.5.1",
+    "prettier": "^2.1.2",
     "typescript": "^3.9.5"
   },
   "resolutions": {

--- a/packages/gatsby-theme-vtex/src/components/Minicart/Drawer/Quantity.tsx
+++ b/packages/gatsby-theme-vtex/src/components/Minicart/Drawer/Quantity.tsx
@@ -1,6 +1,5 @@
-import { useIntl } from '@vtex/gatsby-plugin-i18n'
 import { Spinner, Flex, NumericStepper } from '@vtex/store-ui'
-import React, { useState, FC, ChangeEvent, useCallback } from 'react'
+import React, { useState, FC } from 'react'
 
 import { useItem } from './useItem'
 import { useUpdateItems } from './useUpdateItems'

--- a/packages/store-ui/src/ProductQuantity/useNumericStepper.ts
+++ b/packages/store-ui/src/ProductQuantity/useNumericStepper.ts
@@ -25,7 +25,7 @@ export const useNumericStepper = ({
       setValue(narrowed)
       raiseOnChange(narrowed)
     },
-    [value, min, max, raiseOnChange]
+    [min, max, raiseOnChange]
   )
 
   const narrowValue = useCallback(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9318,10 +9318,10 @@ eslint-config-react-app@^5.0.2, eslint-config-react-app@^5.2.1:
   dependencies:
     confusing-browser-globals "^1.0.9"
 
-eslint-config-vtex-react@^6.7.12:
-  version "6.7.12"
-  resolved "https://registry.yarnpkg.com/eslint-config-vtex-react/-/eslint-config-vtex-react-6.7.12.tgz#ab32d6ccecf02e179634f135b8707b4ec5d18e4a"
-  integrity sha512-/d71EiqFFWnem9TIw/iMlQ6loedroXseivs17XaCkfRlW5w1S9yaNViRRhu4bmxYwXaFt8BDGdOkBO7SSWSKvw==
+eslint-config-vtex-react@^6.8.2:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-vtex-react/-/eslint-config-vtex-react-6.8.2.tgz#4303be49f57f7a169caaeda9b862dadd21d803ae"
+  integrity sha512-1eiLz1hMi7IxP6/hBnOYFto/q/bcvwU8ZJIReTyXc61FX/voCixT3+zwSkFvJ+Ak1+TT5eniNoptoZro4FpOqA==
   dependencies:
     eslint-config-vtex "^12.8.10"
     eslint-plugin-jsx-a11y "^6.3.1"
@@ -9633,7 +9633,7 @@ eslint@^6.1.0, eslint@^6.6.0, eslint@^6.8.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^7.2.0:
+eslint@^7.13.0:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.13.0.tgz#7f180126c0dcdef327bfb54b211d7802decc08da"
   integrity sha512-uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==
@@ -11986,7 +11986,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^4.2.5:
+husky@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.0.tgz#0b2ec1d66424e9219d359e26a51c58ec5278f0de"
   integrity sha512-tTMeLCLqSBqnflBZnlVDhpaIMucSGaYyX6855jM4AguGeWCeSzNdb1mfyWduTZ3pe3SJVvVWGL0jO1iKZVPfTA==
@@ -14738,7 +14738,7 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.2.11:
+lint-staged@^10.5.1:
   version "10.5.1"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.5.1.tgz#901e915c2360072dded0e7d752a0d9a49e079daa"
   integrity sha512-fTkTGFtwFIJJzn/PbUO3RXyEBHIhbfYBE7+rJyLcOXabViaO/h6OslgeK6zpeUtzkDrzkgyAYDTLAwx6JzDTHw==
@@ -18067,7 +18067,7 @@ prettier@^1.19.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.0.5:
+prettier@^2.0.5, prettier@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==


### PR DESCRIPTION
## What's the purpose of this pull request?

Currently, our `react-preset/gatsby` is only matched against `*.tsx` files, which means every `use*.ts`, `hooks.ts`, `theme.ts` etc were not being checked properly.

Now, there are a bunch of hooks-deps related errors. I'm not confident enough to automatically change them so I'll ask for help with this in future PRs 😁 