### PR TITLE
Add PageType to PageView event

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.275.0",
+  "version": "0.276.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.275.0",
+  "version": "0.276.0-alpha.0",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.275.0",
+    "@vtex/gatsby-theme-store": "^0.276.0-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/src/pixel/handler.ts
+++ b/packages/gatsby-plugin-google-tag-manager/src/pixel/handler.ts
@@ -3,21 +3,10 @@ import type { PixelEventHandler } from '@vtex/gatsby-theme-store/src/sdk/pixel/u
 
 const getDataFromEvent = (event: PixelEvent) => {
   switch (event.type) {
-    case 'vtex:homeView': {
-      return {
-        event: 'homeView',
-        location: event.data.pageUrl,
-        page: event.data.pageUrl.replace(window.origin, ''),
-        referrer: event.data.referrer,
-        ...(event.data.pageTitle && {
-          title: event.data.pageTitle,
-        }),
-      }
-    }
-
     case 'vtex:pageView': {
       return {
         event: 'pageView',
+        pageType: event.data.pageType,
         location: event.data.pageUrl,
         page: event.data.pageUrl.replace(window.origin, ''),
         referrer: event.data.referrer,
@@ -30,6 +19,7 @@ const getDataFromEvent = (event: PixelEvent) => {
     case 'vtex:internalSiteSearchView': {
       return {
         event: 'internalSiteSearchView',
+        pageType: event.data.pageType,
         siteSearchTerm: event.data.term,
         siteSearchResults: event.data.results,
       }

--- a/packages/gatsby-plugin-google-tag-manager/src/pixel/handler.ts
+++ b/packages/gatsby-plugin-google-tag-manager/src/pixel/handler.ts
@@ -32,7 +32,14 @@ const getDataFromEvent = (event: PixelEvent) => {
         return
       }
 
-      const { productName, brand, items, ...rest } = event.data.product
+      const {
+        productName,
+        brand,
+        items,
+        productId,
+        ...rest
+      } = event.data.product
+
       const price = items?.[0]?.sellers?.[0]?.commercialOffer?.price
 
       return {
@@ -43,6 +50,7 @@ const getDataFromEvent = (event: PixelEvent) => {
                 brand,
                 name: productName,
                 price,
+                productID: productId,
                 ...rest,
               },
             ],

--- a/packages/gatsby-plugin-google-tag-manager/src/pixel/handler.ts
+++ b/packages/gatsby-plugin-google-tag-manager/src/pixel/handler.ts
@@ -32,7 +32,7 @@ const getDataFromEvent = (event: PixelEvent) => {
         return
       }
 
-      const { productName, brand, items } = event.data.product
+      const { productName, brand, items, ...rest } = event.data.product
       const price = items?.[0]?.sellers?.[0]?.commercialOffer?.price
 
       return {
@@ -43,6 +43,7 @@ const getDataFromEvent = (event: PixelEvent) => {
                 brand,
                 name: productName,
                 price,
+                ...rest,
               },
             ],
           },

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.275.0",
+  "version": "0.276.0-alpha.0",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.275.0",
+    "@vtex/gatsby-theme-store": "^0.276.0-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.275.0",
+  "version": "0.276.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/src/pages/index.tsx
+++ b/packages/gatsby-theme-store/src/pages/index.tsx
@@ -8,6 +8,7 @@ import SEO from '../components/HomePage/SEO'
 import Layout from '../components/Layout'
 import SuspenseViewport from '../components/Suspense/Viewport'
 import { usePixelSendEvent } from '../sdk/pixel/usePixelSendEvent'
+import type { PageViewData } from '../sdk/pixel/events'
 
 const belowTheFoldPreloader = () =>
   import('../components/HomePage/BelowTheFold')
@@ -18,17 +19,15 @@ type Props = PageProps<unknown>
 
 const Home: FC<Props> = (props) => {
   usePixelSendEvent(() => {
-    const event = {
+    const event: PageViewData = {
+      pageType: 'home',
       pageUrl: window.location.href,
       pageTitle: document.title,
       referrer: '',
       accountName: process.env.GATSBY_STORE_ID!,
     }
 
-    return [
-      { type: 'vtex:homeView', data: event },
-      { type: 'vtex:pageView', data: event },
-    ]
+    return { type: 'vtex:pageView', data: event }
   })
 
   return (

--- a/packages/gatsby-theme-store/src/sdk/pixel/events.ts
+++ b/packages/gatsby-theme-store/src/sdk/pixel/events.ts
@@ -8,6 +8,7 @@ export interface PageViewData {
   pageTitle: string
   pageUrl: string
   referrer: string
+  pageType: 'home' | 'fullText' | 'pdp' | 'plp'
 }
 
 export interface UserData extends PageViewData {
@@ -23,8 +24,6 @@ export interface UserData extends PageViewData {
 export interface CartIdData extends PageViewData {
   cartId: string
 }
-
-export type HomeViewData = PageViewData
 
 export type ProductPageInfoData = PageViewData
 

--- a/packages/gatsby-theme-store/src/sdk/pixel/pixel.ts
+++ b/packages/gatsby-theme-store/src/sdk/pixel/pixel.ts
@@ -1,5 +1,4 @@
 import type {
-  HomeViewData,
   ProductViewData,
   ProductClickData,
   ProductImpressionData,
@@ -15,7 +14,6 @@ import type {
 } from './events'
 
 export type PixelEvent =
-  | { type: 'vtex:homeView'; data: HomeViewData }
   | { type: 'vtex:productView'; data: ProductViewData }
   | { type: 'vtex:productClick'; data: ProductClickData }
   | { type: 'vtex:productImpression'; data: ProductImpressionData }

--- a/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/handler.ts
+++ b/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/handler.ts
@@ -3,11 +3,15 @@ import type { PixelEvent } from '../pixel'
 
 const getDataFromEvent = (event: PixelEvent) => {
   switch (event.type) {
-    case 'vtex:homeView': {
-      return {
-        type: 'homeView',
-        payload: undefined,
+    case 'vtex:pageView': {
+      if (event.data.pageType === 'home') {
+        return {
+          type: 'homeView',
+          payload: undefined,
+        }
       }
+
+      return
     }
 
     case 'vtex:productView': {

--- a/packages/gatsby-theme-store/src/templates/product.tsx
+++ b/packages/gatsby-theme-store/src/templates/product.tsx
@@ -50,6 +50,7 @@ const ProductPage: FC<ProductPageProps> = (props) => {
       {
         type: 'vtex:pageView',
         data: {
+          pageType: 'pdp',
           pageUrl: window.location.href,
           pageTitle: document.title,
           referrer: document.referrer,

--- a/packages/gatsby-theme-store/src/templates/search.tsx
+++ b/packages/gatsby-theme-store/src/templates/search.tsx
@@ -50,28 +50,34 @@ const SearchPage: FC<SearchPageProps> = (props) => {
   })
 
   usePixelSendEvent(
-    () => [
-      {
-        type: 'vtex:pageView',
-        data: {
-          pageUrl: window.location.href,
-          pageTitle: document.title,
-          referrer: document.referrer,
-          accountName: process.env.GATSBY_STORE_ID!,
+    () => {
+      const pageType = filters.fullText ? 'fullText' : 'plp'
+
+      return [
+        {
+          type: 'vtex:pageView',
+          data: {
+            pageUrl: window.location.href,
+            pageTitle: document.title,
+            referrer: document.referrer,
+            accountName: process.env.GATSBY_STORE_ID!,
+            pageType,
+          },
         },
-      },
-      {
-        type: 'vtex:internalSiteSearchView',
-        data: {
-          accountName: process.env.GATSBY_STORE_ID!,
-          pageUrl: window.location.href,
-          pageTitle: document.title,
-          referrer: document.referrer,
-          term: filters.fullText ?? '',
-          results: data?.vtex.productSearch?.recordsFiltered ?? 0,
+        {
+          type: 'vtex:internalSiteSearchView',
+          data: {
+            accountName: process.env.GATSBY_STORE_ID!,
+            pageUrl: window.location.href,
+            pageTitle: document.title,
+            referrer: document.referrer,
+            term: filters.fullText ?? filters.query ?? '',
+            results: data?.vtex.productSearch?.recordsFiltered ?? 0,
+            pageType,
+          },
         },
-      },
-    ],
+      ]
+    },
     isServer ? '' : window.location.href
   )
 


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds PageType to PageView event on datalayer

PageType may be one of the following `'home' | 'fullText' | 'pdp' | 'plp'`

This way the user can verify each page on the GTM

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
