### PR TITLE
Error handler in page wrapper

### DIFF
--- a/packages/gatsby-theme-store/i18n/en.json
+++ b/packages/gatsby-theme-store/i18n/en.json
@@ -118,5 +118,10 @@
   "login.button.greeting": "Hello, {name}",
   "login.button.action": "Sign In",
 
-  "preview.not-found": "No Preview found. Waiting for input"
+  "preview.not-found": "No Preview found. Waiting for input",
+
+  "error.title": "Ops, an error has occured!",
+  "error.action": "Please, go back and try again",
+  "error.action.button": "Go Back",
+  "error.detail": "Error: {errorId}"
 }

--- a/packages/gatsby-theme-store/i18n/en.json
+++ b/packages/gatsby-theme-store/i18n/en.json
@@ -118,8 +118,6 @@
   "login.button.greeting": "Hello, {name}",
   "login.button.action": "Sign In",
 
-  "preview.not-found": "No Preview found. Waiting for input",
-
   "error.title": "Ops, an error has occured!",
   "error.action": "Please, go back and try again",
   "error.action.button": "Go Back",

--- a/packages/gatsby-theme-store/i18n/pt.json
+++ b/packages/gatsby-theme-store/i18n/pt.json
@@ -118,5 +118,10 @@
   "login.button.greeting": "Ola {name}",
   "login.button.action": "Entrar",
 
-  "preview.not-found": "Pre-visualização não econtrada. Esperando por entradas"
+  "preview.not-found": "Pre-visualização não econtrada. Esperando por entradas",
+
+  "error.title": "Ops, ocorreu um erro!",
+  "error.action": "Por favor, volte ao início e tente novamente",
+  "error.action.button": "Voltar ao início",
+  "error.detail": "Erro: {errorId}"
 }

--- a/packages/gatsby-theme-store/i18n/pt.json
+++ b/packages/gatsby-theme-store/i18n/pt.json
@@ -118,8 +118,6 @@
   "login.button.greeting": "Ola {name}",
   "login.button.action": "Entrar",
 
-  "preview.not-found": "Pre-visualização não econtrada. Esperando por entradas",
-
   "error.title": "Ops, ocorreu um erro!",
   "error.action": "Por favor, volte ao início e tente novamente",
   "error.action.button": "Voltar ao início",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.226.0-alpha.1",
+  "version": "0.226.0-alpha.2",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.224.0",
+  "version": "0.225.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.225.0-alpha.0",
+  "version": "0.226.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.226.0-alpha.0",
+  "version": "0.226.0-alpha.1",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.226.0-alpha.2",
+  "version": "0.226.0-alpha.3",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/src/components/Error/Error.tsx
+++ b/packages/gatsby-theme-store/src/components/Error/Error.tsx
@@ -8,7 +8,7 @@ import Container from '../Container'
 
 type Props = {
   error: any
-  errorId: string
+  errorId?: string
 }
 
 const uuidv4 = () =>

--- a/packages/gatsby-theme-store/src/components/Error/Error.tsx
+++ b/packages/gatsby-theme-store/src/components/Error/Error.tsx
@@ -1,18 +1,81 @@
-import React from 'react'
+import { FormattedMessage, useLocalizedPath } from '@vtex/gatsby-plugin-i18n'
+import React, { useEffect, useMemo, useState } from 'react'
 import type { FC } from 'react'
+import { Box, Button, Flex } from '@vtex/store-ui'
 
 import Layout from '../Layout'
+import Container from '../Container'
 
 type Props = {
   error: any
+  errorId: string
 }
 
