### PR TITLE
Fix Footer MenuLink slug and name

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-cms",
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.277.2-alpha.0",
+    "@vtex/gatsby-theme-store": "^0.277.2",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.277.1",
+    "@vtex/gatsby-theme-store": "^0.277.2-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-nginx",
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "main": "index.js",
   "license": "MIT",

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.277.2-alpha.0",
+    "@vtex/gatsby-theme-store": "^0.277.2",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.277.1",
+    "@vtex/gatsby-theme-store": "^0.277.2-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^2.24.37",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -33,10 +33,10 @@
   },
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
-    "@vtex/gatsby-plugin-graphql": "^0.277.2-alpha.0",
-    "@vtex/gatsby-plugin-i18n": "^0.277.2-alpha.0",
-    "@vtex/gatsby-plugin-theme-ui": "^0.277.2-alpha.0",
-    "@vtex/store-ui": "^0.277.2-alpha.0",
+    "@vtex/gatsby-plugin-graphql": "^0.277.2",
+    "@vtex/gatsby-plugin-i18n": "^0.277.2",
+    "@vtex/gatsby-plugin-theme-ui": "^0.277.2",
+    "@vtex/store-ui": "^0.277.2",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -33,10 +33,10 @@
   },
   "dependencies": {
     "@theme-ui/match-media": "^0.3.1",
-    "@vtex/gatsby-plugin-graphql": "^0.277.1",
-    "@vtex/gatsby-plugin-i18n": "^0.277.1",
-    "@vtex/gatsby-plugin-theme-ui": "^0.277.1",
-    "@vtex/store-ui": "^0.277.1",
+    "@vtex/gatsby-plugin-graphql": "^0.277.2-alpha.0",
+    "@vtex/gatsby-plugin-i18n": "^0.277.2-alpha.0",
+    "@vtex/gatsby-plugin-theme-ui": "^0.277.2-alpha.0",
+    "@vtex/store-ui": "^0.277.2-alpha.0",
     "gatsby-plugin-bundle-stats": "^2.2.0",
     "gatsby-plugin-react-helmet-async": "^1.1.0",
     "html-loader": "^1.1.0",

--- a/packages/gatsby-theme-store/src/components/Footer.tsx
+++ b/packages/gatsby-theme-store/src/components/Footer.tsx
@@ -12,7 +12,7 @@ interface Item {
 }
 
 const MenuLink: FC<Item> = ({ slug, name }) => (
-  <LocalizedLink to={`/${slug}`}>{name!.split(' ')[0]}</LocalizedLink>
+  <LocalizedLink to={slug!}>{name!.replace(/[,\s].*/, '')}</LocalizedLink>
 )
 
 const Footer: FC = () => {

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lighthouse-config",
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": "vtex/lighthouse-config",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.277.2-alpha.0",
+  "version": "0.277.2",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.277.2-alpha.0",
+    "@vtex/gatsby-plugin-i18n": "^0.277.2",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.277.1",
+  "version": "0.277.2-alpha.0",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@types/theme-ui__components": "^0.2.6",
     "@vtex-components/accordion": "^0.2.3",
     "@vtex-components/drawer": "^0.2.4",
-    "@vtex/gatsby-plugin-i18n": "^0.277.1",
+    "@vtex/gatsby-plugin-i18n": "^0.277.2-alpha.0",
     "deepmerge": "^4.2.2",
     "gatsby-link": "^2.4.13",
     "react-swipeable": "^6.0.0",


### PR DESCRIPTION
## What's the purpose of this pull request?
Fix the footer menu link slug and name.

## How it works? 
To fix the slug, just remove the unnecessary `/` character. To fix the name, used this [regex](https://regex101.com/r/VgZosd/2).