### PR TITLE
Move redirects to source vtex

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.210.0-alpha.2",
+  "version": "0.210.0-alpha.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.210.0-alpha.5",
+  "version": "0.210.0-alpha.6",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.210.0-alpha.0",
+  "version": "0.210.0-alpha.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.210.0-alpha.3",
+  "version": "0.210.0-alpha.4",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.210.0-alpha.4",
+  "version": "0.210.0-alpha.5",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
@@ -7,7 +7,5 @@
       "message": "Release: %v"
     }
   },
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.210.0-alpha.1",
+  "version": "0.210.0-alpha.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.209.0",
+  "version": "0.210.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.210.0-alpha.4",
+  "version": "0.210.0-alpha.5",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.210.0-alpha.1",
+  "version": "0.210.0-alpha.2",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.210.0-alpha.2",
+  "version": "0.210.0-alpha.3",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.210.0-alpha.3",
+  "version": "0.210.0-alpha.4",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -31,6 +31,5 @@
   "peerDependencies": {
     "gatsby": "^2.24.37",
     "graphql": "^14.0.0 || ^15.0.0"
-  },
-  "gitHead": "153ac9574f9d8192c86dbfa0def5e555bf2175ff"
+  }
 }

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -32,5 +32,5 @@
     "gatsby": "^2.24.37",
     "graphql": "^14.0.0 || ^15.0.0"
   },
-  "gitHead": "e8ef4489cbb0d8f651f68c30e880f26e777b7016"
+  "gitHead": "153ac9574f9d8192c86dbfa0def5e555bf2175ff"
 }

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -32,5 +32,5 @@
     "gatsby": "^2.24.37",
     "graphql": "^14.0.0 || ^15.0.0"
   },
-  "gitHead": "90d34406c25f5be820dffa049e471acaf1ec3bad"
+  "gitHead": "e8ef4489cbb0d8f651f68c30e880f26e777b7016"
 }

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.207.0",
+  "version": "0.210.0-alpha.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.210.0-alpha.0",
+  "version": "0.210.0-alpha.1",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -31,5 +31,6 @@
   "peerDependencies": {
     "gatsby": "^2.24.37",
     "graphql": "^14.0.0 || ^15.0.0"
-  }
+  },
+  "gitHead": "90d34406c25f5be820dffa049e471acaf1ec3bad"
 }

--- a/packages/gatsby-source-vtex/src/gatsby-config.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-config.ts
@@ -1,0 +1,47 @@
+import { Options } from './gatsby-node'
+
+/**
+ * Create all proxy rules.
+ * If adding a new rule, don't forget to create a redirect in ./gatsby-node.ts
+ * so the redirect works in production websites as well
+ */
+module.exports = ({ tenant, workspace, environment }: Options) => ({
+  proxy: [
+    {
+      prefix: '/api/io',
+      url: `https://${workspace}--${tenant}.myvtex.com`,
+    },
+    {
+      prefix: '/api',
+      url: `https://${tenant}.${environment}.com.br`,
+    },
+    {
+      prefix: '/checkout',
+      url: `https://${workspace}--${tenant}.myvtex.com`,
+    },
+    {
+      prefix: '/arquivos',
+      url: `https://${tenant}.vtexassets.com`,
+    },
+    {
+      prefix: '/files',
+      url: `https://${tenant}.vtexassets.com`,
+    },
+    {
+      prefix: '/graphql',
+      url: `https://${workspace}--${tenant}.myvtex.com`,
+    },
+    {
+      prefix: '/sitemap.xml',
+      url: `https://${workspace}--${tenant}.myvtex.com`,
+    },
+    {
+      prefix: '/sitemap',
+      url: `https://${workspace}--${tenant}.myvtex.com`,
+    },
+    {
+      prefix: '/XMLData',
+      url: `https://${tenant}.${environment}.com.br`,
+    },
+  ],
+})

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -17,7 +17,7 @@ import { createDepartmentNode, createChannelNode } from './utils'
 const getGraphQLUrl = (tenant: string, workspace: string) =>
   `http://${workspace}--${tenant}.myvtex.com/graphql`
 