-const Error: FC<Props> = ({ error }) => (
-  <Layout>
-    <div>
-      Something went wrong. <pre>{JSON.stringify(error, null, 2)}</pre>
-    </div>
-  </Layout>
-)
+const uuidv4 = () =>
+  'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+
+    return v.toString(16)
+  })
+
+const Error: FC<Props> = ({ error, errorId = uuidv4() }) => {
+  const path = useLocalizedPath('/')
+
+  useEffect(() => console.error(error))
+
+  return (
+    <Layout>
+      <Container>
+        <Flex p={2} sx={{ alignItems: 'center', flexDirection: 'column' }}>
+          <Box
+            as="h3"
+            sx={{
+              fontSize: '43px',
+              fontWeight: '600',
+              textAlign: 'center',
+              color: 'primary',
+              mt: '50px',
+            }}
+          >
+            <FormattedMessage id="error.title" />
+          </Box>
+          <Box
+            as="p"
+            sx={{
+              paddingX: '15px',
+              fontSize: '20px',
+              textAlign: 'center',
+              marginBottom: '30px',
+            }}
+          >
+            <FormattedMessage id="error.action" />
+          </Box>
+
+          <Button
+            onClick={() => {
+              window.location.href = path
+            }}
+          >
+            <FormattedMessage id="error.action.button" />
+          </Button>
+
+          <Box
+            as="p"
+            sx={{
+              paddingX: '15px',
+              fontSize: '14px',
+              textAlign: 'center',
+              marginTop: '20px',
+              color: '#656565',
+            }}
+          >
+            <FormattedMessage id="error.detail" values={{ errorId }} />
+          </Box>
+        </Flex>
+      </Container>
+    </Layout>
+  )
+}
 
 export default Error

--- a/packages/gatsby-theme-store/src/components/Error/Error.tsx
+++ b/packages/gatsby-theme-store/src/components/Error/Error.tsx
@@ -1,5 +1,5 @@
 import { FormattedMessage, useLocalizedPath } from '@vtex/gatsby-plugin-i18n'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect } from 'react'
 import type { FC } from 'react'
 import { Box, Button, Flex } from '@vtex/store-ui'
 

--- a/packages/gatsby-theme-store/src/gatsby-browser.tsx
+++ b/packages/gatsby-theme-store/src/gatsby-browser.tsx
@@ -11,6 +11,11 @@ import type { ElementType } from 'react'
 const { OrderFormProvider } = require('./src/sdk/orderForm/Provider')
 const { MinicartProvider } = require('./src/sdk/minicart/index')
 const { default: VTEXRCProvider } = require('./src/sdk/pixel/vtexrc/index')
