### PR TITLE
Refactor i18n

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.211.0-alpha.7",
+  "version": "0.211.0-alpha.8",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.210.0",
+  "version": "0.211.0-alpha.7",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   },
   "devDependencies": {
     "@vtex/prettier-config": "^0.3.5",
-    "eslint": "^7.14.0",
-    "eslint-config-vtex": "^12.8.11",
-    "eslint-config-vtex-react": "^6.8.4",
+    "eslint": "^7.15.0",
+    "eslint-config-vtex": "^12.8.14",
+    "eslint-config-vtex-react": "^6.8.7",
     "husky": "^4.3.0",
     "lerna": "^3.22.1",
     "lint-staged": "^10.5.1",
-    "prettier": "^2.2.0",
+    "prettier": "^2.2.1",
     "typescript": "^3.9.5"
   },
   "resolutions": {

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.207.0",
+  "version": "0.211.0-alpha.7",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",
@@ -20,7 +20,12 @@
     "react": "*"
   },
   "dependencies": {
-    "@formatjs/cli": "^2.7.7",
+    "@babel/parser": "^7.12.7",
+    "@babel/preset-typescript": "^7.12.7",
+    "@babel/register": "^7.12.1",
+    "@babel/traverse": "^7.12.9",
+    "@babel/types": "^7.12.7",
+    "intl-messageformat-parser": "^6.0.18",
     "react-intl": "^5.7.1"
   }
 }

--- a/packages/gatsby-plugin-i18n/src/babel.ts
+++ b/packages/gatsby-plugin-i18n/src/babel.ts
@@ -1,0 +1,74 @@
+/* eslint-disable global-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
+import { dirname } from 'path'
+
+import type { Visitor } from '@babel/traverse'
+import type { MessageFormatElement } from 'intl-messageformat-parser'
+import { parse } from '@babel/parser'
+import { parse as intlParse } from 'intl-messageformat-parser'
+
+interface Options {
+  inPath: string
+}
+
+require('@babel/register')({
+  extensions: ['.ts'],
+  presets: ['@babel/preset-typescript'],
+})
+
+const template = (serialized: string) => `
+function getMessages () {
+  return JSON.parse(${serialized})
+}
+
+export default getMessages
+`
+
+const plugin = (_: any, options: Options) => {
+  const { inPath } = options
+
+  const visitor: Visitor = {
+    Program: (path, state: any) => {
+      const {
+        file: {
+          opts: { filename },
+        },
+      } = state
+
+      const filepath = dirname(filename)
+
+      // Only compile files inside the `i18n` folder
+      if (filepath !== inPath) {
+        return
+      }
+
+      // Run code so all merge happens in compile time
+      const { default: messages } = require(filename) as {
+        default: Record<string, string>
+      }
+
+      // Creates ASTs so we don't need to include the ICU parser at runtime
+      const asts = Object.entries(messages).reduce((acc, [key, value]) => {
+        acc[key] = intlParse(value)
+
+        return acc
+      }, {} as Record<string, MessageFormatElement[]>)
+
+      // Serializes the JSON so we can optimize parse/compile times
+      const serialized = JSON.stringify(JSON.stringify(asts))
+
+      // Replace file with optimized template
+      const parsed = parse(template(serialized), {
+        sourceType: 'module',
+      })
+
+      path.replaceWith(parsed.program)
+      path.skip()
+    },
+  }
+
+  return { visitor }
+}
+
+export default plugin

--- a/packages/gatsby-plugin-i18n/src/components/provider.tsx
+++ b/packages/gatsby-plugin-i18n/src/components/provider.tsx
@@ -1,20 +1,44 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable global-require */
+/* eslint-disable @typescript-eslint/no-require-imports */
 import React from 'react'
 import { IntlProvider } from 'react-intl'
-import { WrapRootElementBrowserArgs, WrapRootElementNodeArgs } from 'gatsby'
+import type { WrapRootElementBrowserArgs } from 'gatsby'
 
-type Props = WrapRootElementBrowserArgs | WrapRootElementNodeArgs | any
+import type { PluginOptions } from '../gatsby-node'
+import { localeFromPath } from '../helpers/path'
 
-export const wrapPageElement = ({
-  props: {
-    pageContext: { messages, locale, defaultLocale },
-  },
-  element: children,
-}: Props) => (
-  <IntlProvider
-    locale={locale}
-    defaultLocale={defaultLocale}
-    messages={messages}
-  >
-    {children}
-  </IntlProvider>
-)
+const getLocale = (
+  pathname: string,
+  locales: string[],
+  defaultLocale: string
+) => {
+  const locale = localeFromPath(pathname)
+  const index = locales.indexOf(locale)
+
+  if (index > -1) {
+    return locales[index]
+  }
+
+  return defaultLocale
+}
+
+export const wrapRootElement = (
+  { element: children, pathname }: WrapRootElementBrowserArgs,
+  { defaultLocale, locales }: PluginOptions
+) => {
+  const path = pathname || window.location.pathname
+  const locale = getLocale(path, locales, defaultLocale)
+  const { default: getMessages } = require(`../i18n/${locale}`)
+  const messages = getMessages()
+
+  return (
+    <IntlProvider
+      locale={locale}
+      defaultLocale={defaultLocale}
+      messages={messages}
+    >
+      {children}
+    </IntlProvider>
+  )
+}

--- a/packages/gatsby-plugin-i18n/src/gatsby-browser.ts
+++ b/packages/gatsby-plugin-i18n/src/gatsby-browser.ts
@@ -1,3 +1,3 @@
-const { wrapPageElement: wrapper } = require('./src/components/provider')
+const { wrapRootElement: wrapper } = require('./src/components/provider')
 
-export const wrapPageElement = wrapper
+export const wrapRootElement = wrapper

