### PR TITLE
Fix `once` function

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.231.4",
+  "version": "0.232.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.231.4",
+  "version": "0.232.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/src/sdk/once.ts
+++ b/packages/gatsby-theme-store/src/sdk/once.ts
@@ -4,7 +4,7 @@ export const once = <T extends (...args: any[]) => any>(fn: T) => {
 
   return (...args: Parameters<T>) => {
     if (run === true) {
-      res = fn(args)
+      res = fn(...args)
       run = false
     }
 


### PR DESCRIPTION
## What's the purpose of this pull request?
`once` function parameters were wrong, this caused the [nprogress](https://ricostacruz.com/nprogress/) loading bar to not being displayed

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
[marin](https://github.com/vtex-sites/marinbrasil.store/pull/309)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/436)
[btglobal](https://github.com/vtex-sites/btglobal.store/pull/2)

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
