### PR TITLE
Fixes priceValidUntil when null

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.218.0-alpha.0",
+  "version": "0.219.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.217.1",
+  "version": "0.218.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.219.0-alpha.0",
+  "version": "0.220.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.217.1",
+  "version": "0.218.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.218.0-alpha.0",
+  "version": "0.219.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.219.0-alpha.0",
+  "version": "0.220.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/src/components/ProductPage/SEO/useStructuredProduct.ts
+++ b/packages/gatsby-theme-store/src/components/ProductPage/SEO/useStructuredProduct.ts
@@ -19,7 +19,7 @@ const getSkuOffers = (
     price: seller!.commercialOffer!.price!,
     priceCurrency: currency,
     url,
-    priceValidUntil: `${seller!.commercialOffer!.priceValidUntil}`.slice(0, 10),
+    priceValidUntil: seller!.commercialOffer!.priceValidUntil?.slice(0, 10),
     availability:
       seller!.commercialOffer!.availableQuantity! > 0
         ? 'https://schema.org/InStock'


### PR DESCRIPTION
## What's the purpose of this pull request?
When priceValidUntill is null, we must return null, and not the string "null" so google does not complain

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 

## References
[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/282)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/415)

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
