### PR TITLE
Changing files redirect and adding legacy_extensions proxy

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.294.0",
+  "version": "0.294.1-fabi.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-source-vtex",
-  "version": "0.294.0",
+  "version": "0.294.1-fabi.0",
   "description": "Gatsby source plugin for building websites using VTEX as a data source.",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-source-vtex/src/gatsby-config.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-config.ts
@@ -5,7 +5,12 @@ import type { Options } from './gatsby-node'
  * If adding a new rule, don't forget to create a redirect in ./gatsby-node.ts
  * so the redirect works in production websites as well
  */
-module.exports = ({ tenant, workspace, environment }: Options) => ({
+module.exports = ({
+  tenant,
+  workspace,
+  environment,
+  filesNewPath = false,
+}: Options) => ({
   proxy: [
     {
       prefix: '/api/io',
@@ -20,12 +25,18 @@ module.exports = ({ tenant, workspace, environment }: Options) => ({
       url: `https://${workspace}--${tenant}.myvtex.com`,
     },
     {
+      prefix: '/legacy_extensions',
+      url: `https://${workspace}--${tenant}.myvtex.com`,
+    },
+    {
       prefix: '/arquivos',
       url: `https://${tenant}.vtexassets.com`,
     },
     {
       prefix: '/files',
-      url: `https://${tenant}.vtexassets.com`,
+      url: filesNewPath
+        ? `https://${workspace}--${tenant}.myvtex.com`
+        : `https://${tenant}.vtexassets.com`,
     },
     {
       prefix: '/graphql',

--- a/packages/gatsby-source-vtex/src/gatsby-config.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-config.ts
@@ -5,12 +5,7 @@ import type { Options } from './gatsby-node'
  * If adding a new rule, don't forget to create a redirect in ./gatsby-node.ts
  * so the redirect works in production websites as well
  */
-module.exports = ({
-  tenant,
-  workspace,
-  environment,
-  filesNewPath = false,
-}: Options) => ({
+module.exports = ({ tenant, workspace, environment }: Options) => ({
   proxy: [
     {
       prefix: '/api/io',
@@ -34,9 +29,7 @@ module.exports = ({
     },
     {
       prefix: '/files',
-      url: filesNewPath
-        ? `https://${workspace}--${tenant}.myvtex.com`
-        : `https://${tenant}.vtexassets.com`,
+      url: `https://${workspace}--${tenant}.myvtex.com`,
     },
     {
       prefix: '/graphql',

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -37,6 +37,7 @@ export interface Options extends PluginOptions, VTEXOptions {
   pageTypes?: Array<PageType['pageType']>
   ignorePaths?: string[]
   concurrency?: number
+  filesNewPath?: boolean
 }
 
 const DEFAULT_PAGE_TYPES_WHITELIST = [
@@ -221,7 +222,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
 
 export const createPages = async (
   { actions: { createRedirect }, reporter }: CreatePageArgs,
-  { tenant, workspace, environment, getRedirects }: Options
+  { tenant, workspace, environment, filesNewPath, getRedirects }: Options
 ) => {
   /**
    * Create all proxy rules for VTEX Store
@@ -306,16 +307,18 @@ export const createPages = async (
     },
   })
 
-  createRedirect({
-    fromPath: '/files/*',
-    toPath: `https://${tenant}.vtexassets.com/files/:splat`,
-    statusCode: 200,
-    proxyHeaders: {
-      // VTEX ID needs the forwarded host in order to set the cookie correctly
-      'x-forwarded-host': '$origin_host',
-      via: "''",
-    },
-  })
+  if (!filesNewPath) {
+    createRedirect({
+      fromPath: '/files/*',
+      toPath: `https://${tenant}.vtexassets.com/files/:splat`,
+      statusCode: 200,
+      proxyHeaders: {
+        // VTEX ID needs the forwarded host in order to set the cookie correctly
+        'x-forwarded-host': '$origin_host',
+        via: "''",
+      },
+    })
+  }
 
   // Use graphql-gateway from VTEX IO
   createRedirect({

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -37,7 +37,6 @@ export interface Options extends PluginOptions, VTEXOptions {
   pageTypes?: Array<PageType['pageType']>
   ignorePaths?: string[]
   concurrency?: number
-  filesNewPath?: boolean
 }
 
 const DEFAULT_PAGE_TYPES_WHITELIST = [
@@ -307,18 +306,16 @@ export const createPages = async (
     },
   })
 
-  if (!filesNewPath) {
-    createRedirect({
-      fromPath: '/files/*',
-      toPath: `https://${tenant}.vtexassets.com/files/:splat`,
-      statusCode: 200,
-      proxyHeaders: {
-        // VTEX ID needs the forwarded host in order to set the cookie correctly
-        'x-forwarded-host': '$origin_host',
-        via: "''",
-      },
-    })
-  }
+  createRedirect({
+    fromPath: '/files/*',
+    toPath: `https://${workspace}--${tenant}.myvtex.com/files/:splat`,
+    statusCode: 200,
+    proxyHeaders: {
+      // VTEX ID needs the forwarded host in order to set the cookie correctly
+      'x-forwarded-host': '$origin_host',
+      via: "''",
+    },
+  })
 
   // Use graphql-gateway from VTEX IO
   createRedirect({

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -221,7 +221,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
 
 export const createPages = async (
   { actions: { createRedirect }, reporter }: CreatePageArgs,
-  { tenant, workspace, environment, filesNewPath, getRedirects }: Options
+  { tenant, workspace, environment, getRedirects }: Options
 ) => {
   /**
    * Create all proxy rules for VTEX Store


### PR DESCRIPTION
## What's the purpose of this pull request?
To change the proxy and the redirect for the `/files` path, in order to be able to get files such as the CSS ones that are defined by customizing the checkout, which is done by Carrefour. Besides that, we add the proxy rule for the legacy extensions path, which was a redirect previously defined, but with no proxy related to it.

[Marin #435](https://github.com/vtex-sites/marinbrasil.store/pull/435) 
[Boti #355](https://github.com/vtex-sites/btglobal.store/pull/355)
