### PR TITLE
Search | Faceted navigation

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.283.0-alpha.0",
+  "version": "0.283.0-alpha.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.283.0-alpha.2",
+  "version": "0.283.0-alpha.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.283.0-alpha.1",
+  "version": "0.283.0-alpha.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.282.0",
+  "version": "0.283.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.283.0-alpha.0",
+  "version": "0.283.0-alpha.1",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.283.0-alpha.0",
+    "@vtex/gatsby-theme-store": "^0.283.0-alpha.1",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.283.0-alpha.2",
+  "version": "0.283.0-alpha.3",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.283.0-alpha.2",
+    "@vtex/gatsby-theme-store": "^0.283.0-alpha.3",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -26,6 +26,5 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^3.1.1"
-  },
-  "gitHead": "0f4948ed164f9acd72b9146e5db5b269e4da8cc1"
+  }
 }

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.283.0-alpha.1",
+  "version": "0.283.0-alpha.2",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.283.0-alpha.1",
+    "@vtex/gatsby-theme-store": "^0.283.0-alpha.2",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.282.0",
+  "version": "0.283.0-alpha.0",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.282.0",
+    "@vtex/gatsby-theme-store": "^0.283.0-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -26,5 +26,6 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^3.1.1"
-  }
+  },
+  "gitHead": "0f4948ed164f9acd72b9146e5db5b269e4da8cc1"
 }

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.282.0",
+  "version": "0.283.0-alpha.0",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.282.0",
+    "@vtex/gatsby-theme-store": "^0.283.0-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.283.0-alpha.0",
+  "version": "0.283.0-alpha.1",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.283.0-alpha.0",
+    "@vtex/gatsby-theme-store": "^0.283.0-alpha.1",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -26,6 +26,5 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^3.1.1"
-  },
-  "gitHead": "0f4948ed164f9acd72b9146e5db5b269e4da8cc1"
+  }
 }

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.283.0-alpha.2",
+  "version": "0.283.0-alpha.3",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.283.0-alpha.2",
+    "@vtex/gatsby-theme-store": "^0.283.0-alpha.3",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.283.0-alpha.1",
+  "version": "0.283.0-alpha.2",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.283.0-alpha.1",
+    "@vtex/gatsby-theme-store": "^0.283.0-alpha.2",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -26,5 +26,6 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^3.1.1"
-  }
+  },
+  "gitHead": "0f4948ed164f9acd72b9146e5db5b269e4da8cc1"
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -51,6 +51,5 @@
     "requestidlecallback-polyfill": "^1.0.2",
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0"
-  },
-  "gitHead": "0f4948ed164f9acd72b9146e5db5b269e4da8cc1"
+  }
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.283.0-alpha.0",
+  "version": "0.283.0-alpha.1",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.283.0-alpha.1",
+  "version": "0.283.0-alpha.2",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.282.0",
+  "version": "0.283.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.283.0-alpha.2",
+  "version": "0.283.0-alpha.3",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -51,5 +51,6 @@
     "requestidlecallback-polyfill": "^1.0.2",
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0"
-  }
+  },
+  "gitHead": "0f4948ed164f9acd72b9146e5db5b269e4da8cc1"
 }