-interface Options extends PluginOptions, VTEXOptions {}
+export interface Options extends PluginOptions, VTEXOptions {}
 
 export const sourceNodes: GatsbyNode['sourceNodes'] = async (
   args: SourceNodesArgs,
@@ -102,6 +102,12 @@ export const createPage = (
   { actions: { createRedirect } }: CreatePageArgs,
   { tenant, workspace, environment }: Options
 ) => {
+  /**
+   * Create all proxy rules for VTEX Store
+   * If adding a new rule, don't forget to modify ./gatsby-config.ts dev proxy
+   * so it also works in dev mode
+   */
+
   // Redirect API
   createRedirect({
     fromPath: '/api/io/*',

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -98,7 +98,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
   departments.forEach((department) => createDepartmentNode(args, department))
 }
 
-export const createPage = (
+export const createPages = (
   { actions: { createRedirect } }: CreatePageArgs,
   { tenant, workspace, environment }: Options
 ) => {

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -1,7 +1,13 @@
 import { AsyncExecutor } from '@graphql-tools/delegate'
 import { introspectSchema, wrapSchema } from '@graphql-tools/wrap'
-import { GatsbyNode, PluginOptions, SourceNodesArgs } from 'gatsby'
 import { print } from 'graphql'
+import {
+  GatsbyNode,
+  PluginOptions,
+  SourceNodesArgs,
+  CreatePageArgs,
+  PluginOptionsSchemaArgs,
+} from 'gatsby'
 
 import { api } from './api'
 import { fetchVTEX, VTEXOptions } from './fetch'
@@ -91,3 +97,105 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
 
   departments.forEach((department) => createDepartmentNode(args, department))
 }
+
+export const createPage = (
+  { actions: { createRedirect } }: CreatePageArgs,
+  { tenant, workspace, environment }: Options
+) => {
+  // Redirect API
+  createRedirect({
+    fromPath: '/api/io/*',
+    toPath: `https://${workspace}--${tenant}.myvtex.com/:splat`,
+    statusCode: 200,
+    headers: {
+      // VTEX ID needs the forwarded host in order to set the cookie correctly
+      'x-forwarded-host': '$host',
+    },
+  })
+
+  createRedirect({
+    fromPath: '/api/*',
+    toPath: `https://${tenant}.${environment}.com.br/api/:splat`,
+    statusCode: 200,
+    headers: {
+      // VTEX ID needs the forwarded host in order to set the cookie correctly
+      'x-forwarded-host': '$host',
+    },
+  })
+
+  // Use legacy checkout
+  createRedirect({
+    fromPath: '/checkout/*',
+    toPath: `https://${tenant}.${environment}.com.br/checkout/:splat`,
+    statusCode: 200,
+    headers: {
+      // VTEX ID needs the forwarded host in order to set the cookie correctly
+      'x-forwarded-host': '$host',
+    },
+  })
+
+  // Static assets checkout uses
+  createRedirect({
+    fromPath: '/arquivos/*',
+    toPath: `https://${tenant}.vtexassets.com/arquivos/:splat`,
+    statusCode: 200,
+  })
+
+  createRedirect({
+    fromPath: '/files/*',
+    toPath: `https://${tenant}.vtexassets.com/files/:splat`,
+    statusCode: 200,
+  })
+
+  // Use graphql-gateway from VTEX IO
+  createRedirect({
+    fromPath: '/graphql/*',
+    toPath: `https://${workspace}--${tenant}.myvtex.com/graphql/:splat`,
+    statusCode: 200,
+    headers: {
+      // VTEX ID needs the forwarded host in order to set the cookie correctly
+      'x-forwarded-host': '$host',
+    },
+  })
+
+  // Use sitemap from VTEX
+  createRedirect({
+    fromPath: '/sitemap.xml',
+    toPath: `https://${workspace}--${tenant}.myvtex.com/sitemap.xml`,
+    statusCode: 200,
+    headers: {
+      // VTEX ID needs the forwarded host in order to set the cookie correctly
+      'x-forwarded-host': '$host',
+    },
+  })
+
+  createRedirect({
+    fromPath: '/sitemap/*',
+    toPath: `https://${workspace}--${tenant}.myvtex.com/sitemap/:splat`,
+    statusCode: 200,
+    headers: {
+      // VTEX ID needs the forwarded host in order to set the cookie correctly
+      'x-forwarded-host': '$host',
+    },
+  })
+
+  // Some people use XMLData integration via their main domains
+  createRedirect({
+    fromPath: '/XMLData/*',
+    toPath: `https://${tenant}.${environment}.com.br/XMLData/:splat`,
+    statusCode: 200,
+    headers: {
+      // VTEX ID needs the forwarded host in order to set the cookie correctly
+      'x-forwarded-host': '$host',
+    },
+  })
+}
+
+export const pluginOptionsSchema = ({ Joi }: PluginOptionsSchemaArgs) =>
+  Joi.object({
+    tenant: Joi.string().required(),
+    workspace: Joi.string().required(),
+    environment: Joi.string().pattern(
+      /^(vtexcommercestable|vtexcommercebeta)$/
+    ),
+  })

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -55,5 +55,5 @@
     "swr": "^0.3.0",
     "text-mask-core": "^5.1.0"
   },
-  "gitHead": "106bd1f8fa393567aca6af853de47dcc0bf19138"
+  "gitHead": "90d34406c25f5be820dffa049e471acaf1ec3bad"
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -35,7 +35,6 @@
     "@vtex/gatsby-plugin-graphql": "^0.120.0",
     "@vtex/gatsby-plugin-i18n": "^0.120.0",
     "@vtex/gatsby-plugin-theme-ui": "^0.120.1",
-    "@vtex/gatsby-source-vtex": "^0.120.0",
     "@vtex/store-ui": "^0.207.0",
     "babel-gql": "^0.1.3",
     "common-tags": "^1.8.0",
@@ -54,5 +53,5 @@
     "swr": "^0.3.0",
     "text-mask-core": "^5.1.0"
   },
-  "gitHead": "e8ef4489cbb0d8f651f68c30e880f26e777b7016"
+  "gitHead": "153ac9574f9d8192c86dbfa0def5e555bf2175ff"
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.210.0-alpha.0",
+  "version": "0.210.0-alpha.1",
   "description": "Gatsby theme for building e-commerce websites",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.209.0",
+  "version": "0.210.0-alpha.0",
   "description": "Gatsby theme for building e-commerce websites",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.210.0-alpha.2",
+  "version": "0.210.0-alpha.3",
   "description": "Gatsby theme for building e-commerce websites",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.210.0-alpha.4",
+  "version": "0.210.0-alpha.5",
   "description": "Gatsby theme for building e-commerce websites",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.210.0-alpha.1",
+  "version": "0.210.0-alpha.2",
   "description": "Gatsby theme for building e-commerce websites",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -55,5 +55,5 @@
     "swr": "^0.3.0",
     "text-mask-core": "^5.1.0"
   },
-  "gitHead": "90d34406c25f5be820dffa049e471acaf1ec3bad"
+  "gitHead": "e8ef4489cbb0d8f651f68c30e880f26e777b7016"
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.210.0-alpha.3",
+  "version": "0.210.0-alpha.4",
   "description": "Gatsby theme for building e-commerce websites",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -52,6 +52,5 @@
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0",
     "text-mask-core": "^5.1.0"
-  },
-  "gitHead": "153ac9574f9d8192c86dbfa0def5e555bf2175ff"
+  }
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -39,7 +39,6 @@
     "@vtex/store-ui": "^0.207.0",
     "babel-gql": "^0.1.3",
     "common-tags": "^1.8.0",
