### PR TITLE
Add title template with catalog

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.256.1-alpha.3",
+  "version": "0.256.1-alpha.4",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.256.1-alpha.2",
+  "version": "0.256.1-alpha.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.256.1-alpha.4",
+  "version": "0.256.1-alpha.5",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.5",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -34,5 +34,6 @@
     "fs-extra": "^9.0.1",
     "gatsby-graphql-source-toolkit": "^0.6.3",
     "p-map": "^4.0.0"
-  }
+  },
+  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
 }

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -34,6 +34,5 @@
     "fs-extra": "^9.0.1",
     "gatsby-graphql-source-toolkit": "^0.6.3",
     "p-map": "^4.0.0"
-  },
-  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
+  }
 }

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -35,5 +35,5 @@
     "gatsby-graphql-source-toolkit": "^0.6.3",
     "p-map": "^4.0.0"
   },
-  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
+  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
 }

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -27,5 +27,5 @@
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^2.24.37"
   },
-  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
+  "gitHead": "a043cb04135085514e57b08b2676241bb21f2da5"
 }

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -26,5 +26,6 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^2.24.37"
-  }
+  },
+  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
 }

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.1-alpha.0",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.1",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.256.1-alpha.2",
+  "version": "0.256.1-alpha.3",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.1-alpha.2",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.3",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.256.1-alpha.4",
+  "version": "0.256.1-alpha.5",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.1-alpha.4",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.5",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.256.1-alpha.3",
+  "version": "0.256.1-alpha.4",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.1-alpha.3",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.4",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -27,5 +27,5 @@
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^2.24.37"
   },
-  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
+  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
 }

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -26,6 +26,5 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^2.24.37"
-  },
-  "gitHead": "a043cb04135085514e57b08b2676241bb21f2da5"
+  }
 }

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.255.8",
+    "@vtex/gatsby-theme-store": "^0.256.0-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.0-alpha.0",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.2",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.1-alpha.1",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.2",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -35,5 +35,5 @@
     "@graphql-tools/relay-operation-optimizer": "^6.0.15",
     "fs-extra": "^9.0.1"
   },
-  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
+  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
 }

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.5",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -34,6 +34,5 @@
     "@graphql-codegen/typescript-operations": "^1.17.7",
     "@graphql-tools/relay-operation-optimizer": "^6.0.15",
     "fs-extra": "^9.0.1"
-  },
-  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
+  }
 }

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -34,5 +34,6 @@
     "@graphql-codegen/typescript-operations": "^1.17.7",
     "@graphql-tools/relay-operation-optimizer": "^6.0.15",
     "fs-extra": "^9.0.1"
-  }
+  },
+  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
 }

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.5",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -28,5 +28,6 @@
     "@babel/types": "^7.12.7",
     "intl-messageformat-parser": "^6.0.18",
     "react-intl": "^5.7.1"
-  }
+  },
+  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
 }

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -28,6 +28,5 @@
     "@babel/types": "^7.12.7",
     "intl-messageformat-parser": "^6.0.18",
     "react-intl": "^5.7.1"
-  },
-  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
+  }
 }

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -29,5 +29,5 @@
     "intl-messageformat-parser": "^6.0.18",
     "react-intl": "^5.7.1"
   },
-  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
+  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
 }

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -32,5 +32,5 @@
   "peerDependencies": {
     "gatsby": "^2.31.0"
   },
-  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
+  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
 }

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -31,6 +31,5 @@
   },
   "peerDependencies": {
     "gatsby": "^2.31.0"
-  },
-  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
+  }
 }

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -31,5 +31,6 @@
   },
   "peerDependencies": {
     "gatsby": "^2.31.0"
-  }
+  },
+  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
 }

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.5",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -27,5 +27,5 @@
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^2.24.37"
   },
