### PR TITLE
Chore | Disable revalidation SWR 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.245.0-alpha.0",
+  "version": "0.246.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.244.0-alpha.0",
+  "version": "0.245.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.243.1",
+  "version": "0.244.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
@@ -7,7 +7,5 @@
       "message": "Release: %v"
     }
   },
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.243.1",
+  "version": "0.244.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.244.0-alpha.0",
+  "version": "0.245.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.245.0-alpha.0",
+  "version": "0.246.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/src/sdk/graphql/useLazyQuery.ts
+++ b/packages/gatsby-theme-store/src/sdk/graphql/useLazyQuery.ts
@@ -1,21 +1,17 @@
 import useSWR from 'swr'
-import type { ConfigInterface } from 'swr'
 
 import { request } from './request'
-import type { RequestOptions } from './request'
-
-type QueryOptions = ConfigInterface & RequestOptions
-
-// TODO: Change here
-const getKey = (options: QueryOptions) =>
-  `${options.sha256Hash}::${JSON.stringify(options.variables)}`
+import { DEFAULT_OPTIONS, getKey } from './useQuery'
+import type { QueryOptions } from './useQuery'
 
 export const useLazyQuery = <Query = any, Variables = any>(
   options: QueryOptions
 ) => {
-  const response = useSWR<Query | null, any[]>(getKey(options), () => null, {
-    revalidateOnFocus: false,
-  })
+  const response = useSWR<Query | null, any[]>(
+    getKey(options),
+    () => null,
+    DEFAULT_OPTIONS
+  )
 
   const execute = async (variables: Variables) => {
     const data = await request<Query, Variables>({

--- a/packages/gatsby-theme-store/src/sdk/graphql/useQuery.ts
+++ b/packages/gatsby-theme-store/src/sdk/graphql/useQuery.ts
@@ -7,11 +7,22 @@ import type { RequestOptions } from './request'
 export type QueryOptions = ConfigInterface & RequestOptions
 
 // TODO: Change here
-const getKey = (options: QueryOptions) =>
+export const getKey = (options: QueryOptions) =>
   `${options.sha256Hash}::${JSON.stringify(options.variables)}`
+
+export const DEFAULT_OPTIONS = {
+  errorRetryCount: 3,
+  refreshWhenHidden: false,
+  refreshWhenOffline: false,
+  revalidateOnFocus: false,
+  revalidateOnMount: false,
+  revalidateOnReconnect: false,
+  shouldRetryOnError: true,
+}
 
 export const useQuery = <Query = any, Variables = any>(options: QueryOptions) =>
   useSWR<Query, any[]>(getKey(options), {
     fetcher: () => request<Query, Variables>(options),
+    ...DEFAULT_OPTIONS,
     ...options,
   })

--- a/packages/gatsby-theme-store/src/sdk/graphql/useQueryInfinite.ts
+++ b/packages/gatsby-theme-store/src/sdk/graphql/useQueryInfinite.ts
@@ -1,6 +1,7 @@
 import { useSWRInfinite } from 'swr'
 import type { SWRInfiniteConfigInterface } from 'swr'
 
+import { DEFAULT_OPTIONS } from './useQuery'
 import { request } from './request'
 import type { RequestOptions } from './request'
 
@@ -27,5 +28,9 @@ export const useQueryInfinite = <Query = any, Variables = any>(
         ...queryOptions,
         variables,
       }),
-    config
+    {
+      ...DEFAULT_OPTIONS,
+      revalidateAll: false,
+      ...config,
+    }
   )


### PR DESCRIPTION
## What's the purpose of this pull request?
SWR revalidates on many different cases. This may lead to previous static data being replaced right in the middle of a page navigation making the page to `samba`

This PR disable by default all revalidation related features from SWR so all static data is well preserved during the navigation. Of course, if the user desires, he can still opt-in for these features

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/332)
[btglobal](https://github.com/vtex-sites/btglobal.store/pull/31)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/461)

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
