### PR TITLE
Adds content-visibility auto to below the fold loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ packages/gatsby-**/**/*.json
 
 # gatsby-plugin-nginx manual tests
 !**/manual-test/**
+
+# Watchman
+**/.watchmanconfig

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.288.0",
+  "version": "0.289.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.288.0",
+  "version": "0.289.0-alpha.0",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.288.0",
+    "@vtex/gatsby-theme-store": "^0.289.0-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.288.0",
+  "version": "0.289.0-alpha.0",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.288.0",
+    "@vtex/gatsby-theme-store": "^0.289.0-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.288.0",
+  "version": "0.289.0-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-theme-store/src/components/HomePage/BelowTheFoldPreview.tsx
+++ b/packages/gatsby-theme-store/src/components/HomePage/BelowTheFoldPreview.tsx
@@ -1,11 +1,20 @@
 import { Center, Spinner } from '@vtex/store-ui'
-import type { FC } from 'react'
+import type { FC, CSSProperties } from 'react'
 import React from 'react'
 
 const BelowTheFoldPreview: FC = () => (
-  <Center height="500px">
-    <Spinner />
-  </Center>
+  <div
+    style={
+      ({
+        contentVisibility: 'auto',
+        containIntrinsicSize: '500px',
+      } as unknown) as CSSProperties
+    }
+  >
+    <Center height="500px">
+      <Spinner />
+    </Center>
+  </div>
 )
 
 export default BelowTheFoldPreview

--- a/packages/gatsby-theme-store/src/components/ProductPage/BelowTheFoldPreview.tsx
+++ b/packages/gatsby-theme-store/src/components/ProductPage/BelowTheFoldPreview.tsx
@@ -1,11 +1,20 @@
 import { Center, Spinner } from '@vtex/store-ui'
 import React from 'react'
-import type { FC } from 'react'
+import type { FC, CSSProperties } from 'react'
 
 const BelowTheFoldPreview: FC = () => (
-  <Center height="500px">
-    <Spinner />
-  </Center>
+  <div
+    style={
+      ({
+        contentVisibility: 'auto',
+        containIntrinsicSize: '500px',
+      } as unknown) as CSSProperties
+    }
+  >
+    <Center height="500px">
+      <Spinner />
+    </Center>
+  </div>
 )
 
 export default BelowTheFoldPreview

--- a/packages/gatsby-theme-store/src/components/SearchPage/BelowTheFoldPreview.tsx
+++ b/packages/gatsby-theme-store/src/components/SearchPage/BelowTheFoldPreview.tsx
@@ -1,11 +1,20 @@
 import { Center, Spinner } from '@vtex/store-ui'
 import React from 'react'
-import type { FC } from 'react'
+import type { FC, CSSProperties } from 'react'
 
 const BelowTheFoldPreview: FC = () => (
-  <Center height="500px">
-    <Spinner />
-  </Center>
+  <div
+    style={
+      ({
+        contentVisibility: 'auto',
+        containIntrinsicSize: '500px',
+      } as unknown) as CSSProperties
+    }
+  >
+    <Center height="500px">
+      <Spinner />
+    </Center>
+  </div>
 )
 
 export default BelowTheFoldPreview


### PR DESCRIPTION
## What's the purpose of this pull request?
I was following [this guide](https://web.dev/content-visibility/) on how to improve the browser's rendering  pipeline. 

Since we are already following the above/below the fold split of rendering I think we don't run into much trouble in here, however I thought it was good to give it a try. 

After this PR, I've got an average reduction of 50ms in rendering on btglobal

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
[btglobal](https://github.com/vtex-sites/btglobal.store/pull/338)
[marinbrasil](https://github.com/vtex-sites/marinbrasil.store/pull/425)
[storecomponents](https://github.com/vtex-sites/storecomponents.store/pull/686)

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