-    "dotenv": "^8.2.0",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.210.0-alpha.5",
+  "version": "0.210.0-alpha.6",
   "description": "Gatsby theme for building e-commerce websites",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-store/src/gatsby-config.ts
+++ b/packages/gatsby-theme-store/src/gatsby-config.ts
@@ -1,20 +1,11 @@
-const root = process.cwd()
+import type { LocalizationThemeOptions, Options } from './gatsby-node'
 
-interface LocalizationThemeOptions {
-  messagesPath?: string
-  locales?: string[]
-  defaultLocale?: string
-}
+const root = process.cwd()
 
 const defaultLocalizationThemeOptions: Required<LocalizationThemeOptions> = {
   messagesPath: './i18n/messages',
   locales: ['en'],
   defaultLocale: 'en',
-}
-
-export interface Options {
-  getStaticPaths?: () => Promise<string[]>
-  localizationThemeOptions?: LocalizationThemeOptions
 }
 
 module.exports = ({ localizationThemeOptions }: Options) => ({

--- a/packages/gatsby-theme-store/src/gatsby-config.ts
+++ b/packages/gatsby-theme-store/src/gatsby-config.ts
@@ -1,12 +1,4 @@
-import assert from 'assert'
-
 const root = process.cwd()
-
-require('dotenv').config({
-  path: `${root}/vtex.env`,
-})
-
-export type Environment = 'vtexcommercestable' | 'vtexcommercebeta'
 
 interface LocalizationThemeOptions {
   messagesPath?: string
@@ -21,110 +13,46 @@ const defaultLocalizationThemeOptions: Required<LocalizationThemeOptions> = {
 }
 
 export interface Options {
-  title: string
-  description: string
   getStaticPaths?: () => Promise<string[]>
   localizationThemeOptions?: LocalizationThemeOptions
 }
 
-const tenant = process.env.GATSBY_VTEX_TENANT as string
-const environment = process.env.GATSBY_VTEX_ENVIRONMENT as Environment
-const workspace = process.env.GATSBY_VTEX_IO_WORKSPACE as string
-
-module.exports = ({
-  title,
-  description,
-  localizationThemeOptions,
-}: Options) => {
-  assert(
-    tenant,
-    `Tenant not found in gatsby-theme-store. Do you have a vtex.env configuration file ?`
-  )
-  assert(
-    environment,
-    `Environment not found in gatsby-theme-store. Do you have a vtex.env configuration file ?`
-  )
-  assert(
-    workspace,
-    `Workspace not found in gatsby-theme-store. Do you have a vtex.env configuration file ?`
-  )
-
-  return {
-    siteMetadata: {
-      title,
-      description,
-      vtex: {
-        tenant,
+module.exports = ({ localizationThemeOptions }: Options) => ({
+  plugins: [
+    {
+      resolve: require.resolve('gatsby-plugin-bundle-stats'),
+      options: {
+        compare: true,
+        baseline: true,
+        html: true,
+        json: true,
+        outDir: `.`,
+        stats: {
+          context: `${root}/src`,
+        },
       },
     },
-    plugins: [
-      {
-        resolve: require.resolve('gatsby-plugin-bundle-stats'),
-        options: {
-          compare: true,
-          baseline: true,
-          html: true,
-          json: true,
-          outDir: `.`,
-          stats: {
-            context: `${root}/src`,
-          },
-        },
-      },
-      {
-        resolve: require.resolve('gatsby-plugin-react-helmet-async'),
-      },
-      {
-        resolve: require.resolve('@vtex/gatsby-plugin-theme-ui'),
-      },
-      {
-        // Makes it possible to share graphql queries between
-        // client/server side queries
-        //
-        // Since graphql-js library must be a singleton, we resolve
-        // this path not relative to this folder but to the app
-        // using this theme, that's why this odd way of requiring the
-        // plugin
-        resolve: require.resolve(
-          `${root}/node_modules/@vtex/gatsby-plugin-graphql`
-        ),
-      },
-      {
-        // Adds search info into the Gatsby's source graph. This is
-        // the plugin responsible for adding Product/Category/Brand
-        // info into the gatsby's source graph
-        //
-        // Since graphql-js library must be a singleton, we resolve
-        // this path not relative to this folder but to the app
-        // using this theme, that's why this odd way of requiring the
-        // plugin
-        resolve: require.resolve(
-          `${root}/node_modules/@vtex/gatsby-source-vtex`
-        ),
-        options: {
-          tenant,
-          environment,
-          workspace,
-        },
-      },
-      {
-        resolve: '@vtex/gatsby-plugin-i18n',
-        options: localizationThemeOptions ?? defaultLocalizationThemeOptions,
-      },
-    ],
-    proxy: [
-      {
-        prefix: '/api',
-        url: `https://${tenant}.${environment}.com.br`,
-      },
-      {
-        prefix: '/graphql',
-        url: `https://${workspace}--${tenant}.myvtex.com`,
-      },
-      {
-        prefix: '/checkout',
-        url: `https://${workspace}--${tenant}.myvtex.com`,
-      },
-    ],
-  }
-}
+    {
+      resolve: require.resolve('gatsby-plugin-react-helmet-async'),
+    },
+    {
+      resolve: require.resolve('@vtex/gatsby-plugin-theme-ui'),
+    },
+    {
+      // Makes it possible to share graphql queries between
+      // client/server side queries
+      //
+      // Since graphql-js library must be a singleton, we resolve
+      // this path not relative to this folder but to the app
+      // using this theme, that's why this odd way of requiring the
+      // plugin
+      resolve: require.resolve(
+        `${root}/node_modules/@vtex/gatsby-plugin-graphql`
+      ),
+    },
+    {
+      resolve: '@vtex/gatsby-plugin-i18n',
+      options: localizationThemeOptions ?? defaultLocalizationThemeOptions,
+    },
+  ],
+})

--- a/packages/gatsby-theme-store/src/gatsby-node.ts
+++ b/packages/gatsby-theme-store/src/gatsby-node.ts
@@ -4,9 +4,38 @@ import {
   CreatePagesArgs,
   CreateWebpackConfigArgs,
   PluginOptionsSchemaArgs,
+  ParentSpanPluginArgs,
 } from 'gatsby'
 
-import { Options } from './gatsby-config'
+export const onPostBootstrap = (
+  _: ParentSpanPluginArgs,
+  { storeId }: Options
+) => {
+  process.env.GATSBY_STORE_ID = storeId
+}
+
+export interface LocalizationThemeOptions {
+  messagesPath?: string
+  locales?: string[]
+  defaultLocale?: string
+}
+
+export interface Options {
+  storeId: string
+  getStaticPaths?: () => Promise<string[]>
+  localizationThemeOptions?: LocalizationThemeOptions
+}
+
+export const pluginOptionsSchema = ({ Joi }: PluginOptionsSchemaArgs) =>
+  Joi.object({
+    storeId: Joi.string().required(),
+    localizationThemeOptions: Joi.object({
+      messagesPath: Joi.string(),
+      locales: Joi.array().items(Joi.string()),
+      defaultLocale: Joi.string(),
+    }),
+    getStaticPaths: Joi.function().arity(0).required(),
+  })
 
 const getRoute = (path: string) => {
   const splitted = path.split('/')

--- a/packages/gatsby-theme-store/src/gatsby-node.ts
+++ b/packages/gatsby-theme-store/src/gatsby-node.ts
@@ -1,6 +1,10 @@
 import { resolve } from 'path'
 
-import { CreatePagesArgs, CreateWebpackConfigArgs } from 'gatsby'
+import {
+  CreatePagesArgs,
+  CreateWebpackConfigArgs,
+  PluginOptionsSchemaArgs,
+} from 'gatsby'
 
 import { Options } from './gatsby-config'
 

--- a/packages/gatsby-theme-store/src/gatsby-node.ts
+++ b/packages/gatsby-theme-store/src/gatsby-node.ts
@@ -2,11 +2,7 @@ import { resolve } from 'path'
 
 import { CreatePagesArgs, CreateWebpackConfigArgs } from 'gatsby'
 
-import { Environment, Options } from './gatsby-config'
-
-const tenant = process.env.GATSBY_VTEX_TENANT as string
-const environment = process.env.GATSBY_VTEX_ENVIRONMENT as Environment
-const workspace = process.env.GATSBY_VTEX_IO_WORKSPACE as string
+import { Options } from './gatsby-config'
 
 const getRoute = (path: string) => {
   const splitted = path.split('/')
@@ -27,91 +23,9 @@ const getRoute = (path: string) => {
 }
 
 export const createPages = async (
-  { actions: { createPage, createRedirect } }: CreatePagesArgs,
+  { actions: { createPage } }: CreatePagesArgs,
   { getStaticPaths }: Options
 ) => {
-  createRedirect({
-    fromPath: '/api/io/*',
-    toPath: `https://${workspace}--${tenant}.myvtex.com/:splat`,
-    statusCode: 200,
-    headers: {
-      // VTEX ID needs the forwarded host in order to set the cookie correctly
-      'x-forwarded-host': '$host',
-    },
-  })
-
-  createRedirect({
-    fromPath: '/api/*',
-    toPath: `https://${tenant}.${environment}.com.br/api/:splat`,
-    statusCode: 200,
-    headers: {
-      // VTEX ID needs the forwarded host in order to set the cookie correctly
-      'x-forwarded-host': '$host',
-    },
-  })
-
-  createRedirect({
-    fromPath: '/checkout/*',
-    toPath: `https://${tenant}.${environment}.com.br/checkout/:splat`,
-    statusCode: 200,
-    headers: {
-      // VTEX ID needs the forwarded host in order to set the cookie correctly
-      'x-forwarded-host': '$host',
-    },
-  })
-
-  createRedirect({
-    fromPath: '/graphql/*',
-    toPath: `https://${workspace}--${tenant}.myvtex.com/graphql/:splat`,
-    statusCode: 200,
-    headers: {
-      // VTEX ID needs the forwarded host in order to set the cookie correctly
-      'x-forwarded-host': '$host',
-    },
-  })
-
-  createRedirect({
-    fromPath: '/sitemap.xml',
-    toPath: `https://${workspace}--${tenant}.myvtex.com/sitemap.xml`,
-    statusCode: 200,
-    headers: {
-      // VTEX ID needs the forwarded host in order to set the cookie correctly
-      'x-forwarded-host': '$host',
-    },
-  })
-
-  createRedirect({
-    fromPath: '/sitemap/*',
-    toPath: `https://${workspace}--${tenant}.myvtex.com/sitemap/:splat`,
-    statusCode: 200,
-    headers: {
-      // VTEX ID needs the forwarded host in order to set the cookie correctly
-      'x-forwarded-host': '$host',
-    },
-  })
-
-  createRedirect({
-    fromPath: '/XMLData/*',
-    toPath: `https://${tenant}.${environment}.com.br/XMLData/:splat`,
-    statusCode: 200,
-    headers: {
-      // VTEX ID needs the forwarded host in order to set the cookie correctly
-      'x-forwarded-host': '$host',
-    },
-  })
-
-  createRedirect({
-    fromPath: '/arquivos/*',
-    toPath: `https://${tenant}.vtexassets.com/arquivos/:splat`,
-    statusCode: 200,
-  })
-
-  createRedirect({
-    fromPath: '/files/*',
-    toPath: `https://${tenant}.vtexassets.com/files/:splat`,
-    statusCode: 200,
-  })
-
   /**
    * STATIC PATHS
    */

--- a/packages/gatsby-theme-store/src/pages/account.tsx
+++ b/packages/gatsby-theme-store/src/pages/account.tsx
@@ -18,7 +18,7 @@ const ONE_MIN_IN_MILLI = 60 * 100
 
 const render = async (locale: string) => {
   const loader = new RenderExtensionLoader({
-    account: process.env.GATSBY_VTEX_TENANT,
+    account: process.env.GATSBY_STORE_ID,
     workspace: process.env.GATSBY_VTEX_IO_WORKSPACE,
     verbose: process.env.NODE_ENV !== 'production',
     publicEndpoint: undefined,

--- a/packages/gatsby-theme-store/src/pages/index.tsx
+++ b/packages/gatsby-theme-store/src/pages/index.tsx
@@ -23,7 +23,7 @@ const Home: FC<Props> = (props) => {
       pageUrl: window.location.href,
       pageTitle: document.title,
       referrer: '',
-      accountName: process.env.GATSBY_VTEX_TENANT!,
+      accountName: process.env.GATSBY_STORE_ID!,
     }
 
     return [

--- a/packages/gatsby-theme-store/src/sdk/auth/Service/api.ts
+++ b/packages/gatsby-theme-store/src/sdk/auth/Service/api.ts
@@ -1,5 +1,3 @@
-export const tenant = process.env.GATSBY_VTEX_TENANT as string
-
 const base = `/api/vtexid`
 
 export const api = {

--- a/packages/gatsby-theme-store/src/sdk/auth/Service/startLogin.ts
+++ b/packages/gatsby-theme-store/src/sdk/auth/Service/startLogin.ts
@@ -1,4 +1,4 @@
-import { api, tenant } from './api'
+import { api } from './api'
 
 interface Options {
   fingerprint?: string
@@ -6,6 +6,8 @@ interface Options {
   user?: string
   returnUrl: string
 }
+
+const storeId = process.env.GATSBY_STORE_ID as string
 
 export const startLogin = async ({
   returnUrl,
@@ -18,8 +20,8 @@ export const startLogin = async ({
   form.append('fingerprint', fingerprint)
   form.append('callbackUrl', callbackUrl)
   form.append('returnUrl', returnUrl)
-  form.append('accountName', tenant)
-  form.append('scope', tenant)
+  form.append('accountName', storeId)
+  form.append('scope', storeId)
   form.append('user', user)
 
   const response = await fetch(api.pub.authentication.startlogin, {

--- a/packages/gatsby-theme-store/src/templates/product.tsx
+++ b/packages/gatsby-theme-store/src/templates/product.tsx
@@ -53,7 +53,7 @@ const ProductPage: FC<ProductPageProps> = (props) => {
           pageUrl: window.location.href,
           pageTitle: document.title,
           referrer: document.referrer,
-          accountName: process.env.GATSBY_VTEX_TENANT!,
+          accountName: process.env.GATSBY_STORE_ID!,
         },
       },
       {

--- a/packages/gatsby-theme-store/src/templates/search.tsx
+++ b/packages/gatsby-theme-store/src/templates/search.tsx
@@ -58,13 +58,13 @@ const SearchPage: FC<SearchPageProps> = (props) => {
           pageUrl: window.location.href,
           pageTitle: document.title,
           referrer: document.referrer,
-          accountName: process.env.GATSBY_VTEX_TENANT!,
+          accountName: process.env.GATSBY_STORE_ID!,
         },
       },
       {
         type: 'vtex:internalSiteSearchView',
         data: {
-          accountName: process.env.GATSBY_VTEX_TENANT!,
+          accountName: process.env.GATSBY_STORE_ID!,
           pageUrl: window.location.href,
           pageTitle: document.title,
           referrer: document.referrer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4660,17 +4660,6 @@
     create-emotion-server "^10.0.27"
     theme-ui "^0.3.1"
 
-"@vtex/gatsby-source-vtex@^0.120.0":
-  version "0.120.0"
-  resolved "https://registry.yarnpkg.com/@vtex/gatsby-source-vtex/-/gatsby-source-vtex-0.120.0.tgz#a8f62620c2b3b4309cab90435e88859ce08883a7"
-  integrity sha512-pfTxa5ChA/56pMSTpuZzcKpKG2I5vGh6wa9HAH5x/owVIZ3rXmuvu7FLW7oNPOidR6pBpsj4ArVoRBDsQPEBKw==
-  dependencies:
-    "@graphql-tools/delegate" "^6.0.15"
-    "@graphql-tools/wrap" "^6.0.15"
-    isomorphic-unfetch "^3.0.0"
-    p-map "^4.0.0"
-    uuid "^8.3.0"
-
 "@vtex/prettier-config@^0.3.5":
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/@vtex/prettier-config/-/prettier-config-0.3.5.tgz#99e44c6235c541a8d2b7cd50fc9662c7bc17309a"


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR moves most of VTEX related code from theme-store to source-vtex. This will make us closer to the OpenStore initiative.
Also, this PR adds schema validation to theme-store and source-vtex options and changes the env var VTEX_TENANT to STORE_ID

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
