### PR TITLE
CMS Fixtures API

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.224.0",
+  "version": "0.225.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
@@ -7,7 +7,5 @@
       "message": "Release: %v"
     }
   },
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.225.0-alpha.0",
+  "version": "0.225.1-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.12.7",
     "@babel/register": "^7.12.1",
+    "chokidar": "^3.5.0",
     "fs-extra": "^9.0.1",
     "gatsby-graphql-source-toolkit": "^0.6.3",
     "p-map": "^4.0.0"

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.225.0-alpha.0",
+  "version": "0.225.1-alpha.0",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.223.1",
+  "version": "0.225.0-alpha.0",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-cms/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-cms/src/gatsby-node.ts
@@ -20,9 +20,6 @@ import type {
 import { sourceAllLocalNodes } from './node-api/sourceAllLocalNodes'
 import type { ContentTypes, Schemas } from './index'
 
-// VTEX IO workspace
-const WORKSPACE = process.env.GATSBY_VTEX_IO_WORKSPACE ?? 'master'
-
 interface CMSContentType {
   id: string
   name: string
@@ -47,20 +44,22 @@ const PREVIEW_PATH = '/cms/preview'
 
 interface Options {
   tenant: string
+  workspace?: string
 }
 
 export const pluginOptionsSchema = ({ Joi }: PluginOptionsSchemaArgs) =>
   Joi.object({
     tenant: Joi.string().required(),
+    workspace: Joi.string(),
   })
 
 export const sourceNodes = async (
   args: SourceNodesArgs,
-  { tenant }: Options
+  { tenant, workspace = 'master' }: Options
 ) => {
   // Step1. Set up remote schema:
   const executor = createDefaultQueryExecutor(
-    `https://${WORKSPACE}--${tenant}.myvtex.com/graphql`,
+    `https://${workspace}--${tenant}.myvtex.com/graphql`,
     {
       method: 'POST',
       headers: {

--- a/packages/gatsby-plugin-cms/src/index.ts
+++ b/packages/gatsby-plugin-cms/src/index.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema6 } from 'json-schema'
 
-interface Schema extends JSONSchema6 {
+export interface Schema extends JSONSchema6 {
   title: string
   description: string
 }

--- a/packages/gatsby-plugin-cms/src/node-api/actions/createNode.ts
+++ b/packages/gatsby-plugin-cms/src/node-api/actions/createNode.ts
@@ -1,0 +1,35 @@
+import { basename } from 'path'
+
+import { readJSON } from 'fs-extra'
+import type { ISourcingContext } from 'gatsby-graphql-source-toolkit/dist/types'
+import { createNodes } from 'gatsby-graphql-source-toolkit'
+
+import { remoteId } from '../remoteId'
+
+export const createNode = async (
+  context: ISourcingContext,
+  path: string,
+  update = false
+) => {
+  if (!path.endsWith('.json')) {
+    return
+  }
+
+  const json = await readJSON(path)
+
+  // TODO: We should add a verification if the json complies with the exported JSON schema
+  if (!json || Object.keys(json).length === 0) {
+    return
+  }
+
+  json.remoteId = remoteId(path)
+  json.remoteTypeName = 'PageContent'
+
+  context.gatsbyApi.reporter.info(
+    `[gatsby-plugin-cms]: ${
+      update ? 'Updating' : 'Creating'
+    } fixture from: ${basename(path)}`
+  )
+
+  createNodes(context, json.remoteTypeName, [json] as any)
+}

--- a/packages/gatsby-plugin-cms/src/node-api/actions/deleteNode.ts
+++ b/packages/gatsby-plugin-cms/src/node-api/actions/deleteNode.ts
@@ -1,0 +1,27 @@
+import { basename } from 'path'
+
+import { deleteNodes } from 'gatsby-graphql-source-toolkit'
+import type {
+  INodeDeleteEvent,
+  ISourcingContext,
+} from 'gatsby-graphql-source-toolkit/dist/types'
+
+import { remoteId } from '../remoteId'
+
+export const deleteNode = async (context: ISourcingContext, path: string) => {
+  if (!path.endsWith('.json')) {
+    return
+  }
+
+  context.gatsbyApi.reporter.info(
+    `[gatsby-plugin-cms]: Deleting fixture from: ${basename(path)}`
+  )
+
+  const event: INodeDeleteEvent = {
+    eventName: 'DELETE',
+    remoteTypeName: 'PageContent',
+    remoteId: { id: remoteId(path) },
+  }
+
+  deleteNodes(context, [event])
+}

--- a/packages/gatsby-plugin-cms/src/node-api/remoteId.ts
+++ b/packages/gatsby-plugin-cms/src/node-api/remoteId.ts
@@ -1,0 +1,3 @@
+import { basename } from 'path'
+
+export const remoteId = (path: string) => `fixture:${basename(path, '.json')}`

--- a/packages/gatsby-plugin-cms/src/node-api/sourceAllLocalNodes.ts
+++ b/packages/gatsby-plugin-cms/src/node-api/sourceAllLocalNodes.ts
@@ -1,0 +1,42 @@
+import { join } from 'path'
+
+import chokidar from 'chokidar'
+import { createSourcingContext } from 'gatsby-graphql-source-toolkit'
+import type { ISourcingConfig } from 'gatsby-graphql-source-toolkit/dist/types'
+
+import { createNode } from './actions/createNode'
+import { deleteNode } from './actions/deleteNode'
+
+/** Source Nodes from fixtures folder */
+export const sourceAllLocalNodes = async (
+  config: ISourcingConfig,
+  root: string,
+  name: string
+) => {
+  const context = createSourcingContext(config)
+
+  const watcher = chokidar.watch(join(root, 'src', name, 'fixtures'), {
+    ignoreInitial: false,
+    depth: 1,
+  })
+
+  watcher.on('add', (path) => createNode(context, path))
+  watcher.on('change', (path) => createNode(context, path, true))
+  watcher.on('unlink', (path) => deleteNode(context, path))
+
+  // Wait for chokidar ready event.
+  //
+  // If we don't wait for this event, gatsby will think this plugin didn't source any
+  // node and will ask to the developer to remove it. Since we are `ignoreInitial: false`
+  // we are sure chokidar will fire the ready event and not stall the build process
+  const onReady = new Promise((resolve) => {
+    watcher.on('ready', resolve)
+  })
+
+  await onReady
+
+  // Do not keep the watcher in `gatsby build`
+  if (process.env.NODE_ENV === 'production') {
+    watcher.close()
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4498,60 +4498,61 @@
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
 "@typescript-eslint/eslint-plugin@^2.10.0", "@typescript-eslint/eslint-plugin@^2.12.0", "@typescript-eslint/eslint-plugin@^2.24.0", "@typescript-eslint/eslint-plugin@^4", "@typescript-eslint/eslint-plugin@^4.8.1":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.10.0.tgz#19ed3baf4bc4232c5a7fcd32eaca75c3a5baf9f3"
-  integrity sha512-h6/V46o6aXpKRlarP1AiJEXuCJ7cMQdlpfMDrcllIgX3dFkLwEBTXAoNP98ZoOmqd1xvymMVRAI4e7yVvlzWEg==
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.13.0.tgz#5f580ea520fa46442deb82c038460c3dd3524bb6"
+  integrity sha512-ygqDUm+BUPvrr0jrXqoteMqmIaZ/bixYOc3A4BRwzEPTZPi6E+n44rzNZWaB0YvtukgP+aoj0i/fyx7FkM2p1w==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.10.0"
-    "@typescript-eslint/scope-manager" "4.10.0"
+    "@typescript-eslint/experimental-utils" "4.13.0"
+    "@typescript-eslint/scope-manager" "4.13.0"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
+    lodash "^4.17.15"
     regexpp "^3.0.0"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.10.0", "@typescript-eslint/experimental-utils@^4.0.1":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.10.0.tgz#dbf5d0f89802d5feaf7d11e5b32df29bbc2f3a0e"
-  integrity sha512-opX+7ai1sdWBOIoBgpVJrH5e89ra1KoLrJTz0UtWAa4IekkKmqDosk5r6xqRaNJfCXEfteW4HXQAwMdx+jjEmw==
+"@typescript-eslint/experimental-utils@4.13.0", "@typescript-eslint/experimental-utils@^4.0.1":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.13.0.tgz#9dc9ab375d65603b43d938a0786190a0c72be44e"
+  integrity sha512-/ZsuWmqagOzNkx30VWYV3MNB/Re/CGv/7EzlqZo5RegBN8tMuPaBgNK6vPBCQA8tcYrbsrTdbx3ixMRRKEEGVw==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.10.0"
-    "@typescript-eslint/types" "4.10.0"
-    "@typescript-eslint/typescript-estree" "4.10.0"
+    "@typescript-eslint/scope-manager" "4.13.0"
+    "@typescript-eslint/types" "4.13.0"
+    "@typescript-eslint/typescript-estree" "4.13.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
 "@typescript-eslint/parser@^2.10.0", "@typescript-eslint/parser@^2.12.0", "@typescript-eslint/parser@^2.24.0", "@typescript-eslint/parser@^4", "@typescript-eslint/parser@^4.8.1":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.10.0.tgz#1a622b0847b765b2d8f0ede6f0cdd85f03d76031"
-  integrity sha512-amBvUUGBMadzCW6c/qaZmfr3t9PyevcSWw7hY2FuevdZVp5QPw/K76VSQ5Sw3BxlgYCHZcK6DjIhSZK0PQNsQg==
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.13.0.tgz#c413d640ea66120cfcc37f891e8cb3fd1c9d247d"
+  integrity sha512-KO0J5SRF08pMXzq9+abyHnaGQgUJZ3Z3ax+pmqz9vl81JxmTTOUfQmq7/4awVfq09b6C4owNlOgOwp61pYRBSg==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.10.0"
-    "@typescript-eslint/types" "4.10.0"
-    "@typescript-eslint/typescript-estree" "4.10.0"
+    "@typescript-eslint/scope-manager" "4.13.0"
+    "@typescript-eslint/types" "4.13.0"
+    "@typescript-eslint/typescript-estree" "4.13.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.10.0":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.10.0.tgz#dbd7e1fc63d7363e3aaff742a6f2b8afdbac9d27"
-  integrity sha512-WAPVw35P+fcnOa8DEic0tQUhoJJsgt+g6DEcz257G7vHFMwmag58EfowdVbiNcdfcV27EFR0tUBVXkDoIvfisQ==
+"@typescript-eslint/scope-manager@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.13.0.tgz#5b45912a9aa26b29603d8fa28f5e09088b947141"
+  integrity sha512-UpK7YLG2JlTp/9G4CHe7GxOwd93RBf3aHO5L+pfjIrhtBvZjHKbMhBXTIQNkbz7HZ9XOe++yKrXutYm5KmjWgQ==
   dependencies:
-    "@typescript-eslint/types" "4.10.0"
-    "@typescript-eslint/visitor-keys" "4.10.0"
+    "@typescript-eslint/types" "4.13.0"
+    "@typescript-eslint/visitor-keys" "4.13.0"
 
-"@typescript-eslint/types@4.10.0":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.10.0.tgz#12f983750ebad867f0c806e705c1953cd6415789"
-  integrity sha512-+dt5w1+Lqyd7wIPMa4XhJxUuE8+YF+vxQ6zxHyhLGHJjHiunPf0wSV8LtQwkpmAsRi1lEOoOIR30FG5S2HS33g==
+"@typescript-eslint/types@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.13.0.tgz#6a7c6015a59a08fbd70daa8c83dfff86250502f8"
+  integrity sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==
 
-"@typescript-eslint/typescript-estree@4.10.0":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.10.0.tgz#1e62e45fd57866afd42daf5e9fb6bd4e8dbcfa75"
-  integrity sha512-mGK0YRp9TOk6ZqZ98F++bW6X5kMTzCRROJkGXH62d2azhghmq+1LNLylkGe6uGUOQzD452NOAEth5VAF6PDo5g==
+"@typescript-eslint/typescript-estree@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.13.0.tgz#cf6e2207c7d760f5dfd8d18051428fadfc37b45e"
+  integrity sha512-9A0/DFZZLlGXn5XA349dWQFwPZxcyYyCFX5X88nWs2uachRDwGeyPz46oTsm9ZJE66EALvEns1lvBwa4d9QxMg==
   dependencies:
-    "@typescript-eslint/types" "4.10.0"
-    "@typescript-eslint/visitor-keys" "4.10.0"
+    "@typescript-eslint/types" "4.13.0"
+    "@typescript-eslint/visitor-keys" "4.13.0"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -4559,12 +4560,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.10.0":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.10.0.tgz#9478822329a9bc8ebcc80623d7f79a01da5ee451"
-  integrity sha512-hPyz5qmDMuZWFtHZkjcCpkAKHX8vdu1G3YsCLEd25ryZgnJfj6FQuJ5/O7R+dB1ueszilJmAFMtlU4CA6se3Jg==
+"@typescript-eslint/visitor-keys@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.13.0.tgz#9acb1772d3b3183182b6540d3734143dce9476fe"
+  integrity sha512-6RoxWK05PAibukE7jElqAtNMq+RWZyqJ6Q/GdIxaiUj2Ept8jh8+FUVlbq9WxMYxkmEOPvCE5cRSyupMpwW31g==
   dependencies:
-    "@typescript-eslint/types" "4.10.0"
+    "@typescript-eslint/types" "4.13.0"
     eslint-visitor-keys "^2.0.0"
 
 "@vtex-components/accordion@^0.2.3":
@@ -6963,6 +6964,21 @@ chokidar@^3.3.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.4.3:
     readdirp "~3.5.0"
   optionalDependencies:
     fsevents "~2.1.2"
+
+chokidar@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.0.tgz#458a4816a415e9d3b3caa4faec2b96a6935a9e65"
+  integrity sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
 
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
@@ -9375,9 +9391,9 @@ eslint-plugin-prettier@^3.1.0:
     prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-prettier@^3.1.4:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.0.tgz#61e295349a65688ffac0b7808ef0a8244bdd8d40"
-  integrity sha512-tMTwO8iUWlSRZIwS9k7/E4vrTsfvsrcM5p1eftyuqWH25nKsz/o6/54I7jwQ/3zobISyC7wMy9ZsFwgTxOcOpQ==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
+  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -10485,6 +10501,11 @@ fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
+fsevents@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
+  integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
 
 function-bind@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR makes it possible to use fixtures for local development using the CMS plugin. Also, this implies that starters may define standard pages for initial development

## How it works? 
Any json added to the `fixtures` folder in the shadowed path will appear as a `PageContent` instance.
The developer can then query this artificial `PageContent` to program the pages locally.  In the future, we may be able to create an interface that outputs the PageContent automatically and help the development process.  

All changes done inside the `fixtures` folder is watched by a filesystem watcher that re-sources any changed node, thus making incremental builds possible

To a more detailed implementation: [check out how storecomponents use this feature](https://github.com/vtex-sites/storecomponents.store/pull/428)

## How to test it?
<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
