### PR TITLE
Feature | Brand page

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.250.0-alpha.4",
+  "version": "0.250.0-alpha.5",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.250.0-alpha.0",
+  "version": "0.250.0-alpha.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.250.0-alpha.1",
+  "version": "0.250.0-alpha.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.249.1",
+  "version": "0.250.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.250.0-alpha.5",
+  "version": "0.250.0-alpha.6",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.250.0-alpha.2",
+  "version": "0.250.0-alpha.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.250.0-alpha.3",
+  "version": "0.250.0-alpha.4",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.250.0-alpha.3",
+  "version": "0.250.0-alpha.5",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.250.0-alpha.0",
+  "version": "0.250.0-alpha.1",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.250.0-alpha.1",
+  "version": "0.250.0-alpha.2",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.250.0-alpha.5",
+  "version": "0.250.0-alpha.6",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -26,6 +26,7 @@
     "@graphql-tools/wrap": "^6.0.15",
     "isomorphic-unfetch": "^3.0.0",
     "p-map": "^4.0.0",
+    "slugify": "^1.4.6",
     "uuid": "^8.3.0"
   },
   "peerDependencies": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.248.0",
+  "version": "0.250.0-alpha.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.250.0-alpha.2",
+  "version": "0.250.0-alpha.3",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/src/api.ts
+++ b/packages/gatsby-source-vtex/src/api.ts
@@ -2,6 +2,13 @@ import type { Sort } from './types'
 
 export const api = {
   catalog: {
+    brand: {
+      list: '/api/catalog_system/pub/brand/list',
+    },
+    portal: {
+      pageType: (path: string) =>
+        `/api/catalog_system/pub/portal/pagetype${path}`,
+    },
     category: {
       tree: (depth: number) => `/api/catalog_system/pub/category/tree/${depth}`,
       search: ({

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -32,13 +32,28 @@ const getGraphQLUrl = (tenant: string, workspace: string) =>
 
 export interface Options extends PluginOptions, VTEXOptions {
   getStaticPaths?: () => Promise<string[]>
+  pageTypes?: Array<PageType['pageType']>
 }
+
+const DEFAULT_PAGE_TYPES_WHITELIST = [
+  'Product',
+  'Department',
+  'Category',
+  'Brand',
+  'SubCategory',
+]
 
 export const sourceNodes: GatsbyNode['sourceNodes'] = async (
   args: SourceNodesArgs,
   options: Options
 ) => {
-  const { tenant, workspace, getStaticPaths } = options
+  const {
+    tenant,
+    workspace,
+    getStaticPaths,
+    pageTypes: pageTypesWhitelist = DEFAULT_PAGE_TYPES_WHITELIST,
+  } = options
+
   const {
     actions: { addThirdPartySchema },
     reporter,
@@ -180,14 +195,6 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
     return
   }
 
-  const pageTypesWhitelist = [
-    'Product',
-    'Department',
-    'Category',
-    'Brand',
-    'SubCategory',
-  ]
-
   for (let it = 0; it < pageTypes.length; it++) {
     const pageType = pageTypes[it]
     const staticPath = staticPaths[it]
@@ -324,4 +331,5 @@ export const pluginOptionsSchema = ({ Joi }: PluginOptionsSchemaArgs) =>
       /^(vtexcommercestable|vtexcommercebeta)$/
     ),
     getStaticPaths: Joi.function().arity(0),
+    pageTypes: Joi.array().items(Joi.string()),
   })

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -180,8 +180,19 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
     return
   }
 
+  const pageTypesWhitelist = ['Product', 'Department', 'Category', 'Brand']
+
   for (let it = 0; it < pageTypes.length; it++) {
-    createStaticPathNode(args, pageTypes[it], staticPaths[it])
+    const pageType = pageTypes[it]
+    const staticPath = staticPaths[it]
+
+    if (!pageTypesWhitelist.includes(pageType.pageType)) {
+      reporter.warn(`[gatsby-source-vtex]: Dropping path ${staticPath}`)
+
+      continue
+    }
+
+    createStaticPathNode(args, pageType, staticPath)
   }
 
   activity.end()

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -180,7 +180,13 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
     return
   }
 
-  const pageTypesWhitelist = ['Product', 'Department', 'Category', 'Brand']
+  const pageTypesWhitelist = [
+    'Product',
+    'Department',
+    'Category',
+    'Brand',
+    'SubCategory',
+  ]
 
   for (let it = 0; it < pageTypes.length; it++) {
     const pageType = pageTypes[it]

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -187,7 +187,9 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
     const staticPath = staticPaths[it]
 
     if (!pageTypesWhitelist.includes(pageType.pageType)) {
-      reporter.warn(`[gatsby-source-vtex]: Dropping path ${staticPath}`)
+      reporter.warn(
+        `[gatsby-source-vtex]: Dropping path. Reason: PageType API reported ${pageType.pageType} for path: ${staticPath}`
+      )
 
       continue
     }

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -165,7 +165,8 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
 
   const pageTypes = await pMap(
     staticPaths,
-    (path) => fetchVTEX<PageType>(api.catalog.portal.pageType(path), options),
+    (path: string) =>
+      fetchVTEX<PageType>(api.catalog.portal.pageType(path), options),
     {
       concurrency: 20,
     }

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -13,26 +13,42 @@ import type {
   CreatePageArgs,
   PluginOptionsSchemaArgs,
 } from 'gatsby'
+import pMap from 'p-map'
 
 import { api } from './api'
 import { fetchVTEX } from './fetch'
-import { createChannelNode, createDepartmentNode } from './utils'
+import {
+  createChannelNode,
+  createDepartmentNode,
+  createStaticPathNode,
+  normalizePath,
+} from './utils'
 import type { VTEXOptions } from './fetch'
-import type { Category, Tenant } from './types'
+import type { Category, PageType, Tenant } from './types'
+import defaultStaticPaths from './staticPaths'
 
 const getGraphQLUrl = (tenant: string, workspace: string) =>
   `http://${workspace}--${tenant}.myvtex.com/graphql`
 
-export interface Options extends PluginOptions, VTEXOptions {}
+export interface Options extends PluginOptions, VTEXOptions {
+  getStaticPaths?: () => Promise<string[]>
+}
 
 export const sourceNodes: GatsbyNode['sourceNodes'] = async (
   args: SourceNodesArgs,
   options: Options
 ) => {
-  const { tenant, workspace } = options
+  const { tenant, workspace, getStaticPaths } = options
   const {
     actions: { addThirdPartySchema },
+    reporter,
   } = args
+
+  let activity = reporter.activityTimer(
+    '[gatsby-source-vtex]: adding VTEX GraphQL Schema'
+  )
+
+  activity.start()
 
   /**
    * VTEX GraphQL API
@@ -92,25 +108,82 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
 
   addThirdPartySchema({ schema })
 
+  activity.end()
+
   /**
    * VTEX HTTP API fetches
    * */
 
   // Bindings
+  activity = reporter.activityTimer(
+    '[gatsby-source-vtex]: fetching VTEX Bindings'
+  )
+  activity.start()
+
   const { bindings } = await fetchVTEX<Tenant>(
     api.tenants.tenant(tenant),
     options
   )
 
-  bindings.forEach((binding) => createChannelNode(args, binding))
+  for (const binding of bindings) {
+    createChannelNode(args, binding)
+  }
+
+  activity.end()
 
   // Catetgories
+  activity = reporter.activityTimer(
+    '[gatsby-source-vtex]: fetching VTEX Departments'
+  )
+  activity.start()
+
   const departments = await fetchVTEX<Category[]>(
     api.catalog.category.tree(1),
     options
   )
 
-  departments.forEach((department) => createDepartmentNode(args, department))
+  for (const department of departments) {
+    createDepartmentNode(args, department)
+  }
+
+  activity.end()
+
+  /**
+   * Static Paths used to generate pages
+   */
+
+  activity = reporter.activityTimer(
+    '[gatsby-source-vtex]: fetching StaticPaths'
+  )
+
+  activity.start()
+
+  const staticPaths = (typeof getStaticPaths === 'function'
+    ? await getStaticPaths()
+    : await defaultStaticPaths(options)
+  ).map(normalizePath)
+
+  const pageTypes = await pMap(
+    staticPaths,
+    (path) => fetchVTEX<PageType>(api.catalog.portal.pageType(path), options),
+    {
+      concurrency: 20,
+    }
+  )
+
+  if (pageTypes.length !== staticPaths.length) {
+    reporter.panicOnBuild(
+      '[gatsby-source-vtex]: Length of PageTypes and staticPaths do not agree. No static path will be generated'
+    )
+
+    return
+  }
+
+  for (let it = 0; it < pageTypes.length; it++) {
+    createStaticPathNode(args, pageTypes[it], staticPaths[it])
+  }
+
+  activity.end()
 }
 
 export const createPages = (
@@ -230,4 +303,5 @@ export const pluginOptionsSchema = ({ Joi }: PluginOptionsSchemaArgs) =>
     environment: Joi.string().pattern(
       /^(vtexcommercestable|vtexcommercebeta)$/
     ),
+    getStaticPaths: Joi.function().arity(0),
   })

--- a/packages/gatsby-source-vtex/src/staticPaths.ts
+++ b/packages/gatsby-source-vtex/src/staticPaths.ts
@@ -1,8 +1,13 @@
+import { promisify } from 'util'
+import { join } from 'path'
+import { readFile } from 'fs'
+
+import slugify from 'slugify'
 import pMap from 'p-map'
 
 import { api } from './api'
 import { fetchVTEX } from './fetch'
-import type { Category } from './types'
+import type { Brand, Category } from './types'
 
 interface Options {
   tenant: string
@@ -10,6 +15,8 @@ interface Options {
   environment?: 'vtexcommercestable' | 'vtexcommercebeta'
   pages?: number // max number of staticPaths to generate
 }
+
+const readFileAsync = promisify(readFile)
 
 const dfs = (root: Category, paths: string[]) => {
   const url = new URL(root.url)
@@ -21,13 +28,24 @@ const dfs = (root: Category, paths: string[]) => {
   }
 }
 
+const staticPathsFromJson = async () => {
+  const path = join(process.cwd(), 'staticPaths.json')
+  const staticPaths = await readFileAsync(path, { encoding: 'utf-8' })
+
+  return JSON.parse(staticPaths)
+}
+
 const staticPaths = async ({
   tenant,
   workspace = 'master',
   environment = 'vtexcommercestable',
   pages = 100,
 }: Options): Promise<string[]> => {
-  const paths: string[] = [] // final array containing all paths
+  const paths: string[] = await staticPathsFromJson() // final array containing all paths
+
+  if (process.env.NODE_ENV === 'development') {
+    return paths
+  }
 
   const options = {
     tenant,
@@ -44,6 +62,16 @@ const staticPaths = async ({
 
   for (const node of tree) {
     dfs(node, paths)
+  }
+
+  const brands = await fetchVTEX<Brand[]>(api.catalog.brand.list, options)
+
+  for (const brand of brands) {
+    if (!brand.isActive) {
+      continue
+    }
+
+    paths.push(`/${slugify(brand.name, { replacement: '-', lower: true })}`)
   }
 
   // Add product paths into the final array

--- a/packages/gatsby-source-vtex/src/staticPaths.ts
+++ b/packages/gatsby-source-vtex/src/staticPaths.ts
@@ -71,7 +71,9 @@ const staticPaths = async ({
       continue
     }
 
-    paths.push(`/${slugify(brand.name, { replacement: '-', lower: true })}`)
+    paths.push(
+      `/${slugify(brand.name, { replacement: '-', lower: true, strict: true })}`
+    )
   }
 
   // Add product paths into the final array

--- a/packages/gatsby-source-vtex/src/types.ts
+++ b/packages/gatsby-source-vtex/src/types.ts
@@ -70,6 +70,7 @@ export interface PageType {
   metaTagDescription: string
   pageType:
     | 'Product'
+    | 'SubCategory'
     | 'Department'
     | 'Category'
     | 'Brand'

--- a/packages/gatsby-source-vtex/src/types.ts
+++ b/packages/gatsby-source-vtex/src/types.ts
@@ -53,6 +53,30 @@ export interface Category {
   LinkId: string
 }
 
+export interface Brand {
+  id: number
+  name: string
+  isActive: boolean
+  title: string
+  metaTagDescription: string
+  imageUrl: string | null
+}
+
+export interface PageType {
+  id: string
+  name: string
+  url: string
+  title: string
+  metaTagDescription: string
+  pageType:
+    | 'Product'
+    | 'Department'
+    | 'Category'
+    | 'Brand'
+    | 'FullText'
+    | 'NotFound'
+}
+
 export type Sort =
   | 'OrderByPriceDESC'
   | 'OrderByPriceASC'

--- a/packages/gatsby-source-vtex/src/utils.ts
+++ b/packages/gatsby-source-vtex/src/utils.ts
@@ -1,6 +1,6 @@
 import type { SourceNodesArgs } from 'gatsby'
 
-import type { Category, Channel } from './types'
+import type { Category, Channel, PageType } from './types'
 
 export const createChannelNode = (
   {
@@ -54,4 +54,42 @@ export const createDepartmentNode = (
       contentDigest: createContentDigest(data),
     },
   })
+}
+
+export const createStaticPathNode = (
+  {
+    actions: { createNode },
+    createNodeId,
+    createContentDigest,
+  }: SourceNodesArgs,
+  { id, name, title, metaTagDescription, pageType }: PageType,
+  path: string
+) => {
+  const NODE_TYPE = 'StaticPath'
+
+  const data = {
+    id,
+    name,
+    title,
+    metaTagDescription,
+    path,
+    pageType,
+  }
+
+  createNode({
+    ...data,
+    id: createNodeId(`${NODE_TYPE}-${data.id}-${data.pageType}`),
+    internal: {
+      type: NODE_TYPE,
+      content: JSON.stringify(data),
+      contentDigest: createContentDigest(data),
+    },
+  })
+}
+
+export const normalizePath = (path: string) => {
+  const i = path[0] === '/' ? 1 : 0
+  const j = path[path.length - 1] === '/' ? path.length - 1 : path.length
+
+  return `/${path.slice(i, j)}`
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.250.0-alpha.0",
+  "version": "0.250.0-alpha.4",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.249.1",
+  "version": "0.250.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/src/components/SearchPage/SEO/SiteMetadata.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchPage/SEO/SiteMetadata.tsx
@@ -23,7 +23,7 @@ const SiteMetadata: FC<Props> = (props) => {
   return (
     <DefaultSiteMetadata
       {...siteMetadata}
-      title={productSearch!.titleTag ?? siteMetadata.title}
+      title={productSearch?.titleTag ?? siteMetadata.title}
     />
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4498,12 +4498,12 @@
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
 "@typescript-eslint/eslint-plugin@^2.10.0", "@typescript-eslint/eslint-plugin@^2.12.0", "@typescript-eslint/eslint-plugin@^2.24.0", "@typescript-eslint/eslint-plugin@^4", "@typescript-eslint/eslint-plugin@^4.8.1":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.13.0.tgz#5f580ea520fa46442deb82c038460c3dd3524bb6"
-  integrity sha512-ygqDUm+BUPvrr0jrXqoteMqmIaZ/bixYOc3A4BRwzEPTZPi6E+n44rzNZWaB0YvtukgP+aoj0i/fyx7FkM2p1w==
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.1.tgz#22dd301ce228aaab3416b14ead10b1db3e7d3180"
+  integrity sha512-5JriGbYhtqMS1kRcZTQxndz1lKMwwEXKbwZbkUZNnp6MJX0+OVXnG0kOlBZP4LUAxEyzu3cs+EXd/97MJXsGfw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.13.0"
-    "@typescript-eslint/scope-manager" "4.13.0"
+    "@typescript-eslint/experimental-utils" "4.14.1"
+    "@typescript-eslint/scope-manager" "4.14.1"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     lodash "^4.17.15"
@@ -4511,48 +4511,48 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.13.0", "@typescript-eslint/experimental-utils@^4.0.1":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.13.0.tgz#9dc9ab375d65603b43d938a0786190a0c72be44e"
-  integrity sha512-/ZsuWmqagOzNkx30VWYV3MNB/Re/CGv/7EzlqZo5RegBN8tMuPaBgNK6vPBCQA8tcYrbsrTdbx3ixMRRKEEGVw==
+"@typescript-eslint/experimental-utils@4.14.1", "@typescript-eslint/experimental-utils@^4.0.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.1.tgz#a5c945cb24dabb96747180e1cfc8487f8066f471"
+  integrity sha512-2CuHWOJwvpw0LofbyG5gvYjEyoJeSvVH2PnfUQSn0KQr4v8Dql2pr43ohmx4fdPQ/eVoTSFjTi/bsGEXl/zUUQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.13.0"
-    "@typescript-eslint/types" "4.13.0"
-    "@typescript-eslint/typescript-estree" "4.13.0"
+    "@typescript-eslint/scope-manager" "4.14.1"
+    "@typescript-eslint/types" "4.14.1"
+    "@typescript-eslint/typescript-estree" "4.14.1"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
 "@typescript-eslint/parser@^2.10.0", "@typescript-eslint/parser@^2.12.0", "@typescript-eslint/parser@^2.24.0", "@typescript-eslint/parser@^4", "@typescript-eslint/parser@^4.8.1":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.13.0.tgz#c413d640ea66120cfcc37f891e8cb3fd1c9d247d"
-  integrity sha512-KO0J5SRF08pMXzq9+abyHnaGQgUJZ3Z3ax+pmqz9vl81JxmTTOUfQmq7/4awVfq09b6C4owNlOgOwp61pYRBSg==
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.14.1.tgz#3bd6c24710cd557d8446625284bcc9c6d52817c6"
+  integrity sha512-mL3+gU18g9JPsHZuKMZ8Z0Ss9YP1S5xYZ7n68Z98GnPq02pYNQuRXL85b9GYhl6jpdvUc45Km7hAl71vybjUmw==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.13.0"
-    "@typescript-eslint/types" "4.13.0"
-    "@typescript-eslint/typescript-estree" "4.13.0"
+    "@typescript-eslint/scope-manager" "4.14.1"
+    "@typescript-eslint/types" "4.14.1"
+    "@typescript-eslint/typescript-estree" "4.14.1"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.13.0.tgz#5b45912a9aa26b29603d8fa28f5e09088b947141"
-  integrity sha512-UpK7YLG2JlTp/9G4CHe7GxOwd93RBf3aHO5L+pfjIrhtBvZjHKbMhBXTIQNkbz7HZ9XOe++yKrXutYm5KmjWgQ==
+"@typescript-eslint/scope-manager@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.1.tgz#8444534254c6f370e9aa974f035ced7fe713ce02"
+  integrity sha512-F4bjJcSqXqHnC9JGUlnqSa3fC2YH5zTtmACS1Hk+WX/nFB0guuynVK5ev35D4XZbdKjulXBAQMyRr216kmxghw==
   dependencies:
-    "@typescript-eslint/types" "4.13.0"
-    "@typescript-eslint/visitor-keys" "4.13.0"
+    "@typescript-eslint/types" "4.14.1"
+    "@typescript-eslint/visitor-keys" "4.14.1"
 
-"@typescript-eslint/types@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.13.0.tgz#6a7c6015a59a08fbd70daa8c83dfff86250502f8"
-  integrity sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==
+"@typescript-eslint/types@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.1.tgz#b3d2eb91dafd0fd8b3fce7c61512ac66bd0364aa"
+  integrity sha512-SkhzHdI/AllAgQSxXM89XwS1Tkic7csPdndUuTKabEwRcEfR8uQ/iPA3Dgio1rqsV3jtqZhY0QQni8rLswJM2w==
 
-"@typescript-eslint/typescript-estree@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.13.0.tgz#cf6e2207c7d760f5dfd8d18051428fadfc37b45e"
-  integrity sha512-9A0/DFZZLlGXn5XA349dWQFwPZxcyYyCFX5X88nWs2uachRDwGeyPz46oTsm9ZJE66EALvEns1lvBwa4d9QxMg==
+"@typescript-eslint/typescript-estree@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.1.tgz#20d3b8c8e3cdc8f764bdd5e5b0606dd83da6075b"
+  integrity sha512-M8+7MbzKC1PvJIA8kR2sSBnex8bsR5auatLCnVlNTJczmJgqRn8M+sAlQfkEq7M4IY3WmaNJ+LJjPVRrREVSHQ==
   dependencies:
-    "@typescript-eslint/types" "4.13.0"
-    "@typescript-eslint/visitor-keys" "4.13.0"
+    "@typescript-eslint/types" "4.14.1"
+    "@typescript-eslint/visitor-keys" "4.14.1"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -4560,12 +4560,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.13.0.tgz#9acb1772d3b3183182b6540d3734143dce9476fe"
-  integrity sha512-6RoxWK05PAibukE7jElqAtNMq+RWZyqJ6Q/GdIxaiUj2Ept8jh8+FUVlbq9WxMYxkmEOPvCE5cRSyupMpwW31g==
+"@typescript-eslint/visitor-keys@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.1.tgz#e93c2ff27f47ee477a929b970ca89d60a117da91"
+  integrity sha512-TAblbDXOI7bd0C/9PE1G+AFo7R5uc+ty1ArDoxmrC1ah61Hn6shURKy7gLdRb1qKJmjHkqu5Oq+e4Kt0jwf1IA==
   dependencies:
-    "@typescript-eslint/types" "4.13.0"
+    "@typescript-eslint/types" "4.14.1"
     eslint-visitor-keys "^2.0.0"
 
 "@vtex-components/accordion@^0.2.3":
@@ -20199,7 +20199,7 @@ slide@^1.1.6:
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
-slugify@^1.4.4:
+slugify@^1.4.4, slugify@^1.4.6:
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.6.tgz#ef288d920a47fb01c2be56b3487b6722f5e34ace"
   integrity sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ==


### PR DESCRIPTION
## What's the purpose of this pull request?
Add brand pages generation.

## How it works? 
This PR moves the `getStaticPaths` parameter function from `gatsby-theme-store` to `gatsby-source-vtex` and adds a default behavior to getStaticPaths, so we don't need to write it into the store repo anymore. Note that the repo may still overwrite the `getStaticPaths` function.
This change allow other `source` plugins to define other staticPaths without relying solely on VTEX APIs. `gatsby-theme-store` nows only queries gatsby's graphql for staticPaths. This may also lead to faster build times, since all Network IO was moved to `node sourcing` step, that can now be run in parallel via `PARALLEL_SOURCING` flag

Also, this PR adds logic for brand page generation, by using a the `pageType` API. In the future, we may remove the need for the pageType API when the default getStaticPaths function is used for faster build times.

## How to test it?
[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/344)
[btglobal](https://github.com/vtex-sites/btglobal.store/pull/57)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/466)

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
