### PR TITLE
Add deny rule for nginx.conf

### DIFF
--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -155,6 +155,15 @@ function generateNginxConfiguration({
                 // https://www.gatsbyjs.com/docs/how-to/adding-common-features/add-404-page/
                 { cmd: ['error_page', '404', '/404.html'] },
 
+                // Block nginx.conf
+                {
+                  cmd: ['location', '/nginx.conf'],
+                  children: [
+                    { cmd: ['deny', 'all'] },
+                    { cmd: ['return', '404'] },
+                  ],
+                },
+
                 ...locations,
               ],
             },

--- a/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
+++ b/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
@@ -232,6 +232,10 @@ describe('generateNginxConfiguration', () => {
           listen 0.0.0.0:$PORT default_server;
           resolver 8.8.8.8;
           error_page 404 /404.html;
+          location /nginx.conf {
+            deny all;
+            return 404;
+          }
           location = /foo {
             add_header a \\"b\\";
             try_files /foo/index.html =404;


### PR DESCRIPTION
## What's the purpose of this pull request?
Stops serving nginx.conf

## How it works? 
When nginx.conf is request a 404 page is returned.

## How to test it?
<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
