### PR TITLE
Add Codesandbox CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,8 +1,18 @@
 {
   "packages": ["packages/*"],
   "publishDirectory": {
-    "@vtex/store-ui": "packages/store-ui",
-    "@vtex/store-sdk": "packages/store-sdk"
+    "@vtex/gatsby-plugin-cms": ".",
+    "@vtex/gatsby-plugin-theme-ui": ".",
+    "@vtex/gatsby-plugin-google-tag-manager": ".",
+    "@vtex/gatsby-source-vtex": ".",
+    "@vtex/gatsby-plugin-graphql": ".",
+    "@vtex/gatsby-theme-store": ".",
+    "@vtex/gatsby-plugin-i18n": ".",
+    "@vtex/lighthouse-config": ".",
+    "@vtex/gatsby-plugin-nginx": ".",
+    "@vtex/store-sdk": ".",
+    "@vtex/gatsby-plugin-pixel-facebook": ".",
+    "@vtex/store-ui": "."
   },
   "node": "14"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,18 +1,18 @@
 {
   "packages": ["packages/*"],
   "publishDirectory": {
-    "gatsby-plugin-cms": ".",
-    "gatsby-plugin-theme-ui": ".",
-    "gatsby-plugin-google-tag-manager": ".",
-    "gatsby-source-vtex": ".",
-    "gatsby-plugin-graphql": ".",
-    "gatsby-theme-store": ".",
-    "gatsby-plugin-i18n": ".",
-    "lighthouse-config": ".",
-    "gatsby-plugin-nginx": ".",
-    "store-sdk": ".",
-    "gatsby-plugin-pixel-facebook": ".",
-    "store-ui": "."
+    "gatsby-plugin-cms": "packages/gatsby-plugin-cms",
+    "gatsby-plugin-theme-ui": "packages/gatsby-plugin-theme-ui",
+    "gatsby-plugin-google-tag-manager": "packages/gatsby-plugin-google-tag-manager",
+    "gatsby-source-vtex": "packages/gatsby-source-vtex",
+    "gatsby-plugin-graphql": "packages/gatsby-plugin-graphql",
+    "gatsby-theme-store": "packages/gatsby-theme-store",
+    "gatsby-plugin-i18n": "packages/gatsby-plugin-i18n",
+    "lighthouse-config": "packages/lighthouse-config",
+    "gatsby-plugin-nginx": "packages/gatsby-plugin-nginx",
+    "store-sdk": "packages/store-sdk",
+    "gatsby-plugin-pixel-facebook": "packages/gatsby-plugin-pixel-facebook",
+    "store-ui": "packages/store-ui"
   },
   "node": "14"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,4 @@
 {
-  "installCommand": "install",
-  "buildCommand": "build",
   "packages": ["packages/*"],
   "publishDirectory": {
     "@vtex/store-ui": "packages/store-ui",

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "build",
+  "packages": ["packages/*"],
+  "node": "14"
+}

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,18 +1,18 @@
 {
   "packages": ["packages/*"],
   "publishDirectory": {
-    "@vtex/gatsby-plugin-cms": ".",
-    "@vtex/gatsby-plugin-theme-ui": ".",
-    "@vtex/gatsby-plugin-google-tag-manager": ".",
-    "@vtex/gatsby-source-vtex": ".",
-    "@vtex/gatsby-plugin-graphql": ".",
-    "@vtex/gatsby-theme-store": ".",
-    "@vtex/gatsby-plugin-i18n": ".",
-    "@vtex/lighthouse-config": ".",
-    "@vtex/gatsby-plugin-nginx": ".",
-    "@vtex/store-sdk": ".",
-    "@vtex/gatsby-plugin-pixel-facebook": ".",
-    "@vtex/store-ui": "."
+    "gatsby-plugin-cms": ".",
+    "gatsby-plugin-theme-ui": ".",
+    "gatsby-plugin-google-tag-manager": ".",
+    "gatsby-source-vtex": ".",
+    "gatsby-plugin-graphql": ".",
+    "gatsby-theme-store": ".",
+    "gatsby-plugin-i18n": ".",
+    "lighthouse-config": ".",
+    "gatsby-plugin-nginx": ".",
+    "store-sdk": ".",
+    "gatsby-plugin-pixel-facebook": ".",
+    "store-ui": "."
   },
   "node": "14"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,10 @@
 {
+  "installCommand": "install",
   "buildCommand": "build",
   "packages": ["packages/*"],
+  "publishDirectory": {
+    "@vtex/store-ui": "packages/store-ui",
+    "@vtex/store-sdk": "packages/store-sdk"
+  },
   "node": "14"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,18 +1,4 @@
 {
   "packages": ["packages/*"],
-  "publishDirectory": {
-    "gatsby-plugin-cms": "packages/gatsby-plugin-cms",
-    "gatsby-plugin-theme-ui": "packages/gatsby-plugin-theme-ui",
-    "gatsby-plugin-google-tag-manager": "packages/gatsby-plugin-google-tag-manager",
-    "gatsby-source-vtex": "packages/gatsby-source-vtex",
-    "gatsby-plugin-graphql": "packages/gatsby-plugin-graphql",
-    "gatsby-theme-store": "packages/gatsby-theme-store",
-    "gatsby-plugin-i18n": "packages/gatsby-plugin-i18n",
-    "lighthouse-config": "packages/lighthouse-config",
-    "gatsby-plugin-nginx": "packages/gatsby-plugin-nginx",
-    "store-sdk": "packages/store-sdk",
-    "gatsby-plugin-pixel-facebook": "packages/gatsby-plugin-pixel-facebook",
-    "store-ui": "packages/store-ui"
-  },
   "node": "14"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,22 +44,3 @@ jobs:
 
       - name: Test
         run: yarn test --ci --maxWorkers=2
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Use Node 14.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: '14.x'
-
-      - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@v1
-
-      - name: Build
-        run: yarn build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openstore",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Plugins and libraries for building a lightning fast ecommerce in JAMStack",
   "main": "index.js",
   "repository": "git@github.com:vtex/faststore.git",
@@ -49,6 +49,5 @@
   "resolutions": {
     "@typescript-eslint/eslint-plugin": "^4",
     "@typescript-eslint/parser": "^4"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/gatsby-plugin-google-tag-manager/src/pixel/handler.ts
+++ b/packages/gatsby-plugin-google-tag-manager/src/pixel/handler.ts
@@ -1,5 +1,4 @@
-import type { PixelEvent } from '@vtex/gatsby-theme-store/src/sdk/pixel/pixel'
-import type { PixelEventHandler } from '@vtex/gatsby-theme-store/src/sdk/pixel/usePixelEvent'
+import type { PixelEvent, PixelEventHandler } from '@vtex/gatsby-theme-store'
 
 const getDataFromEvent = (event: PixelEvent) => {
   switch (event.type) {

--- a/packages/gatsby-plugin-google-tag-manager/src/pixel/index.tsx
+++ b/packages/gatsby-plugin-google-tag-manager/src/pixel/index.tsx
@@ -1,8 +1,6 @@
 import React, { Fragment, useMemo } from 'react'
 import type { FC } from 'react'
-import { useLazyScript } from '@vtex/gatsby-theme-store/src/sdk/lazyScript/useLazyScript'
-import { usePixelEvent } from '@vtex/gatsby-theme-store/src/sdk/pixel/usePixelEvent'
-import { once } from '@vtex/gatsby-theme-store/src/sdk/once'
+import { useLazyScript, usePixelEvent, once } from '@vtex/gatsby-theme-store'
 
 import { handler } from './handler'
 import { DEFAULT_DATALAYER_CONFIG } from './constants'

--- a/packages/gatsby-plugin-pixel-facebook/src/pixel/handler.ts
+++ b/packages/gatsby-plugin-pixel-facebook/src/pixel/handler.ts
@@ -45,7 +45,8 @@ export const handler: PixelEventHandler = (event) => {
 
       fbq('track', 'AddToCart', {
         value: items.reduce(
-          (acc, item) => acc + (item.price ? item.price : 0),
+          (acc: number, { price }) =>
+            acc + (typeof price === 'number' ? price : 0),
           0
         ),
         content_ids: items.map((sku) => sku.id),

--- a/packages/gatsby-plugin-pixel-facebook/src/pixel/handler.ts
+++ b/packages/gatsby-plugin-pixel-facebook/src/pixel/handler.ts
@@ -1,8 +1,8 @@
-import type { PixelEventHandler } from '@vtex/gatsby-theme-store/src/sdk/pixel/usePixelEvent'
 import type {
+  PixelEventHandler,
   ProductOrder,
   ProductViewData,
-} from '@vtex/gatsby-theme-store/src/sdk/pixel/events'
+} from '@vtex/gatsby-theme-store'
 
 export const handler: PixelEventHandler = (event) => {
   switch (event.type) {

--- a/packages/gatsby-plugin-pixel-facebook/src/pixel/index.tsx
+++ b/packages/gatsby-plugin-pixel-facebook/src/pixel/index.tsx
@@ -1,8 +1,6 @@
 import React, { Fragment, useMemo } from 'react'
 import type { FC } from 'react'
-import { useLazyScript } from '@vtex/gatsby-theme-store/src/sdk/lazyScript/useLazyScript'
-import { usePixelEvent } from '@vtex/gatsby-theme-store/src/sdk/pixel/usePixelEvent'
-import { once } from '@vtex/gatsby-theme-store/src/sdk/once'
+import { useLazyScript, usePixelEvent, once } from '@vtex/gatsby-theme-store'
 
 import type { FBPixelProviderProps } from './types'
 import { handler } from './handler'

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -36,7 +36,6 @@
   "peerDependencies": {
     "@vtex/gatsby-plugin-i18n": "^0.338.0",
     "@vtex/store-sdk": "^0.338.0",
-    "@vtex/store-ui": "^0.338.0",
     "gatsby": "^3.1.1",
     "gatsby-plugin-next-seo": "^1.7.0",
     "react": "^17.0.2",
@@ -65,6 +64,7 @@
     "@vtex/gatsby-plugin-theme-ui": "^0.339.0",
     "@vtex/order-items": "^0.6.1",
     "@vtex/order-manager": "^0.5.2",
+    "@vtex/store-ui": "^0.338.0",
     "gatsby-plugin-bundle-stats": "^2.7.2",
     "html-loader": "^2.1.2",
     "intersection-observer": "^0.11.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -36,6 +36,7 @@
   "peerDependencies": {
     "@vtex/gatsby-plugin-i18n": "^0.338.0",
     "@vtex/store-sdk": "^0.338.0",
+    "@vtex/store-ui": "^0.338.0",
     "gatsby": "^3.1.1",
     "gatsby-plugin-next-seo": "^1.7.0",
     "react": "^17.0.2",
@@ -64,7 +65,6 @@
     "@vtex/gatsby-plugin-theme-ui": "^0.339.0",
     "@vtex/order-items": "^0.6.1",
     "@vtex/order-manager": "^0.5.2",
-    "@vtex/store-ui": "^0.338.0",
     "gatsby-plugin-bundle-stats": "^2.7.2",
     "html-loader": "^2.1.2",
     "intersection-observer": "^0.11.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -8,7 +8,6 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc",
-    "prepare": "cross-env NODE_ENV=production yarn run build",
     "develop": "tsc --watch",
     "test": "tsdx test"
   },

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -34,9 +34,9 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@vtex/gatsby-plugin-i18n": "^0.280.0",
-    "@vtex/store-sdk": "^0.325.0-alpha.0",
-    "@vtex/store-ui": "^0.326.3-alpha.3",
+    "@vtex/gatsby-plugin-i18n": "^0.338.0",
+    "@vtex/store-sdk": "^0.338.0",
+    "@vtex/store-ui": "^0.338.0",
     "gatsby": "^3.1.1",
     "gatsby-plugin-next-seo": "^1.7.0",
     "react": "^17.0.2",

--- a/packages/gatsby-theme-store/src/index.ts
+++ b/packages/gatsby-theme-store/src/index.ts
@@ -67,3 +67,11 @@ export { useRegion } from './sdk/region/useRegion'
 export { setRegion } from './sdk/region/setRegion'
 
 export { useToast } from './sdk/toast/useToast'
+
+export { usePixelSendEvent } from './sdk/pixel/usePixelSendEvent'
+export { usePixelEvent } from './sdk/pixel/usePixelEvent'
+export type { PixelEvent } from './sdk/pixel/pixel'
+export type { PixelEventHandler } from './sdk/pixel/usePixelEvent'
+export * from './sdk/pixel/events'
+
+export { once } from './sdk/once'

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "develop": "tsdx watch",
     "build": "tsdx build",
-    "test": "tsdx test --passWithNoTests",
-    "prepare": "tsdx build"
+    "test": "tsdx test --passWithNoTests"
   },
   "devDependencies": {
     "@vtex/tsconfig": "^0.5.6",

--- a/packages/store-sdk/package.json
+++ b/packages/store-sdk/package.json
@@ -19,7 +19,6 @@
     "build": "tsdx build",
     "test": "tsdx test",
     "lint": "tsdx lint",
-    "prepare": "tsdx build",
     "size": "size-limit",
     "analyze": "size-limit --why"
   },

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -20,7 +20,6 @@
     "develop": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test --passWithNoTests",
-    "prepare": "tsdx build",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17457,6 +17457,9 @@ minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17457,9 +17457,6 @@ minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
-  dependencies:
-    minipass "^3.0.0"
-    yallist "^4.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

The goal of this CI is to make it easier for you to test faststore packages without publishing to npm yet. 

## How it works? 
Every `push` event generates a build in codesandbox. This build will publish a version in codesandbox registry. To acces the published version and use it in your prs:
1. Wait for the Codesandbox CI to finish its job
2. Click on the `here` link. This will take you to codesandbox
![image](https://user-images.githubusercontent.com/1753396/118362643-adacb280-b566-11eb-8776-1a72925aa42b.png)
 3. On the right hand side, you will find a box called `local install instructions`.
![image](https://user-images.githubusercontent.com/1753396/118362675-dcc32400-b566-11eb-8270-83bdf9da801f.png)
4. Copy the install instructions and paste on one of our store's repo.

The changes I had to do to make this CI to work is that I had to remove the `prepare` script for all packages to avoid building twice and thus breaking concurrent builds. Also, I've removed the github action build step, since we are already doing this on codesandbox.

## How to test it?
Go to a store and make sure you can install the built packages

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