+const { default: ErrorHandler } = require('./src/components/Error/ErrorHandler')
+const {
+  default: ErrorBoundary,
+} = require('./src/components/Error/ErrorBoundary')
+// eslint-disable-next-line padding-line-between-statements
 const {
   Progress,
   onRouteUpdate: progressOnRouteUpdate,
@@ -60,7 +65,9 @@ export const wrapPageElement = ({
   element,
   props: { location },
 }: WrapRootElementBrowserArgs | any) => (
-  <Progress location={location}>{element}</Progress>
+  <ErrorBoundary fallback={(error: any) => <ErrorHandler error={error} />}>
+    <Progress location={location}>{element}</Progress>
+  </ErrorBoundary>
 )
 
 export const onRouteUpdate = () => {

--- a/packages/gatsby-theme-store/src/pages/account.tsx
+++ b/packages/gatsby-theme-store/src/pages/account.tsx
@@ -5,8 +5,6 @@ import React, { useEffect, useState } from 'react'
 import type { FC } from 'react'
 
 import Container from '../components/Container'
-import ErrorBoundary from '../components/Error/ErrorBoundary'
-import ErrorHandler from '../components/Error/ErrorHandler'
 import Layout from '../components/Layout'
 import SuspenseSSR from '../components/Suspense/SSR'
 import RenderExtensionLoader from '../sdk/RenderExtensionLoader'
@@ -90,15 +88,13 @@ const MyAccount: FC = () => {
 }
 
 const Page: FC = () => (
-  <ErrorBoundary fallback={(error) => <ErrorHandler error={error} />}>
-    <Layout>
-      <Container>
-        <SuspenseSSR fallback={<Loading />}>
-          <MyAccount />
-        </SuspenseSSR>
-      </Container>
-    </Layout>
-  </ErrorBoundary>
+  <Layout>
+    <Container>
+      <SuspenseSSR fallback={<Loading />}>
+        <MyAccount />
+      </SuspenseSSR>
+    </Container>
+  </Layout>
 )
 
 export default Page

--- a/packages/gatsby-theme-store/src/pages/index.tsx
+++ b/packages/gatsby-theme-store/src/pages/index.tsx
@@ -2,8 +2,6 @@ import React, { lazy } from 'react'
 import type { PageProps } from 'gatsby'
 import type { FC } from 'react'
 
-import ErrorBoundary from '../components/Error/ErrorBoundary'
-import ErrorHandler from '../components/Error/ErrorHandler'
 import AboveTheFold from '../components/HomePage/AboveTheFold'
 import BelowTheFoldPreview from '../components/HomePage/BelowTheFoldPreview'
 import SEO from '../components/HomePage/SEO'
@@ -34,18 +32,16 @@ const Home: FC<Props> = (props) => {
   })
 
   return (
-    <ErrorBoundary fallback={(error) => <ErrorHandler error={error} />}>
-      <Layout>
-        <SEO {...props} />
-        <AboveTheFold {...props} />
-        <SuspenseViewport
-          fallback={<BelowTheFoldPreview />}
-          preloader={belowTheFoldPreloader}
-        >
-          <BelowTheFold {...props} />
-        </SuspenseViewport>
-      </Layout>
-    </ErrorBoundary>
+    <Layout>
+      <SEO {...props} />
+      <AboveTheFold {...props} />
+      <SuspenseViewport
+        fallback={<BelowTheFoldPreview />}
+        preloader={belowTheFoldPreloader}
+      >
+        <BelowTheFold {...props} />
+      </SuspenseViewport>
+    </Layout>
   )
 }
 

--- a/packages/gatsby-theme-store/src/pages/login.tsx
+++ b/packages/gatsby-theme-store/src/pages/login.tsx
@@ -5,8 +5,6 @@ import type { FC } from 'react'
 import type { PageProps } from 'gatsby'
 
 import { AUTH_PROVIDERS } from '../components/Auth/Providers'
-import ErrorBoundary from '../components/Error/ErrorBoundary'
-import ErrorHandler from '../components/Error/ErrorHandler'
 import Layout from '../components/Layout'
 import SuspenseSSR from '../components/Suspense/SSR'
 import { useOnLoginSuccessful } from '../sdk/auth/useOnLoginSuccessful'
