### PR TITLE
Add values to product queryes

### DIFF
--- a/packages/gatsby-theme-store/src/components/ProductPage/AboveTheFold.tsx
+++ b/packages/gatsby-theme-store/src/components/ProductPage/AboveTheFold.tsx
@@ -78,6 +78,7 @@ export const fragment = graphql`
     }
     productClusters {
       name
+      id
     }
   }
 `

--- a/packages/gatsby-theme-store/src/components/ProductPage/AboveTheFold.tsx
+++ b/packages/gatsby-theme-store/src/components/ProductPage/AboveTheFold.tsx
@@ -77,8 +77,14 @@ export const fragment = graphql`
       }
     }
     productClusters {
+      id
       name
       id
+    }
+    properties {
+      name
+      originalName
+      values
     }
   }
 `

--- a/packages/gatsby-theme-store/src/components/ProductSummary/index.tsx
+++ b/packages/gatsby-theme-store/src/components/ProductSummary/index.tsx
@@ -69,11 +69,6 @@ export const fragment = graphql`
       id
       name
     }
-    properties {
-      name
-      originalName
-      values
-    }
   }
 `
 

--- a/packages/gatsby-theme-store/src/components/ProductSummary/index.tsx
+++ b/packages/gatsby-theme-store/src/components/ProductSummary/index.tsx
@@ -37,9 +37,6 @@ export const fragment = graphql`
     id: productId
     productName
     linkText
-    productClusters {
-      name
-    }
     items {
       itemId
       images {
@@ -67,6 +64,15 @@ export const fragment = graphql`
           }
         }
       }
+    }
+    productClusters {
+      id
+      name
+    }
+    properties {
+      name
+      originalName
+      values
     }
   }
 `


### PR DESCRIPTION
## What's the purpose of this pull request?
Be able to access product clusters id at Product Page and ProductSummary.

## How it works? 
The `id` value was added at the product details query.

## How to test it?
Check on the network tab at devtools like the example: 
![image](https://user-images.githubusercontent.com/27689698/113027705-c4d34480-9160-11eb-8e13-7e0edc8a3eaa.png)