-  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
+  "gitHead": "a043cb04135085514e57b08b2676241bb21f2da5"
 }

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.256.1-alpha.4",
+  "version": "0.256.1-alpha.5",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.1-alpha.4",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.5",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -26,5 +26,6 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^2.24.37"
-  }
+  },
+  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
 }

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.256.1-alpha.2",
+  "version": "0.256.1-alpha.3",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.1-alpha.2",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.3",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.255.8",
+    "@vtex/gatsby-theme-store": "^0.256.0-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.0-alpha.0",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -27,5 +27,5 @@
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^2.24.37"
   },
-  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
+  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
 }

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -26,6 +26,5 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^2.24.37"
-  },
-  "gitHead": "a043cb04135085514e57b08b2676241bb21f2da5"
+  }
 }

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.2",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.1-alpha.1",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.2",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.1-alpha.0",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.1",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.256.1-alpha.3",
+  "version": "0.256.1-alpha.4",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.256.1-alpha.3",
+    "@vtex/gatsby-theme-store": "^0.256.1-alpha.4",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.5",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -34,6 +34,5 @@
     "@babel/types": "^7.11.0",
     "create-emotion-server": "^10.0.27",
     "theme-ui": "^0.3.1"
-  },
-  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
+  }
 }

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -34,5 +34,6 @@
     "@babel/types": "^7.11.0",
     "create-emotion-server": "^10.0.27",
     "theme-ui": "^0.3.1"
-  }
+  },
+  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
 }

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -35,5 +35,5 @@
     "create-emotion-server": "^10.0.27",
     "theme-ui": "^0.3.1"
   },
-  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
+  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
 }

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -32,6 +32,5 @@
   "peerDependencies": {
     "gatsby": "^2.31.0",
     "graphql": "^14.0.0 || ^15.0.0"
-  },
-  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
+  }
 }

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.5",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -33,5 +33,5 @@
     "gatsby": "^2.31.0",
     "graphql": "^14.0.0 || ^15.0.0"
   },
-  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
+  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
 }

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -32,5 +32,6 @@
   "peerDependencies": {
     "gatsby": "^2.31.0",
     "graphql": "^14.0.0 || ^15.0.0"
-  }
+  },
+  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -50,6 +50,5 @@
     "requestidlecallback-polyfill": "^1.0.2",
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0"
-  },
-  "gitHead": "a043cb04135085514e57b08b2676241bb21f2da5"
+  }
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.256.1-alpha.4",
+  "version": "0.256.1-alpha.5",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -33,10 +33,10 @@
   },
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
-    "@vtex/gatsby-plugin-graphql": "^0.256.1-alpha.1",
-    "@vtex/gatsby-plugin-i18n": "^0.256.1-alpha.1",
-    "@vtex/gatsby-plugin-theme-ui": "^0.256.1-alpha.1",
-    "@vtex/store-ui": "^0.256.1-alpha.1",
+    "@vtex/gatsby-plugin-graphql": "^0.256.1-alpha.5",
+    "@vtex/gatsby-plugin-i18n": "^0.256.1-alpha.5",
+    "@vtex/gatsby-plugin-theme-ui": "^0.256.1-alpha.5",
+    "@vtex/store-ui": "^0.256.1-alpha.5",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.256.1-alpha.2",
+  "version": "0.256.1-alpha.3",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -33,10 +33,10 @@
   },
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
-    "@vtex/gatsby-plugin-graphql": "^0.256.1-alpha.0",
-    "@vtex/gatsby-plugin-i18n": "^0.256.1-alpha.0",
-    "@vtex/gatsby-plugin-theme-ui": "^0.256.1-alpha.0",
-    "@vtex/store-ui": "^0.256.1-alpha.0",
+    "@vtex/gatsby-plugin-graphql": "^0.256.1-alpha.1",
+    "@vtex/gatsby-plugin-i18n": "^0.256.1-alpha.1",
+    "@vtex/gatsby-plugin-theme-ui": "^0.256.1-alpha.1",
+    "@vtex/store-ui": "^0.256.1-alpha.1",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -33,10 +33,10 @@
   },
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
-    "@vtex/gatsby-plugin-graphql": "^0.255.8",
-    "@vtex/gatsby-plugin-i18n": "^0.255.8",
-    "@vtex/gatsby-plugin-theme-ui": "^0.255.8",
-    "@vtex/store-ui": "^0.255.8",
+    "@vtex/gatsby-plugin-graphql": "^0.256.0-alpha.0",
+    "@vtex/gatsby-plugin-i18n": "^0.256.0-alpha.0",
+    "@vtex/gatsby-plugin-theme-ui": "^0.256.0-alpha.0",
+    "@vtex/store-ui": "^0.256.0-alpha.0",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -33,10 +33,10 @@
   },
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
-    "@vtex/gatsby-plugin-graphql": "^0.256.0-alpha.0",
-    "@vtex/gatsby-plugin-i18n": "^0.256.0-alpha.0",
-    "@vtex/gatsby-plugin-theme-ui": "^0.256.0-alpha.0",
-    "@vtex/store-ui": "^0.256.0-alpha.0",
+    "@vtex/gatsby-plugin-graphql": "^0.256.1-alpha.0",
+    "@vtex/gatsby-plugin-i18n": "^0.256.1-alpha.0",
+    "@vtex/gatsby-plugin-theme-ui": "^0.256.1-alpha.0",
+    "@vtex/store-ui": "^0.256.1-alpha.0",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.2",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -50,5 +50,6 @@
     "requestidlecallback-polyfill": "^1.0.2",
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0"
-  }
+  },
+  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -51,5 +51,5 @@
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0"
   },
