### PR TITLE
Fix | First selected filter removed from filters list

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.217.2-antiq.1",
+  "version": "0.217.2-antiq.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.217.1",
+  "version": "0.217.2-antiq.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.217.2-antiq.0",
+  "version": "0.217.2-antiq.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.217.1",
+  "version": "0.217.2-antiq.0",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.217.2-antiq.0",
+  "version": "0.217.2-antiq.2",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.217.2-antiq.0",
+  "version": "0.217.2-antiq.2",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.217.1",
+  "version": "0.217.2-antiq.0",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.217.2-antiq.0",
+  "version": "0.217.2-antiq.2",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.217.1",
+  "version": "0.217.2-antiq.0",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.217.2-antiq.0",
+  "version": "0.217.2-antiq.2",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.217.1",
+  "version": "0.217.2-antiq.0",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.217.2-antiq.0",
+  "version": "0.217.2-antiq.2",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.217.1",
+  "version": "0.217.2-antiq.0",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.217.2-antiq.0",
+  "version": "0.217.2-antiq.2",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.217.1",
+  "version": "0.217.2-antiq.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.217.1",
+  "version": "0.217.2-antiq.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -34,9 +34,9 @@
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
     "@vtex/gatsby-plugin-graphql": "^0.214.0-alpha.6",
-    "@vtex/gatsby-plugin-i18n": "^0.217.1",
-    "@vtex/gatsby-plugin-theme-ui": "^0.217.1",
-    "@vtex/store-ui": "^0.217.1",
+    "@vtex/gatsby-plugin-i18n": "^0.217.2-antiq.0",
+    "@vtex/gatsby-plugin-theme-ui": "^0.217.2-antiq.0",
+    "@vtex/store-ui": "^0.217.2-antiq.0",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.217.2-antiq.0",
+  "version": "0.217.2-antiq.1",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.217.2-antiq.1",
+  "version": "0.217.2-antiq.2",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -34,9 +34,9 @@
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
     "@vtex/gatsby-plugin-graphql": "^0.214.0-alpha.6",
-    "@vtex/gatsby-plugin-i18n": "^0.217.2-antiq.0",
-    "@vtex/gatsby-plugin-theme-ui": "^0.217.2-antiq.0",
-    "@vtex/store-ui": "^0.217.2-antiq.0",
+    "@vtex/gatsby-plugin-i18n": "^0.217.2-antiq.2",
+    "@vtex/gatsby-plugin-theme-ui": "^0.217.2-antiq.2",
+    "@vtex/store-ui": "^0.217.2-antiq.2",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/gatsby-theme-store/src/sdk/search/controller.ts
+++ b/packages/gatsby-theme-store/src/sdk/search/controller.ts
@@ -53,16 +53,9 @@ export const toggleItem = (item: SearchFilterItem, filters: SearchFilters) => {
 
     const index = splittedQuery?.findIndex((s) => s === value)
 
-    // Unselecting the base path. This is not allowed since it would redirect
-    // the user to the home page. In the future we should return a visual
-    // feedback for the user
-    if (index === 0) {
-      return
-    }
-
     // eslint-disable-next-line no-console
     console.assert(
-      index !== undefined && index > -1,
+      index && index > -1,
       `${value} is marked as selected but does not exist in ${query}`
     )
 

--- a/packages/gatsby-theme-store/src/sdk/search/useFacets.ts
+++ b/packages/gatsby-theme-store/src/sdk/search/useFacets.ts
@@ -83,6 +83,17 @@ export const useFacets = () => {
           return acc
         }
 
+        // Skip the root department facet selected
+        if (facet.name === 'Departamento') {
+          const rootFacet = focusCategoryFacet(rawFacet as any, filters)
+
+          facet.values?.forEach((value: any, index: number) => {
+            if (value.name === rootFacet.name) {
+              facet.values?.splice(index, 1)
+            }
+          })
+        }
+
         // Fill facet name
         facet!.name = facet!.name || (NAME_FROM_TYPE as any)[facet!.type!]
 

--- a/packages/gatsby-theme-store/src/sdk/search/useFacets.ts
+++ b/packages/gatsby-theme-store/src/sdk/search/useFacets.ts
@@ -86,7 +86,7 @@ export const useFacets = () => {
           return acc
         }
 
-        // Skip the root department facet selected
+        // Skip the root department (filter) facet selected
         const rootFacet = focusCategoryFacet(rawFacet as any, filters)
 
         if (rootFacet.value && facet.values) {

--- a/packages/gatsby-theme-store/src/sdk/search/useFacets.ts
+++ b/packages/gatsby-theme-store/src/sdk/search/useFacets.ts
@@ -21,6 +21,7 @@ export interface Facet {
   name: string
   type: Vtex_FilterType
   values: SearchFilterItem[]
+  value?: SearchFilterItem
 }
 
 const focusCategoryFacet = (facet: Facet, filters: SearchFilters): Facet => {
@@ -43,7 +44,9 @@ const focusCategoryFacet = (facet: Facet, filters: SearchFilters): Facet => {
     }
 
     const maybeFacet = focus.values.find(
-      (item) => item.value.toLowerCase() === splittedQuery[i].toLowerCase()
+      (item) =>
+        item.value &&
+        item.value.toLowerCase() === splittedQuery[i].toLowerCase()
     )
 
     if (!maybeFacet) {
@@ -84,14 +87,16 @@ export const useFacets = () => {
         }
 
         // Skip the root department facet selected
-        if (facet.name === 'Departamento') {
-          const rootFacet = focusCategoryFacet(rawFacet as any, filters)
+        const rootFacet = focusCategoryFacet(rawFacet as any, filters)
 
-          facet.values?.forEach((value: any, index: number) => {
-            if (value.name === rootFacet.name) {
-              facet.values?.splice(index, 1)
-            }
-          })
+        if (rootFacet.value && facet.values) {
+          const index = facet.values.findIndex(
+            (value: any) => value.name === rootFacet.name
+          )
+
+          if (index >= 0) {
+            facet.values?.splice(index, 1)
+          }
         }
 
         // Fill facet name

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.217.2-antiq.0",
+  "version": "0.217.2-antiq.2",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.217.1",
+  "version": "0.217.2-antiq.0",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.217.1",
+  "version": "0.217.2-antiq.0",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.217.1",
+    "@vtex/gatsby-plugin-i18n": "^0.217.2-antiq.0",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.217.2-antiq.0",
+  "version": "0.217.2-antiq.2",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.217.2-antiq.0",
+    "@vtex/gatsby-plugin-i18n": "^0.217.2-antiq.2",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",


### PR DESCRIPTION
## What's the purpose of this pull request?
When the user remove the last filter (root department) from the search page, nothing happens.

## How it works? 
Now the last filter will not appear to the user, because these changes search the "root department"(last filter) and remove it from facets list.

## How to test it?
In a store, select a department at the navbar. In the search page, see if the department selected appears in the filter list.

Closes #356
