### PR TITLE
Static Paths

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.233.0-alpha.0",
+  "version": "0.233.0-alpha.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.233.0-alpha.2",
+  "version": "0.233.0-alpha.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.233.0-alpha.1",
+  "version": "0.233.0-alpha.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.232.0",
+  "version": "0.233.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.233.0-alpha.0",
+  "version": "0.233.0-alpha.1",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.233.0-alpha.2",
+  "version": "0.233.0-alpha.3",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.233.0-alpha.1",
+  "version": "0.233.0-alpha.2",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.230.0",
+  "version": "0.233.0-alpha.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/src/api.ts
+++ b/packages/gatsby-source-vtex/src/api.ts
@@ -5,7 +5,7 @@ export const api = {
     category: {
       tree: (depth: number) => `/api/catalog_system/pub/category/tree/${depth}`,
       search: ({
-        sort = 'OrderByTopSaleDESC',
+        sort = '',
         from,
         to,
       }: {

--- a/packages/gatsby-source-vtex/src/api.ts
+++ b/packages/gatsby-source-vtex/src/api.ts
@@ -1,7 +1,19 @@
+import type { Sort } from './types'
+
 export const api = {
   catalog: {
     category: {
       tree: (depth: number) => `/api/catalog_system/pub/category/tree/${depth}`,
+      search: ({
+        sort = 'OrderByTopSaleDESC',
+        from,
+        to,
+      }: {
+        sort?: Sort
+        from: number
+        to: number
+      }) =>
+        `/api/catalog_system/pub/products/search?O=${sort}&_from=${from}&_to=${to}`,
     },
   },
   tenants: {

--- a/packages/gatsby-source-vtex/src/staticPaths.ts
+++ b/packages/gatsby-source-vtex/src/staticPaths.ts
@@ -50,7 +50,7 @@ const staticPaths = async ({
 
   // This generates at least `itemsPerPage` and at most 2500 product paths
   // `itemsPerPage` is an arbritary number, however 2500 is hard coded in VTEX search
-  const itemsPerPage = 49
+  const itemsPerPage = 25
   const pagination = new Array(
     Math.ceil(
       Math.min(2500, Math.max(itemsPerPage, pages - paths.length)) /

--- a/packages/gatsby-source-vtex/src/staticPaths.ts
+++ b/packages/gatsby-source-vtex/src/staticPaths.ts
@@ -63,6 +63,7 @@ const staticPaths = async ({
     (_, pageIndex) =>
       fetchVTEX<Array<{ linkText?: string }>>(
         api.catalog.category.search({
+          sort: 'OrderByTopSaleDESC',
           from: pageIndex * itemsPerPage,
           to: pageIndex * itemsPerPage + itemsPerPage,
         }),

--- a/packages/gatsby-source-vtex/src/staticPaths.ts
+++ b/packages/gatsby-source-vtex/src/staticPaths.ts
@@ -1,0 +1,60 @@
+import { api } from './api'
+import { fetchVTEX } from './fetch'
+import type { Category } from './types'
+
+interface Options {
+  tenant: string
+  workspace?: string
+  environment?: 'vtexcommercestable' | 'vtexcommercebeta'
+  pages?: number // max number of staticPaths to generate
+}
+
+const dfs = (root: Category, paths: string[]) => {
+  const url = new URL(root.url)
+
+  paths.push(url.pathname.toLowerCase())
+
+  for (const child of root.children) {
+    dfs(child, paths)
+  }
+}
+
+const staticPaths = async ({
+  tenant,
+  workspace = 'master',
+  environment = 'vtexcommercestable',
+  pages = 500,
+}: Options): Promise<string[]> => {
+  const options = {
+    tenant,
+    workspace,
+    environment,
+  }
+
+  const tree = await fetchVTEX<Category[]>(
+    api.catalog.category.tree(4),
+    options
+  )
+
+  const paths: string[] = []
+
+  for (const node of tree) {
+    dfs(node, paths)
+  }
+
+  const products = await fetchVTEX<Array<{ linkText: string }>>(
+    api.catalog.category.search({
+      from: 0,
+      to: Math.max(10, pages - paths.length), // at least 10 products
+    }),
+    options
+  )
+
+  for (const { linkText } of products) {
+    paths.push(`/${linkText}/p`)
+  }
+
+  return paths
+}
+
+export default staticPaths

--- a/packages/gatsby-source-vtex/src/staticPaths.ts
+++ b/packages/gatsby-source-vtex/src/staticPaths.ts
@@ -25,6 +25,9 @@ const staticPaths = async ({
   environment = 'vtexcommercestable',
   pages = 500,
 }: Options): Promise<string[]> => {
+  // eslint-disable-next-line no-console
+  console.log('[gatsby-source-vtex]: starting getting staticPaths')
+
   const options = {
     tenant,
     workspace,
@@ -42,6 +45,9 @@ const staticPaths = async ({
     dfs(node, paths)
   }
 
+  // eslint-disable-next-line no-console
+  console.log('[gatsby-source-vtex]: categories', paths)
+
   const products = await fetchVTEX<Array<{ linkText: string }>>(
     api.catalog.category.search({
       from: 0,
@@ -53,6 +59,9 @@ const staticPaths = async ({
   for (const { linkText } of products) {
     paths.push(`/${linkText}/p`)
   }
+
+  // eslint-disable-next-line no-console
+  console.log('[gatsby-source-vtex]: categories + products', paths)
 
   return paths
 }

--- a/packages/gatsby-source-vtex/src/types.ts
+++ b/packages/gatsby-source-vtex/src/types.ts
@@ -52,3 +52,14 @@ export interface Category {
   MetaTagDescription: string
   LinkId: string
 }
+
+export type Sort =
+  | 'OrderByPriceDESC'
+  | 'OrderByPriceASC'
+  | 'OrderByTopSaleDESC'
+  | 'OrderByReviewRateDESC'
+  | 'OrderByNameASC'
+  | 'OrderByNameDESC'
+  | 'OrderByReleaseDateDESC'
+  | 'OrderByBestDiscountDESC'
+  | 'OrderByScoreDESC'

--- a/packages/gatsby-source-vtex/src/types.ts
+++ b/packages/gatsby-source-vtex/src/types.ts
@@ -63,3 +63,4 @@ export type Sort =
   | 'OrderByReleaseDateDESC'
   | 'OrderByBestDiscountDESC'
   | 'OrderByScoreDESC'
+  | ''


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR exposes a new function called `staticPaths` from `@vtex/gatsby-source-vtex` to generate the staticPaths. This function exports all category paths along with the best selling products to statically generate the most importante pages. This is the first step toward an intelligent page generation algorithm

## How it works? 
Generates all category paths, alongside the best selling products.

## How to test it?
[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/310)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/439)
[btglobal](https://github.com/vtex-sites/btglobal.store/pull/4)

## References
<em>Spread the knowledge: is this any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em> 