-  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
+  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.256.1-alpha.3",
+  "version": "0.256.1-alpha.4",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -51,5 +51,5 @@
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0"
   },
-  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
+  "gitHead": "a043cb04135085514e57b08b2676241bb21f2da5"
 }

--- a/packages/gatsby-theme-store/src/components/ProductPage/SEO/SiteMetadata.tsx
+++ b/packages/gatsby-theme-store/src/components/ProductPage/SEO/SiteMetadata.tsx
@@ -20,8 +20,8 @@ const SiteMetadata: FC<Props> = ({
 }) => (
   <DefaultSiteMetadata
     {...siteMetadata}
-    title={product!.titleTag ?? siteMetadata.title}
-    description={product!.metaTagDescription ?? siteMetadata.description}
+    title={product!.titleTag || siteMetadata.title}
+    description={product!.metaTagDescription || siteMetadata.description}
   />
 )
 

--- a/packages/gatsby-theme-store/src/components/ProductPage/SEO/SiteMetadata.tsx
+++ b/packages/gatsby-theme-store/src/components/ProductPage/SEO/SiteMetadata.tsx
@@ -21,6 +21,7 @@ const SiteMetadata: FC<Props> = ({
   <DefaultSiteMetadata
     {...siteMetadata}
     title={product!.titleTag ?? siteMetadata.title}
+    description={product!.metaTagDescription ?? siteMetadata.description}
   />
 )
 

--- a/packages/gatsby-theme-store/src/components/ProductPage/SEO/SiteMetadata.tsx
+++ b/packages/gatsby-theme-store/src/components/ProductPage/SEO/SiteMetadata.tsx
@@ -12,8 +12,16 @@ interface Props extends ProductPageProps {
   }
 }
 
