### PR TITLE
Fix one click buy

### DIFF
--- a/packages/gatsby-theme-store/src/sdk/buyButton/useBuyButton.ts
+++ b/packages/gatsby-theme-store/src/sdk/buyButton/useBuyButton.ts
@@ -29,8 +29,8 @@ export interface Props {
 export const useBuyButton = ({
   sku,
   quantity,
-  oneClickBuy,
-  openMinicart,
+  oneClickBuy = false,
+  openMinicart = true,
 }: Props) => {
   const minicart = useMinicart()
   const [loading, setLoading] = useState(false)
@@ -40,13 +40,13 @@ export const useBuyButton = ({
 
   // Redirects the user to checkout after reassuring the pixel event was received
   usePixelEvent((e) => {
-    if (!oneClickBuy || e.type !== 'vtex:addToCart') {
+    if (e.type !== 'vtex:addToCart') {
       return
     }
 
     const isThisItem = e.data.items[0].id?.toString() === sku?.itemId
 
-    if (!isThisItem) {
+    if (!isThisItem || !e.data.oneClickBuy) {
       return
     }
 
@@ -84,6 +84,7 @@ export const useBuyButton = ({
         type: 'vtex:addToCart',
         data: {
           items,
+          oneClickBuy,
         },
       })
     } catch (err) {

--- a/packages/gatsby-theme-store/src/sdk/pixel/events.ts
+++ b/packages/gatsby-theme-store/src/sdk/pixel/events.ts
@@ -45,6 +45,7 @@ export interface InternalSiteSearchViewData extends PageViewData {
 
 export interface AddToCartData {
   items: OrderFormItem[]
+  oneClickBuy?: boolean
 }
 
 export interface RemoveFromCartData {


### PR DESCRIPTION
## What's the purpose of this pull request?
Make it possible to have an interface like:
![image](https://user-images.githubusercontent.com/1753396/104455378-f7b86400-5585-11eb-868f-6806b71b27c5.png)

## How it works? 
Because we were not sending the oneClickBuy in the pixel event, if we had two buttons, one with oneClickBuy option an another without it, the pixel event would be launched and we would always end up navigating into the checkout. This PR fixes this bug by sending the oneClickBuy option to the event

## How to test it?
<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