@@ -74,19 +72,17 @@ const Page: FC = () => {
 // We split into two components to avoid re-rendering the <Layout/> when
 // selecting Auth method
 const PageWithLayout: FC<Props> = () => (
-  <ErrorBoundary fallback={(error) => <ErrorHandler error={error} />}>
-    <Layout>
-      <SuspenseSSR
-        fallback={
-          <Center height="300px">
-            <Spinner />
-          </Center>
-        }
-      >
-        <Page />
-      </SuspenseSSR>
-    </Layout>
-  </ErrorBoundary>
+  <Layout>
+    <SuspenseSSR
+      fallback={
+        <Center height="300px">
+          <Spinner />
+        </Center>
+      }
+    >
+      <Page />
+    </SuspenseSSR>
+  </Layout>
 )
 
 export default PageWithLayout

--- a/packages/gatsby-theme-store/src/templates/404.tsx
+++ b/packages/gatsby-theme-store/src/templates/404.tsx
@@ -2,21 +2,17 @@ import React from 'react'
 import type { FC } from 'react'
 
 import Container from '../components/Container'
-import ErrorBoundary from '../components/Error/ErrorBoundary'
-import ErrorHandler from '../components/Error/ErrorHandler'
 import SiteMetadata from '../components/SEO/SiteMetadata'
 import Layout from '../components/Layout'
 
 const NotFoundPage: FC = () => (
-  <ErrorBoundary fallback={(error) => <ErrorHandler error={error} />}>
-    <Layout>
-      <SiteMetadata title="404: Not found" />
-      <Container>
-        <h1>NOT FOUND</h1>
-        <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
-      </Container>
-    </Layout>
-  </ErrorBoundary>
+  <Layout>
+    <SiteMetadata title="404: Not found" />
+    <Container>
+      <h1>NOT FOUND</h1>
+      <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+    </Container>
+  </Layout>
 )
 
 export default NotFoundPage

--- a/packages/gatsby-theme-store/src/templates/product.tsx
+++ b/packages/gatsby-theme-store/src/templates/product.tsx
@@ -3,8 +3,6 @@ import React, { lazy } from 'react'
 import type { PageProps } from 'gatsby'
 import type { FC } from 'react'
 
-import ErrorBoundary from '../components/Error/ErrorBoundary'
-import ErrorHandler from '../components/Error/ErrorHandler'
 import HybridWrapper from '../components/HybridWrapper'
 import Layout from '../components/Layout'
 import AboveTheFold from '../components/ProductPage/AboveTheFold'
@@ -94,16 +92,14 @@ const Page: FC<ProductPageProps> = (props) => {
   } = props
 
   return (
-    <ErrorBoundary fallback={(error) => <ErrorHandler error={error} />}>
-      <Layout>
-        <HybridWrapper
-          isPrerendered={staticPath}
-          fallback={<AboveTheFoldPreview />}
-        >
-          <ProductPage {...props} />
-        </HybridWrapper>
-      </Layout>
-    </ErrorBoundary>
+    <Layout>
+      <HybridWrapper
+        isPrerendered={staticPath}
+        fallback={<AboveTheFoldPreview />}
+      >
+        <ProductPage {...props} />
+      </HybridWrapper>
+    </Layout>
   )
 }
 

--- a/packages/gatsby-theme-store/src/templates/search.tsx
+++ b/packages/gatsby-theme-store/src/templates/search.tsx
@@ -1,10 +1,8 @@
 import { graphql } from 'gatsby'
-import type { FC } from 'react'
 import React, { lazy } from 'react'
+import type { FC } from 'react'
 import type { PageProps } from 'gatsby'
 
-import ErrorBoundary from '../components/Error/ErrorBoundary'
-import ErrorHandler from '../components/Error/ErrorHandler'
 import HybridWrapper from '../components/HybridWrapper'
 import Layout from '../components/Layout'
 import AboveTheFold from '../components/SearchPage/AboveTheFold'
@@ -103,16 +101,14 @@ const Page: FC<SearchPageProps> = (props) => {
   } = props
 
   return (
-    <ErrorBoundary fallback={(error) => <ErrorHandler error={error} />}>
-      <Layout>
-        <HybridWrapper
-          isPrerendered={staticPath}
-          fallback={<AboveTheFoldPreview />}
-        >
-          <SearchPage {...props} />
-        </HybridWrapper>
-      </Layout>
-    </ErrorBoundary>
+    <Layout>
+      <HybridWrapper
+        isPrerendered={staticPath}
+        fallback={<AboveTheFoldPreview />}
+      >
+        <SearchPage {...props} />
+      </HybridWrapper>
+    </Layout>
   )
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?
Move error boundary to page wrapper

Error boundaries had to be manually inserted in each page. If a developer didn't think about error boundaries, no error boundary would be added to the page. We had such error in the `institucional` pages at marinbrasil were no error boundaries were present.

## How it works? 
Error boundaries were moved from each page into the `wrapPageElement`.  When we were developing error boundaries the first time, we couldn't place it into wrapPageElement because the i18n plugin used the same API, thus breaking a lot of error handling pages. After a complete refactor in i18n plugin, it uses the wrapRootElement API and we can now add default error boundaries in `wrapPageElement`

## How to test it?
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/431)
[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/298)

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
