### PR TITLE
Remove custom browser config from package.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.326.3-alpha.3",
+  "version": "0.326.3-alpha.4",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.326.3-alpha.1",
+  "version": "0.326.3-alpha.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.325.0",
+  "version": "0.326.3-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
@@ -7,5 +7,7 @@
       "message": "Release: %v"
     }
   },
-  "packages": ["packages/*"]
+  "packages": [
+    "packages/*"
+  ]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.326.3-alpha.2",
+  "version": "0.326.3-alpha.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.326.3-alpha.0",
+  "version": "0.326.3-alpha.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
@@ -7,7 +7,5 @@
       "message": "Release: %v"
     }
   },
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.326.3-alpha.2",
+  "version": "0.326.3-alpha.3",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.326.3-alpha.2",
+    "@vtex/gatsby-theme-store": "^0.326.3-alpha.3",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.326.3-alpha.3",
+  "version": "0.326.3-alpha.4",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.326.3-alpha.3",
+    "@vtex/gatsby-theme-store": "^0.326.3-alpha.4",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.326.3-alpha.0",
+  "version": "0.326.3-alpha.1",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.326.3-alpha.0",
+    "@vtex/gatsby-theme-store": "^0.326.3-alpha.1",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.326.3-alpha.1",
+  "version": "0.326.3-alpha.2",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.326.3-alpha.1",
+    "@vtex/gatsby-theme-store": "^0.326.3-alpha.2",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -26,5 +26,6 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^3.1.1"
-  }
+  },
+  "gitHead": "afb00a07fb4055657d7f17e37fea1912d1cb1474"
 }

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -27,5 +27,5 @@
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^3.1.1"
   },
-  "gitHead": "afb00a07fb4055657d7f17e37fea1912d1cb1474"
+  "gitHead": "ec018f1f4145a8bf36f6857c9589714ea89855fb"
 }

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -26,6 +26,5 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^3.1.1"
-  },
-  "gitHead": "ec018f1f4145a8bf36f6857c9589714ea89855fb"
+  }
 }

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
-  "version": "0.325.0",
+  "version": "0.326.3-alpha.0",
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.325.0",
+    "@vtex/gatsby-theme-store": "^0.326.3-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.325.0",
+  "version": "0.326.3-alpha.0",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.325.0",
+    "@vtex/gatsby-theme-store": "^0.326.3-alpha.0",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.326.3-alpha.0",
+  "version": "0.326.3-alpha.1",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.326.3-alpha.0",
+    "@vtex/gatsby-theme-store": "^0.326.3-alpha.1",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.326.3-alpha.1",
+  "version": "0.326.3-alpha.2",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.326.3-alpha.1",
+    "@vtex/gatsby-theme-store": "^0.326.3-alpha.2",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.326.3-alpha.2",
+  "version": "0.326.3-alpha.3",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.326.3-alpha.2",
+    "@vtex/gatsby-theme-store": "^0.326.3-alpha.3",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -26,5 +26,6 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^3.1.1"
-  }
+  },
+  "gitHead": "afb00a07fb4055657d7f17e37fea1912d1cb1474"
 }

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -27,5 +27,5 @@
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^3.1.1"
   },
-  "gitHead": "afb00a07fb4055657d7f17e37fea1912d1cb1474"
+  "gitHead": "ec018f1f4145a8bf36f6857c9589714ea89855fb"
 }

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -26,6 +26,5 @@
   "peerDependencies": {
     "@vtex/gatsby-theme-store": "^0.255.6-alpha.0",
     "gatsby": "^3.1.1"
-  },
-  "gitHead": "ec018f1f4145a8bf36f6857c9589714ea89855fb"
+  }
 }

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-plugin-pixel-facebook",
-  "version": "0.326.3-alpha.3",
+  "version": "0.326.3-alpha.4",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
   "main": "index.js",
   "browser": "src/index.ts",
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@vtex/gatsby-theme-store": "^0.326.3-alpha.3",
+    "@vtex/gatsby-theme-store": "^0.326.3-alpha.4",
     "cross-env": "^7.0.2",
     "gatsby": "^3.1.1",
     "typescript": "^4.1.2"

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.326.3-alpha.1",
+  "version": "0.326.3-alpha.2",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "module": "src/index.ts",
@@ -61,7 +61,7 @@
     "@vtex/gatsby-plugin-theme-ui": "^0.325.0",
     "@vtex/order-items": "^0.6.1",
     "@vtex/order-manager": "^0.5.2",