--- a/packages/gatsby-plugin-i18n/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-i18n/src/gatsby-node.ts
@@ -1,151 +1,44 @@
-import {
+import { join } from 'path'
+
+import type {
+  CreateBabelConfigArgs,
   CreatePageArgs,
   CreateWebpackConfigArgs,
-  Node,
-  SourceNodesArgs,
+  PluginOptionsSchemaArgs,
 } from 'gatsby'
-import { readJSON, outputFile, unlink } from 'fs-extra'
-import { compile } from '@formatjs/cli'
 
 import { localizedPath } from './helpers/path'
 
-interface LanguageDataNode extends Node {
-  messages: string
-  locale: string
-}
+const root = process.cwd()
+const name = '@vtex/gatsby-plugin-i18n'
 
-interface LanguageConfigNode extends Node {
-  defaultLocale: string
-  locales: string[]
-}
-
-interface ThemeOptions {
-  locales?: string[]
-  defaultLocale?: string
-  messagesPath?: string
-}
-
-const localesArrayDefault = ['en']
-
-export const sourceNodes = async (
-  args: SourceNodesArgs,
-  options: ThemeOptions
-) => {
-  const {
-    actions: { createNode },
-    createNodeId,
-    createContentDigest,
-    reporter,
-  } = args
-
-  const {
-    messagesPath,
-    locales = localesArrayDefault,
-    defaultLocale = 'en',
-  } = options
-
-  if (messagesPath == null) {
-    reporter.panicOnBuild(
-      'Please provide the path to the JSON files with translations'
-    )
-
-    return
-  }
-
-  if (!locales.includes(defaultLocale)) {
-    reporter.panicOnBuild(
-      'Please provide a default locale that is contained in your provided locales array'
-    )
-
-    return
-  }
-
-  for (const locale of locales) {
-    let languageJson = null as Record<string, string> | null
-
-    try {
-      languageJson = await readJSON(`${messagesPath}/${locale}.json`, {
-        encoding: 'utf-8',
-      })
-    } catch (e) {
-      languageJson = null
-    }
-
-    if (languageJson == null && locale === defaultLocale) {
-      reporter.panicOnBuild(`Error reading strings for default locale`)
-
-      return
-    }
-
-    if (languageJson == null) {
-      reporter.info(`Error reading strings for locale ${locale}`)
-      continue
-    }
-
-    const withDefaultMessage = Object.entries(languageJson).reduce(
-      (acc, [key, val]) => {
-        acc[key] = { defaultMessage: val }
-
-        return acc
-      },
-      {} as Record<string, { defaultMessage: string }>
-    )
-
-    await outputFile(
-      `${messagesPath}/${locale}-temp.json`,
-      JSON.stringify(withDefaultMessage)
-    )
-
-    const resultAsString = await compile(
-      [`${messagesPath}/${locale}-temp.json`],
-      { ast: true }
-    )
-
-    await unlink(`${messagesPath}/${locale}-temp.json`)
-    const data = { messages: resultAsString, locale }
-
-    createNode({
-      ...data,
-      id: createNodeId(`LanguageData-${locale}`),
-      internal: {
-        type: 'LanguageData',
-        content: JSON.stringify(data),
-        contentDigest: createContentDigest(data),
-      },
-    })
-  }
-
-  const languageDataConfig = {
-    locales,
-    defaultLocale,
-  }
-
-  createNode({
-    ...languageDataConfig,
-    id: createNodeId(`LanguageDataConfig`),
-    internal: {
-      type: 'LanguageDataConfig',
-      content: JSON.stringify(languageDataConfig),
-      contentDigest: createContentDigest(languageDataConfig),
-    },
-  })
-}
+const base = join(root, 'src', name, 'i18n')
 
 export const onCreateWebpackConfig = ({ actions }: CreateWebpackConfigArgs) => {
   actions.setWebpackConfig({
     resolve: {
       alias: {
-        'react-intl$': 'react-intl/react-intl-no-parser.umd',
+        'intl-messageformat-parser': 'intl-messageformat-parser/lib/dummy',
       },
     },
   })
 }
 
-export const onCreatePage = async ({
-  page,
-  actions,
-  getNodesByType,
-}: CreatePageArgs) => {
+export const onCreateBabelConfig = ({
+  actions: { setBabelPlugin },
+}: CreateBabelConfigArgs) => {
+  setBabelPlugin({
+    name: require.resolve('./babel'),
+    options: {
+      inPath: base,
+    },
+  })
+}
+
+export const onCreatePage = async (
+  { page, actions }: CreatePageArgs,
+  { defaultLocale, locales }: PluginOptions
+) => {
   const { createPage, deletePage } = actions
 
   // Check if originalPath was already set and bail early as otherwise an infinite loop could occur
@@ -154,33 +47,30 @@ export const onCreatePage = async ({
     return
   }
 
-  const originalPath = page.path
+  const { path, matchPath } = page
 
   deletePage(page)
 
-  const languageNodes = getNodesByType('LanguageData') as LanguageDataNode[]
-  const languageConfig = getNodesByType(
-    'LanguageDataConfig'
-  )[0] as LanguageConfigNode
-
-  const { defaultLocale } = languageConfig
-
-  for (const languageData of languageNodes) {
-    const { locale, messages } = languageData
-
+  for (const locale of locales) {
     createPage({
       ...page,
-      path: localizedPath(defaultLocale, locale, page.path),
-      matchPath: page.matchPath
-        ? localizedPath(defaultLocale, locale, page.matchPath)
-        : page.matchPath,
+      path: localizedPath(defaultLocale, locale, path),
+      matchPath: matchPath && localizedPath(defaultLocale, locale, matchPath),
       context: {
         ...page.context,
-        messages: JSON.parse(messages || ''),
-        locale,
-        defaultLocale,
-        originalPath,
+        originalPath: path,
       },
     })
   }
 }
+
+export interface PluginOptions {
+  locales: string[]
+  defaultLocale: string
+}
+
+export const pluginOptionsSchema = ({ Joi }: PluginOptionsSchemaArgs) =>
+  Joi.object({
+    locales: Joi.array().items(Joi.string()).required(),
+    defaultLocale: Joi.string().required(),
+  })

--- a/packages/gatsby-plugin-i18n/src/gatsby-ssr.ts
+++ b/packages/gatsby-plugin-i18n/src/gatsby-ssr.ts
@@ -1,3 +1,3 @@
-const { wrapPageElement: wrapper } = require('./src/components/provider')
+const { wrapRootElement: wrapper } = require('./src/components/provider')
 
-export const wrapPageElement = wrapper
+export const wrapRootElement = wrapper

--- a/packages/gatsby-plugin-i18n/src/helpers/path.ts
+++ b/packages/gatsby-plugin-i18n/src/helpers/path.ts
@@ -1,3 +1,9 @@
+export const localeFromPath = (pathname: string) => {
+  const [, base] = pathname.split(`/`)
+
+  return base
+}
+
 export const localizedPath = (
   defaultLocale: string,
   locale: string,
@@ -8,7 +14,7 @@ export const localizedPath = (
     return path
   }
 
-  const [, base] = path.split(`/`)
+  const base = localeFromPath(path)
 
   // If for whatever reason we receive an already localized path
   // (e.g. if the path was made with location.pathname)

--- a/packages/gatsby-plugin-i18n/src/i18n/en.ts
+++ b/packages/gatsby-plugin-i18n/src/i18n/en.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/packages/gatsby-plugin-i18n/src/index.ts
+++ b/packages/gatsby-plugin-i18n/src/index.ts
@@ -1,4 +1,4 @@
-export { useIntl, IntlShape } from 'react-intl'
+export * from 'react-intl'
 
 export { localizedPath } from './helpers/path'
 export { useLocalizedPath } from './helpers/useLocalizedPath'

--- a/packages/gatsby-theme-store/i18n/en.json
+++ b/packages/gatsby-theme-store/i18n/en.json
@@ -1,31 +1,35 @@
 {
+  "buy-button.add-to-cart": "ADD TO CART",
+
   "minicart.drawer.close": "Close",
   "minicart.drawer.count": "Count ({count})",
-  "minicart.drawer.quantity.remove": "0 - to remove",
   "minicart.drawer.subtotal": "Subtotal",
   "minicart.drawer.total": "Total",
   "minicart.drawer.shipping-disclaimer": "Shipping and taxes calculated at checkout.",
   "minicart.drawer.go-checkout": "GO TO CHECKOUT",
 
   "facets.filters": "Filters",
-  "search.page-list.more": "Show More",
-  "search.page-list.more.loading": "Loading...",
+
+  "loading": "Loading...",
 
   "notification-bar.sale": "SELECTED ITEMS ON SALE! CHECK IT OUT!",
 
-  "product.quantity.title": "Quantity",
+  "search.page-list.more": "Show More",
+  "search.page-list.more.loading": "Loading...",
 
   "suggestions.autocomplete.title": "Suggestions",
   "suggestions.autocomplete.notFound": "No Suggestions",
-  "suggestions.products.title": "Producst for: {term}",
+  "suggestions.products.title": "Products for: {term}",
   "suggestions.products.total": "Check all {count} items",
   "suggestions.products.notFound": "No product found",
   "suggestions.history.title": "History",
   "suggestions.history.empty": "No history yet",
-  "suggestions.topSearches.title": "Top Searches",
+  "suggestions.topSearches.title": "Top searches",
+
+  "product.quantity.title": "Quantity",
 
   "searchControls.totalCount": "{count,plural,=0{ PRODUCTS}one{ PRODUCT}other{ PRODUCTS}}",
-  "searchControls.filters": "FILTERS",
+  "searchControls.filters": "FILTERS ",
   "searchControls.select.scoreDesc": "Relevance",
   "searchControls.select.priceDesc": "Price: High to Low",
   "searchControls.select.priceAsc": "Price: Low to High",
@@ -36,24 +40,29 @@
   "searchControls.select.releaseDateDesc": "Release date",
   "searchControls.select.bestDiscountDesc": "Discount",
 
-  "shippingSimulator.label": "Calcular",
-  "shippingEstimate-bd": "{timeAmount, plural, =0 {Today} one {In # business day} other {Up to # business days}}",
-  "shippingEstimate-d": "{timeAmount, plural, =0 {Today} one {In # day} other {Up to # days}}",
-  "shippingEstimate-h": "{timeAmount, plural, =0 {Now} one {In # hour} other {Up to # hours}}",
-  "shippingEstimate-m": "{timeAmount, plural, =0 {Now} one {In # minute} other {Up to # minutes}}",
-  "shippingEstimate-scheduled": "{date}, between {startDate} and {endDate}",
-  "shippingEstimate-scheduled-no-dates": "Scheduled",
-  "shippingEstimatePickup-bd": "{timeAmount, plural, =0 {Ready today} one {Ready in up to # business day} other {Ready in up to # business days}}",
-  "shippingEstimatePickup-d": "{timeAmount, plural, =0 {Ready today} one {Ready in up to # day} other {Ready in up to # days}}",
-  "shippingEstimatePickup-h": "{timeAmount, plural, =0 {Ready for pickup} one {Ready in up to # hour} other {Ready in up to # hours}}",
-  "shippingEstimatePickup-m": "{timeAmount, plural, =0 {Ready for pickup} one {Ready in up to # minute} other {Ready in up to # minutes}}",
+  "shippingSimulator.label": "OK",
+  "shipping.postalCodeLabel": "Shipping prices and dates",
+  "shipping.free": "Free Shipping",
+  "shipping.label.id": "Kind",
+  "shipping.label.estimate": "Date",
+  "shipping.label.price": "Price",
 
-  "login.page.title": "Choose a sign in option",
+  "shippingEstimate-bd": "{timeAmount, plural, =0 {Today} one {In # business day} other {Up to # business days}}",
+  "shippingEstimate-d": "{timeAmount, plural, =0 {Hoje} one {In # day} other {Up to # days}}",
+  "shippingEstimate-h": "{timeAmount, plural, =0 {Now} one {In # hours} other {Up to # hours}}",
+  "shippingEstimate-m": "{timeAmount, plural, =0 {Now} one {In # minutes} other {Up to # minutes}}",
+  "shippingEstimate-scheduled": "{date}, Between {startDate} and {endDate}",
+  "shippingEstimate-scheduled-no-dates": "Assigned",
+
+  "login.page.title": "Choose a login provider",
 
   "login.page.emailAndPassword.signUpForm.title": "Validate email and create new password",
   "login.page.emailAndPassword.signUpForm.subTitle": "Insert the code we sent to the email {email} and create a new password",
+  "login.page.emailAndPassword.signUpForm.accessCodeLabel": "Access code",
   "login.page.emailAndPassword.signUpForm.accessCodePlaceholder": "Add your access code",
+  "login.page.emailAndPassword.signUpForm.passwordLabel": "Password:",
   "login.page.emailAndPassword.signUpForm.passwordPlaceholder": "Insert your password",
+  "login.page.emailAndPassword.signUpForm.confirmPasswordLabel": "Confirm Password",
   "login.page.emailAndPassword.signUpForm.confirmPasswordPlaceholder": "Confirm your password",
   "login.page.emailAndPassword.signUpForm.invalidAccessCodeInput": "Invalid access code",
   "login.page.emailAndPassword.signUpForm.invalidPassword": "Invalid password. Your password needs to have at least eight digits, one lower case and one upper case letter, with at least one digit",
@@ -72,7 +81,7 @@
   "login.page.emailAndPassword.signInForm.submitButton": "Sign In",
   "login.page.emailAndPassword.signInForm.signupButton": "Don't have an account yet ? Sign Up",
 
-  "login.page.emailAndPassword.emailForm.title": "Receive access code by e-mail",
+  "login.page.emailAndPassword.emailForm.title": "Don't have an account yet ? Sign Up",
   "login.page.emailAndPassword.emailForm.emailPlaceholder": "Add your email",
   "login.page.emailAndPassword.emailForm.invalidEmailInput": "Please insert a valid email",
   "login.page.emailAndPassword.emailForm.error": "Something went wrong, please try again later",
@@ -96,8 +105,8 @@
 
   "login.page.emailVerification.button": "Receive access code by e-mail",
 
-  "login.page.facebookOAuth.button": "Sign in with Facebook",
-  "login.page.facebookOAuth.title": "Signing in with Facebook",
+  "login.page.facebookOAuth.button": "Sign in with facebook",
+  "login.page.facebookOAuth.title": "Signing in with facebook",
   "login.page.facebookOAuth.error": "Signing in with Facebook failed. Please try again later or click on the button below to try again",
   "login.page.facebookOAuth.tryAgain": "Try Again",
 
@@ -106,6 +115,8 @@
   "login.page.googleOAuth.error": "Signing in with Google failed. Please try again later or click on the button below to try again",
   "login.page.googleOAuth.tryAgain": "Try Again",
 
-  "login.button.greeting": "Hello {name}",
-  "login.button.action": "Sign In"
+  "login.button.greeting": "Hello, {name}",
+  "login.button.action": "Sign In",
+
+  "preview.not-found": "No Preview found. Waiting for input"
 }

--- a/packages/gatsby-theme-store/i18n/pt.json
+++ b/packages/gatsby-theme-store/i18n/pt.json
@@ -1,0 +1,122 @@
+{
+  "buy-button.add-to-cart": "ADICIONAR AO CARRINHO",
+
+  "minicart.drawer.close": "Fechar",
+  "minicart.drawer.count": "Carrinho ({count})",
+  "minicart.drawer.subtotal": "Subtotal",
+  "minicart.drawer.total": "Total",
+  "minicart.drawer.shipping-disclaimer": "Frete e impostos são calculados no checkout.",
+  "minicart.drawer.go-checkout": "FINALIZAR COMPRA",
+
+  "facets.filters": "Filtrar Por:",
+
+  "loading": "Carregando...",
+
+  "notification-bar.sale": "ITEM SELECIONADOS EM PROMOÇÃO! DÊ UMA OLHADA!",
+
+  "search.page-list.more": "Mostrar Mais",
+  "search.page-list.more.loading": "Carregando...",
+
+  "suggestions.autocomplete.title": "Sugestões",
+  "suggestions.autocomplete.notFound": "Sem sugestões",
+  "suggestions.products.title": "Produtos para: {term}",
+  "suggestions.products.total": "Ver todos os {count} items",
+  "suggestions.products.notFound": "Nenhum produto encontrado",
+  "suggestions.history.title": "Historico",
+  "suggestions.history.empty": "Nenhuma pesquisa encontrada",
+  "suggestions.topSearches.title": "Termos mais buscados",
+
+  "product.quantity.title": "Quantidade",
+
+  "searchControls.totalCount": "{count,plural,=0{ PRODUTOS}one{ PRODUTO}other{ PRODUTOS}}",
+  "searchControls.filters": "Filtros",
+  "searchControls.select.scoreDesc": "Relevância",
+  "searchControls.select.priceDesc": "Preço: Menor ao Maior",
+  "searchControls.select.priceAsc": "Preço: Maior ao Menor",
+  "searchControls.select.topSaleDesc": "Mais vendidos",
+  "searchControls.select.reviewRateDesc": "Reviews",
+  "searchControls.select.nameDesc": "Nome, crescente",
+  "searchControls.select.nameAsc": "Nome, decrescente",
+  "searchControls.select.releaseDateDesc": "Lançamentos",
+  "searchControls.select.bestDiscountDesc": "Desconto",
+
+  "shippingSimulator.label": "OK",
+  "shipping.postalCodeLabel": "Calcular frete e prazo de entrega:",
+  "shipping.free": "Entrega Grátis",
+  "shipping.label.id": "Tipo",
+  "shipping.label.estimate": "Prazo",
+  "shipping.label.price": "Preço",
+
+  "shippingEstimate-bd": "{timeAmount, plural, =0 {Hoje} one {Em # dia útil} other {Até # dias úteis}}",
+  "shippingEstimate-d": "{timeAmount, plural, =0 {Hoje} one {Em # dia} other {Até # dias}}",
+  "shippingEstimate-h": "{timeAmount, plural, =0 {Now} one {Em # hora} other {Até # horas}}",
+  "shippingEstimate-m": "{timeAmount, plural, =0 {Now} one {Em # minuto} other {Até # minutos}}",
+  "shippingEstimate-scheduled": "{date}, entre {startDate} e {endDate}",
+  "shippingEstimate-scheduled-no-dates": "Marcado",
+
+  "login.page.title": "Escolha uma forma de login",
+
+  "login.page.emailAndPassword.signUpForm.title": "Valide o email crie uma nova senha",
+  "login.page.emailAndPassword.signUpForm.subTitle": "Insira o código enviado para {email} e crie uma nova senha",
+  "login.page.emailAndPassword.signUpForm.accessCodeLabel": "Código de acesso:",
+  "login.page.emailAndPassword.signUpForm.accessCodePlaceholder": "Adicione o codigo de acesso",
+  "login.page.emailAndPassword.signUpForm.passwordLabel": "Senha:",
+  "login.page.emailAndPassword.signUpForm.passwordPlaceholder": "Insira a senha",
+  "login.page.emailAndPassword.signUpForm.confirmPasswordLabel": "Confirmaçāo de senha:",
+  "login.page.emailAndPassword.signUpForm.confirmPasswordPlaceholder": "Confirme sua senha",
+  "login.page.emailAndPassword.signUpForm.invalidAccessCodeInput": "Codigo de acesso inválido",
+  "login.page.emailAndPassword.signUpForm.invalidPassword": "Senha inválida. Sua senha deve conter no mínimo oito dígitos, um dígito minúsculo e outro maiúsculo, e ao menos 1 número",
+  "login.page.emailAndPassword.signUpForm.passwordDoNotMatch": "Senhas nāo coincidem",
+  "login.page.emailAndPassword.signUpForm.error": "Erro. Por favor tente outra vez",
+  "login.page.emailAndPassword.signUpForm.submitButton": "Criar",
+  "login.page.emailAndPassword.signUpForm.backButton": "Voltar",
+
+  "login.page.emailAndPassword.signInForm.title": "Entrar com email e senha",
+  "login.page.emailAndPassword.signInForm.emailPlaceholder": "Ex: exemplo@gmail.com",
+  "login.page.emailAndPassword.signInForm.password": "Insira a sua senha",
+  "login.page.emailAndPassword.signInForm.forgotPassword": "Esqueci minha senha",
+  "login.page.emailAndPassword.signInForm.invalidEmailInput": "Email invalido",
+  "login.page.emailAndPassword.signInForm.invalidPasswordInput": "Senha invalida",
+  "login.page.emailAndPassword.signInForm.authError": "Algo de errado aconteceu. Por favor tente outra vez",
+  "login.page.emailAndPassword.signInForm.submitButton": "Entrar",
+  "login.page.emailAndPassword.signInForm.signupButton": "Não tem uma conta ainda ? Cadastre-se",
+
+  "login.page.emailAndPassword.emailForm.title": "Receba codigo de acesso por email",
+  "login.page.emailAndPassword.emailForm.emailPlaceholder": "Adicione seu email",
+  "login.page.emailAndPassword.emailForm.invalidEmailInput": "Email invalido",
+  "login.page.emailAndPassword.emailForm.error": "Algo deu errado, por favor, tente outra vez",
+  "login.page.emailAndPassword.emailForm.submitButton": "Confirmar",
+  "login.page.emailAndPassword.emailForm.backButton": "Voltar",
+
+  "login.page.emailAndPassword.button": "Entrar com email e senha",
+
+  "login.page.emailVerification.accessCodeForm.title": "Entre com o codigo de acesso enviado ao seu email",
+  "login.page.emailVerification.accessCodeForm.codePlaceholder": "Adicione seu codigo de acesso",
+  "login.page.emailVerification.accessCodeForm.invalidAccessCode": "Insira um codigo de 6 digitos valido",
+  "login.page.emailVerification.accessCodeForm.authError": "Algo deu errado com o seu codigo de acesso. Por favor, confira o numero e tente outra vez",
+  "login.page.emailVerification.accessCodeForm.submitButton": "Confirmar",
+  "login.page.emailVerification.accessCodeForm.backButton": "Voltar",
+
+  "login.page.emailVerification.emailForm.title": "Receba codigo de acesso por email",
+  "login.page.emailVerification.emailForm.emailPlaceholder": "Adicione seu email",
+  "login.page.emailVerification.emailForm.invalidEmailInput": "Email invalido",
+  "login.page.emailVerification.emailForm.error": "Algo deu errado, por favor, tente outra vez",
+  "login.page.emailVerification.emailForm.submitButton": "Enviar",
+
+  "login.page.emailVerification.button": "Receba codigo de acesso por email",
+
+  "login.page.facebookOAuth.button": "Entrar usando Facebook",
+  "login.page.facebookOAuth.title": "Entrando com Facebook",
+  "login.page.facebookOAuth.error": "Entrar usando Facebook falhou. Clique no botao abaixo para tentar novamente",
+  "login.page.facebookOAuth.tryAgain": "Tentar novamente",
+
+  "login.page.googleOAuth.button": "Entrar usando Google",
+  "login.page.googleOAuth.title": "Entrando com Google",
+  "login.page.googleOAuth.error": "Entrar usando Google falhou. Clique no botao abaixo para tentar novamente",
+  "login.page.googleOAuth.tryAgain": "Tentar novamente",
+
+  "login.button.greeting": "Ola {name}",
+  "login.button.action": "Entrar",
+
+  "preview.not-found": "Pre-visualização não econtrada. Esperando por entradas"
+}

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.210.0",
+  "version": "0.211.0-alpha.7",
   "description": "Gatsby theme for building e-commerce websites",
   "main": "index.js",
   "scripts": {
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
-    "@vtex/gatsby-plugin-graphql": "^0.120.0",
-    "@vtex/gatsby-plugin-i18n": "^0.120.0",
-    "@vtex/gatsby-plugin-theme-ui": "^0.120.1",
-    "@vtex/store-ui": "^0.207.0",
+    "@vtex/gatsby-plugin-graphql": "^0.207.0",
+    "@vtex/gatsby-plugin-i18n": "^0.211.0-alpha.7",
+    "@vtex/gatsby-plugin-theme-ui": "^0.207.0",
+    "@vtex/store-ui": "^0.211.0-alpha.7",
     "babel-gql": "^0.1.3",
     "common-tags": "^1.8.0",
     "gatsby-plugin-bundle-stats": "^2.2.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.211.0-alpha.7",
+  "version": "0.211.0-alpha.8",
   "description": "Gatsby theme for building e-commerce websites",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-store/src/components/Auth/Providers/EmailAndPassword/Button.tsx
+++ b/packages/gatsby-theme-store/src/components/Auth/Providers/EmailAndPassword/Button.tsx
@@ -1,8 +1,9 @@
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
 import { Button } from '@vtex/store-ui'
-import React, { FC } from 'react'
+import type { FC } from 'react'
+import React from 'react'
 
-import { AuthProviderButtonProps } from '../types'
+import type { AuthProviderButtonProps } from '../types'
 
 const EmailAndPasswordButton: FC<AuthProviderButtonProps> = ({
   variant,
@@ -14,7 +15,6 @@ const EmailAndPasswordButton: FC<AuthProviderButtonProps> = ({
     <Button variant={`${variant}.emailAndPassword`} as="button" {...rest}>
       {formatMessage({
         id: 'login.page.emailAndPassword.button',
-        defaultMessage: 'Sign in with email and password',
       })}
     </Button>
   )

--- a/packages/gatsby-theme-store/src/components/Auth/Providers/EmailAndPassword/EmailForm.tsx
+++ b/packages/gatsby-theme-store/src/components/Auth/Providers/EmailAndPassword/EmailForm.tsx
@@ -1,8 +1,9 @@
-import React, { FC, useRef } from 'react'
-import { Alert, Box, Button, Input } from '@vtex/store-ui'
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
+import { Alert, Box, Button, Input } from '@vtex/store-ui'
+import React, { useRef } from 'react'
+import type { FC } from 'react'
 
-import { State } from './state'
+import type { State } from './state'
 
 interface Props {
   variant: string
@@ -25,7 +26,6 @@ const EmailForm: FC<Props> = ({
       <Box variant={`${variant}.title`}>
         {formatMessage({
           id: 'login.page.emailAndPassword.emailForm.title',
-          defaultMessage: 'Receive access code by e-mail',
         })}
       </Box>
       <Box
@@ -43,7 +43,6 @@ const EmailForm: FC<Props> = ({
           id="emailform-email"
           placeholder={formatMessage({
             id: 'login.page.emailAndPassword.emailForm.emailPlaceholder',
-            defaultMessage: 'Add your email',
           })}
         />
 
@@ -51,7 +50,6 @@ const EmailForm: FC<Props> = ({
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.emailAndPassword.emailForm.invalidEmailInput',
-              defaultMessage: 'Please insert a valid email',
             })}
           </Alert>
         )}
@@ -60,7 +58,6 @@ const EmailForm: FC<Props> = ({
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.emailAndPassword.emailForm.error',
-              defaultMessage: 'Something went wrong, please try again later',
             })}
           </Alert>
         )}
@@ -68,7 +65,6 @@ const EmailForm: FC<Props> = ({
         <Button>
           {formatMessage({
             id: 'login.page.emailAndPassword.emailForm.submitButton',
-            defaultMessage: 'Confirm',
           })}
         </Button>
       </Box>
@@ -80,7 +76,6 @@ const EmailForm: FC<Props> = ({
       >
         {formatMessage({
           id: 'login.page.emailAndPassword.emailForm.backButton',
-          defaultMessage: 'Back',
         })}
       </Button>
     </>

--- a/packages/gatsby-theme-store/src/components/Auth/Providers/EmailAndPassword/SignInForm.tsx
+++ b/packages/gatsby-theme-store/src/components/Auth/Providers/EmailAndPassword/SignInForm.tsx
@@ -1,8 +1,9 @@
-import React, { FC, useRef } from 'react'
-import { Alert, Box, Button, Input } from '@vtex/store-ui'
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
+import { Alert, Box, Button, Input } from '@vtex/store-ui'
+import React, { useRef } from 'react'
+import type { FC } from 'react'
 
-import { State } from './state'
+import type { State } from './state'
 
 interface Props {
   variant: string
@@ -28,7 +29,6 @@ const SignInForm: FC<Props> = ({
       <Box variant={`${variant}.title`}>
         {formatMessage({
           id: 'login.page.emailAndPassword.signInForm.title',
-          defaultMessage: 'Sign in with e-mail and password',
         })}
       </Box>
       <Box
@@ -47,7 +47,6 @@ const SignInForm: FC<Props> = ({
           id="signin-email"
           placeholder={formatMessage({
             id: 'login.page.emailAndPassword.signInForm.emailPlaceholder',
-            defaultMessage: 'Eg: example@gmail.com',
           })}
           autoComplete="username"
         />
@@ -58,7 +57,6 @@ const SignInForm: FC<Props> = ({
           id="signin-password"
           placeholder={formatMessage({
             id: 'login.page.emailAndPassword.signInForm.password',
-            defaultMessage: 'Insert your password',
           })}
           autoComplete="current-password"
         />
@@ -68,7 +66,6 @@ const SignInForm: FC<Props> = ({
         >
           {formatMessage({
             id: 'login.page.emailAndPassword.signInForm.forgotPassword',
-            defaultMessage: 'Forgot my password',
           })}
         </Box>
 
@@ -76,7 +73,6 @@ const SignInForm: FC<Props> = ({
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.emailAndPassword.signInForm.invalidEmailInput',
-              defaultMessage: 'Sign in with a valid e-mail',
             })}
           </Alert>
         )}
@@ -85,7 +81,6 @@ const SignInForm: FC<Props> = ({
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.emailAndPassword.signInForm.invalidPasswordInput',
-              defaultMessage: 'Sign in with a valid password',
             })}
           </Alert>
         )}
@@ -94,7 +89,6 @@ const SignInForm: FC<Props> = ({
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.emailAndPassword.signInForm.authError',
-              defaultMessage: 'Signing in failed. Please try again later',
             })}
           </Alert>
         )}
@@ -102,14 +96,12 @@ const SignInForm: FC<Props> = ({
         <Button>
           {formatMessage({
             id: 'login.page.emailAndPassword.signInForm.submitButton',
-            defaultMessage: 'Sign In',
           })}
         </Button>
       </Box>
       <Box variant={`${variant}.signup`} onClick={() => onSignUp()}>
         {formatMessage({
           id: 'login.page.emailAndPassword.signInForm.signupButton',
-          defaultMessage: "Don't have an account yet ? Sign Up",
         })}
       </Box>
     </>

--- a/packages/gatsby-theme-store/src/components/Auth/Providers/EmailAndPassword/SignUpForm.tsx
+++ b/packages/gatsby-theme-store/src/components/Auth/Providers/EmailAndPassword/SignUpForm.tsx
@@ -1,8 +1,9 @@
-import React, { FC, useRef } from 'react'
-import { Alert, Box, Button, Input, Label } from '@vtex/store-ui'
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
+import { Alert, Box, Button, Input, Label } from '@vtex/store-ui'
+import React, { useRef } from 'react'
+import type { FC } from 'react'
 
-import { State } from './state'
+import type { State } from './state'
 
 interface Props {
   variant: string
@@ -31,15 +32,12 @@ const SignUpForm: FC<Props> = ({
       <Box variant={`${variant}.title`}>
         {formatMessage({
           id: 'login.page.emailAndPassword.signUpForm.title',
-          defaultMessage: 'Validate email and create new password',
         })}
       </Box>
       <Box variant={`${variant}.subTitle`}>
         {formatMessage(
           {
             id: 'login.page.emailAndPassword.signUpForm.subTitle',
-            defaultMessage:
-              'Insert the code we sent to the email {email} and create a new password',
           },
           {
             email,
@@ -62,7 +60,6 @@ const SignUpForm: FC<Props> = ({
         <Label htmlFor="signup-code">
           {formatMessage({
             id: 'login.page.emailAndPassword.signUpForm.accessCodeLabel',
-            defaultMessage: 'Access code',
           })}
         </Label>
         <Input
@@ -72,13 +69,11 @@ const SignUpForm: FC<Props> = ({
           id="signup-code"
           placeholder={formatMessage({
             id: 'login.page.emailAndPassword.signUpForm.accessCodePlaceholder',
-            defaultMessage: 'Add your access code',
           })}
         />
         <Label htmlFor="signup-password">
           {formatMessage({
             id: 'login.page.emailAndPassword.signUpForm.passwordLabel',
-            defaultMessage: 'Password',
           })}
         </Label>
         <Input
@@ -88,14 +83,12 @@ const SignUpForm: FC<Props> = ({
           id="signup-password"
           placeholder={formatMessage({
             id: 'login.page.emailAndPassword.signUpForm.passwordPlaceholder',
-            defaultMessage: 'Insert your password',
           })}
           autoComplete="new-password"
         />
         <Label htmlFor="signup-confirm-password">
           {formatMessage({
             id: 'login.page.emailAndPassword.signUpForm.confirmPasswordLabel',
-            defaultMessage: 'Confirm Password',
           })}
         </Label>
         <Input
@@ -106,7 +99,6 @@ const SignUpForm: FC<Props> = ({
           placeholder={formatMessage({
             id:
               'login.page.emailAndPassword.signUpForm.confirmPasswordPlaceholder',
-            defaultMessage: 'Confirm your password',
           })}
           autoComplete="new-password"
         />
@@ -116,7 +108,6 @@ const SignUpForm: FC<Props> = ({
             {formatMessage({
               id:
                 'login.page.emailAndPassword.signUpForm.invalidAccessCodeInput',
-              defaultMessage: 'Invalid access code',
             })}
           </Alert>
         )}
@@ -125,8 +116,6 @@ const SignUpForm: FC<Props> = ({
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.emailAndPassword.signUpForm.invalidPassword',
-              defaultMessage:
-                'Invalid password. Your password needs to have at least eight digits, one lower case and one upper case letter, with at least one digit',
             })}
           </Alert>
         )}
@@ -135,7 +124,6 @@ const SignUpForm: FC<Props> = ({
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.emailAndPassword.signUpForm.passwordDoNotMatch',
-              defaultMessage: 'Passwords do not match',
             })}
           </Alert>
         )}
@@ -144,7 +132,6 @@ const SignUpForm: FC<Props> = ({
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.emailAndPassword.signUpForm.error',
-              defaultMessage: 'Signing in failed. Please try again later',
             })}
           </Alert>
         )}
@@ -152,7 +139,6 @@ const SignUpForm: FC<Props> = ({
         <Button>
           {formatMessage({
             id: 'login.page.emailAndPassword.signUpForm.submitButton',
-            defaultMessage: 'Create',
           })}
         </Button>
       </Box>
@@ -164,7 +150,6 @@ const SignUpForm: FC<Props> = ({
       >
         {formatMessage({
           id: 'login.page.emailAndPassword.signUpForm.backButton',
-          defaultMessage: 'Back',
         })}
       </Button>
     </>

--- a/packages/gatsby-theme-store/src/components/Auth/Providers/EmailVerification/AccessCodeForm.tsx
+++ b/packages/gatsby-theme-store/src/components/Auth/Providers/EmailVerification/AccessCodeForm.tsx
@@ -1,8 +1,9 @@
-import React, { FC, useRef } from 'react'
-import { Alert, Box, Button, Input } from '@vtex/store-ui'
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
+import { Alert, Box, Button, Input } from '@vtex/store-ui'
+import React, { useRef } from 'react'
+import type { FC } from 'react'
 
-import { State } from './state'
+import type { State } from './state'
 
 interface Props {
   variant: string
@@ -25,7 +26,6 @@ const AccessCodeForm: FC<Props> = ({
       <Box variant={`${variant}.title`}>
         {formatMessage({
           id: 'login.page.emailVerification.accessCodeForm.title',
-          defaultMessage: 'Enter the access code sent to your e-mail',
         })}
       </Box>
       <Box
@@ -43,7 +43,6 @@ const AccessCodeForm: FC<Props> = ({
           id="accesscodeform-code"
           placeholder={formatMessage({
             id: 'login.page.emailVerification.accessCodeForm.codePlaceholder',
-            defaultMessage: 'Add your access code',
           })}
         />
 
@@ -52,7 +51,6 @@ const AccessCodeForm: FC<Props> = ({
             {formatMessage({
               id:
                 'login.page.emailVerification.accessCodeForm.invalidAccessCode',
-              defaultMessage: 'Insert a valid 6-digit access code',
             })}
           </Alert>
         )}
@@ -61,8 +59,6 @@ const AccessCodeForm: FC<Props> = ({
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.emailVerification.accessCodeForm.authError',
-              defaultMessage:
-                'Something went wrong with your access code. Please recheck it and try again',
             })}
           </Alert>
         )}
@@ -70,7 +66,6 @@ const AccessCodeForm: FC<Props> = ({
         <Button>
           {formatMessage({
             id: 'login.page.emailVerification.accessCodeForm.submitButton',
-            defaultMessage: 'Confirm',
           })}
         </Button>
       </Box>
@@ -82,7 +77,6 @@ const AccessCodeForm: FC<Props> = ({
       >
         {formatMessage({
           id: 'login.page.emailVerification.accessCodeForm.backButton',
-          defaultMessage: 'Back',
         })}
       </Button>
     </>

--- a/packages/gatsby-theme-store/src/components/Auth/Providers/EmailVerification/Button.tsx
+++ b/packages/gatsby-theme-store/src/components/Auth/Providers/EmailVerification/Button.tsx
@@ -1,8 +1,9 @@
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
 import { Button } from '@vtex/store-ui'
-import React, { FC } from 'react'
+import React from 'react'
+import type { FC } from 'react'
 
-import { AuthProviderButtonProps } from '../types'
+import type { AuthProviderButtonProps } from '../types'
 
 const EmailVerificationButton: FC<AuthProviderButtonProps> = ({
   variant,
@@ -14,7 +15,6 @@ const EmailVerificationButton: FC<AuthProviderButtonProps> = ({
     <Button variant={`${variant}.emailVerification`} as="button" {...rest}>
       {formatMessage({
         id: 'login.page.emailVerification.button',
-        defaultMessage: 'Receive access code by e-mail',
       })}
     </Button>
   )

--- a/packages/gatsby-theme-store/src/components/Auth/Providers/EmailVerification/EmailForm.tsx
+++ b/packages/gatsby-theme-store/src/components/Auth/Providers/EmailVerification/EmailForm.tsx
@@ -1,8 +1,9 @@
-import React, { FC, useRef } from 'react'
-import { Alert, Box, Button, Input } from '@vtex/store-ui'
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
+import { Alert, Box, Button, Input } from '@vtex/store-ui'
+import React, { useRef } from 'react'
+import type { FC } from 'react'
 
-import { State } from './state'
+import type { State } from './state'
 
 interface Props {
   variant: string
@@ -19,7 +20,6 @@ const EmailForm: FC<Props> = ({ variant, state: { state }, onSubmit }) => {
       <Box variant={`${variant}.title`}>
         {formatMessage({
           id: 'login.page.emailVerification.emailForm.title',
-          defaultMessage: 'Receive access code by e-mail',
         })}
       </Box>
       <Box
@@ -37,7 +37,6 @@ const EmailForm: FC<Props> = ({ variant, state: { state }, onSubmit }) => {
           id="emailform-email"
           placeholder={formatMessage({
             id: 'login.page.emailVerification.emailForm.emailPlaceholder',
-            defaultMessage: 'Add your email',
           })}
         />
 
@@ -45,7 +44,6 @@ const EmailForm: FC<Props> = ({ variant, state: { state }, onSubmit }) => {
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.emailVerification.emailForm.invalidEmailInput',
-              defaultMessage: 'Please insert a valid email',
             })}
           </Alert>
         )}
@@ -54,7 +52,6 @@ const EmailForm: FC<Props> = ({ variant, state: { state }, onSubmit }) => {
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.emailVerification.emailForm.error',
-              defaultMessage: 'Something went wrong, please try again later',
             })}
           </Alert>
         )}
@@ -62,7 +59,6 @@ const EmailForm: FC<Props> = ({ variant, state: { state }, onSubmit }) => {
         <Button>
           {formatMessage({
             id: 'login.page.emailVerification.emailForm.submitButton',
-            defaultMessage: 'Send',
           })}
         </Button>
       </Box>

--- a/packages/gatsby-theme-store/src/components/Auth/Providers/Facebook/Button.tsx
+++ b/packages/gatsby-theme-store/src/components/Auth/Providers/Facebook/Button.tsx
@@ -1,8 +1,9 @@
-import React, { FC } from 'react'
-import { Box, Button, Center } from '@vtex/store-ui'
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
+import { Box, Button, Center } from '@vtex/store-ui'
+import React from 'react'
+import type { FC } from 'react'
 
-import { AuthProviderButtonProps } from '../types'
+import type { AuthProviderButtonProps } from '../types'
 
 const Logo: FC = () => (
   <svg
@@ -31,7 +32,6 @@ const FacebookOAuthButton: FC<AuthProviderButtonProps> = ({
         <Box ml={2}>
           {formatMessage({
             id: 'login.page.facebookOAuth.button',
-            defaultMessage: 'Sign in with facebook',
           })}
         </Box>
       </Center>

--- a/packages/gatsby-theme-store/src/components/Auth/Providers/Facebook/index.tsx
+++ b/packages/gatsby-theme-store/src/components/Auth/Providers/Facebook/index.tsx
@@ -1,10 +1,11 @@
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
 import { Alert, Box, Button, Center, Spinner } from '@vtex/store-ui'
-import React, { FC, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import type { FC } from 'react'
 
 import { oAuthCallbackUrl, oAuthRedirectUrl } from '../../../../sdk/auth/OAuth'
 import { useStartLogin } from '../../../../sdk/auth/useStartLogin'
-import { AuthProviderComponentProps } from '../types'
+import type { AuthProviderComponentProps } from '../types'
 
 type State = 'initial' | 'error'
 
@@ -35,7 +36,6 @@ const FacebookOAuth: FC<AuthProviderComponentProps> = ({ variant: v }) => {
       <Box variant={`${variant}.title`}>
         {formatMessage({
           id: 'login.page.facebookOAuth.title',
-          defaultMessage: 'Signing in with facebook',
         })}
       </Box>
       {state === 'initial' ? (
@@ -47,14 +47,11 @@ const FacebookOAuth: FC<AuthProviderComponentProps> = ({ variant: v }) => {
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.facebookOAuth.error',
-              defaultMessage:
-                'Signing in with Facebook failed. Please try again later or click on the button below to try again',
             })}
           </Alert>
           <Button onClick={() => setState('initial')}>
             {formatMessage({
               id: 'login.page.facebookOAuth.tryAgain',
-              defaultMessage: 'Try Again',
             })}
           </Button>
         </>

--- a/packages/gatsby-theme-store/src/components/Auth/Providers/Google/Button.tsx
+++ b/packages/gatsby-theme-store/src/components/Auth/Providers/Google/Button.tsx
@@ -1,8 +1,9 @@
-import React, { FC } from 'react'
-import { Box, Button, Center } from '@vtex/store-ui'
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
+import { Box, Button, Center } from '@vtex/store-ui'
+import React from 'react'
+import type { FC } from 'react'
 
-import { AuthProviderButtonProps } from '../types'
+import type { AuthProviderButtonProps } from '../types'
 
 const Logo: FC = () => (
   <svg
@@ -47,7 +48,6 @@ const GoogleOAuthButton: FC<AuthProviderButtonProps> = ({
         <Box ml={2}>
           {formatMessage({
             id: 'login.page.googleOAuth.button',
-            defaultMessage: 'Sign in with Google',
           })}
         </Box>
       </Center>

--- a/packages/gatsby-theme-store/src/components/Auth/Providers/Google/index.tsx
+++ b/packages/gatsby-theme-store/src/components/Auth/Providers/Google/index.tsx
@@ -1,10 +1,11 @@
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
 import { Alert, Box, Button, Center, Spinner } from '@vtex/store-ui'
-import React, { FC, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import type { FC } from 'react'
 
 import { oAuthCallbackUrl, oAuthRedirectUrl } from '../../../../sdk/auth/OAuth'
 import { useStartLogin } from '../../../../sdk/auth/useStartLogin'
-import { AuthProviderComponentProps } from '../types'
+import type { AuthProviderComponentProps } from '../types'
 
 type State = 'initial' | 'error'
 
@@ -35,7 +36,6 @@ const GoogleOAuth: FC<AuthProviderComponentProps> = ({ variant: v }) => {
       <Box variant={`${variant}.title`}>
         {formatMessage({
           id: 'login.page.googleOAuth.title',
-          defaultMessage: 'Signing in with Google',
         })}
       </Box>
       {state === 'initial' ? (
@@ -47,14 +47,11 @@ const GoogleOAuth: FC<AuthProviderComponentProps> = ({ variant: v }) => {
           <Alert variant="signInDanger">
             {formatMessage({
               id: 'login.page.googleOAuth.error',
-              defaultMessage:
-                'Signing in with Google failed. Please try again later or click on the button below to try again',
             })}
           </Alert>
           <Button onClick={() => setState('initial')}>
             {formatMessage({
               id: 'login.page.googleOAuth.tryAgain',
-              defaultMessage: 'Try Again',
             })}
           </Button>
         </>

--- a/packages/gatsby-theme-store/src/components/Login/Anonymous.tsx
+++ b/packages/gatsby-theme-store/src/components/Login/Anonymous.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
 import { Box, LocalizedLink, jsx } from '@vtex/store-ui'
-import { FC } from 'react'
+import type { FC } from 'react'
 
 import Logo from './Logo'
 
@@ -14,7 +14,6 @@ const Anonymous: FC = () => {
       <Box variant="login.button.greeting">
         {formatMessage({
           id: 'login.button.action',
-          defaultMessage: 'Sign In',
         })}
       </Box>
     </LocalizedLink>

--- a/packages/gatsby-theme-store/src/components/Login/Authenticated.tsx
+++ b/packages/gatsby-theme-store/src/components/Login/Authenticated.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
 import { Box, LocalizedLink, jsx } from '@vtex/store-ui'
-import { FC } from 'react'
+import type { FC } from 'react'
 
 import Logo from './Logo'
 
@@ -16,10 +16,7 @@ const Authenticated: FC<Props> = ({ name }) => {
     <LocalizedLink to="/account" sx={{ variant: 'login.button.container' }}>
       <Logo />
       <Box variant="login.button.greeting">
-        {formatMessage(
-          { id: 'login.button.greeting', defaultMessage: 'Hello {name}' },
-          { name }
-        )}
+        {formatMessage({ id: 'login.button.greeting' }, { name })}
       </Box>
     </LocalizedLink>
   )

--- a/packages/gatsby-theme-store/src/components/SearchSuggestions/Autocomplete/index.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchSuggestions/Autocomplete/index.tsx
@@ -1,12 +1,13 @@
-import React, { FC } from 'react'
-import { Box, Center } from '@vtex/store-ui'
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
+import { Box, Center } from '@vtex/store-ui'
+import React from 'react'
+import type { FC } from 'react'
 
-import { useAutocompleteSearchSeggestions } from './hooks'
 import { SearchSuggestionsListContainer } from '../base/Container'
-import { SearchSuggestionsListTitle } from '../base/Title'
-import { SearchSuggestionsList } from '../base/List'
 import { toRequiredItem } from '../base/hooks'
+import { SearchSuggestionsList } from '../base/List'
+import { SearchSuggestionsListTitle } from '../base/Title'
+import { useAutocompleteSearchSeggestions } from './hooks'
 
 interface Props {
   term: string
@@ -38,13 +39,11 @@ const SearchSuggestionsAutocomplete: FC<Required<Props>> = ({
           variant={variant}
           title={formatMessage({
             id: 'suggestions.autocomplete.title',
-            defaultMessage: 'Suggestions',
           })}
         />
         <Center>
           {formatMessage({
             id: 'suggestions.autocomplete.notFound',
-            defaultMessage: 'No suggestions',
           })}
         </Center>
       </>
@@ -57,7 +56,6 @@ const SearchSuggestionsAutocomplete: FC<Required<Props>> = ({
         variant={variant}
         title={formatMessage({
           id: 'suggestions.autocomplete.title',
-          defaultMessage: 'Suggestions',
         })}
       />
       <SearchSuggestionsList items={items} variant={variant}>

--- a/packages/gatsby-theme-store/src/components/SearchSuggestions/Products/index.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchSuggestions/Products/index.tsx
@@ -1,13 +1,14 @@
-import { Box, Center, Spinner } from '@vtex/store-ui'
-import React, { FC, Suspense, lazy } from 'react'
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
+import { Box, Center, Spinner } from '@vtex/store-ui'
+import React, { lazy, Suspense } from 'react'
+import type { FC } from 'react'
 
 import { SearchSuggestionsListContainer } from '../base/Container'
+import { toRequiredItem } from '../base/hooks'
+import { SearchSuggestionsList } from '../base/List'
 import { SearchSuggestionsListTitle } from '../base/Title'
 import { SearchSuggestionsListTotal } from '../base/Total'
-import { SearchSuggestionsList } from '../base/List'
 import { useProductsSuggestions } from './hooks'
-import { toRequiredItem } from '../base/hooks'
 
 const ProductSummary = lazy(() => import('../../ProductSummary'))
 
@@ -38,7 +39,6 @@ const SearchSuggestionsProduct: FC<Required<Props>> = ({
   const title = formatMessage(
     {
       id: 'suggestions.products.title',
-      defaultMessage: 'Products for: {term}',
     },
     { term }
   )
@@ -46,7 +46,6 @@ const SearchSuggestionsProduct: FC<Required<Props>> = ({
   const total = formatMessage(
     {
       id: 'suggestions.products.total',
-      defaultMessage: 'See all {count} items',
     },
     { count }
   )
@@ -73,7 +72,6 @@ const SearchSuggestionsProduct: FC<Required<Props>> = ({
         <Center>
           {formatMessage({
             id: 'suggestions.products.notFound',
-            defaultMessage: 'No products found',
           })}
         </Center>
       </>

--- a/packages/gatsby-theme-store/src/components/SearchSuggestions/SearchHistory/Icon.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchSuggestions/SearchHistory/Icon.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from 'react'
+import React from 'react'
+import type { FC } from 'react'
 
 const Icon: FC = () => (
   <svg

--- a/packages/gatsby-theme-store/src/components/SearchSuggestions/SearchHistory/index.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchSuggestions/SearchHistory/index.tsx
@@ -1,6 +1,7 @@
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
 import { Box, Center } from '@vtex/store-ui'
-import React, { FC } from 'react'
+import React from 'react'
+import type { FC } from 'react'
 
 import { SearchSuggestionsListContainer } from '../base/Container'
 import { SearchSuggestionsList } from '../base/List'
@@ -21,7 +22,6 @@ const SearchSuggestionsHistory: FC<Required<Props>> = ({ variant }) => {
 
   const title = formatMessage({
     id: 'suggestions.history.title',
-    defaultMessage: 'History',
   })
 
   if (!searches) {
@@ -35,7 +35,6 @@ const SearchSuggestionsHistory: FC<Required<Props>> = ({ variant }) => {
         <Center>
           {formatMessage({
             id: 'suggestions.history.empty',
-            defaultMessage: 'No history yet',
           })}
         </Center>
       </>
@@ -48,7 +47,6 @@ const SearchSuggestionsHistory: FC<Required<Props>> = ({ variant }) => {
         variant={variant}
         title={formatMessage({
           id: 'suggestions.history.title',
-          defaultMessage: 'History',
         })}
       />
       <SearchSuggestionsList items={searches} variant={variant}>

--- a/packages/gatsby-theme-store/src/components/SearchSuggestions/TopSearches/index.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchSuggestions/TopSearches/index.tsx
@@ -1,6 +1,7 @@
+import type { FC } from 'react'
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
 import { Box, Center } from '@vtex/store-ui'
-import React, { FC } from 'react'
+import React from 'react'
 
 import { SearchSuggestionsListContainer } from '../base/Container'
 import { toRequiredItem } from '../base/hooks'
@@ -23,7 +24,6 @@ const SearchSuggestionsTopSearches: FC<Required<Props>> = ({ variant }) => {
   const items = searches && toRequiredItem(searches)
   const title = formatMessage({
     id: 'suggestions.topSearches.title',
-    defaultMessage: 'Top Searches',
   })
 
   if (error || !searches) {
@@ -37,7 +37,6 @@ const SearchSuggestionsTopSearches: FC<Required<Props>> = ({ variant }) => {
         <Center>
           {formatMessage({
             id: 'suggestions.topSearches.empty',
-            defaultMessage: 'Type to search',
           })}
         </Center>
       </>

--- a/packages/gatsby-theme-store/src/gatsby-config.ts
+++ b/packages/gatsby-theme-store/src/gatsby-config.ts
@@ -1,14 +1,8 @@
-import type { LocalizationThemeOptions, Options } from './gatsby-node'
+import type { Options } from './gatsby-node'
 
 const root = process.cwd()
 
-const defaultLocalizationThemeOptions: Required<LocalizationThemeOptions> = {
-  messagesPath: './i18n/messages',
-  locales: ['en'],
-  defaultLocale: 'en',
-}
-
-module.exports = ({ localizationThemeOptions }: Options) => ({
+module.exports = ({ locales, defaultLocale }: Options) => ({
   plugins: [
     {
       resolve: require.resolve('gatsby-plugin-bundle-stats'),
@@ -43,7 +37,10 @@ module.exports = ({ localizationThemeOptions }: Options) => ({
     },
     {
       resolve: '@vtex/gatsby-plugin-i18n',
-      options: localizationThemeOptions ?? defaultLocalizationThemeOptions,
+      options: {
+        locales,
+        defaultLocale,
+      },
     },
   ],
 })

--- a/packages/gatsby-theme-store/src/gatsby-node.ts
+++ b/packages/gatsby-theme-store/src/gatsby-node.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 
-import {
+import type {
   CreatePagesArgs,
   CreateWebpackConfigArgs,
   PluginOptionsSchemaArgs,
@@ -14,26 +14,18 @@ export const onPostBootstrap = (
   process.env.GATSBY_STORE_ID = storeId
 }
 
-export interface LocalizationThemeOptions {
-  messagesPath?: string
-  locales?: string[]
-  defaultLocale?: string
-}
-
 export interface Options {
   storeId: string
   getStaticPaths?: () => Promise<string[]>
-  localizationThemeOptions?: LocalizationThemeOptions
+  locales: string[]
+  defaultLocale: string
 }
 
 export const pluginOptionsSchema = ({ Joi }: PluginOptionsSchemaArgs) =>
   Joi.object({
     storeId: Joi.string().required(),
-    localizationThemeOptions: Joi.object({
-      messagesPath: Joi.string(),
-      locales: Joi.array().items(Joi.string()),
-      defaultLocale: Joi.string(),
-    }),
+    locales: Joi.array().items(Joi.string()).required(),
+    defaultLocale: Joi.string().required(),
     getStaticPaths: Joi.function().arity(0).required(),
   })
 

--- a/packages/gatsby-theme-store/src/pages/login.tsx
+++ b/packages/gatsby-theme-store/src/pages/login.tsx
@@ -1,7 +1,8 @@
-import React, { FC, useEffect, useState } from 'react'
+import type { FC } from 'react'
+import type { PageProps } from 'gatsby'
+import React, { useEffect, useState } from 'react'
 import { useIntl } from '@vtex/gatsby-plugin-i18n'
 import { Box, Center, Flex, Spinner } from '@vtex/store-ui'
-import { PageProps } from 'gatsby'
 
 import Layout from '../components/Layout'
 import SuspenseSSR from '../components/Suspense/SSR'
@@ -41,7 +42,6 @@ const Page: FC = () => {
         <Box variant="login.page.group.title">
           {formatMessage({
             id: 'login.page.title',
-            defaultMessage: 'Choose a sign in option',
           })}
         </Box>
 

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.207.0",
+  "version": "0.211.0-alpha.2",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",
@@ -21,7 +21,7 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "tsdx": "^0.14.0",
+    "tsdx": "^0.14.1",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.207.0",
+  "version": "0.211.0-alpha.7",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.207.0",
+    "@vtex/gatsby-plugin-i18n": "^0.211.0-alpha.7",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",
@@ -56,7 +56,7 @@
     "react-dom": "^0.0.0-experimental-7f28234f8",
     "react-scripts": "^3.4.1",
     "ts-loader": "^8.0.1",
-    "tsdx": "^0.13.2",
+    "tsdx": "^0.14.1",
     "typescript": "^3.9.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -422,7 +422,7 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.12.1", "@babel/plugin-proposal-nullish-coalescing-operator@^7.7.4", "@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.12.1", "@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz#3ed4fff31c015e7f3f1467f190dbe545cd7b046c"
   integrity sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==
@@ -480,7 +480,7 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.12.1", "@babel/plugin-proposal-optional-chaining@^7.12.7", "@babel/plugin-proposal-optional-chaining@^7.7.5", "@babel/plugin-proposal-optional-chaining@^7.9.0":
+"@babel/plugin-proposal-optional-chaining@^7.12.1", "@babel/plugin-proposal-optional-chaining@^7.12.7", "@babel/plugin-proposal-optional-chaining@^7.9.0":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz#e02f0ea1b5dc59d401ec16fb824679f683d3303c"
   integrity sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==
@@ -900,7 +900,7 @@
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-regenerator@^7.12.1", "@babel/plugin-transform-regenerator@^7.4.5", "@babel/plugin-transform-regenerator@^7.8.7":
+"@babel/plugin-transform-regenerator@^7.12.1", "@babel/plugin-transform-regenerator@^7.8.7":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz#5f0a28d842f6462281f06a964e88ba8d7ab49753"
   integrity sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==
@@ -924,7 +924,7 @@
     resolve "^1.8.1"
     semver "^5.5.1"
 
-"@babel/plugin-transform-runtime@^7.12.1", "@babel/plugin-transform-runtime@^7.6.0":
+"@babel/plugin-transform-runtime@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.1.tgz#04b792057eb460389ff6a4198e377614ea1e7ba5"
   integrity sha512-Ac/H6G9FEIkS2tXsZjL4RAdS3L3WHxci0usAnz7laPWUmFiGtj7tIASChqKZMHTSQTQY6xDbOq+V1/vIq3QrWg==
@@ -994,14 +994,6 @@
     "@babel/helper-create-regexp-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/polyfill@^7.4.4":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.12.1.tgz#1f2d6371d1261bbd961f3c5d5909150e12d0bd96"
-  integrity sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.4"
-
 "@babel/preset-env@7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.9.0.tgz#a5fc42480e950ae8f5d9f8f2bbc03f52722df3a8"
@@ -1068,7 +1060,7 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.4.4", "@babel/preset-env@^7.4.5":
+"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.4.5":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.7.tgz#54ea21dbe92caf6f10cb1a0a576adc4ebf094b55"
   integrity sha512-OnNdfAr1FUQg7ksb7bmbKoby4qFOHw6DKWWUNB9KqnnCldxhxJlP+21dpyaWFmf2h0rTbOkXJtAGevY3XW1eew==
@@ -1263,6 +1255,21 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.12.9":
+  version "7.12.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.9.tgz#fad26c972eabbc11350e0b695978de6cc8e8596f"
+  integrity sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.5"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.12.7"
+    "@babel/types" "^7.12.7"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
 "@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.12.6", "@babel/types@^7.12.7", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.7.tgz#6039ff1e242640a29452c9ae572162ec9a8f5d13"
@@ -1433,10 +1440,10 @@
     ts-node "^9"
     tslib "^2"
 
-"@eslint/eslintrc@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.1.tgz#f72069c330461a06684d119384435e12a5d76e3c"
-  integrity sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==
+"@eslint/eslintrc@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.2.tgz#d01fc791e2fc33e88a29d6f3dc7e93d0cd784b76"
+  integrity sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -1523,27 +1530,6 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@formatjs/cli@^2.7.7":
-  version "2.13.13"
-  resolved "https://registry.yarnpkg.com/@formatjs/cli/-/cli-2.13.13.tgz#011c4719bef4d076325a1a4d6a8b25b51c96dc91"
-  integrity sha512-soUig6IuvUxiztzZbS66Umhy/RTHUnd1+VdT/UVuOMCFZ/Mhug/hXQFi+cQ0KcNVKeaj0D77MXNccahaebkPYQ==
-  dependencies:
-    "@formatjs/ts-transformer" "2.12.8"
-    "@types/json-stable-stringify" "^1.0.32"
-    "@types/lodash" "^4.14.150"
-    "@types/loud-rejection" "^2.0.0"
-    "@types/node" "14"
-    chalk "^4.0.0"
-    commander "^6.1.0"
-    fast-glob "^3.2.4"
-    fs-extra "^9.0.0"
-    intl-messageformat-parser "6.0.17"
-    json-stable-stringify "^1.0.1"
-    lodash "^4.17.15"
-    loud-rejection "^2.2.0"
-    tslib "^2.0.1"
-    typescript "^4.0"
-
 "@formatjs/ecma402-abstract@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.5.0.tgz#759c8f11ff45e96f8fb58741e7fbdb41096d5ddd"
@@ -1597,15 +1583,6 @@
     intl-messageformat "9.3.19"
     intl-messageformat-parser "6.0.17"
     tslib "^2.0.1"
-
-"@formatjs/ts-transformer@2.12.8":
-  version "2.12.8"
-  resolved "https://registry.yarnpkg.com/@formatjs/ts-transformer/-/ts-transformer-2.12.8.tgz#5e1415bcb8ceb725f22dd6263b8b9900dd80df9b"
-  integrity sha512-gu1Nj1tNXM1yO5PKQtaT+/bedzbQGQrj+u2hrTeZN3Mto1+ofAEdF3/cB131ba9rKTQiG3eCoxByWNuQkvTxFA==
-  dependencies:
-    intl-messageformat-parser "6.0.17"
-    tslib "^2.0.1"
-    typescript "^4.0"
 
 "@graphql-codegen/core@^1.17.7":
   version "1.17.8"
@@ -3295,17 +3272,6 @@
   dependencies:
     "@rollup/pluginutils" "^3.0.8"
 
-"@rollup/plugin-node-resolve@^7.1.0":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
-  integrity sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==
-  dependencies:
-    "@rollup/pluginutils" "^3.0.8"
-    "@types/resolve" "0.0.8"
-    builtin-modules "^3.1.0"
-    is-module "^1.0.0"
-    resolve "^1.14.2"
-
 "@rollup/plugin-node-resolve@^9.0.0":
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz#39bd0034ce9126b39c1699695f440b4b7d2b62e6"
@@ -4206,13 +4172,6 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^24.0.15":
-  version "24.9.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
-  integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
-  dependencies:
-    jest-diff "^24.3.0"
-
 "@types/jest@^25.2.1":
   version "25.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.3.tgz#33d27e4c4716caae4eced355097a47ad363fdcaf"
@@ -4234,27 +4193,15 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
-"@types/json-stable-stringify@^1.0.32":
-  version "1.0.32"
-  resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
-  integrity sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw==
-
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.150", "@types/lodash@^4.14.92":
+"@types/lodash@^4.14.92":
   version "4.14.165"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
   integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
-
-"@types/loud-rejection@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/loud-rejection/-/loud-rejection-2.0.0.tgz#271bb21c63f51776e1156604cda3b21a2d3f60f3"
-  integrity sha512-oTHISsIybJGoh3b3Ay/10csbAd2k0su7G7DGrE1QWciC+IdydPm0WMw1+Gr9YMYjPiJ5poB3g5Ev73IlLoavLw==
-  dependencies:
-    loud-rejection "*"
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -4281,7 +4228,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@14", "@types/node@>= 8", "@types/node@^14.6.0":
+"@types/node@*", "@types/node@>= 8", "@types/node@^14.6.0":
   version "14.14.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.9.tgz#04afc9a25c6ff93da14deabd65dc44485b53c8d6"
   integrity sha512-JsoLXFppG62tWTklIoO4knA+oDTYsmqWxHRvd4lpmfQRNhX6osheUOWETP2jMoV/2bEHuMra8Pp3Dmo/stBFcw==
@@ -4379,13 +4326,6 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
-
-"@types/resolve@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
-  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
-  dependencies:
-    "@types/node" "*"
 
 "@types/resolve@1.17.1":
   version "1.17.1"
@@ -4547,60 +4487,60 @@
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
 "@typescript-eslint/eslint-plugin@^2.10.0", "@typescript-eslint/eslint-plugin@^2.12.0", "@typescript-eslint/eslint-plugin@^2.24.0", "@typescript-eslint/eslint-plugin@^4", "@typescript-eslint/eslint-plugin@^4.8.1":
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.8.2.tgz#cf9102ec800391caa574f589ffe0623cca1d9308"
-  integrity sha512-gQ06QLV5l1DtvYtqOyFLXD9PdcILYqlrJj2l+CGDlPtmgLUzc1GpqciJFIRvyfvgLALpnxYINFuw+n9AZhPBKQ==
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.9.1.tgz#66758cbe129b965fe9c63b04b405d0cf5280868b"
+  integrity sha512-QRLDSvIPeI1pz5tVuurD+cStNR4sle4avtHhxA+2uyixWGFjKzJ+EaFVRW6dA/jOgjV5DTAjOxboQkRDE8cRlQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.8.2"
-    "@typescript-eslint/scope-manager" "4.8.2"
+    "@typescript-eslint/experimental-utils" "4.9.1"
+    "@typescript-eslint/scope-manager" "4.9.1"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.8.2", "@typescript-eslint/experimental-utils@^4.0.1":
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.8.2.tgz#8909a5732f19329cf5ef0c39766170476bff5e50"
-  integrity sha512-hpTw6o6IhBZEsQsjuw/4RWmceRyESfAiEzAEnXHKG1X7S5DXFaZ4IO1JO7CW1aQ604leQBzjZmuMI9QBCAJX8Q==
+"@typescript-eslint/experimental-utils@4.9.1", "@typescript-eslint/experimental-utils@^4.0.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.9.1.tgz#86633e8395191d65786a808dc3df030a55267ae2"
+  integrity sha512-c3k/xJqk0exLFs+cWSJxIjqLYwdHCuLWhnpnikmPQD2+NGAx9KjLYlBDcSI81EArh9FDYSL6dslAUSwILeWOxg==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.8.2"
-    "@typescript-eslint/types" "4.8.2"
-    "@typescript-eslint/typescript-estree" "4.8.2"
+    "@typescript-eslint/scope-manager" "4.9.1"
+    "@typescript-eslint/types" "4.9.1"
+    "@typescript-eslint/typescript-estree" "4.9.1"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
 "@typescript-eslint/parser@^2.10.0", "@typescript-eslint/parser@^2.12.0", "@typescript-eslint/parser@^2.24.0", "@typescript-eslint/parser@^4", "@typescript-eslint/parser@^4.8.1":
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.8.2.tgz#78dccbe5124de2b8dea2d4c363dee9f769151ca8"
-  integrity sha512-u0leyJqmclYr3KcXOqd2fmx6SDGBO0MUNHHAjr0JS4Crbb3C3d8dwAdlazy133PLCcPn+aOUFiHn72wcuc5wYw==
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.9.1.tgz#2d74c4db5dd5117379a9659081a4d1ec02629055"
+  integrity sha512-Gv2VpqiomvQ2v4UL+dXlQcZ8zCX4eTkoIW+1aGVWT6yTO+6jbxsw7yQl2z2pPl/4B9qa5JXeIbhJpONKjXIy3g==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.8.2"
-    "@typescript-eslint/types" "4.8.2"
-    "@typescript-eslint/typescript-estree" "4.8.2"
+    "@typescript-eslint/scope-manager" "4.9.1"
+    "@typescript-eslint/types" "4.9.1"
+    "@typescript-eslint/typescript-estree" "4.9.1"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.8.2":
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.8.2.tgz#a18388c63ae9c17adde519384f539392f2c4f0d9"
-  integrity sha512-qHQ8ODi7mMin4Sq2eh/6eu03uVzsf5TX+J43xRmiq8ujng7ViQSHNPLOHGw/Wr5dFEoxq/ubKhzClIIdQy5q3g==
+"@typescript-eslint/scope-manager@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.9.1.tgz#cc2fde310b3f3deafe8436a924e784eaab265103"
+  integrity sha512-sa4L9yUfD/1sg9Kl8OxPxvpUcqxKXRjBeZxBuZSSV1v13hjfEJkn84n0An2hN8oLQ1PmEl2uA6FkI07idXeFgQ==
   dependencies:
-    "@typescript-eslint/types" "4.8.2"
-    "@typescript-eslint/visitor-keys" "4.8.2"
+    "@typescript-eslint/types" "4.9.1"
+    "@typescript-eslint/visitor-keys" "4.9.1"
 
-"@typescript-eslint/types@4.8.2":
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.8.2.tgz#c862dd0e569d9478eb82d6aee662ea53f5661a36"
-  integrity sha512-z1/AVcVF8ju5ObaHe2fOpZYEQrwHyZ7PTOlmjd3EoFeX9sv7UekQhfrCmgUO7PruLNfSHrJGQvrW3Q7xQ8EoAw==
+"@typescript-eslint/types@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.9.1.tgz#a1a7dd80e4e5ac2c593bc458d75dd1edaf77faa2"
+  integrity sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA==
 
-"@typescript-eslint/typescript-estree@4.8.2":
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.2.tgz#eeec34707d8577600fb21661b5287226cc8b3bed"
-  integrity sha512-HToGNwI6fekH0dOw3XEVESUm71Onfam0AKin6f26S2FtUmO7o3cLlWgrIaT1q3vjB3wCTdww3Dx2iGq5wtUOCg==
+"@typescript-eslint/typescript-estree@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.9.1.tgz#6e5b86ff5a5f66809e1f347469fadeec69ac50bf"
+  integrity sha512-bzP8vqwX6Vgmvs81bPtCkLtM/Skh36NE6unu6tsDeU/ZFoYthlTXbBmpIrvosgiDKlWTfb2ZpPELHH89aQjeQw==
   dependencies:
-    "@typescript-eslint/types" "4.8.2"
-    "@typescript-eslint/visitor-keys" "4.8.2"
+    "@typescript-eslint/types" "4.9.1"
+    "@typescript-eslint/visitor-keys" "4.9.1"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -4608,12 +4548,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.8.2":
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.2.tgz#62cd3fbbbf65f8eccfbe6f159eb1b84a243a3f77"
-  integrity sha512-Vg+/SJTMZJEKKGHW7YC21QxgKJrSbxoYYd3MEUGtW7zuytHuEcksewq0DUmo4eh/CTNrVJGSdIY9AtRb6riWFw==
+"@typescript-eslint/visitor-keys@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.9.1.tgz#d76374a58c4ead9e92b454d186fea63487b25ae1"
+  integrity sha512-9gspzc6UqLQHd7lXQS7oWs+hrYggspv/rk6zzEMhCbYwPE/sF7oxo7GAjkS35Tdlt7wguIG+ViWCPtVZHz/ybQ==
   dependencies:
-    "@typescript-eslint/types" "4.8.2"
+    "@typescript-eslint/types" "4.9.1"
     eslint-visitor-keys "^2.0.0"
 
 "@vtex-components/accordion@^0.2.3":
@@ -4625,40 +4565,6 @@
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@vtex-components/drawer/-/drawer-0.2.4.tgz#682e627135c8f6cb134ffcc6661206163de6d7e8"
   integrity sha512-bv39LunQ9q+mtMN9eGzZSfRUx8VgJkOrMr5LDt8kdlA1+NemohiROTshj0RUwLGxCD6HcOOsQE25imIklKc1FQ==
-
-"@vtex/gatsby-plugin-graphql@^0.120.0":
-  version "0.120.0"
-  resolved "https://registry.yarnpkg.com/@vtex/gatsby-plugin-graphql/-/gatsby-plugin-graphql-0.120.0.tgz#5f165d25c05e0f687d754d54bed1230abc953ba7"
-  integrity sha512-7o+fl2SR679FTqU12IyaQNyoS9BiVwrbVuUymul3tk4vTfF9GsWZ5wLKgWNp4JCK5oHu8AXiA5FbdAxYf94S4Q==
-  dependencies:
-    "@graphql-codegen/core" "^1.17.7"
-    "@graphql-codegen/plugin-helpers" "^1.17.7"
-    "@graphql-codegen/typescript" "^1.17.7"
-    "@graphql-codegen/typescript-operations" "^1.17.7"
-    "@graphql-tools/relay-operation-optimizer" "^6.0.15"
-    fs-extra "^9.0.1"
-
-"@vtex/gatsby-plugin-i18n@^0.120.0":
-  version "0.120.0"
-  resolved "https://registry.yarnpkg.com/@vtex/gatsby-plugin-i18n/-/gatsby-plugin-i18n-0.120.0.tgz#1930ab6d83cb38c7d203063443652c9549bcd00a"
-  integrity sha512-Rw9DSD6GwuB2j3Hq77aq0OAygxLhLD96jzLX4yHTT9tjke789N1I5PsbLkgd6cfX0WZT8C5LmN6uWAenSVNijA==
-  dependencies:
-    "@formatjs/cli" "^2.7.7"
-    react-intl "^5.7.1"
-
-"@vtex/gatsby-plugin-theme-ui@^0.120.1":
-  version "0.120.1"
-  resolved "https://registry.yarnpkg.com/@vtex/gatsby-plugin-theme-ui/-/gatsby-plugin-theme-ui-0.120.1.tgz#e4259d551d1b033f050bdf3dea5fe754eaf1c6bd"
-  integrity sha512-udvU9kCrGo5h7+Q7RtcNb2C28X96fA0XIWaeEp4Zr20Hgagjc2Rc3U0GZldCoCrEYhaBCePTJegclXsssnbIkQ==
-  dependencies:
-    "@babel/core" "^7.11.4"
-    "@babel/parser" "^7.11.4"
-    "@babel/preset-typescript" "^7.10.4"
-    "@babel/register" "^7.11.5"
-    "@babel/traverse" "^7.11.0"
-    "@babel/types" "^7.11.0"
-    create-emotion-server "^10.0.27"
-    theme-ui "^0.3.1"
 
 "@vtex/prettier-config@^0.3.5":
   version "0.3.5"
@@ -5034,7 +4940,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.2.0:
+acorn-jsx@^5.2.0, acorn-jsx@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
@@ -5773,13 +5679,6 @@ babel-loader@^8.1.0:
     pify "^4.0.1"
     schema-utils "^2.6.5"
 
-babel-messages@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
-  integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-add-module-exports@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.3.3.tgz#b9f7c0a93b989170dce07c3e97071a905a13fc29"
@@ -6008,11 +5907,6 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   version "7.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
-
-babel-plugin-transform-async-to-promises@^0.8.14:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz#13b6d8ef13676b4e3c576d3600b85344bb1ba346"
-  integrity sha512-fDXP68ZqcinZO2WCiimCL9zhGjGXOnn3D33zvbh+yheZ/qOrNVVDDIBtAaM3Faz8TRvQzHiRKsu3hfrBAhEncQ==
 
 babel-plugin-transform-inline-consecutive-adds@^0.4.3:
   version "0.4.3"
@@ -6253,38 +6147,13 @@ babel-preset-react-app@^9.1.2:
     babel-plugin-macros "2.8.0"
     babel-plugin-transform-react-remove-prop-types "0.4.24"
 
-babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
-
-babel-traverse@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-  integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    debug "^2.6.8"
-    globals "^9.18.0"
-    invariant "^2.2.2"
-    lodash "^4.17.4"
-
-babel-types@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -6884,14 +6753,6 @@ camel-case@4.1.1, camel-case@^4.1.1:
     pascal-case "^3.1.1"
     tslib "^1.10.0"
 
-camel-case@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
-  integrity sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=
-  dependencies:
-    no-case "^2.2.0"
-    upper-case "^1.1.1"
-
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -6918,7 +6779,7 @@ camelcase-keys@^6.2.2:
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
 
-camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.2.0, camelcase@^5.3.1:
+camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -7166,7 +7027,7 @@ cli-spinners@^1.3.1:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
   integrity sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==
 
-cli-spinners@^2.0.0, cli-spinners@^2.2.0:
+cli-spinners@^2.2.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.5.0.tgz#12763e47251bf951cb75c201dfa58ff1bcb2d047"
   integrity sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==
@@ -7389,7 +7250,7 @@ commander@^4.0.1, commander@^4.1.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^6.1.0, commander@^6.2.0:
+commander@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
   integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
@@ -7751,7 +7612,7 @@ core-js-pure@^3.0.0, core-js-pure@^3.0.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.7.0.tgz#28a57c861d5698e053f0ff36905f7a3301b4191e"
   integrity sha512-EZD2ckZysv8MMt4J6HSvS9K2GdtlZtdBncKAmF9lr2n0c9dJUaUN88PSTjvgwCgQPWKTkERXITgS6JJRAnljtg==
 
-core-js@^2.4.0, core-js@^2.4.1, core-js@^2.6.5:
+core-js@^2.4.0, core-js@^2.4.1:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
@@ -8309,7 +8170,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -9283,27 +9144,27 @@ eslint-config-prettier@^6.0.0, eslint-config-prettier@^6.15.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-react-app@^5.0.2, eslint-config-react-app@^5.2.1:
+eslint-config-react-app@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-5.2.1.tgz#698bf7aeee27f0cea0139eaef261c7bf7dd623df"
   integrity sha512-pGIZ8t0mFLcV+6ZirRgYK6RVqUIKRIi9MmgzUEmrIknsn3AdO0I32asO86dJgloHq+9ZPl8UIg8mYrvgP5u2wQ==
   dependencies:
     confusing-browser-globals "^1.0.9"
 
-eslint-config-vtex-react@^6.8.4:
-  version "6.8.4"
-  resolved "https://registry.yarnpkg.com/eslint-config-vtex-react/-/eslint-config-vtex-react-6.8.4.tgz#a2d6e1652d3c79b014c6cde28975b2442f3bf668"
-  integrity sha512-HA/2DvV6bBjomkuTWoLwlzhU4otdEQgYnvlhGaI/TTx7Fl5GREkS1OCzdvYXPx3cvwxP5UHywVekckHhX0D73A==
+eslint-config-vtex-react@^6.8.7:
+  version "6.8.7"
+  resolved "https://registry.yarnpkg.com/eslint-config-vtex-react/-/eslint-config-vtex-react-6.8.7.tgz#e4df5568d68aefb12ef1c65f638f7f98c7ec8eff"
+  integrity sha512-DyvF2RVx9GF59V+GWYlyzEqFxRePdyFqemIdITn1zMo89s22Ecwz092XWGxemCB8DK2ROVs+wsnSOW759BN+Iw==
   dependencies:
-    eslint-config-vtex "^12.8.11"
+    eslint-config-vtex "^12.8.14"
     eslint-plugin-jsx-a11y "^6.3.1"
     eslint-plugin-react "^7.20.6"
     eslint-plugin-react-hooks "^4.1.0"
 
-eslint-config-vtex@^12.8.11:
-  version "12.8.11"
-  resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-12.8.11.tgz#4eddf3e0f1e93e96734dc4a84347ae082e833912"
-  integrity sha512-/FAHIh3S1FEMLErYbdIdz9vYXE0QmOp6eJ+JjQlsZF4OUvrlk/j23gENbCa67+zf0Yg/zAOUUJYm3/MwalF3Hw==
+eslint-config-vtex@^12.8.14:
+  version "12.8.14"
+  resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-12.8.14.tgz#3a1bfe90d5b50fe3814309ab2c5ecce595dd779f"
+  integrity sha512-O+LVmaPaYRsr+ss7usJHIc1tIRRDUAKgXvTz3OiATfJaPd9ns/mXTZYoJEle2caUtso+LjsVW7hsHtG7K1aCLg==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^4.8.1"
     "@typescript-eslint/parser" "^4.8.1"
@@ -9313,7 +9174,7 @@ eslint-config-vtex@^12.8.11:
     eslint-plugin-import "^2.22.1"
     eslint-plugin-jest "^24.1.3"
     eslint-plugin-prettier "^3.1.4"
-    eslint-plugin-vtex "^2.0.7"
+    eslint-plugin-vtex "^2.0.9"
 
 eslint-import-resolver-node@^0.3.2, eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
@@ -9460,10 +9321,17 @@ eslint-plugin-jsx-a11y@^6.2.3, eslint-plugin-jsx-a11y@^6.3.1:
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
 
-eslint-plugin-prettier@^3.1.0, eslint-plugin-prettier@^3.1.4:
+eslint-plugin-prettier@^3.1.0:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
   integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-prettier@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.2.0.tgz#af391b2226fa0e15c96f36c733f6e9035dbd952c"
+  integrity sha512-kOUSJnFjAUFKwVxuzy6sA5yyMx6+o9ino4gCdShzBNx4eyFRudWRYKCFolKjoM40PEiuU6Cn7wBLfq3WsGg7qg==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -9517,10 +9385,10 @@ eslint-plugin-react@^7.14.3, eslint-plugin-react@^7.20.6:
     resolve "^1.18.1"
     string.prototype.matchall "^4.0.2"
 
-eslint-plugin-vtex@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-vtex/-/eslint-plugin-vtex-2.0.7.tgz#707f3ba41acf5bf976ee4fac8a658579cab141ef"
-  integrity sha512-BB9Ms0Fs3scl1/jzFmV9soH1FOwvE0Ak6Zy8YqwFs+z076c+ChPBFc/qjAe0eAau8izVd6VF2cumPZ1OfsU0Mw==
+eslint-plugin-vtex@^2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vtex/-/eslint-plugin-vtex-2.0.9.tgz#33412ecd1f85fc5c8f935990b01fb4e8caf0a6bd"
+  integrity sha512-wMcWHKhNttjhXxRXJsJs6HB39p50Nyph/M/EewOlgYow8RaWb9Zo6TaVfNe8yvtYhOJIpTsEw8kPzEjpEI47rw==
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -9605,13 +9473,13 @@ eslint@^6.1.0, eslint@^6.6.0, eslint@^6.8.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^7.14.0:
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.14.0.tgz#2d2cac1d28174c510a97b377f122a5507958e344"
-  integrity sha512-5YubdnPXrlrYAFCKybPuHIAH++PINe1pmKNc5wQRB9HSbqIK1ywAnntE3Wwua4giKu0bjligf1gLF6qxMGOYRA==
+eslint@^7.15.0:
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.15.0.tgz#eb155fb8ed0865fcf5d903f76be2e5b6cd7e0bc7"
+  integrity sha512-Vr64xFDT8w30wFll643e7cGrIkPEU50yIiI36OdSIDoSGguIeaLzBo0vpGvzo9RECUqq7htURfwEtKqwytkqzA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.2.1"
+    "@eslint/eslintrc" "^0.2.2"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -9621,10 +9489,10 @@ eslint@^7.14.0:
     eslint-scope "^5.1.1"
     eslint-utils "^2.1.0"
     eslint-visitor-keys "^2.0.0"
-    espree "^7.3.0"
+    espree "^7.3.1"
     esquery "^1.2.0"
     esutils "^2.0.2"
-    file-entry-cache "^5.0.1"
+    file-entry-cache "^6.0.0"
     functional-red-black-tree "^1.0.1"
     glob-parent "^5.0.0"
     globals "^12.1.0"
@@ -9657,13 +9525,13 @@ espree@^6.1.2:
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
-espree@^7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.0.tgz#dc30437cf67947cf576121ebd780f15eeac72348"
-  integrity sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==
+espree@^7.3.0, espree@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
+  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
   dependencies:
     acorn "^7.4.0"
-    acorn-jsx "^5.2.0"
+    acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
 
 esprima@^4.0.0, esprima@^4.0.1:
@@ -9761,22 +9629,6 @@ exec-sh@^0.3.2:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
   integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
-
-execa@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-3.2.0.tgz#18326b79c7ab7fbd6610fd900c1b9e95fa48f90a"
-  integrity sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==
-  dependencies:
-    cross-spawn "^7.0.0"
-    get-stream "^5.0.0"
-    human-signals "^1.1.1"
-    is-stream "^2.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^4.0.0"
-    onetime "^5.1.0"
-    p-finally "^2.0.0"
-    signal-exit "^3.0.2"
-    strip-final-newline "^2.0.0"
 
 execa@^1.0.0:
   version "1.0.0"
@@ -10025,7 +9877,7 @@ fast-glob@^2.0.2, fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.4:
+fast-glob@^3.0.3, fast-glob@^3.1.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
   integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
@@ -10152,6 +10004,13 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+file-entry-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.0.tgz#7921a89c391c6d93efec2169ac6bf300c527ea0a"
+  integrity sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==
+  dependencies:
+    flat-cache "^3.0.4"
+
 file-loader@4.3.0, file-loader@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-4.3.0.tgz#780f040f729b3d18019f20605f723e844b8a58af"
@@ -10245,7 +10104,7 @@ find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-cache-dir@^3.0.0, find-cache-dir@^3.1.0, find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
+find-cache-dir@^3.0.0, find-cache-dir@^3.1.0, find-cache-dir@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
   integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
@@ -10305,10 +10164,23 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
 flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+flatted@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
+  integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
 
 flatten@^1.0.2:
   version "1.0.3"
@@ -11229,11 +11101,6 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
-
-globals@^9.18.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
-  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
 globalthis@^1.0.0:
   version "1.0.1"
@@ -12341,6 +12208,14 @@ intl-messageformat-parser@6.0.17:
     "@formatjs/ecma402-abstract" "1.5.0"
     tslib "^2.0.1"
 
+intl-messageformat-parser@^6.0.18:
+  version "6.0.18"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-6.0.18.tgz#bf2855b82b0749e1f34e452f0a15d08d3277c8c7"
+  integrity sha512-vLjACEunfi5uSUCWFLOR4PXQ9DGLpED3tM7o9zsYsOvjl0VIheoxyG0WZXnsnhn+S+Zu158M6CkuHXeNZfKRRg==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.5.0"
+    tslib "^2.0.1"
+
 intl-messageformat@9.3.19:
   version "9.3.19"
   resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-9.3.19.tgz#c4fc4d40e9736e5f5ccd4c2656acf63cf533c8f6"
@@ -13274,7 +13149,7 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^24.3.0, jest-diff@^24.9.0:
+jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
@@ -14121,7 +13996,7 @@ jest-validate@^26.6.2:
     leven "^3.1.0"
     pretty-format "^26.6.2"
 
-jest-watch-typeahead@0.4.2, jest-watch-typeahead@^0.4.0:
+jest-watch-typeahead@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-0.4.2.tgz#e5be959698a7fa2302229a5082c488c3c8780a4a"
   integrity sha512-f7VpLebTdaXs81rg/oj4Vg/ObZy2QtGzAmGLNsqUS5G5KtSN68tFcIsbvNODfNyQxU78g7D8x77o3bgfBTR+2Q==
@@ -14210,7 +14085,7 @@ jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest@24.9.0, jest@^24.8.0:
+jest@24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
   integrity sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==
@@ -15133,7 +15008,7 @@ lodash@4.17.20, "lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.11, lodash@^4.1
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-log-symbols@^2.1.0, log-symbols@^2.2.0:
+log-symbols@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
@@ -15205,14 +15080,6 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-loud-rejection@*, loud-rejection@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-2.2.0.tgz#4255eb6e9c74045b0edc021fa7397ab655a8517c"
-  integrity sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==
-  dependencies:
-    currently-unhandled "^0.4.1"
-    signal-exit "^3.0.2"
-
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
@@ -15221,17 +15088,20 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+loud-rejection@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-2.2.0.tgz#4255eb6e9c74045b0edc021fa7397ab655a8517c"
+  integrity sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==
+  dependencies:
+    currently-unhandled "^0.4.1"
+    signal-exit "^3.0.2"
+
 lower-case@2.0.1, lower-case@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.1.tgz#39eeb36e396115cc05e29422eaea9e692c9408c7"
   integrity sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==
   dependencies:
     tslib "^1.10.0"
-
-lower-case@^1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
-  integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
 
 lowercase-keys@1.0.0:
   version "1.0.0"
@@ -15985,13 +15855,6 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-no-case@^2.2.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
-  integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
-  dependencies:
-    lower-case "^1.1.1"
-
 no-case@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.3.tgz#c21b434c1ffe48b39087e86cfb4d2582e9df18f8"
@@ -16601,18 +16464,6 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
-ora@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318"
-  integrity sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==
-  dependencies:
-    chalk "^2.4.2"
-    cli-cursor "^2.1.0"
-    cli-spinners "^2.0.0"
-    log-symbols "^2.2.0"
-    strip-ansi "^5.2.0"
-    wcwidth "^1.0.1"
-
 ora@^4.0.3:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ora/-/ora-4.1.1.tgz#566cc0348a15c36f5f0e979612842e02ba9dddbc"
@@ -17025,14 +16876,6 @@ pascal-case@3.1.1, pascal-case@^3.1.1:
   dependencies:
     no-case "^3.0.3"
     tslib "^1.10.0"
-
-pascal-case@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-2.0.1.tgz#2d578d3455f660da65eca18ef95b4e0de912761e"
-  integrity sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=
-  dependencies:
-    camel-case "^3.0.0"
-    upper-case-first "^1.1.0"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -18044,10 +17887,10 @@ prettier@^2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
-prettier@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
-  integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-bytes@^5.1.0:
   version "5.4.1"
@@ -19539,13 +19382,6 @@ resolve@1.15.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@1.15.1:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
-  integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
-  dependencies:
-    path-parse "^1.0.6"
-
 resolve@1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
@@ -19553,7 +19389,7 @@ resolve@1.17.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@1.x, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.8.1:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
@@ -19641,7 +19477,7 @@ rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimra
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -19655,22 +19491,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
-
-rollup-plugin-babel@^4.3.2:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz#d15bd259466a9d1accbdb2fe2fff17c52d030acb"
-  integrity sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    rollup-pluginutils "^2.8.1"
-
-rollup-plugin-sourcemaps@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.4.2.tgz#62125aa94087aadf7b83ef4dfaf629b473135e87"
-  integrity sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=
-  dependencies:
-    rollup-pluginutils "^2.0.1"
-    source-map-resolve "^0.5.0"
 
 rollup-plugin-sourcemaps@^0.6.2:
   version "0.6.3"
@@ -19691,17 +19511,6 @@ rollup-plugin-terser@^5.1.2:
     serialize-javascript "^4.0.0"
     terser "^4.6.2"
 
-rollup-plugin-typescript2@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.26.0.tgz#cee2b44d51d9623686656d76dc30a73c4de91672"
-  integrity sha512-lUK7XZVG77tu8dmv1L/0LZFlavED/5Yo6e4iMMl6fdox/yKdj4IFRRPPJEXNdmEaT1nDQQeCi7b5IwKHffMNeg==
-  dependencies:
-    find-cache-dir "^3.2.0"
-    fs-extra "8.1.0"
-    resolve "1.15.1"
-    rollup-pluginutils "2.8.2"
-    tslib "1.10.0"
-
 rollup-plugin-typescript2@^0.27.3:
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.27.3.tgz#cd9455ac026d325b20c5728d2cc54a08a771b68b"
@@ -19713,7 +19522,7 @@ rollup-plugin-typescript2@^0.27.3:
     resolve "1.17.0"
     tslib "2.0.1"
 
-rollup-pluginutils@2.8.2, rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
+rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
@@ -19944,7 +19753,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -19959,10 +19768,17 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^7.1.1, semver@^7.2.1, semver@^7.3.2:
+semver@^7.1.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+semver@^7.2.1:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"
@@ -21422,11 +21238,6 @@ to-arraybuffer@^1.0.0:
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
 
-to-fast-properties@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-  integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
-
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -21555,22 +21366,6 @@ ts-dedent@^1.1.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-1.2.0.tgz#6aa2229d837159bb6d635b6b233002423b91e0b0"
   integrity sha512-6zSJp23uQI+Txyz5LlXMXAHpUhY4Hi0oluXny0OgIR7g/Cromq4vDBnhtbBdyIV34g0pgwxUvnvg+jLJe4c1NA==
 
-ts-jest@^24.0.2:
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.3.0.tgz#b97814e3eab359ea840a1ac112deae68aa440869"
-  integrity sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==
-  dependencies:
-    bs-logger "0.x"
-    buffer-from "1.x"
-    fast-json-stable-stringify "2.x"
-    json5 "2.x"
-    lodash.memoize "4.x"
-    make-error "1.x"
-    mkdirp "0.x"
-    resolve "1.x"
-    semver "^5.5"
-    yargs-parser "10.x"
-
 ts-jest@^25.3.1:
   version "25.5.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.5.1.tgz#2913afd08f28385d54f2f4e828be4d261f4337c7"
@@ -21629,74 +21424,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tsdx@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/tsdx/-/tsdx-0.13.3.tgz#b8a23ed1cb06f1d00bfd0f541f5d3cac90b611f5"
-  integrity sha512-IzEzSygWpGC/E6UQ1rPxRRpeRLPQ3RBSmisTcX2p9PKFItrwG50MaW8DfVDIolkk4Xt9cYUfgjJ+g01qN2gMYQ==
-  dependencies:
-    "@babel/core" "^7.4.4"
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.4.4"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.7.4"
-    "@babel/plugin-proposal-optional-chaining" "^7.7.5"
-    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
-    "@babel/plugin-transform-regenerator" "^7.4.5"
-    "@babel/plugin-transform-runtime" "^7.6.0"
-    "@babel/polyfill" "^7.4.4"
-    "@babel/preset-env" "^7.4.4"
-    "@rollup/plugin-commonjs" "^11.0.0"
-    "@rollup/plugin-json" "^4.0.0"
-    "@rollup/plugin-node-resolve" "^7.1.0"
-    "@rollup/plugin-replace" "^2.2.1"
-    "@types/jest" "^24.0.15"
-    "@typescript-eslint/eslint-plugin" "^2.12.0"
-    "@typescript-eslint/parser" "^2.12.0"
-    ansi-escapes "^4.2.1"
-    asyncro "^3.0.0"
-    babel-eslint "^10.0.3"
-    babel-plugin-annotate-pure-calls "^0.4.0"
-    babel-plugin-dev-expression "^0.2.1"
-    babel-plugin-macros "^2.6.1"
-    babel-plugin-transform-async-to-promises "^0.8.14"
-    babel-plugin-transform-rename-import "^2.3.0"
-    babel-traverse "^6.26.0"
-    babylon "^6.18.0"
-    camelcase "^5.2.0"
-    chalk "^2.4.2"
-    enquirer "^2.3.4"
-    eslint "^6.1.0"
-    eslint-config-prettier "^6.0.0"
-    eslint-config-react-app "^5.0.2"
-    eslint-plugin-flowtype "^3.13.0"
-    eslint-plugin-import "^2.18.2"
-    eslint-plugin-jsx-a11y "^6.2.3"
-    eslint-plugin-prettier "^3.1.0"
-    eslint-plugin-react "^7.14.3"
-    eslint-plugin-react-hooks "^2.2.0"
-    execa "3.2.0"
-    fs-extra "^8.0.1"
-    jest "^24.8.0"
-    jest-watch-typeahead "^0.4.0"
-    jpjs "^1.2.1"
-    lodash.merge "^4.6.2"
-    ora "^3.4.0"
-    pascal-case "^2.0.1"
-    prettier "^1.19.1"
-    progress-estimator "^0.2.2"
-    rollup "^1.32.1"
-    rollup-plugin-babel "^4.3.2"
-    rollup-plugin-sourcemaps "^0.4.2"
-    rollup-plugin-terser "^5.1.2"
-    rollup-plugin-typescript2 "^0.26.0"
-    sade "^1.4.2"
-    semver "^7.1.1"
-    shelljs "^0.8.3"
-    tiny-glob "^0.2.6"
-    ts-jest "^24.0.2"
-    tslib "^1.9.3"
-    typescript "^3.7.3"
-
-tsdx@^0.14.0:
+tsdx@^0.14.1:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/tsdx/-/tsdx-0.14.1.tgz#8771d509b6fc523ad971bae3a63ebe3a88355ab3"
   integrity sha512-keHmFdCL2kx5nYFlBdbE3639HQ2v9iGedAFAajobrUTH2wfX0nLPdDhbHv+GHLQZqf0c5ur1XteE8ek/+Eyj5w==
@@ -21757,11 +21485,6 @@ tsdx@^0.14.0:
     ts-jest "^25.3.1"
     tslib "^1.9.3"
     typescript "^3.7.3"
-
-tslib@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tslib@2.0.1:
   version "2.0.1"
@@ -21896,7 +21619,7 @@ typescript@^3.7.3, typescript@^3.9.5, typescript@^3.9.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
-typescript@^4.0, typescript@^4.0.3:
+typescript@^4.0.3:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
   integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
@@ -22157,24 +21880,12 @@ update-notifier@^4.1.3:
     semver-diff "^3.1.1"
     xdg-basedir "^4.0.0"
 
-upper-case-first@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-1.1.2.tgz#5d79bedcff14419518fd2edb0a0507c9b6859115"
-  integrity sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=
-  dependencies:
-    upper-case "^1.1.1"
-
 upper-case@2.0.1, upper-case@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.1.tgz#6214d05e235dc817822464ccbae85822b3d8665f"
   integrity sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==
   dependencies:
     tslib "^1.10.0"
-
-upper-case@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
-  integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
 
 uri-js@^4.2.2:
   version "4.4.0"
@@ -23183,13 +22894,6 @@ yaml@^1.10.0, yaml@^1.7.2, yaml@^1.8.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
-
-yargs-parser@10.x:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
-  dependencies:
-    camelcase "^4.1.0"
 
 yargs-parser@18.x, yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR solves two problems with the i18n plugin. 

1. Removes messages from pageContext
2. Messages reuse in stores.

## How it works? 
### Removes messages from pageContext
React intl provider was being created on `wrapPageElement`. This meant that at each page navigation, the react-intl provider was re-created. Also, the messages were inserted directly into the page's pageContext variable. This means that the client downloaded ALL messages at each navigation.

This PR moves react-intl provider creation to `wrapRootElement` and includes all messages only once. This way the provider is not re-created multiple times and the messages are not re-downloaded at each navigation 

### Messages reuse in stores
Our i18n plugin used a folder with many `jsons` for ingesting the locales and translations. This meant that all translations had to be written on the store's implementations and at each new message in the component's implementations made us open a PR in each store, upgrading these messages.

This PR uses shadowing and `ts` files so the store's may define their own merge strategies with our own custom messages, allowing us to deliver new messages by only upgrading the dependencies. The final result is [in here](https://github.com/vtex-sites/storecomponents.store/pull/399/files#diff-b0bd4830ff9392d0174e94836499b90475e8ce2ce1cae1e6a9e7c194fe1bf941)

Also, this PR adds webpack magic and a babel plugin to optimize messages and remove react-intl ICU parser on the frontend

## How to test it?
[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/263)
[faststore](https://github.com/vtex-sites/storecomponents.store/pull/399)

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