-const SiteMetadata: FC<Props> = (props) => (
-  <DefaultSiteMetadata {...props.siteMetadata} />
+const SiteMetadata: FC<Props> = ({
+  data: {
+    vtex: { product },
+  },
+  siteMetadata,
+}) => (
+  <DefaultSiteMetadata
+    {...siteMetadata}
+    title={product!.titleTag ?? siteMetadata.title}
+  />
 )
 
 export default SiteMetadata

--- a/packages/gatsby-theme-store/src/components/ProductPage/SEO/__generated__/ProductPageSEOQuery.graphql.ts
+++ b/packages/gatsby-theme-store/src/components/ProductPage/SEO/__generated__/ProductPageSEOQuery.graphql.ts
@@ -20,14 +20,14 @@ type Scalars = {
 export type ProductPageSeoQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ProductPageSeoQueryQuery = { site: Maybe<{ siteMetadata: Maybe<{ title: Maybe<string>, siteUrl: Maybe<string>, description: Maybe<string>, author: Maybe<string> }> }> };
+export type ProductPageSeoQueryQuery = { site: Maybe<{ siteMetadata: Maybe<{ title: Maybe<string>, titleTemplate: Maybe<string>, siteUrl: Maybe<string>, description: Maybe<string>, author: Maybe<string> }> }> };
 
 
 // Query Related Code
 
 export const ProductPageSEOQuery = {
   query: undefined,
-  sha256Hash: "ed8024d5948bc83c090cd6a3ad4d83dcb3ef593999d1ef783f31559bd50d57b2",
+  sha256Hash: "622ef2a0fa8091aed1c191ceb132b5e9665ca28e47bdcc5e70eba6a4788c0191",
   operationName: "ProductPageSEOQuery",
 }
 

--- a/packages/gatsby-theme-store/src/components/ProductPage/SEO/index.tsx
+++ b/packages/gatsby-theme-store/src/components/ProductPage/SEO/index.tsx
@@ -1,27 +1,20 @@
 import { graphql, useStaticQuery } from 'gatsby'
-import React, { useState } from 'react'
+import React from 'react'
 import type { FC } from 'react'
 
-import { useIdleEffect } from '../../../sdk/useIdleEffect'
-import { isBot, isDevelopment } from '../../../utils/env'
 import Canonical from './Canonical'
-import StructuredData from './StructuredData'
 import SiteMetadata from './SiteMetadata'
+import StructuredData from './StructuredData'
 import type { ProductPageProps } from '../../../templates/product'
 
-const withSyncMetadata = isBot || isDevelopment
-
 const SEO: FC<ProductPageProps> = (props) => {
-  const [metadata, setMetadata] = useState(withSyncMetadata)
-
-  useIdleEffect(() => setMetadata(true), [])
-
   const { site } = useStaticQuery(
     graphql`
       query ProductPageSEOQuery {
         site {
           siteMetadata {
             title
+            titleTemplate
             siteUrl
             description
             author
@@ -30,10 +23,6 @@ const SEO: FC<ProductPageProps> = (props) => {
       }
     `
   )
-
-  if (!metadata) {
-    return null
-  }
 
   const { siteMetadata } = site!
 

--- a/packages/gatsby-theme-store/src/components/SEO/SiteMetadata.tsx
+++ b/packages/gatsby-theme-store/src/components/SEO/SiteMetadata.tsx
@@ -9,19 +9,22 @@ export interface Props {
   meta?: any[]
   title: string
   author?: string
+  titleTemplate?: string
 }
 
 const SiteMetadata: FC<Props> = ({
+  title,
+  titleTemplate,
   description,
   lang = 'en',
-  meta = [],
-  title,
   author = 'VTEX',
+  meta = [],
 }) => (
   <Helmet
     htmlAttributes={{
       lang,
     }}
+    titleTemplate={titleTemplate}
     title={title}
     meta={[
       {

--- a/packages/gatsby-theme-store/src/components/SearchPage/SEO/SiteMetadata.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchPage/SEO/SiteMetadata.tsx
@@ -15,7 +15,7 @@ interface Props extends SearchPageProps {
 const SiteMetadata: FC<Props> = (props) => {
   const {
     data: {
-      vtex: { productSearch },
+      vtex: { searchMetadata },
     },
     siteMetadata,
   } = props
@@ -23,7 +23,8 @@ const SiteMetadata: FC<Props> = (props) => {
   return (
     <DefaultSiteMetadata
       {...siteMetadata}
-      title={productSearch?.titleTag ?? siteMetadata.title}
+      title={searchMetadata?.title ?? siteMetadata.title}
+      description={searchMetadata?.description ?? siteMetadata.description}
     />
   )
 }

--- a/packages/gatsby-theme-store/src/components/SearchPage/SEO/SiteMetadata.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchPage/SEO/SiteMetadata.tsx
@@ -23,8 +23,8 @@ const SiteMetadata: FC<Props> = (props) => {
   return (
     <DefaultSiteMetadata
       {...siteMetadata}
-      title={searchMetadata?.title ?? siteMetadata.title}
-      description={searchMetadata?.description ?? siteMetadata.description}
+      title={searchMetadata?.title || siteMetadata.title}
+      description={searchMetadata?.description || siteMetadata.description}
     />
   )
 }

--- a/packages/gatsby-theme-store/src/components/SearchPage/SEO/StructuredData.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchPage/SEO/StructuredData.tsx
@@ -41,8 +41,13 @@ const StructuredData: FC<Props> = ({
     vtex: { facets },
   },
   siteMetadata: { siteUrl },
+  staticPath,
 }) => {
   const breadcrumb = useStructuredBreadcrumb(facets!.breadcrumb, siteUrl)
+
+  if (staticPath !== true) {
+    return null
+  }
 
   return (
     <Helmet

--- a/packages/gatsby-theme-store/src/components/SearchPage/SEO/__generated__/SearchPageSEOQuery.graphql.ts
+++ b/packages/gatsby-theme-store/src/components/SearchPage/SEO/__generated__/SearchPageSEOQuery.graphql.ts
@@ -20,14 +20,14 @@ type Scalars = {
 export type SearchPageSeoQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SearchPageSeoQueryQuery = { site: Maybe<{ siteMetadata: Maybe<{ title: Maybe<string>, siteUrl: Maybe<string>, description: Maybe<string>, author: Maybe<string> }> }> };
+export type SearchPageSeoQueryQuery = { site: Maybe<{ siteMetadata: Maybe<{ title: Maybe<string>, titleTemplate: Maybe<string>, siteUrl: Maybe<string>, description: Maybe<string>, author: Maybe<string> }> }> };
 
 
 // Query Related Code
 
 export const SearchPageSEOQuery = {
   query: undefined,
-  sha256Hash: "0a1dc02e238fe0141de8070972491e15946f3d9e448df48c6e90487029196ca8",
+  sha256Hash: "78467c58ecaaf9bd3b276104e60367355ce000d298fac563bf7f6c7b2d1e7d18",
   operationName: "SearchPageSEOQuery",
 }
 

--- a/packages/gatsby-theme-store/src/components/SearchPage/SEO/index.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchPage/SEO/index.tsx
@@ -9,13 +9,6 @@ import type { SearchPageProps } from '../../../templates/search'
 
 const SEO: FC<SearchPageProps> = (props) => {
   const {
-    data: {
-      vtex: { productSearch },
-    },
-    staticPath,
-  } = props
-
-  const {
     site: { siteMetadata },
   } = useStaticQuery(
     graphql`
@@ -23,6 +16,7 @@ const SEO: FC<SearchPageProps> = (props) => {
         site {
           siteMetadata {
             title
+            titleTemplate
             siteUrl
             description
             author
@@ -40,7 +34,7 @@ const SEO: FC<SearchPageProps> = (props) => {
   return (
     <>
       <SiteMetadata {...subProps} />
-      {staticPath === true && <StructuredData {...subProps} />}
+      <StructuredData {...subProps} />
       <Canonical {...subProps} />
     </>
   )

--- a/packages/gatsby-theme-store/src/templates/__generated__/ProductPageQuery.graphql.ts
+++ b/packages/gatsby-theme-store/src/templates/__generated__/ProductPageQuery.graphql.ts
@@ -23,14 +23,14 @@ export type ProductPageQueryQueryVariables = Exact<{
 }>;
 
 
-export type ProductPageQueryQuery = { vtex: { product?: Maybe<{ productReference: Maybe<string>, productName: Maybe<string>, linkText: Maybe<string>, description: Maybe<string>, brand: Maybe<string>, titleTag: Maybe<string>, productId: Maybe<string>, items: Maybe<Array<Maybe<{ name: Maybe<string>, complementName: Maybe<string>, itemId: Maybe<string>, ean: Maybe<string>, referenceId: Maybe<Array<Maybe<{ value: Maybe<string> }>>>, images: Maybe<Array<Maybe<{ imageUrl: Maybe<string>, imageText: Maybe<string> }>>>, videos: Maybe<Array<Maybe<{ videoUrl: Maybe<string> }>>>, sellers: Maybe<Array<Maybe<{ commercialOffer: Maybe<{ price: Maybe<number>, availableQuantity: Maybe<number>, priceValidUntil: Maybe<string> }> }>>> }>>>, productClusters: Maybe<Array<Maybe<{ name: Maybe<string> }>>>, categoryTree: Maybe<Array<Maybe<{ href: Maybe<string>, name: Maybe<string> }>>> }> } };
+export type ProductPageQueryQuery = { vtex: { product?: Maybe<{ productReference: Maybe<string>, productName: Maybe<string>, linkText: Maybe<string>, description: Maybe<string>, brand: Maybe<string>, titleTag: Maybe<string>, metaTagDescription: Maybe<string>, productId: Maybe<string>, items: Maybe<Array<Maybe<{ name: Maybe<string>, complementName: Maybe<string>, itemId: Maybe<string>, ean: Maybe<string>, referenceId: Maybe<Array<Maybe<{ value: Maybe<string> }>>>, images: Maybe<Array<Maybe<{ imageUrl: Maybe<string>, imageText: Maybe<string> }>>>, videos: Maybe<Array<Maybe<{ videoUrl: Maybe<string> }>>>, sellers: Maybe<Array<Maybe<{ commercialOffer: Maybe<{ price: Maybe<number>, availableQuantity: Maybe<number>, priceValidUntil: Maybe<string> }> }>>> }>>>, productClusters: Maybe<Array<Maybe<{ name: Maybe<string> }>>>, categoryTree: Maybe<Array<Maybe<{ href: Maybe<string>, name: Maybe<string> }>>> }> } };
 
 
 // Query Related Code
 
 export const ProductPageQuery = {
   query: undefined,
-  sha256Hash: "d809862c3f702ef22bcc50ffb5069c977f5d3167bbab612a2c206e8d91a255e0",
+  sha256Hash: "9cdc7da82d5d6cb789073d51dea68d8e622a3477a953ae65d2b456c32b26c06c",
   operationName: "ProductPageQuery",
 }
 

--- a/packages/gatsby-theme-store/src/templates/__generated__/ProductPageQuery.graphql.ts
+++ b/packages/gatsby-theme-store/src/templates/__generated__/ProductPageQuery.graphql.ts
@@ -23,14 +23,14 @@ export type ProductPageQueryQueryVariables = Exact<{
 }>;
 
 
-export type ProductPageQueryQuery = { vtex: { product?: Maybe<{ productReference: Maybe<string>, productName: Maybe<string>, linkText: Maybe<string>, description: Maybe<string>, brand: Maybe<string>, productId: Maybe<string>, items: Maybe<Array<Maybe<{ name: Maybe<string>, complementName: Maybe<string>, itemId: Maybe<string>, ean: Maybe<string>, referenceId: Maybe<Array<Maybe<{ value: Maybe<string> }>>>, images: Maybe<Array<Maybe<{ imageUrl: Maybe<string>, imageText: Maybe<string> }>>>, videos: Maybe<Array<Maybe<{ videoUrl: Maybe<string> }>>>, sellers: Maybe<Array<Maybe<{ commercialOffer: Maybe<{ price: Maybe<number>, availableQuantity: Maybe<number>, priceValidUntil: Maybe<string> }> }>>> }>>>, productClusters: Maybe<Array<Maybe<{ name: Maybe<string> }>>>, categoryTree: Maybe<Array<Maybe<{ href: Maybe<string>, name: Maybe<string> }>>> }> } };
+export type ProductPageQueryQuery = { vtex: { product?: Maybe<{ productReference: Maybe<string>, productName: Maybe<string>, linkText: Maybe<string>, description: Maybe<string>, brand: Maybe<string>, titleTag: Maybe<string>, productId: Maybe<string>, items: Maybe<Array<Maybe<{ name: Maybe<string>, complementName: Maybe<string>, itemId: Maybe<string>, ean: Maybe<string>, referenceId: Maybe<Array<Maybe<{ value: Maybe<string> }>>>, images: Maybe<Array<Maybe<{ imageUrl: Maybe<string>, imageText: Maybe<string> }>>>, videos: Maybe<Array<Maybe<{ videoUrl: Maybe<string> }>>>, sellers: Maybe<Array<Maybe<{ commercialOffer: Maybe<{ price: Maybe<number>, availableQuantity: Maybe<number>, priceValidUntil: Maybe<string> }> }>>> }>>>, productClusters: Maybe<Array<Maybe<{ name: Maybe<string> }>>>, categoryTree: Maybe<Array<Maybe<{ href: Maybe<string>, name: Maybe<string> }>>> }> } };
 
 
 // Query Related Code
 
 export const ProductPageQuery = {
   query: undefined,
-  sha256Hash: "d4aacb826e7f654ea695eaa2c18347e1ae87145daa3c300bf1119d1a37469675",
+  sha256Hash: "d809862c3f702ef22bcc50ffb5069c977f5d3167bbab612a2c206e8d91a255e0",
   operationName: "ProductPageQuery",
 }
 

--- a/packages/gatsby-theme-store/src/templates/__generated__/SearchPageQuery.graphql.ts
+++ b/packages/gatsby-theme-store/src/templates/__generated__/SearchPageQuery.graphql.ts
@@ -27,14 +27,14 @@ export type SearchPageQueryQueryVariables = Exact<{
 }>;
 
 
-export type SearchPageQueryQuery = { vtex: { productSearch?: Maybe<{ titleTag: Maybe<string>, recordsFiltered: Maybe<number>, products: Maybe<Array<Maybe<{ productId: Maybe<string>, productName: Maybe<string>, linkText: Maybe<string>, items: Maybe<Array<Maybe<{ itemId: Maybe<string>, images: Maybe<Array<Maybe<{ imageUrl: Maybe<string>, imageText: Maybe<string> }>>> }>>> }>>> }>, facets?: Maybe<{ breadcrumb: Maybe<Array<Maybe<{ href: Maybe<string>, name: Maybe<string> }>>>, facets: Maybe<Array<Maybe<{ name: Maybe<string>, type: Maybe<Vtex_FilterType>, values: Maybe<Array<Maybe<{ key: Maybe<string>, name: Maybe<string>, value: Maybe<string>, selected: Maybe<boolean>, quantity: number, values: Maybe<Array<Maybe<{ key: Maybe<string>, name: Maybe<string>, value: Maybe<string>, selected: Maybe<boolean>, quantity: number, values: Maybe<Array<Maybe<{ key: Maybe<string>, name: Maybe<string>, value: Maybe<string>, selected: Maybe<boolean>, quantity: number }>>> }>>> }>>> }>>> }> } };
+export type SearchPageQueryQuery = { vtex: { searchMetadata: Maybe<{ title: Maybe<string>, description: Maybe<string> }>, productSearch?: Maybe<{ recordsFiltered: Maybe<number>, products: Maybe<Array<Maybe<{ productId: Maybe<string>, productName: Maybe<string>, linkText: Maybe<string>, items: Maybe<Array<Maybe<{ itemId: Maybe<string>, images: Maybe<Array<Maybe<{ imageUrl: Maybe<string>, imageText: Maybe<string> }>>> }>>> }>>> }>, facets?: Maybe<{ breadcrumb: Maybe<Array<Maybe<{ href: Maybe<string>, name: Maybe<string> }>>>, facets: Maybe<Array<Maybe<{ name: Maybe<string>, type: Maybe<Vtex_FilterType>, values: Maybe<Array<Maybe<{ key: Maybe<string>, name: Maybe<string>, value: Maybe<string>, selected: Maybe<boolean>, quantity: number, values: Maybe<Array<Maybe<{ key: Maybe<string>, name: Maybe<string>, value: Maybe<string>, selected: Maybe<boolean>, quantity: number, values: Maybe<Array<Maybe<{ key: Maybe<string>, name: Maybe<string>, value: Maybe<string>, selected: Maybe<boolean>, quantity: number }>>> }>>> }>>> }>>> }> } };
 
 
 // Query Related Code
 
 export const SearchPageQuery = {
   query: undefined,
-  sha256Hash: "5b3852bf935acbbf4cd0e5592ea64fd85998e27f1047189d7804607239832a23",
+  sha256Hash: "5af2fd846059b8cffaf2b9e17ce5beed87bcd1284a42bf930102acefdb4415d8",
   operationName: "SearchPageQuery",
 }
 

--- a/packages/gatsby-theme-store/src/templates/product.tsx
+++ b/packages/gatsby-theme-store/src/templates/product.tsx
@@ -109,6 +109,7 @@ export const query = graphql`
       product(slug: $slug) @include(if: $staticPath) {
         ...ProductDetailsTemplate_product
         ...StructuredProductFragment_product
+        titleTag
         productId
         description
         categoryTree {

--- a/packages/gatsby-theme-store/src/templates/product.tsx
+++ b/packages/gatsby-theme-store/src/templates/product.tsx
@@ -110,6 +110,7 @@ export const query = graphql`
         ...ProductDetailsTemplate_product
         ...StructuredProductFragment_product
         titleTag
+        metaTagDescription
         productId
         description
         categoryTree {

--- a/packages/gatsby-theme-store/src/templates/search.tsx
+++ b/packages/gatsby-theme-store/src/templates/search.tsx
@@ -144,8 +144,16 @@ export const query = graphql`
             }
           }
         }
-        titleTag
         recordsFiltered
+      }
+      searchMetadata(
+        query: $query
+        map: $map
+        fullText: $fullText
+        selectedFacets: $selectedFacets
+      ) {
+        title: titleTag
+        description: metaTagDescription
       }
       facets(
         query: $query

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.5",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -24,5 +24,5 @@
     "tsdx": "^0.14.1",
     "typescript": "^4.1.2"
   },
-  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
+  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
 }

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -23,6 +23,5 @@
   "devDependencies": {
     "tsdx": "^0.14.1",
     "typescript": "^4.1.2"
-  },
-  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
+  }
 }

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -23,5 +23,6 @@
   "devDependencies": {
     "tsdx": "^0.14.1",
     "typescript": "^4.1.2"
-  }
+  },
+  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
 }

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -60,5 +60,5 @@
     "tsdx": "^0.14.1",
     "typescript": "^4.1.2"
   },
-  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
+  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
 }

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.256.1-alpha.1",
+  "version": "0.256.1-alpha.5",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.256.1-alpha.1",
+    "@vtex/gatsby-plugin-i18n": "^0.256.1-alpha.5",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -59,5 +59,6 @@
     "ts-loader": "^8.0.1",
     "tsdx": "^0.14.1",
     "typescript": "^4.1.2"
-  }
+  },
+  "gitHead": "6b9e7d6e28ebe4a916ee7966b39e28c1b3ec56d3"
 }

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.256.1-alpha.0",
+  "version": "0.256.1-alpha.1",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.256.1-alpha.0",
+    "@vtex/gatsby-plugin-i18n": "^0.256.1-alpha.1",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -59,6 +59,5 @@
     "ts-loader": "^8.0.1",
     "tsdx": "^0.14.1",
     "typescript": "^4.1.2"
-  },
-  "gitHead": "1dab3cceb5ac01598ad0cf0ab5386863a0a60c07"
+  }
 }

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.256.0-alpha.0",
+  "version": "0.256.1-alpha.0",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.256.0-alpha.0",
+    "@vtex/gatsby-plugin-i18n": "^0.256.1-alpha.0",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.255.8",
+  "version": "0.256.0-alpha.0",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.255.8",
+    "@vtex/gatsby-plugin-i18n": "^0.256.0-alpha.0",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR uses the catalog's `titleTag` and `metaTagDescription` as default title and description tags for both product and search.

Also, the template used for such a feature is the `titleTemplate` variable added in Gatsby's siteMetadata section

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/352)
[btglobal](https://github.com/vtex-sites/btglobal.store/pull/146)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/482)

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
