### PR TITLE
Move RichText and Shelf to store-ui

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.243.0",
+  "version": "0.243.1-shelf.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
@@ -7,5 +7,7 @@
       "message": "Release: %v"
     }
   },
-  "packages": ["packages/*"]
+  "packages": [
+    "packages/*"
+  ]
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.243.0",
+  "version": "0.243.1-shelf.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -36,7 +36,7 @@
     "@vtex/gatsby-plugin-graphql": "^0.214.0-alpha.6",
     "@vtex/gatsby-plugin-i18n": "^0.243.0",
     "@vtex/gatsby-plugin-theme-ui": "^0.243.0",
-    "@vtex/store-ui": "^0.243.0",
+    "@vtex/store-ui": "^0.243.1-shelf.0",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/gatsby-theme-store/src/components/Shelf/index.tsx
+++ b/packages/gatsby-theme-store/src/components/Shelf/index.tsx
@@ -50,18 +50,18 @@ const Shelf: FC<Props> = ({
     autoplay,
   })
 
-  showArrows =
+  const shouldShowArrows =
     showArrows && products && products.length >= Math.max(...pageSizes)
 
   return (
     <>
       {title && <ShelfTitle variant={variant}>{title}</ShelfTitle>}
       <Flex {...dragHandlers}>
-        {showArrows && (
+        {shouldShowArrows && (
           <ShelfArrowLeft variant={variant} onClick={() => setPreviousPage()} />
         )}
         <ShelfPage variant={variant} items={items} pageSizes={pageSizes} />
-        {showArrows && (
+        {shouldShowArrows && (
           <ShelfArrowRight variant={variant} onClick={() => setNextPage()} />
         )}
       </Flex>

--- a/packages/gatsby-theme-store/src/components/Shelf/index.tsx
+++ b/packages/gatsby-theme-store/src/components/Shelf/index.tsx
@@ -19,7 +19,7 @@ export interface Props {
   pageSizes?: number[]
   title?: JSX.Element | string
   variant?: string
-  showArrows?: Maybe<boolean>
+  showArrows?: boolean | null
   showDots?: boolean
   autoplay?: number
 }

--- a/packages/gatsby-theme-store/src/components/Shelf/index.tsx
+++ b/packages/gatsby-theme-store/src/components/Shelf/index.tsx
@@ -1,12 +1,15 @@
-import { Flex, useResponsiveSlider } from '@vtex/store-ui'
+import {
+  Flex,
+  useResponsiveSlider,
+  ShelfArrowLeft,
+  ShelfArrowRight,
+  ShelfPaginationDots,
+  ShelfTitle,
+} from '@vtex/store-ui'
 import React from 'react'
 import type { FC } from 'react'
 
-import ShelfArrowLeft from './ArrowLeft'
-import ShelfArrowRight from './ArrowRight'
 import ShelfPage from './Page'
-import ShelfPaginationDots from './PaginationDots'
-import ShelfTitle from './Title'
 import type { ProductSummary_ProductFragment } from '../ProductSummary/__generated__/ProductSummary_product.graphql'
 
 type Product = Maybe<ProductSummary_ProductFragment>
@@ -16,7 +19,7 @@ export interface Props {
   pageSizes?: number[]
   title?: JSX.Element | string
   variant?: string
-  showArrows: Maybe<boolean>
+  showArrows?: Maybe<boolean>
   showDots?: boolean
   autoplay?: number
 }

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.243.0",
+  "version": "0.243.1-shelf.0",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",

--- a/packages/store-ui/src/RichText/index.tsx
+++ b/packages/store-ui/src/RichText/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import type { FC } from 'react'
-import { jsx } from '@vtex/store-ui'
+import { jsx } from 'theme-ui'
 
 interface Props {
   text: string

--- a/packages/store-ui/src/Shelf/ArrowLeft.tsx
+++ b/packages/store-ui/src/Shelf/ArrowLeft.tsx
@@ -1,6 +1,7 @@
-import { SliderArrowLeft } from '@vtex/store-ui'
 import React from 'react'
 import type { ComponentProps, FC } from 'react'
+
+import SliderArrowLeft from '../Slider/ArrowLeft'
 
 type Props = ComponentProps<typeof SliderArrowLeft>
 

--- a/packages/store-ui/src/Shelf/ArrowRight.tsx
+++ b/packages/store-ui/src/Shelf/ArrowRight.tsx
@@ -1,10 +1,11 @@
-import { SliderArrowRight } from '@vtex/store-ui'
 import React from 'react'
 import type { ComponentProps, FC } from 'react'
 
+import SliderArrowRight from '../Slider/ArrowRight'
+
 type Props = ComponentProps<typeof SliderArrowRight>
 
-const ShelfArrowLeft: FC<Props> = ({ variant, ...rest }) => (
+const ShelfArrowRight: FC<Props> = ({ variant, ...rest }) => (
   <SliderArrowRight
     variant={`shelf.${variant}`}
     aria-label="See shelf next page"
@@ -12,4 +13,4 @@ const ShelfArrowLeft: FC<Props> = ({ variant, ...rest }) => (
   />
 )
 
-export default ShelfArrowLeft
+export default ShelfArrowRight

--- a/packages/store-ui/src/Shelf/Container.tsx
+++ b/packages/store-ui/src/Shelf/Container.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@vtex/store-ui'
+import { Box } from 'theme-ui'
 import React from 'react'
 import type { FC } from 'react'
 

--- a/packages/store-ui/src/Shelf/PaginationDots.tsx
+++ b/packages/store-ui/src/Shelf/PaginationDots.tsx
@@ -1,6 +1,7 @@
-import { SliderPaginationDots } from '@vtex/store-ui'
 import React from 'react'
 import type { FC, ComponentProps } from 'react'
+
+import SliderPaginationDots from '../Slider/PaginationDots'
 
 type Props = ComponentProps<typeof SliderPaginationDots>
 

--- a/packages/store-ui/src/Shelf/Title.tsx
+++ b/packages/store-ui/src/Shelf/Title.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@vtex/store-ui'
+import { Box } from 'theme-ui'
 import React from 'react'
 import type { FC } from 'react'
 

--- a/packages/store-ui/src/index.tsx
+++ b/packages/store-ui/src/index.tsx
@@ -50,6 +50,8 @@ export { default as LocalizedLink } from './LocalizedLink'
 export { default as Banner } from './Banner'
 // RichMarkdown
 export { default as RichMarkdown } from './RichMarkdown'
+// RichText
+export { default as RichText } from './RichText'
 // Search Filters
 export * from './SearchFilter/Accordion'
 export * from './SearchFilter/AccordionItemCheckbox'
@@ -60,6 +62,12 @@ export * from './SearchControls/FiltersButton'
 export * from './SearchControls/totalCount'
 export * from './SearchControls/Select'
 export * from './SearchControls/theme'
+// Shelf
+export { default as ShelfArrowLeft } from './Shelf/ArrowLeft'
+export { default as ShelfArrowRight } from './Shelf/ArrowRight'
+export { default as ShelfContainer } from './Shelf/Container'
+export { default as ShelfPaginationDots } from './Shelf/PaginationDots'
+export { default as ShelfTitle } from './Shelf/Title'
 // Breadcrumb
 export * from './Breadcrumb'
 export { default as breadcrumbTheme } from './Breadcrumb/theme'


### PR DESCRIPTION
## What's the purpose of this pull request?

Move UI components of RichText and some Shelf components to @vtex/store-ui.

I left `Shelf/index.tsx` and `Shelf/Page.tsx` in the `@vtex/gatsby-theme-store` because it connects with GraphQL queries.

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
