### PR TITLE
No follow no index in `/account` and in `/login`

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.230.0",
+  "version": "0.231.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.230.0",
+  "version": "0.231.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/src/pages/account.tsx
+++ b/packages/gatsby-theme-store/src/pages/account.tsx
@@ -3,6 +3,7 @@ import { Center, Spinner } from '@vtex/store-ui'
 import { navigate } from 'gatsby'
 import React, { useEffect, useState } from 'react'
 import type { FC } from 'react'
+import { Helmet } from 'react-helmet-async'
 
 import Container from '../components/Container'
 import Layout from '../components/Layout'
@@ -88,13 +89,18 @@ const MyAccount: FC = () => {
 }
 
 const Page: FC = () => (
-  <Layout>
-    <Container>
-      <SuspenseSSR fallback={<Loading />}>
-        <MyAccount />
-      </SuspenseSSR>
-    </Container>
-  </Layout>
+  <>
+    <Helmet>
+      <meta name="robots" content="noindex, nofollow" />
+    </Helmet>
+    <Layout>
+      <Container>
+        <SuspenseSSR fallback={<Loading />}>
+          <MyAccount />
+        </SuspenseSSR>
+      </Container>
+    </Layout>
+  </>
 )
 
 export default Page

--- a/packages/gatsby-theme-store/src/pages/account.tsx
+++ b/packages/gatsby-theme-store/src/pages/account.tsx
@@ -3,13 +3,13 @@ import { Center, Spinner } from '@vtex/store-ui'
 import { navigate } from 'gatsby'
 import React, { useEffect, useState } from 'react'
 import type { FC } from 'react'
-import { Helmet } from 'react-helmet-async'
 
 import Container from '../components/Container'
 import Layout from '../components/Layout'
 import SuspenseSSR from '../components/Suspense/SSR'
 import RenderExtensionLoader from '../sdk/RenderExtensionLoader'
 import { useProfile } from '../sdk/session/useProfile'
+import Helmet from '../components/SEO/Helmet'
 
 const MY_ACCOUNT_PATH = '/account'
 const MY_ACCOUNT_DIV_NAME = 'my-account'
@@ -90,9 +90,15 @@ const MyAccount: FC = () => {
 
 const Page: FC = () => (
   <>
-    <Helmet defer={false} async={false}>
-      <meta name="robots" content="noindex, nofollow" />
-    </Helmet>
+    <Helmet
+      meta={[
+        {
+          name: 'robots',
+          content: 'noindex, nofollow',
+        },
+      ]}
+    />
+
     <Layout>
       <Container>
         <SuspenseSSR fallback={<Loading />}>

--- a/packages/gatsby-theme-store/src/pages/account.tsx
+++ b/packages/gatsby-theme-store/src/pages/account.tsx
@@ -90,7 +90,7 @@ const MyAccount: FC = () => {
 
 const Page: FC = () => (
   <>
-    <Helmet>
+    <Helmet defer={false} async={false}>
       <meta name="robots" content="noindex, nofollow" />
     </Helmet>
     <Layout>

--- a/packages/gatsby-theme-store/src/pages/login.tsx
+++ b/packages/gatsby-theme-store/src/pages/login.tsx
@@ -3,13 +3,13 @@ import { Box, Center, Flex, Spinner } from '@vtex/store-ui'
 import React, { useEffect, useState } from 'react'
 import type { FC } from 'react'
 import type { PageProps } from 'gatsby'
-import { Helmet } from 'react-helmet-async'
 
 import { AUTH_PROVIDERS } from '../components/Auth/Providers'
 import Layout from '../components/Layout'
 import SuspenseSSR from '../components/Suspense/SSR'
 import { useOnLoginSuccessful } from '../sdk/auth/useOnLoginSuccessful'
 import { useProfile } from '../sdk/session/useProfile'
+import Helmet from '../components/SEO/Helmet'
 
 type Props = PageProps<unknown>
 
@@ -74,9 +74,15 @@ const Page: FC = () => {
 // selecting Auth method
 const PageWithLayout: FC<Props> = () => (
   <>
-    <Helmet defer={false} async={false}>
-      <meta name="robots" content="noindex, nofollow" />
-    </Helmet>
+    <Helmet
+      meta={[
+        {
+          name: 'robots',
+          content: 'noindex, nofollow',
+        },
+      ]}
+    />
+
     <Layout>
       <SuspenseSSR
         fallback={

--- a/packages/gatsby-theme-store/src/pages/login.tsx
+++ b/packages/gatsby-theme-store/src/pages/login.tsx
@@ -3,6 +3,7 @@ import { Box, Center, Flex, Spinner } from '@vtex/store-ui'
 import React, { useEffect, useState } from 'react'
 import type { FC } from 'react'
 import type { PageProps } from 'gatsby'
+import { Helmet } from 'react-helmet-async'
 
 import { AUTH_PROVIDERS } from '../components/Auth/Providers'
 import Layout from '../components/Layout'
@@ -72,17 +73,22 @@ const Page: FC = () => {
 // We split into two components to avoid re-rendering the <Layout/> when
 // selecting Auth method
 const PageWithLayout: FC<Props> = () => (
-  <Layout>
-    <SuspenseSSR
-      fallback={
-        <Center height="300px">
-          <Spinner />
-        </Center>
-      }
-    >
-      <Page />
-    </SuspenseSSR>
-  </Layout>
+  <>
+    <Helmet>
+      <meta name="robots" content="noindex, nofollow" />
+    </Helmet>
+    <Layout>
+      <SuspenseSSR
+        fallback={
+          <Center height="300px">
+            <Spinner />
+          </Center>
+        }
+      >
+        <Page />
+      </SuspenseSSR>
+    </Layout>
+  </>
 )
 
 export default PageWithLayout

--- a/packages/gatsby-theme-store/src/pages/login.tsx
+++ b/packages/gatsby-theme-store/src/pages/login.tsx
@@ -74,7 +74,7 @@ const Page: FC = () => {
 // selecting Auth method
 const PageWithLayout: FC<Props> = () => (
   <>
-    <Helmet>
+    <Helmet defer={false} async={false}>
       <meta name="robots" content="noindex, nofollow" />
     </Helmet>
     <Layout>


### PR DESCRIPTION
## What's the purpose of this pull request?
As title says, this adds `<meta name="robots" content="noindex, nofollow" />` on these pages because google was indexing them

![image](https://user-images.githubusercontent.com/1753396/104632002-d33eb380-567b-11eb-91dd-662e4a4ee567.png)

With this PR we hope to make google remove this `Entrar` in google search page

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
