### PR TITLE
Adding region context to search suggestions

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.301.0",
+  "version": "0.301.1-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.301.0",
+  "version": "0.301.1-alpha.0",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.301.0",
+    "@vtex/gatsby-theme-store": "^0.301.1-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.301.0",
+  "version": "0.301.1-alpha.0",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.301.0",
+    "@vtex/gatsby-theme-store": "^0.301.1-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.301.0",
+  "version": "0.301.1-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "module": "src/index.ts",

--- a/packages/gatsby-theme-store/src/components/SearchSuggestions/Products/__generated__/ProductsSuggestionsQuery.graphql.ts
+++ b/packages/gatsby-theme-store/src/components/SearchSuggestions/Products/__generated__/ProductsSuggestionsQuery.graphql.ts
@@ -19,6 +19,7 @@ type Scalars = {
 // Operation related types
 export type ProductsSuggestionsQueryQueryVariables = Exact<{
   fullText: Scalars['String'];
+  regionId: Maybe<Scalars['String']>;
   facetKey: Maybe<Scalars['String']>;
   facetValue: Maybe<Scalars['String']>;
   productOriginVtex?: Maybe<Scalars['Boolean']>;
@@ -32,8 +33,8 @@ export type ProductsSuggestionsQueryQuery = { vtex: { productSuggestions: Maybe<
 // Query Related Code
 
 export const ProductsSuggestionsQuery = {
-  query: process.env.NODE_ENV === 'production' ? undefined : "query ProductsSuggestionsQuery($fullText: String!, $facetKey: String, $facetValue: String, $productOriginVtex: Boolean = true, $simulationBehavior: VTEX_SimulationBehavior = default) {\n  vtex {\n    productSuggestions(\n      fullText: $fullText\n      facetKey: $facetKey\n      facetValue: $facetValue\n      productOriginVtex: $productOriginVtex\n      simulationBehavior: $simulationBehavior\n    ) {\n      count\n      products {\n        key: productId\n        id: productId\n        productName\n        linkText\n        productClusters {\n          name\n        }\n        items {\n          itemId\n          images {\n            imageUrl\n            imageText\n          }\n          sellers {\n            sellerId\n            commercialOffer: commertialOffer {\n              maxInstallments: Installments(criteria: MAX_WITHOUT_INTEREST) {\n                value: Value\n                numberOfInstallments: NumberOfInstallments\n              }\n              installments: Installments(criteria: ALL) {\n                value: Value\n                numberOfInstallments: NumberOfInstallments\n                interestRate: InterestRate\n              }\n              availableQuantity: AvailableQuantity\n              price: Price\n              listPrice: ListPrice\n              spotPrice\n              teasers {\n                name\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n",
-  sha256Hash: "988797b1289521adb62c39f19a5a057acbcf6a81e3917f0234ced2fcad8359c6",
+  query: process.env.NODE_ENV === 'production' ? undefined : "query ProductsSuggestionsQuery($fullText: String!, $regionId: String, $facetKey: String, $facetValue: String, $productOriginVtex: Boolean = true, $simulationBehavior: VTEX_SimulationBehavior = default) {\n  vtex {\n    productSuggestions(\n      fullText: $fullText\n      regionId: $regionId\n      facetKey: $facetKey\n      facetValue: $facetValue\n      productOriginVtex: $productOriginVtex\n      simulationBehavior: $simulationBehavior\n    ) {\n      count\n      products {\n        key: productId\n        id: productId\n        productName\n        linkText\n        productClusters {\n          name\n        }\n        items {\n          itemId\n          images {\n            imageUrl\n            imageText\n          }\n          sellers {\n            sellerId\n            commercialOffer: commertialOffer {\n              maxInstallments: Installments(criteria: MAX_WITHOUT_INTEREST) {\n                value: Value\n                numberOfInstallments: NumberOfInstallments\n              }\n              installments: Installments(criteria: ALL) {\n                value: Value\n                numberOfInstallments: NumberOfInstallments\n                interestRate: InterestRate\n              }\n              availableQuantity: AvailableQuantity\n              price: Price\n              listPrice: ListPrice\n              spotPrice\n              teasers {\n                name\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n",
+  sha256Hash: "34ac9974b643156fcdc8d796f7cfafde88b052637ba07f89fd7aa13847aea0bf",
   operationName: "ProductsSuggestionsQuery",
 }
 

--- a/packages/gatsby-theme-store/src/components/SearchSuggestions/Products/hooks.ts
+++ b/packages/gatsby-theme-store/src/components/SearchSuggestions/Products/hooks.ts
@@ -1,6 +1,7 @@
 import { gql } from '@vtex/gatsby-plugin-graphql'
 
 import { useQuery } from '../../../sdk/graphql/useQuery'
+import { useRegion } from '../../../sdk/region/useRegion'
 import { useSearchSuggestionsContext } from '../base/hooks'
 import { ProductsSuggestionsQuery } from './__generated__/ProductsSuggestionsQuery.graphql'
 import type {
@@ -14,6 +15,7 @@ interface Props {
 }
 
 export const useProductsSuggestions = ({ maxItems, term }: Props) => {
+  const regionContext = useRegion()
   const context = useSearchSuggestionsContext()
   const response = useQuery<
     ProductsSuggestionsQueryQuery,
@@ -22,6 +24,7 @@ export const useProductsSuggestions = ({ maxItems, term }: Props) => {
     ...ProductsSuggestionsQuery,
     variables: {
       fullText: term,
+      regionId: regionContext.regionId,
     },
     suspense: false,
   })
@@ -50,6 +53,7 @@ export const useProductsSuggestions = ({ maxItems, term }: Props) => {
 export const query = gql`
   query ProductsSuggestionsQuery(
     $fullText: String!
+    $regionId: String
     $facetKey: String
     $facetValue: String
     $productOriginVtex: Boolean = true
@@ -58,6 +62,7 @@ export const query = gql`
     vtex {
       productSuggestions(
         fullText: $fullText
+        regionId: $regionId
         facetKey: $facetKey
         facetValue: $facetValue
         productOriginVtex: $productOriginVtex


### PR DESCRIPTION
## What's the purpose of this pull request?
Solves the problem of having products that are not available in a specific region shown in the search autocomplete.

## How it works? 
It adds the region context, in order to use the region ID in the query that gets the results for the search autocomplete. By doing that, it allows us to have the suggestions filtered by the region.

## How to test it?
<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