--- a/packages/gatsby-theme-store/src/sdk/search/controller.ts
+++ b/packages/gatsby-theme-store/src/sdk/search/controller.ts
@@ -61,7 +61,6 @@ export const setSearchFilters = (filters: SearchFilters) => {
    */
   const spath = pathname.split('/').slice(1)
   const squery = filters.query.split('/')
-
   const it = spath.findIndex((path) => squery[0] === path) ?? 0
 
   const rootPath = spath.slice(0, it).join('/')

--- a/packages/gatsby-theme-store/src/sdk/search/controller.ts
+++ b/packages/gatsby-theme-store/src/sdk/search/controller.ts
@@ -62,11 +62,7 @@ export const setSearchFilters = (filters: SearchFilters) => {
   const spath = pathname.split('/').slice(1)
   const squery = filters.query.split('/')
 
-  let it = 0
-
-  while (it < spath.length && spath[it] !== squery[0]) {
-    it++
-  }
+  const it = spath.findIndex((path) => squery[0] === path) ?? 0
 
   const rootPath = spath.slice(0, it).join('/')
   const path = rootPath ? `${rootPath}/${filters.query}` : filters.query

--- a/packages/gatsby-theme-store/src/sdk/search/controller.ts
+++ b/packages/gatsby-theme-store/src/sdk/search/controller.ts
@@ -29,7 +29,7 @@ export const search = (term: string) => {
 }
 
 export const setSearchFilters = (filters: SearchFilters) => {
-  const { search: searchParams } = window.location
+  const { search: searchParams, pathname } = window.location
   const params = new URLSearchParams(searchParams)
   const filterNames = Object.keys(filters) as Array<keyof SearchFilters>
 
@@ -53,7 +53,25 @@ export const setSearchFilters = (filters: SearchFilters) => {
     }
   }
 
-  navigate(`/${filters.query}?${params.toString()}`)
+  /**
+   * Usually, "filters.query" is the right place to navigate to. However, in landing pages
+   * the "filters.query" contains a different value from the page's root path because the
+   * business user decides the value of "canonicalPath". This makes us have to always
+   * add the root path to the navigation so we never miss the landing page navigation context
+   */
+  const spath = pathname.split('/').slice(1)
+  const squery = filters.query.split('/')
+
+  let it = 0
+
+  while (it < spath.length && spath[it] !== squery[0]) {
+    it++
+  }
+
+  const rootPath = spath.slice(0, it).join('/')
+  const path = rootPath ? `${rootPath}/${filters.query}` : filters.query
+
+  navigate(`/${path}?${params.toString()}`)
 }
 
 // TODO: This function can be moved to the backend if we have a decent graphql layer

--- a/packages/gatsby-theme-store/src/sdk/search/useSearchFiltersFromPageContext.ts
+++ b/packages/gatsby-theme-store/src/sdk/search/useSearchFiltersFromPageContext.ts
@@ -1,57 +1,53 @@
 import { useLocation } from '@reach/router'
 import { useMemo } from 'react'
 
-import type { SearchPageQueryQueryVariables } from '../../templates/__generated__/SearchPageQuery.graphql'
 import { format, parse } from './priceRange'
+import type { SearchPageContext } from '../../templates/search'
 
-// Creates a string with as many `c,c` as pathname has
-// segments.
-// For instance: cozinha/faqueiro-e-talheres would
-// generate the string c,c
-//
-// TODO: this function may have to change in the future
-const createMap = (query: string) => {
-  const splitted = query.split('/')
-
-  // We have generated all departments/brands statically, so it's safe
-  // to assume that, if the process reach this code, the path
-  // is a full text search
-  if (splitted.length === 1) {
-    return 'ft'
-  }
-
-  return new Array(splitted.length).fill('c').join(',')
+export interface SelectedFacets {
+  key: string
+  value: string
 }
 
-// I think this function should change to a more simpler version.
-const selectedFacetsAfterQueryAndMap = (query: string, map: string) => {
-  const smap = map.split(',')
-  const squery = query.split('/')
+const searchParamsFromURL = (pathname: string, params: URLSearchParams) => {
+  const smap = params.get('map')?.split(',')
+  const spath = pathname.split('/').slice(1)
 
-  const selectedFacets: Array<{ key: string; value: string }> = []
-
-  for (let it = 0; it < smap.length; it++) {
-    selectedFacets.push({ key: smap[it], value: squery[it] })
+  if (smap === undefined) {
+    throw new Error(
+      `Search page does not have enough information to create search context from URL. Please add a 'map' querystring to the page`
+    )
   }
 
-  return selectedFacets
-}
+  if (smap.length > spath.length) {
+    throw new Error(
+      `Invalid search querystring. There are more map params than segments on the path: (map: ${smap.join(
+        ','
+      )}, pathname: ${pathname}). `
+    )
+  }
 
-// Removes starting/ending slashes
-// ex: trimQuery('/p0/p1/') -> 'p0/p1'
-//
-// Slice is done only once to improve performance !
-//
-// TODO: This function should be removed eventually
-const trimQuery = (query: string) => {
-  const i = query[0] === '/' ? 1 : 0
-  const j = query[query.length - 1] === '/' ? query.length - 1 : query.length
+  const selectedFacets = new Array<SelectedFacets>(smap.length)
+  const squery = new Array<string>(smap.length)
 
-  return query.slice(i, j)
+  for (let it = smap.length - 1; it >= 0; it--) {
+    squery[it] = spath[it + spath.length - squery.length]
+
+    selectedFacets[it] = {
+      key: smap[it],
+      value: squery[it],
+    }
+  }
+
+  return {
+    query: squery.join('/'),
+    map: smap.join(','),
+    selectedFacets,
+  }
 }
 
 export const useSearchFiltersFromPageContext = (
-  pageContext: SearchPageQueryQueryVariables
+  pageContext: SearchPageContext
 ) => {
   const location = useLocation()
   const { search, pathname } = location
@@ -60,15 +56,17 @@ export const useSearchFiltersFromPageContext = (
     const params = new URLSearchParams(search)
     let query = pageContext.query!
     let map = pageContext.map!
-    let selectedFacets = pageContext.selectedFacets! as Array<{
-      key: string
-      value: string
-    }>
+    let selectedFacets = pageContext.selectedFacets! as SelectedFacets[]
 
+    /**
+     *  Hydrates search context for dynamic search pages.
+     */
     if (pageContext.staticPath === false) {
-      query = trimQuery(pathname)
-      map = params.get('map') ?? createMap(query)
-      selectedFacets = selectedFacetsAfterQueryAndMap(query, map)
+      const searchParams = searchParamsFromURL(pathname, params)
+
+      query = searchParams.query
+      map = searchParams.map
+      selectedFacets = searchParams.selectedFacets
     }
 
     const fullText = map.startsWith('ft') ? query.split('/')[0] : undefined
@@ -100,11 +98,11 @@ export const useSearchFiltersFromPageContext = (
     }
   }, [
     search,
-    pageContext.staticPath,
     pageContext.query,
     pageContext.map,
-    pageContext.orderBy,
     pageContext.selectedFacets,
+    pageContext.staticPath,
+    pageContext.orderBy,
     pathname,
   ])
 }

--- a/packages/gatsby-theme-store/src/templates/search.tsx
+++ b/packages/gatsby-theme-store/src/templates/search.tsx
@@ -26,10 +26,14 @@ const belowTheFoldPreloader = () =>
 
 const BelowTheFold = lazy(belowTheFoldPreloader)
 
+export type SearchPageContext = SearchPageQueryQueryVariables
+
 export type SearchPageProps = PageProps<
   SearchPageQueryQuery,
-  SearchPageQueryQueryVariables
-> & { staticPath: boolean }
+  SearchPageContext
+> & {
+  staticPath: boolean
+}
 
 const SearchPage: FC<SearchPageProps> = (props) => {
   const { pageContext, data: staticData } = props


### PR DESCRIPTION
## What's the purpose of this pull request?
Add root path to search logic. This should allow landing pages to keep their search context on faceted navigation

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
[btglobal](https://github.com/vtex-sites/btglobal.store/pull/325)
[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/416)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/662)

Open https://btglobal.vtex.app/sale and select a filter. After, open https://preview-325--btglobal.vtex.app/sale .Check that in the preview, the image keeps on the screen and that the url starts with `/sale`. Also, check that the canonical tags are correctly appearing

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