-    "@vtex/store-ui": "^0.326.3-alpha.1",
+    "@vtex/store-ui": "^0.326.3-alpha.2",
     "gatsby-plugin-bundle-stats": "^2.7.2",
     "html-loader": "^2.1.2",
     "intersection-observer": "^0.11.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -71,5 +71,6 @@
     "requestidlecallback-polyfill": "^1.0.2",
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0"
-  }
+  },
+  "gitHead": "afb00a07fb4055657d7f17e37fea1912d1cb1474"
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.325.0",
+  "version": "0.326.3-alpha.0",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "module": "src/index.ts",
@@ -61,7 +61,7 @@
     "@vtex/gatsby-plugin-theme-ui": "^0.325.0",
     "@vtex/order-items": "^0.6.1",
     "@vtex/order-manager": "^0.5.2",
-    "@vtex/store-ui": "^0.325.0",
+    "@vtex/store-ui": "^0.326.3-alpha.0",
     "gatsby-plugin-bundle-stats": "^2.7.2",
     "html-loader": "^2.1.2",
     "intersection-observer": "^0.11.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.326.3-alpha.3",
+  "version": "0.326.3-alpha.4",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "module": "src/index.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -71,6 +71,5 @@
     "requestidlecallback-polyfill": "^1.0.2",
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0"
-  },
-  "gitHead": "ec018f1f4145a8bf36f6857c9589714ea89855fb"
+  }
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.326.3-alpha.0",
+  "version": "0.326.3-alpha.1",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "module": "src/index.ts",
@@ -61,7 +61,7 @@
     "@vtex/gatsby-plugin-theme-ui": "^0.325.0",
     "@vtex/order-items": "^0.6.1",
     "@vtex/order-manager": "^0.5.2",
-    "@vtex/store-ui": "^0.326.3-alpha.0",
+    "@vtex/store-ui": "^0.326.3-alpha.1",
     "gatsby-plugin-bundle-stats": "^2.7.2",
     "html-loader": "^2.1.2",
     "intersection-observer": "^0.11.0",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -72,5 +72,5 @@
     "schema-dts": "^0.6.0",
     "swr": "^0.3.0"
   },
-  "gitHead": "afb00a07fb4055657d7f17e37fea1912d1cb1474"
+  "gitHead": "ec018f1f4145a8bf36f6857c9589714ea89855fb"
 }

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/gatsby-theme-store",
-  "version": "0.326.3-alpha.2",
+  "version": "0.326.3-alpha.3",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
   "module": "src/index.ts",
@@ -61,7 +61,7 @@
     "@vtex/gatsby-plugin-theme-ui": "^0.325.0",
     "@vtex/order-items": "^0.6.1",
     "@vtex/order-manager": "^0.5.2",
-    "@vtex/store-ui": "^0.326.3-alpha.2",
+    "@vtex/store-ui": "^0.326.3-alpha.3",
     "gatsby-plugin-bundle-stats": "^2.7.2",
     "html-loader": "^2.1.2",
     "intersection-observer": "^0.11.0",

--- a/packages/gatsby-theme-store/src/components/HomePage/SEO/useSiteLinksSearchBoxJsonLd.ts
+++ b/packages/gatsby-theme-store/src/components/HomePage/SEO/useSiteLinksSearchBoxJsonLd.ts
@@ -14,7 +14,9 @@ interface SiteLinksSearchBoxJSONLD {
   }
 }
 
