### PR TITLE
Support Redirects

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.274.0-alpha.0",
+  "version": "0.274.0-alpha.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.274.0-alpha.4",
+  "version": "0.274.0-alpha.5",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.273.0",
+  "version": "0.274.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.274.0-alpha.2",
+  "version": "0.274.0-alpha.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.274.0-alpha.3",
+  "version": "0.274.0-alpha.4",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
@@ -7,5 +7,7 @@
       "message": "Release: %v"
     }
   },
-  "packages": ["packages/*"]
+  "packages": [
+    "packages/*"
+  ]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.274.0-alpha.5",
+  "version": "0.274.0-alpha.6",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.274.0-alpha.1",
+  "version": "0.274.0-alpha.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "devDependencies": {
     "@vtex/prettier-config": "^0.3.5",
     "eslint": "^7.15.0",
-    "eslint-config-vtex": "^12.9.3",
-    "eslint-config-vtex-react": "^6.9.3",
+    "eslint-config-vtex": "^12.9.4",
+    "eslint-config-vtex-react": "^6.9.4",
     "husky": "^4.3.0",
     "lerna": "^3.22.1",
     "lint-staged": "^10.5.1",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.273.0",
+  "version": "0.274.0-alpha.0",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.274.0-alpha.0",
+  "version": "0.274.0-alpha.2",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.274.0-alpha.2",
+  "version": "0.274.0-alpha.3",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-nginx/src/constants.ts
+++ b/packages/gatsby-plugin-nginx/src/constants.ts
@@ -27,3 +27,10 @@ export const LOCATIONS_ONLY_ENV_VAR = 'NGINX_LOCATIONS_ONLY'
 export const FILE_SERVE_DIRECTIVE_ENV_VAR = 'NGINX_SERVE_FILE_DIRECTIVE'
 
 export const DISABLE_BROTLI_ENV_VAR = 'NGINX_DISABLE_BROTLI'
+
+export const LOCATION_MODIFIERS = {
+  EXACT_MATCH: '=', // this block will be cons idered a match if the request URI exactly matches the location given.
+  CASE_SENSITIVE_REGEX_MATCH: '~', // this location will be interpreted as a case-sensitive regular expression match.
+  CASE_INSENSITIVE_REGEX_MATCH: '~*', // the location block will be interpreted as a case-insensitive regular expression match.
+  BEST_NON_REGEX_MATCH: '^~', // if this block is selected as the best non-regular expression match, regular expression matching will not take place.
+}

