### PR TITLE
SEO | Search canonicals 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.236.0-alpha.1",
+  "version": "0.236.0-alpha.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.235.0",
+  "version": "0.236.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
@@ -7,7 +7,5 @@
       "message": "Release: %v"
     }
   },
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.236.0-alpha.0",
+  "version": "0.236.0-alpha.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.235.0",
+  "version": "0.236.0-alpha.0",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.235.0",
+  "version": "0.236.0-alpha.0",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.235.0",
+  "version": "0.236.0-alpha.0",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.235.0",
+  "version": "0.236.0-alpha.0",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.235.0",
+  "version": "0.236.0-alpha.0",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.235.0",
+  "version": "0.236.0-alpha.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.236.0-alpha.1",
+  "version": "0.236.0-alpha.2",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.236.0-alpha.0",
+  "version": "0.236.0-alpha.1",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.235.0",
+  "version": "0.236.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -34,9 +34,9 @@
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
     "@vtex/gatsby-plugin-graphql": "^0.214.0-alpha.6",
-    "@vtex/gatsby-plugin-i18n": "^0.235.0",
-    "@vtex/gatsby-plugin-theme-ui": "^0.235.0",
-    "@vtex/store-ui": "^0.235.0",
+    "@vtex/gatsby-plugin-i18n": "^0.236.0-alpha.0",
+    "@vtex/gatsby-plugin-theme-ui": "^0.236.0-alpha.0",
+    "@vtex/store-ui": "^0.236.0-alpha.0",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/gatsby-theme-store/src/components/ProductPage/SEO/index.tsx
+++ b/packages/gatsby-theme-store/src/components/ProductPage/SEO/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useLocation } from '@reach/router'
 import type { FC } from 'react'
 
 import { useIdleEffect } from '../../../sdk/useIdleEffect'
@@ -6,11 +7,13 @@ import { isBot, isDevelopment } from '../../../utils/env'
 import SiteMetadata from '../../SEO/SiteMetadata'
 import StructuredData from './StructuredData'
 import type { ProductPageProps } from '../../../templates/product'
+import Helmet from '../../SEO/Helmet'
 
 const withSyncMetadata = isBot || isDevelopment
 
 const SEO: FC<ProductPageProps> = (props) => {
   const [metadata, setMetadata] = useState(withSyncMetadata)
+  const location = useLocation()
 
   useIdleEffect(() => setMetadata(true), [])
 
@@ -22,6 +25,14 @@ const SEO: FC<ProductPageProps> = (props) => {
     <>
       <SiteMetadata {...props} />
       <StructuredData {...props} />
+      <Helmet
+        link={[
+          {
+            rel: 'canonical',
+            href: `https://${location.host}${location.pathname}`,
+          },
+        ]}
+      />
     </>
   )
 }

--- a/packages/gatsby-theme-store/src/components/SearchPage/SEO.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchPage/SEO.tsx
@@ -1,9 +1,10 @@
+import { useLocation } from '@reach/router'
 import React from 'react'
 import type { FC } from 'react'
 
+import Helmet from '../SEO/Helmet'
 import SiteMetadata from '../SEO/SiteMetadata'
 import type { SearchPageProps } from '../../templates/search'
-import Helmet from '../SEO/Helmet'
 
 const SEO: FC<SearchPageProps> = ({
   data: {
@@ -11,18 +12,34 @@ const SEO: FC<SearchPageProps> = ({
   },
   pageContext: { staticPath },
 }) => {
+  const location = useLocation()
+
+  // One should use either noindex or canonical, never both
+  // This deduplicates pages so our pages rank higher in Google
+  const deduplicationTags =
+    staticPath === false ? (
+      <Helmet
+        meta={[
+          {
+            name: 'robots',
+            content: 'noindex',
+          },
+        ]}
+      />
+    ) : (
+      <Helmet
+        link={[
+          {
+            rel: 'canonical',
+            href: `https://${location.host}${location.pathname}`,
+          },
+        ]}
+      />
+    )
+
   return (
     <>
-      {staticPath === false && (
-        <Helmet
-          meta={[
-            {
-              name: 'robots',
-              content: 'noindex',
-            },
-          ]}
-        />
-      )}
+      {deduplicationTags}
       <SiteMetadata title={productSearch!.titleTag!} />
     </>
   )

--- a/packages/gatsby-theme-store/src/components/SearchPage/SEO.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchPage/SEO.tsx
@@ -10,7 +10,7 @@ const SEO: FC<SearchPageProps> = ({
   data: {
     vtex: { productSearch },
   },
-  pageContext: { staticPath },
+  staticPath,
 }) => {
   const location = useLocation()
 

--- a/packages/gatsby-theme-store/src/templates/search.tsx
+++ b/packages/gatsby-theme-store/src/templates/search.tsx
@@ -75,10 +75,6 @@ const SearchPage: FC<SearchPageProps> = (props) => {
 
   const pageProps = {
     ...props,
-    pageContext: {
-      ...pageContext,
-      staticPath,
-    },
     data: data!,
   }
 

--- a/packages/gatsby-theme-store/src/templates/search.tsx
+++ b/packages/gatsby-theme-store/src/templates/search.tsx
@@ -29,7 +29,7 @@ const BelowTheFold = lazy(belowTheFoldPreloader)
 export type SearchPageProps = PageProps<
   SearchPageQueryQuery,
   SearchPageQueryQueryVariables
->
+> & { staticPath: boolean }
 
 const SearchPage: FC<SearchPageProps> = (props) => {
   const { pageContext, data: staticData } = props
@@ -75,6 +75,7 @@ const SearchPage: FC<SearchPageProps> = (props) => {
 
   const pageProps = {
     ...props,
+    staticPath,
     data: data!,
   }
 

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.235.0",
+  "version": "0.236.0-alpha.0",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.235.0",
+  "version": "0.236.0-alpha.0",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.235.0",
+    "@vtex/gatsby-plugin-i18n": "^0.236.0-alpha.0",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",


### PR DESCRIPTION
## What's the purpose of this pull request?
Add `<link rel="canonical">` tags to search/product pages

## How it works? 
Consider you have pre-rendered a search on the path `/foo/bar` and the same content is rendered on /foo/bar?map=c,b 

this PR adds a `<link rel="canonical" href="https://origin/foo/bar">` tag on all /foo/bar variants so we deduplicate content on Google.

Note that if `/foo/bar` is not pre-rendered, it will receive a `<meta name="robots" content="noindex">` tag instead

## How to test it?
[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/315)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/445)
[btglobal](https://github.com/vtex-sites/btglobal.store/pull/9)

## References
<em>Spread the knowledge: is this any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em> 