-export const useSiteLinksSearchBoxJsonLd = (_: Options): SiteLinksSearchBoxJSONLD => {
+export const useSiteLinksSearchBoxJsonLd = (
+  _: Options
+): SiteLinksSearchBoxJSONLD => {
   const { host } = useLocation()
   const url = `https://${host}`
 

--- a/packages/gatsby-theme-store/src/gatsby-browser.tsx
+++ b/packages/gatsby-theme-store/src/gatsby-browser.tsx
@@ -7,22 +7,16 @@ import ReactDOM from 'react-dom'
 import type { WrapRootElementBrowserArgs } from 'gatsby'
 import type { ElementType } from 'react'
 
-// Webpack + TS magic to make this work
-const {
-  Provider: OrderFormProvider,
-} = require('./src/sdk/orderForm/LazyProvider')
-const { Provider: RegionProvider } = require('./src/sdk/region/Provider')
-const { Provider: MinicartProvider } = require('./src/sdk/minicart/Provider')
-const { default: VTEXRCProvider } = require('./src/sdk/pixel/vtexrc/index')
-const {
-  default: ErrorBoundary,
-} = require('./src/components/Error/ErrorBoundary')
-// eslint-disable-next-line padding-line-between-statements
-const {
+import { Provider as OrderFormProvider } from './sdk/orderForm/LazyProvider'
+import { Provider as RegionProvider } from './sdk/region/Provider'
+import { Provider as MinicartProvider } from './sdk/minicart/Provider'
+import { Provider as ToastProvider } from './sdk/toast/Provider'
+import { Provider as VTEXRCProvider } from './sdk/pixel/vtexrc/Provider'
+import ErrorBoundary from './components/Error/ErrorBoundary'
+import {
   Progress,
-  onRouteUpdate: progressOnRouteUpdate,
-} = require('./src/sdk/progress')
-const { Provider: ToastProvider } = require('./src/sdk/toast/Provider')
+  onRouteUpdate as progressOnRouteUpdate,
+} from './sdk/progress'
 
 export const replaceHydrateFunction = () => async (
   element: ElementType,

--- a/packages/gatsby-theme-store/src/gatsby-node.ts
+++ b/packages/gatsby-theme-store/src/gatsby-node.ts
@@ -187,7 +187,11 @@ const resolveToTS = (
   file: 'gatsby-browser' | 'gatsby-ssr' | 'gatsby-node'
 ): Record<string, string> => {
   const root = `${process.cwd()}/.cache`
-  const cjs = relative(root, require.resolve(`${pkg}/${file}.js`))
+  const cjs = relative(
+    root,
+    require.resolve(`${pkg}/${file}.js`, { paths: [process.cwd()] })
+  )
+
   const ts = cjs.replace(`/${file}.js`, `/src/${file}`)
 
   return {
@@ -226,13 +230,13 @@ export const onCreateWebpackConfig = (
         // it can tree shake it or not. This points the webpack directly to the source file so everything is imported
         // using es6 and only the used packages are used
         'gatsby-plugin-next-seo$': resolve(
-          require.resolve('gatsby-plugin-next-seo'),
+          require.resolve('gatsby-plugin-next-seo', { paths: [process.cwd()] }),
           stage === 'build-javascript' || stage === 'develop'
             ? '../../src/index'
             : ''
         ),
         '@vtex/store-ui$': resolve(
-          require.resolve('@vtex/store-ui'),
+          require.resolve('@vtex/store-ui', { paths: [process.cwd()] }),
           stage === 'build-javascript' || stage === 'develop'
             ? '../../src/index'
             : ''

--- a/packages/gatsby-theme-store/src/gatsby-node.ts
+++ b/packages/gatsby-theme-store/src/gatsby-node.ts
@@ -187,11 +187,11 @@ const resolveToTS = (
   file: 'gatsby-browser' | 'gatsby-ssr' | 'gatsby-node'
 ): Record<string, string> => {
   const root = `${process.cwd()}/.cache`
-  const nextSeoFrom = relative(root, require.resolve(`${pkg}/${file}.js`))
-  const nextSeoTo = nextSeoFrom.replace(`/${file}.js`, `/src/${file}`)
+  const cjs = relative(root, require.resolve(`${pkg}/${file}.js`))
+  const ts = cjs.replace(`/${file}.js`, `/src/${file}`)
 
   return {
-    [nextSeoFrom]: nextSeoTo,
+    [cjs]: ts,
   }
 }
 
@@ -231,9 +231,17 @@ export const onCreateWebpackConfig = (
             ? '../../src/index'
             : ''
         ),
+        '@vtex/store-ui$': resolve(
+          require.resolve('@vtex/store-ui'),
+          stage === 'build-javascript' || stage === 'develop'
+            ? '../../src/index'
+            : ''
+        ),
         // Resolve to the .ts versions of gatsby-(browser|ssr) so we don't end up by adding the whole lib.
         ...resolveToTS('gatsby-plugin-next-seo', 'gatsby-browser'),
         ...resolveToTS('gatsby-plugin-next-seo', 'gatsby-ssr'),
+        ...resolveToTS('@vtex/gatsby-theme-store', 'gatsby-browser'),
+        ...resolveToTS('@vtex/gatsby-theme-store', 'gatsby-ssr'),
         '@vtex/order-manager': require.resolve(
           '@vtex/order-manager/src/index.tsx'
         ),

--- a/packages/gatsby-theme-store/src/sdk/orderForm/LazyProvider.tsx
+++ b/packages/gatsby-theme-store/src/sdk/orderForm/LazyProvider.tsx
@@ -1,5 +1,5 @@
-import type { FC, PropsWithChildren } from 'react'
 import React, { Fragment, lazy, Suspense } from 'react'
+import type { FC } from 'react'
 
 const isOfflinePage = window.location.pathname.startsWith('/offline')
 
@@ -19,10 +19,8 @@ const LazyProvider = lazy(() =>
     })
 )
 
-export const Provider = ({ children }: PropsWithChildren<null>) => {
-  return (
-    <Suspense fallback={null}>
-      <LazyProvider>{children}</LazyProvider>
-    </Suspense>
-  )
-}
+export const Provider: FC = ({ children }) => (
+  <Suspense fallback={null}>
+    <LazyProvider>{children}</LazyProvider>
+  </Suspense>
+)

--- a/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/Provider.tsx
+++ b/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/Provider.tsx
@@ -28,7 +28,7 @@ if (!window.vtexrca) {
   })
 }
 
-const Provider: FC = ({ children }) => {
+export const Provider: FC = ({ children }) => {
   useLazyScript({
     src: 'https://io.vtex.com.br/rc/rc.js',
     id: 'async-vtex-rc',
@@ -39,5 +39,3 @@ const Provider: FC = ({ children }) => {
 
   return <Fragment>{children}</Fragment>
 }
-
-export default Provider

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.326.3-alpha.1",
+  "version": "0.326.3-alpha.2",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.325.0",
+  "version": "0.326.3-alpha.0",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.326.3-alpha.2",
+  "version": "0.326.3-alpha.3",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/store-ui",
-  "version": "0.326.3-alpha.0",
+  "version": "0.326.3-alpha.1",
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -79,5 +79,5 @@
     "tsdx": "^0.14.1",
     "typescript": "^4.1.2"
   },
-  "gitHead": "afb00a07fb4055657d7f17e37fea1912d1cb1474"
+  "gitHead": "ec018f1f4145a8bf36f6857c9589714ea89855fb"
 }

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "vtex/gatsby-vtex",
   "main": "dist/index.js",
-  "browser": "src/index.tsx",
   "module": "dist/store-ui.esm.js",
   "typings": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -78,5 +78,6 @@
     "ts-loader": "^8.0.1",
     "tsdx": "^0.14.1",
     "typescript": "^4.1.2"
-  }
+  },
+  "gitHead": "afb00a07fb4055657d7f17e37fea1912d1cb1474"
 }

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -78,6 +78,5 @@
     "ts-loader": "^8.0.1",
     "tsdx": "^0.14.1",
     "typescript": "^4.1.2"
-  },
-  "gitHead": "ec018f1f4145a8bf36f6857c9589714ea89855fb"
+  }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR takes the great idea of @igorbrasileiro changes the webpack config so we no longer need the custom `require()` in gatsby-(browser|ssr). Also this PR removes the "browser" field in store-ui, making it a more suitable lib for being used in other projects

After these changes, bundle-stats reported a decrease of ~20Kb in initial bundle size for marinbrasil and 5Kb for btglobal

I think it would be nice if we do the same changes for all plugins that use gatsby-* APIs. However, for now I'm only considering these core packages 

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
https://github.com/vtex-sites/carrefourbrfood.store/pull/445
https://github.com/vtex-sites/btglobal.store/pull/476
https://github.com/vtex-sites/marinbrasil.store/pull/478
https://github.com/vtex-sites/storecomponents.store/pull/823

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
