### PR TITLE
SEO | Respond with 404 when entering a non existing category

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.234.0",
+  "version": "0.235.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.234.0",
+  "version": "0.235.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/src/components/Error/ErrorHandler.tsx
+++ b/packages/gatsby-theme-store/src/components/Error/ErrorHandler.tsx
@@ -4,7 +4,10 @@ import type { FC } from 'react'
 import Error from './Error'
 
 const ErrorHandler: FC<{ error: any }> = ({ error }) => {
-  if (error?.extensions?.exception?.status === 404) {
+  if (
+    error?.extensions?.exception?.status === 404 ||
+    error.message === 'NotFound'
+  ) {
     window.location.href = `/404?from=${window.location.pathname}`
 
     return null

--- a/packages/gatsby-theme-store/src/sdk/search/controller.ts
+++ b/packages/gatsby-theme-store/src/sdk/search/controller.ts
@@ -48,8 +48,8 @@ export const toggleItem = (item: SearchFilterItem, filters: SearchFilters) => {
   let { map, query } = filters
 
   if (selected) {
-    const splittedQuery = query?.split('/')
-    const splittedMap = map?.split(',')
+    const splittedQuery = query.split('/')
+    const splittedMap = map.split(',')
 
     const index = splittedQuery?.findIndex((s) => s === value)
 


### PR DESCRIPTION
## What's the purpose of this pull request?
Correctly redirect the user when it enters a non existing category

## How it works? 
Since we have generated all the category tree on the server, if the user enters in `/foo/bar` and receives the client-side search html, this means the user entered in a non existing category and thus should be redirected to a `/404` page. 

The only corner case we have right now is for full text searches. This should be addressed once we move all full text searches to `/s/:term` 

## How to test it?
Enter in a non existing category, for instance `/foo/bar` and you should be redirected correctly to `/404` page. 
Entering a valid search page with filters applied should not redirect you to a `/404` page

PRs:

[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/313)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/442)
[btglobal](https://github.com/vtex-sites/btglobal.store/pull/7)

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
