### PR TITLE
Change CMS shape

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.228.3-alpha.0",
+  "version": "0.229.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.228.0",
+  "version": "0.229.0-alpha.0",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-cms/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-cms/src/gatsby-node.ts
@@ -167,51 +167,62 @@ export const createPages = async ({ graphql, reporter }: CreatePagesArgs) => {
   })
   const {
     builderConfig: {
-      contentTypes: ctypes = {},
-      blocks: blks = {},
+      contentTypes: userContentTypes = {},
+      blocks: userBlocks = {},
       messages = {},
     } = {},
   } = require(SHADOWED_INDEX_PATH) as {
     builderConfig: BuilderConfig
   }
 
-  const blocks = Object.keys(blks).map((k) => ({
-    name: k,
-    schema: blks[k],
+  const blocks = Object.keys(userBlocks).map((blockName) => ({
+    name: blockName,
+    schema: userBlocks[blockName],
   }))
 
   // Transform all contentTypes into CMS contentTypes format
-  const contentTypes = Object.keys(ctypes).reduce((acc, key) => {
-    const ct = ctypes[key]
+  const contentTypes = Object.keys(userContentTypes).reduce(
+    (acc, contentTypeName) => {
+      const contentType = userContentTypes[contentTypeName]
 
-    const beforeBlocks = Object.keys(ct.beforeBlocks).map((k) => ({
-      name: k,
-      schema: ct.beforeBlocks[k],
-    }))
+      const beforeBlocks = Object.keys(contentType.beforeBlocks).map(
+        (blockName) => ({
+          name: blockName,
+          schema: contentType.beforeBlocks[blockName],
+        })
+      )
 
-    const afterBlocks = Object.keys(ct.afterBlocks).map((k) => ({
-      name: k,
-      schema: ct.afterBlocks[k],
-    }))
+      const afterBlocks = Object.keys(contentType.afterBlocks).map(
+        (blockName) => ({
+          name: blockName,
+          schema: contentType.afterBlocks[blockName],
+        })
+      )
 
-    const extraBlocks = Object.keys(ct.extraBlocks).map((k) => ({
-      name: k,
-      blocks: Object.keys(ct.extraBlocks[k]).map((kk) => ({
-        name: kk,
-        schema: ct.extraBlocks[k][kk],
-      })),
-    }))
+      const extraBlocks = Object.keys(contentType.extraBlocks).map(
+        (sectionName) => ({
+          name: sectionName,
+          blocks: Object.keys(contentType.extraBlocks[sectionName]).map(
+            (blockName) => ({
+              name: blockName,
+              schema: contentType.extraBlocks[sectionName][blockName],
+            })
+          ),
+        })
+      )
 
-    acc.push({
-      ...ct,
-      id: key,
-      beforeBlocks,
-      afterBlocks,
-      extraBlocks,
-    })
+      acc.push({
+        ...contentType,
+        id: contentTypeName,
+        beforeBlocks,
+        afterBlocks,
+        extraBlocks,
+      })
 
-    return acc
-  }, [] as CMSContentType[])
+      return acc
+    },
+    [] as CMSContentType[]
+  )
 
   const builderConfig: CMSBuilderConfig = {
     id: 'faststore',

--- a/packages/gatsby-plugin-cms/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-cms/src/gatsby-node.ts
@@ -173,7 +173,6 @@ export const createPages = async () => {
     acc.push({
       ...ct,
       id: key,
-      name: key,
       beforeBlocks,
       afterBlocks,
       extraBlocks,

--- a/packages/gatsby-plugin-cms/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-cms/src/gatsby-node.ts
@@ -138,7 +138,11 @@ export const createPages = async () => {
     presets: ['@babel/preset-typescript'],
   })
   const {
-    builderConfig: { contentTypes: ctypes, blocks: blks, messages },
+    builderConfig: {
+      contentTypes: ctypes = {},
+      blocks: blks = {},
+      messages = {},
+    } = {},
   } = require(SHADOWED_INDEX_PATH) as {
     builderConfig: BuilderConfig
   }

--- a/packages/gatsby-plugin-cms/src/index.ts
+++ b/packages/gatsby-plugin-cms/src/index.ts
@@ -8,14 +8,21 @@ export interface Schema extends JSONSchema6 {
 export type Schemas = Record<string, Schema>
 
 interface ContentType {
-  name: string
-  blocks: Schemas
   extraBlocks: Record<string, Schemas>
   beforeBlocks: Schemas
   afterBlocks: Schemas
-  messages: Record<string, string>
 }
 
 export type ContentTypes = Record<string, ContentType>
 
-export const contentTypes: ContentTypes = {}
+export interface BuilderConfig {
+  contentTypes: ContentTypes
+  blocks: Schemas
+  messages: Record<string, string>
+}
+
+export const builderConfig: BuilderConfig = {
+  contentTypes: {},
+  blocks: {},
+  messages: {},
+}

--- a/packages/gatsby-plugin-cms/src/index.ts
+++ b/packages/gatsby-plugin-cms/src/index.ts
@@ -8,6 +8,7 @@ export interface Schema extends JSONSchema6 {
 export type Schemas = Record<string, Schema>
 
 interface ContentType {
+  name: string
   extraBlocks: Record<string, Schemas>
   beforeBlocks: Schemas
   afterBlocks: Schemas

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.228.3-alpha.0",
+  "version": "0.229.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -36,7 +36,7 @@
     "@vtex/gatsby-plugin-graphql": "^0.214.0-alpha.6",
     "@vtex/gatsby-plugin-i18n": "^0.228.0",
     "@vtex/gatsby-plugin-theme-ui": "^0.228.0",
-    "@vtex/store-ui": "^0.228.3-alpha.0",
+    "@vtex/store-ui": "^0.229.0-alpha.0",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.228.3-alpha.0",
+  "version": "0.229.0-alpha.0",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",


### PR DESCRIPTION
## What's the purpose of this pull request?
As required by CMS team, this PR changes the exported config json. 

1. The path `/page-data/_cms/contentTypes.json` was renamed to `/page-data/_cms/builderConfig.json`
2. `blocks` and `messages` were moved to the json's root 
3. A special contentTypes property was created

## How it works? 
The json shapes are available in:
1. [storecomponents](https://deploy-preview-427--faststore.netlify.app/page-data/_cms/builderConfig.json)
2. [marinbrasil](https://deploy-preview-296--marinbrasil.netlify.app/page-data/_cms/builderConfig.json)

## How to test it?
<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