--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -188,7 +188,7 @@ function parseRewrite({
     // Parse as an internal redirect, a.k.a /foo to /bar
     new URL(toPath, 'http://example.org')
 
-    return statusCode === 200 && !isPermanent
+    return statusCode === 200
       ? 'rewrite'
       : statusCode === 301 || statusCode === 302 || isPermanent
       ? 'redirect'
@@ -237,8 +237,12 @@ function generateRewriteChildren({ toPath }: Redirect) {
   ]
 }
 
-function generateRedirectRewriteChildren({ toPath, isPermanent }: Redirect) {
-  const status = isPermanent ? 301 : 302
+function generateRedirectRewriteChildren({
+  toPath,
+  isPermanent,
+  statusCode = 301,
+}: Redirect) {
+  const status = isPermanent ? 301 : statusCode
 
   return [
     {

--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -188,7 +188,7 @@ function parseRewrite({
     // Parse as an internal redirect, a.k.a /foo to /bar
     new URL(toPath, 'http://example.org')
 
-    return statusCode === 200
+    return statusCode === 200 && !isPermanent
       ? 'rewrite'
       : statusCode === 301 || statusCode === 302 || isPermanent
       ? 'redirect'

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@graphql-tools/delegate": "^6.0.15",
     "@graphql-tools/wrap": "^6.0.15",
+    "csvtojson": "^2.0.10",
     "isomorphic-unfetch": "^3.0.0",
     "p-map": "^4.0.0",
     "slugify": "^1.4.6",

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.274.0-alpha.3",
+  "version": "0.274.0-alpha.4",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.274.0-alpha.1",
+  "version": "0.274.0-alpha.3",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.274.0-alpha.0",
+  "version": "0.274.0-alpha.1",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.274.0-alpha.5",
+  "version": "0.274.0-alpha.6",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@graphql-tools/delegate": "^6.0.15",
     "@graphql-tools/wrap": "^6.0.15",
-    "csvtojson": "^2.0.10",
     "isomorphic-unfetch": "^3.0.0",
     "p-map": "^4.0.0",
     "slugify": "^1.4.6",

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.274.0-alpha.4",
+  "version": "0.274.0-alpha.5",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.273.0",
+  "version": "0.274.0-alpha.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -24,14 +24,16 @@ import {
   normalizePath,
 } from './utils'
 import type { VTEXOptions } from './fetch'
-import type { Category, PageType, Tenant } from './types'
+import type { Category, PageType, Redirect, Tenant } from './types'
 import defaultStaticPaths from './staticPaths'
+import defaultGetRedirects from './redirects'
 
 const getGraphQLUrl = (tenant: string, workspace: string) =>
   `http://${workspace}--${tenant}.myvtex.com/graphql`
 
 export interface Options extends PluginOptions, VTEXOptions {
   getStaticPaths?: () => Promise<string[]>
+  getRedirects?: () => Promise<Redirect[]>
   pageTypes?: Array<PageType['pageType']>
 }
 
@@ -213,15 +215,34 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
   activity.end()
 }
 
-export const createPages = (
-  { actions: { createRedirect } }: CreatePageArgs,
-  { tenant, workspace, environment }: Options
+export const createPages = async (
+  { actions: { createRedirect }, reporter }: CreatePageArgs,
+  {
+    tenant,
+    workspace,
+    environment,
+    getRedirects = defaultGetRedirects,
+  }: Options
 ) => {
   /**
    * Create all proxy rules for VTEX Store
    * If adding a new rule, don't forget to modify ./gatsby-config.ts dev proxy
    * so it also works in dev mode
    */
+
+  const activity = reporter.activityTimer(
+    '[gatsby-source-vtex]: soucing Redirects'
+  )
+
+  activity.start()
+
+  const redirects = await getRedirects()
+
+  for (const redirect of redirects) {
+    createRedirect(redirect)
+  }
+
+  activity.end()
 
   // Redirect API
   createRedirect({
@@ -349,5 +370,6 @@ export const pluginOptionsSchema = ({ Joi }: PluginOptionsSchemaArgs) =>
       /^(vtexcommercestable|vtexcommercebeta)$/
     ),
     getStaticPaths: Joi.function().arity(0),
+    getRedirects: Joi.function().arity(0),
     pageTypes: Joi.array().items(Joi.string()),
   })

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -231,7 +231,7 @@ export const createPages = async (
    */
 
   const activity = reporter.activityTimer(
-    '[gatsby-source-vtex]: soucing Redirects'
+    '[gatsby-source-vtex]: sourcing Redirects'
   )
 
   activity.start()

--- a/packages/gatsby-source-vtex/src/redirects.ts
+++ b/packages/gatsby-source-vtex/src/redirects.ts
@@ -20,12 +20,6 @@ export const assertRedirects = (redirects: Redirect[]) => {
       )
     }
 
-    if (fromPath.endsWith('/') || toPath.endsWith('/')) {
-      throw new Error(
-        `[gatsby-source-vtex]: The redirect ${fromPath} -> ${toPath} is not valid in redirects:${line}. The urls must not have trailing slashes`
-      )
-    }
-
     if (isPermanent == null) {
       throw new Error(
         `[gatsby-source-vtex]: Invalid redirect type in redirects:${line}. isPermanent is required`

--- a/packages/gatsby-source-vtex/src/redirects.ts
+++ b/packages/gatsby-source-vtex/src/redirects.ts
@@ -19,7 +19,7 @@ export const redirectsFromCSV = ({
 }
 
 const removeTrailingSlashes = (str: string) =>
-  str.endsWith('/') ? str.substring(0, str.length - 1) : str
+  str.endsWith('/') && str.length > 1 ? str.substring(0, str.length - 1) : str
 
 export const assertRedirects = (maybeRedirects: any[]): Redirect[] => {
   const redirects: Redirect[] = []
@@ -59,6 +59,7 @@ export const assertRedirects = (maybeRedirects: any[]): Redirect[] => {
       fromPath: removeTrailingSlashes(fromPath),
       toPath: removeTrailingSlashes(toPath),
       isPermanent: type === 'PERMANENT',
+      statusCode: type === 'PERMANENT' ? 301 : 302,
     })
   }
 

--- a/packages/gatsby-source-vtex/src/redirects.ts
+++ b/packages/gatsby-source-vtex/src/redirects.ts
@@ -20,6 +20,12 @@ export const assertRedirects = (redirects: Redirect[]) => {
       )
     }
 
+    if (fromPath.endsWith('/') || toPath.endsWith('/')) {
+      throw new Error(
+        `[gatsby-source-vtex]: The redirect ${fromPath} -> ${toPath} is not valid in redirects:${line}. The urls must not have trailing slashes`
+      )
+    }
+
     if (isPermanent == null) {
       throw new Error(
         `[gatsby-source-vtex]: Invalid redirect type in redirects:${line}. isPermanent is required`

--- a/packages/gatsby-source-vtex/src/redirects.ts
+++ b/packages/gatsby-source-vtex/src/redirects.ts
@@ -1,0 +1,74 @@
+import fs from 'fs'
+
+import csv2json from 'csvtojson'
+
+import type { Redirect } from './types'
+
+const csv = `${process.cwd()}/redirects.csv`
+
+export const redirectsFromCSV = ({
+  delimiter = ';',
+}: {
+  delimiter: string
+}) => {
+  if (!fs.existsSync(csv)) {
+    return []
+  }
+
+  return csv2json({ delimiter }).fromFile(csv)
+}
+
+const removeTrailingSlashes = (str: string) =>
+  str.endsWith('/') ? str.substring(0, str.length - 1) : str
+
+export const assertRedirects = (maybeRedirects: any[]): Redirect[] => {
+  const redirects: Redirect[] = []
+  const seen = new Set()
+
+  for (let it = 0; it < maybeRedirects.length; it++) {
+    const { fromPath, toPath, type = 'PERMANENT' } = maybeRedirects[it]
+    const line = it + 1
+
+    if (typeof fromPath !== 'string' || typeof toPath !== 'string') {
+      throw new Error(
+        `[gatsby-source-vtex]: The redirect ${fromPath} -> ${toPath} is not valid in redirects:${line}. Please add a source or target`
+      )
+    }
+
+    if (!fromPath.startsWith('/') || !toPath.startsWith('/')) {
+      throw new Error(
+        `[gatsby-source-vtex]: The redirect ${fromPath} -> ${toPath} is not valid in redirects:${line}. The urls must start with "/"`
+      )
+    }
+
+    if (type !== 'PERMANENT' || type !== 'TEMPORARY') {
+      throw new Error(
+        `[gatsby-source-vtex]: Invalid redirect type in redirects:${line}. Expected TEMPORARY or PERMANENT by received ${type}`
+      )
+    }
+
+    if (seen.has(fromPath)) {
+      throw new Error(
+        `[gatsby-source-vtex]: Redirect ${fromPath} is duplicated in redirects:${line}. Please de-duplicate your redirects before continuing`
+      )
+    }
+
+    seen.add(fromPath)
+
+    redirects.push({
+      fromPath: removeTrailingSlashes(fromPath),
+      toPath: removeTrailingSlashes(toPath),
+      isPermanent: type === 'PERMANENT',
+    })
+  }
+
+  return redirects
+}
+
+const getRedirects = async () => {
+  const maybeRedirects = await redirectsFromCSV({ delimiter: ';' })
+
+  return assertRedirects(maybeRedirects)
+}
+
+export default getRedirects

--- a/packages/gatsby-source-vtex/src/redirects.ts
+++ b/packages/gatsby-source-vtex/src/redirects.ts
@@ -41,9 +41,9 @@ export const assertRedirects = (maybeRedirects: any[]): Redirect[] => {
       )
     }
 
-    if (type !== 'PERMANENT' || type !== 'TEMPORARY') {
+    if (type !== 'PERMANENT' && type !== 'TEMPORARY') {
       throw new Error(
-        `[gatsby-source-vtex]: Invalid redirect type in redirects:${line}. Expected TEMPORARY or PERMANENT by received ${type}`
+        `[gatsby-source-vtex]: Invalid redirect type in redirects:${line}. Expected TEMPORARY or PERMANENT but received ${type}`
       )
     }
 

--- a/packages/gatsby-source-vtex/src/types.ts
+++ b/packages/gatsby-source-vtex/src/types.ts
@@ -89,3 +89,13 @@ export type Sort =
   | 'OrderByBestDiscountDESC'
   | 'OrderByScoreDESC'
   | ''
+
+export interface Redirect {
+  [key: string]: unknown
+  fromPath: string
+  isPermanent?: boolean
+  toPath: string
+  redirectInBrowser?: boolean
+  force?: boolean
+  statusCode?: number
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9669,15 +9669,6 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.5.tgz#7fdec6a28a67ae18647c51668a9ff95bb2fa7bb8"
   integrity sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==
 
-csvtojson@^2.0.10:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/csvtojson/-/csvtojson-2.0.10.tgz#11e7242cc630da54efce7958a45f443210357574"
-  integrity sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==
-  dependencies:
-    bluebird "^3.5.1"
-    lodash "^4.17.3"
-    strip-bom "^2.0.0"
-
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -16866,11 +16857,6 @@ lodash@4.17.20, "lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.17.10, lodash@^4.17.
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.17.3:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^2.1.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5902,13 +5902,13 @@
   resolved "https://registry.yarnpkg.com/@types/yoga-layout/-/yoga-layout-1.9.2.tgz#efaf9e991a7390dc081a0b679185979a83a9639a"
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
-"@typescript-eslint/eslint-plugin@^2.10.0", "@typescript-eslint/eslint-plugin@^2.12.0", "@typescript-eslint/eslint-plugin@^2.24.0", "@typescript-eslint/eslint-plugin@^4", "@typescript-eslint/eslint-plugin@^4.8.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.1.tgz#22dd301ce228aaab3416b14ead10b1db3e7d3180"
-  integrity sha512-5JriGbYhtqMS1kRcZTQxndz1lKMwwEXKbwZbkUZNnp6MJX0+OVXnG0kOlBZP4LUAxEyzu3cs+EXd/97MJXsGfw==
+"@typescript-eslint/eslint-plugin@^2.10.0", "@typescript-eslint/eslint-plugin@^2.12.0", "@typescript-eslint/eslint-plugin@^2.24.0", "@typescript-eslint/eslint-plugin@^4", "@typescript-eslint/eslint-plugin@^4.14.1":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.2.tgz#981b26b4076c62a5a55873fbef3fe98f83360c61"
+  integrity sha512-uiQQeu9tWl3f1+oK0yoAv9lt/KXO24iafxgQTkIYO/kitruILGx3uH+QtIAHqxFV+yIsdnJH+alel9KuE3J15Q==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.14.1"
-    "@typescript-eslint/scope-manager" "4.14.1"
+    "@typescript-eslint/experimental-utils" "4.15.2"
+    "@typescript-eslint/scope-manager" "4.15.2"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     lodash "^4.17.15"
@@ -5916,61 +5916,60 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.14.1", "@typescript-eslint/experimental-utils@^4.0.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.1.tgz#a5c945cb24dabb96747180e1cfc8487f8066f471"
-  integrity sha512-2CuHWOJwvpw0LofbyG5gvYjEyoJeSvVH2PnfUQSn0KQr4v8Dql2pr43ohmx4fdPQ/eVoTSFjTi/bsGEXl/zUUQ==
+"@typescript-eslint/experimental-utils@4.15.2", "@typescript-eslint/experimental-utils@^4.0.1":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.2.tgz#5efd12355bd5b535e1831282e6cf465b9a71cf36"
+  integrity sha512-Fxoshw8+R5X3/Vmqwsjc8nRO/7iTysRtDqx6rlfLZ7HbT8TZhPeQqbPjTyk2RheH3L8afumecTQnUc9EeXxohQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.14.1"
-    "@typescript-eslint/types" "4.14.1"
-    "@typescript-eslint/typescript-estree" "4.14.1"
+    "@typescript-eslint/scope-manager" "4.15.2"
+    "@typescript-eslint/types" "4.15.2"
+    "@typescript-eslint/typescript-estree" "4.15.2"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^2.10.0", "@typescript-eslint/parser@^2.12.0", "@typescript-eslint/parser@^2.24.0", "@typescript-eslint/parser@^4", "@typescript-eslint/parser@^4.8.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.14.1.tgz#3bd6c24710cd557d8446625284bcc9c6d52817c6"
-  integrity sha512-mL3+gU18g9JPsHZuKMZ8Z0Ss9YP1S5xYZ7n68Z98GnPq02pYNQuRXL85b9GYhl6jpdvUc45Km7hAl71vybjUmw==
+"@typescript-eslint/parser@^2.10.0", "@typescript-eslint/parser@^2.12.0", "@typescript-eslint/parser@^2.24.0", "@typescript-eslint/parser@^4", "@typescript-eslint/parser@^4.14.1":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.15.2.tgz#c804474321ef76a3955aec03664808f0d6e7872e"
+  integrity sha512-SHeF8xbsC6z2FKXsaTb1tBCf0QZsjJ94H6Bo51Y1aVEZ4XAefaw5ZAilMoDPlGghe+qtq7XdTiDlGfVTOmvA+Q==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.14.1"
-    "@typescript-eslint/types" "4.14.1"
-    "@typescript-eslint/typescript-estree" "4.14.1"
+    "@typescript-eslint/scope-manager" "4.15.2"
+    "@typescript-eslint/types" "4.15.2"
+    "@typescript-eslint/typescript-estree" "4.15.2"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.14.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.1.tgz#8444534254c6f370e9aa974f035ced7fe713ce02"
-  integrity sha512-F4bjJcSqXqHnC9JGUlnqSa3fC2YH5zTtmACS1Hk+WX/nFB0guuynVK5ev35D4XZbdKjulXBAQMyRr216kmxghw==
+"@typescript-eslint/scope-manager@4.15.2":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.15.2.tgz#5725bda656995960ae1d004bfd1cd70320f37f4f"
+  integrity sha512-Zm0tf/MSKuX6aeJmuXexgdVyxT9/oJJhaCkijv0DvJVT3ui4zY6XYd6iwIo/8GEZGy43cd7w1rFMiCLHbRzAPQ==
   dependencies:
-    "@typescript-eslint/types" "4.14.1"
-    "@typescript-eslint/visitor-keys" "4.14.1"
+    "@typescript-eslint/types" "4.15.2"
+    "@typescript-eslint/visitor-keys" "4.15.2"
 
-"@typescript-eslint/types@4.14.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.1.tgz#b3d2eb91dafd0fd8b3fce7c61512ac66bd0364aa"
-  integrity sha512-SkhzHdI/AllAgQSxXM89XwS1Tkic7csPdndUuTKabEwRcEfR8uQ/iPA3Dgio1rqsV3jtqZhY0QQni8rLswJM2w==
+"@typescript-eslint/types@4.15.2":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.15.2.tgz#04acf3a2dc8001a88985291744241e732ef22c60"
+  integrity sha512-r7lW7HFkAarfUylJ2tKndyO9njwSyoy6cpfDKWPX6/ctZA+QyaYscAHXVAfJqtnY6aaTwDYrOhp+ginlbc7HfQ==
 
-"@typescript-eslint/typescript-estree@4.14.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.1.tgz#20d3b8c8e3cdc8f764bdd5e5b0606dd83da6075b"
-  integrity sha512-M8+7MbzKC1PvJIA8kR2sSBnex8bsR5auatLCnVlNTJczmJgqRn8M+sAlQfkEq7M4IY3WmaNJ+LJjPVRrREVSHQ==
+"@typescript-eslint/typescript-estree@4.15.2":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.2.tgz#c2f7a1e94f3428d229d5ecff3ead6581ee9b62fa"
+  integrity sha512-cGR8C2g5SPtHTQvAymEODeqx90pJHadWsgTtx6GbnTWKqsg7yp6Eaya9nFzUd4KrKhxdYTTFBiYeTPQaz/l8bw==
   dependencies:
-    "@typescript-eslint/types" "4.14.1"
-    "@typescript-eslint/visitor-keys" "4.14.1"
+    "@typescript-eslint/types" "4.15.2"
+    "@typescript-eslint/visitor-keys" "4.15.2"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
-    lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.14.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.1.tgz#e93c2ff27f47ee477a929b970ca89d60a117da91"
-  integrity sha512-TAblbDXOI7bd0C/9PE1G+AFo7R5uc+ty1ArDoxmrC1ah61Hn6shURKy7gLdRb1qKJmjHkqu5Oq+e4Kt0jwf1IA==
+"@typescript-eslint/visitor-keys@4.15.2":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.2.tgz#3d1c7979ce75bf6acf9691109bd0d6b5706192b9"
+  integrity sha512-TME1VgSb7wTwgENN5KVj4Nqg25hP8DisXxNBojM4Nn31rYaNDIocNm5cmjOFfh42n7NVERxWrDFoETO/76ePyg==
   dependencies:
-    "@typescript-eslint/types" "4.14.1"
+    "@typescript-eslint/types" "4.15.2"
     eslint-visitor-keys "^2.0.0"
 
 "@vtex-components/accordion@^0.2.3":
@@ -9670,6 +9669,15 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.5.tgz#7fdec6a28a67ae18647c51668a9ff95bb2fa7bb8"
   integrity sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==
 
+csvtojson@^2.0.10:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/csvtojson/-/csvtojson-2.0.10.tgz#11e7242cc630da54efce7958a45f443210357574"
+  integrity sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==
+  dependencies:
+    bluebird "^3.5.1"
+    lodash "^4.17.3"
+    strip-bom "^2.0.0"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -10783,23 +10791,23 @@ eslint-config-react-app@^5.2.1:
   dependencies:
     confusing-browser-globals "^1.0.9"
 
-eslint-config-vtex-react@^6.9.3:
-  version "6.9.3"
-  resolved "https://registry.yarnpkg.com/eslint-config-vtex-react/-/eslint-config-vtex-react-6.9.3.tgz#a699041b1122b987d5da5abbdbd58d42415b85fe"
-  integrity sha512-qZyBAfrZ5d/4ZxQFO73RsdzvexeD8/bzlAUfFC413kSxw40dNGDQO22e+fBqwrJUJSrePbXiLUkyRisXvxLawg==
+eslint-config-vtex-react@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/eslint-config-vtex-react/-/eslint-config-vtex-react-6.9.4.tgz#0a1518f0496a52d64704de28baff8366966c089b"
+  integrity sha512-kH74cWXleZNUQKgV3Kk29csjmN8n6Gwfu8dcy+50YJ38urAhIoJ9nCWNQZBcbhO7Z9T+RR9kmI8oXlMePT8j9Q==
   dependencies:
-    eslint-config-vtex "^12.9.3"
+    eslint-config-vtex "^12.9.4"
     eslint-plugin-jsx-a11y "^6.3.1"
     eslint-plugin-react "^7.20.6"
     eslint-plugin-react-hooks "^4.1.0"
 
-eslint-config-vtex@^12.9.3:
-  version "12.9.3"
-  resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-12.9.3.tgz#e285fdc31780ddda3ef942e226ef860430b02afb"
-  integrity sha512-lLajiA1Ot2fIGqQbMBC+hnkczKw+i+AbxQsDGuHl87RlRRsQc3YDvVD17AYE7LwNLCKdL39bIMNJeKgOXcRSFQ==
+eslint-config-vtex@^12.9.4:
+  version "12.9.4"
+  resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-12.9.4.tgz#0cfe86fdd98cb1d00c870fce909057e5b8a06085"
+  integrity sha512-D1wwqCJ4LQYaFYk7YcX/Rigqe8bwbs8XSPEHK9NpFoJcFexy0k8mhP7dORcntKfqkfmlPv5cfk+UZws9sNByEA==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "^4.8.1"
-    "@typescript-eslint/parser" "^4.8.1"
+    "@typescript-eslint/eslint-plugin" "^4.14.1"
+    "@typescript-eslint/parser" "^4.14.1"
     confusing-browser-globals "^1.0.9"
     eslint-config-prettier "^6.15.0"
     eslint-plugin-cypress "^2.11.2"
@@ -10915,9 +10923,9 @@ eslint-plugin-import@^2.18.2, eslint-plugin-import@^2.22.0, eslint-plugin-import
     tsconfig-paths "^3.9.0"
 
 eslint-plugin-jest@^24.1.3:
-  version "24.1.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz#fa3db864f06c5623ff43485ca6c0e8fc5fe8ba0c"
-  integrity sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==
+  version "24.1.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.1.5.tgz#1e866a9f0deac587d0a3d5d7cefe99815a580de2"
+  integrity sha512-FIP3lwC8EzEG+rOs1y96cOJmMVpdFNreoDJv29B5vIupVssRi8zrSY3QadogT0K3h1Y8TMxJ6ZSAzYUmFCp2hg==
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 
@@ -16859,6 +16867,11 @@ lodash@4.17.20, "lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.17.10, lodash@^4.17.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lodash@^4.17.3:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-symbols@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
@@ -17575,9 +17588,6 @@ minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
-  dependencies:
-    minipass "^3.0.0"
-    yallist "^4.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?
Usually, VTEX customers need to add custom redirects to their store. This PR adds this first-party capability by making `gatsby-source-vtex` receive a `getRedirects` function. This `async function` receives no argument and must return a list of Redirects. This way, our customer may fetch these redirects list from anywhere he wants.

## How it works? 
Just take a look in the attached PRs:
https://github.com/vtex-sites/btglobal.store/pull/270
https://github.com/vtex-sites/marinbrasil.store/pull/400
https://github.com/vtex-sites/storecomponents.store/pull/565

## How to test it?
<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
