### PR TITLE
Remove orderForm "mudinho"

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.262.0",
+  "version": "0.263.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.262.0",
+  "version": "0.263.0-alpha.0",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.262.0",
+    "@vtex/gatsby-theme-store": "^0.263.0-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.262.0",
+  "version": "0.263.0-alpha.0",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.262.0",
+    "@vtex/gatsby-theme-store": "^0.263.0-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.262.0",
+  "version": "0.263.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/src/sdk/orderForm/Provider.tsx
+++ b/packages/gatsby-theme-store/src/sdk/orderForm/Provider.tsx
@@ -19,6 +19,7 @@ export type OrderFormContext = {
 export const OrderForm = createContext<OrderFormContext>(undefined as any)
 
 export const OrderFormProvider: FC = ({ children }) => {
+  const [error, setError] = useState<Error | null>(null)
   const [
     orderForm,
     setOrderForm,
@@ -26,16 +27,26 @@ export const OrderFormProvider: FC = ({ children }) => {
 
   const id = orderForm?.id
 
+  useEffect(() => {
+    if (error != null && !window.location.pathname.startsWith('/500')) {
+      throw error
+    }
+  }, [error])
+
   // Fetch orderForm on first render
   useEffect(() => {
     let cancel = false
 
     const cbId = window.requestIdleCallback(async () => {
-      const ctl = await controller()
-      const of = await ctl.getOrderForm()
+      try {
+        const ctl = await controller()
+        const of = await ctl.getOrderForm()
 
-      if (!cancel) {
-        setOrderForm(of)
+        if (!cancel) {
+          setOrderForm(of)
+        }
+      } catch (e) {
+        setError(e)
       }
     })
 


### PR DESCRIPTION
## What's the purpose of this pull request?
If orderForm somehow fails to load, the orderFrom queue is never started and the page remains in an inconsistent state. 

## How it works? 
This PR throws the error if anything bad happens with the orderForm request and the user is redirected to the `/500` page. 
Note that in the `/500` page, the error should not be thrown otherwise we risk displaying an empty page

## How to test it?
Open a PR, block the orderForm request. You should be redirected to the `/500`  page.

[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/376)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/513)
[btglobal](https://github.com/vtex-sites/btglobal.store/pull/233)


## References

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
