### PR TITLE
Dynamic search static data

### DIFF
--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -51,6 +51,5 @@
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0",
     "text-mask-core": "^5.1.0"
-  },
-  "gitHead": "9cb5acd30f6ec7710d48ad03176282e199f37526"
+  }
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -52,5 +52,5 @@
     "swr": "^0.3.0",
     "text-mask-core": "^5.1.0"
   },
-  "gitHead": "891336233ec041eaed4c9f2f56756a054ee9b01e"
+  "gitHead": "9cb5acd30f6ec7710d48ad03176282e199f37526"
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -51,5 +51,6 @@
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0",
     "text-mask-core": "^5.1.0"
-  }
+  },
+  "gitHead": "891336233ec041eaed4c9f2f56756a054ee9b01e"
 }

--- a/packages/gatsby-theme-store/src/components/Search/List/Page.tsx
+++ b/packages/gatsby-theme-store/src/components/Search/List/Page.tsx
@@ -10,9 +10,9 @@ interface Props {
 
 const Page: FC<Props> = ({ products }) => (
   <>
-    {products.map((product, index) => (
+    {products.map((product) => (
       <ProductSummary
-        loading={index === 0 ? 'eager' : 'lazy'}
+        loading="lazy"
         key={product!.productId!}
         product={product!}
       />

--- a/packages/gatsby-theme-store/src/components/Search/List/__generated__/SearchQuery.graphql.ts
+++ b/packages/gatsby-theme-store/src/components/Search/List/__generated__/SearchQuery.graphql.ts
@@ -21,7 +21,7 @@ export type SearchQueryQueryVariables = Exact<{
   query: Maybe<Scalars['String']>;
   map: Maybe<Scalars['String']>;
   fullText: Maybe<Scalars['String']>;
-  selectedFacets: Maybe<Array<Vtex_SelectedFacetInput>>;
+  selectedFacets: Maybe<Array<Vtex_SelectedFacetInput> | Vtex_SelectedFacetInput>;
   from: Maybe<Scalars['Int']>;
   to: Maybe<Scalars['Int']>;
   orderBy: Maybe<Scalars['String']>;

--- a/packages/gatsby-theme-store/src/gatsby-node.ts
+++ b/packages/gatsby-theme-store/src/gatsby-node.ts
@@ -29,22 +29,27 @@ export const pluginOptionsSchema = ({ Joi }: PluginOptionsSchemaArgs) =>
     getStaticPaths: Joi.function().arity(0).required(),
   })
 
-const getRoute = (path: string) => {
-  const splitted = path.split('/')
-
-  if (path === '/') {
+const getRoute = (segments: string[]) => {
+  if (segments.length === 1 && segments[0] === '') {
     return null
   }
 
-  if (splitted.length === 3 && path.endsWith('/p')) {
+  if (segments.length === 2 && segments[segments.length - 1] === 'p') {
     return 'product'
   }
 
-  if (splitted.length >= 2) {
+  if (segments.length >= 1) {
     return 'search'
   }
 
-  throw new Error(`Unroutable route: ${path}`)
+  throw new Error(`Unroutable route: /${segments.join('/')}`)
+}
+
+const normalizePath = (path: string) => {
+  const i = path[0] === '/' ? 1 : 0
+  const j = path[path.length - 1] === '/' ? path.length - 1 : path.length
+
+  return `/${path.slice(i, j)}`
 }
 
 export const createPages = async (
@@ -58,13 +63,13 @@ export const createPages = async (
   const staticPaths =
     typeof getStaticPaths === 'function' ? await getStaticPaths() : []
 
-  staticPaths.map(async (path) => {
-    const route = getRoute(path)
-    const splitted = path.split('/')
+  staticPaths.map(normalizePath).map(async (path) => {
+    const [, ...segments] = path.split('/')
+    const route = getRoute(segments)
 
     // Product Pages
     if (route === 'product') {
-      const [, slug] = splitted
+      const [slug] = segments
 
       createPage({
         path,
@@ -78,19 +83,22 @@ export const createPages = async (
 
     // Search Pages
     else if (route === 'search') {
-      const segments = splitted.filter((segment) => !!segment)
+      const searchParams = {
+        orderBy: '',
+        query: segments.join('/'),
+        map: new Array(segments.length).fill('c').join(','),
+        selectedFacets: segments.map((segment) => ({
+          key: 'c',
+          value: segment,
+        })),
+      }
 
       createPage({
         path,
         component: resolve(__dirname, './src/templates/search.tsx'),
         context: {
-          orderBy: '',
-          query: segments.join('/'),
-          map: new Array(segments.length).fill('c').join(','),
-          selectedFacets: segments.map((segment) => ({
-            key: 'c',
-            value: segment,
-          })),
+          ...searchParams,
+          canonicalPath: path,
           staticPath: true,
         },
       })
@@ -100,6 +108,7 @@ export const createPages = async (
         matchPath: `${path}/*`,
         component: resolve(__dirname, './src/templates/search.tsx'),
         context: {
+          canonicalPath: path,
           staticPath: false,
         },
       })

--- a/packages/gatsby-theme-store/src/gatsby-node.ts
+++ b/packages/gatsby-theme-store/src/gatsby-node.ts
@@ -94,6 +94,15 @@ export const createPages = async (
           staticPath: true,
         },
       })
+
+      createPage({
+        path: `${path}/__client_side_search__`,
+        matchPath: `${path}/*`,
+        component: resolve(__dirname, './src/templates/search.tsx'),
+        context: {
+          staticPath: false,
+        },
+      })
     }
   })
 

--- a/packages/gatsby-theme-store/src/sdk/orderForm/controller/__generated__/AddToCartMutation.graphql.ts
+++ b/packages/gatsby-theme-store/src/sdk/orderForm/controller/__generated__/AddToCartMutation.graphql.ts
@@ -19,7 +19,7 @@ type Scalars = {
 // Operation related types
 export type AddToCartMutationMutationVariables = Exact<{
   orderFormId: Maybe<Scalars['ID']>;
-  items: Maybe<Array<Maybe<Vtex_ItemInput>>>;
+  items: Maybe<Array<Maybe<Vtex_ItemInput>> | Maybe<Vtex_ItemInput>>;
   marketingData: Maybe<Vtex_MarketingDataInput>;
 }>;
 

--- a/packages/gatsby-theme-store/src/sdk/orderForm/controller/__generated__/UpdateItemsMutation.graphql.ts
+++ b/packages/gatsby-theme-store/src/sdk/orderForm/controller/__generated__/UpdateItemsMutation.graphql.ts
@@ -19,7 +19,7 @@ type Scalars = {
 // Operation related types
 export type UpdateItemsMutationMutationVariables = Exact<{
   orderFormId: Maybe<Scalars['ID']>;
-  items: Maybe<Array<Maybe<Vtex_ItemInput>>>;
+  items: Maybe<Array<Maybe<Vtex_ItemInput>> | Maybe<Vtex_ItemInput>>;
   splitItem: Maybe<Scalars['Boolean']>;
 }>;
 

--- a/packages/gatsby-theme-store/src/sdk/search/useSearchFiltersFromPageContext.ts
+++ b/packages/gatsby-theme-store/src/sdk/search/useSearchFiltersFromPageContext.ts
@@ -57,12 +57,18 @@ export const useSearchFiltersFromPageContext = (
 
   return useMemo(() => {
     const params = new URLSearchParams(search)
-    const query = pageContext?.query ?? trimQuery(pathname)
-    const map = params.get('map') ?? pageContext?.map ?? createMap(query)
+    let query = pageContext.query!
+    let map = pageContext.map!
+    let selectedFacets = pageContext.selectedFacets!
+
+    if (pageContext.staticPath === false) {
+      query = trimQuery(pathname)
+      map = params.get('map') ?? createMap(query)
+      selectedFacets = selectedFacetsAfterQueryAndMap(query, map)
+    }
+
     const fullText = map.startsWith('ft') ? query.split('/')[0] : undefined
-    const orderBy = params.get('orderBy') ?? pageContext?.orderBy ?? ''
-    const selectedFacets =
-      pageContext?.selectedFacets ?? selectedFacetsAfterQueryAndMap(query, map)
+    const orderBy = params.get('orderBy') ?? pageContext.orderBy ?? ''
 
     return {
       orderBy,
@@ -73,6 +79,7 @@ export const useSearchFiltersFromPageContext = (
     }
   }, [
     search,
+    pageContext.staticPath,
     pageContext.query,
     pageContext.map,
     pageContext.orderBy,

--- a/packages/gatsby-theme-store/src/templates/__generated__/SearchPageQuery.graphql.ts
+++ b/packages/gatsby-theme-store/src/templates/__generated__/SearchPageQuery.graphql.ts
@@ -22,7 +22,7 @@ export type SearchPageQueryQueryVariables = Exact<{
   map: Maybe<Scalars['String']>;
   fullText: Maybe<Scalars['String']>;
   staticPath: Scalars['Boolean'];
-  selectedFacets: Maybe<Array<Vtex_SelectedFacetInput>>;
+  selectedFacets: Maybe<Array<Vtex_SelectedFacetInput> | Vtex_SelectedFacetInput>;
   orderBy?: Maybe<Scalars['String']>;
 }>;
 


### PR DESCRIPTION
## What's the purpose of this pull request?
Here be unicorns 🦄  🦄  🦄 

This PR makes it possible to have data in category pages that only change when the user navigates to a different category page, a.k.a category.

This allow us to have one banner per category.

## How it works? 
Supose we have two categories `/foo` and `/foo/bar`. 

This PR would generate: 
`/foo`
`/foo/__client_side_search__`
`/foo/bar`
`/foo/bar/__client_side_search__`

Both `/foo/bar` and `/foo/bar/__client_side_search__` share the same static data, a.k.a banner

I think we still have some work to do. However, let's do this version and iterate over it

## How to test it?
[btglobal](https://github.com/vtex-sites/btglobal.store/pull/25)
[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/320)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/458)

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
