### PR TITLE
Simplify template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
 ## What's the purpose of this pull request?
-<em>Considering the context, what is the problem we'll solve? Where in VTEX's big picture our issue fits in? Write a tweet about the context and the problem itself.</em>
+<!--- Considering the context, what is the problem we'll solve? Where in VTEX's big picture our issue fits in? Write a tweet about the context and the problem itself. --->
 
 ## How it works? 
-<em>Tell us the role of the new feature, or component, in its context.</em>
+<!--- Tell us the role of the new feature, or component, in its context. --->
 
 ## How to test it?
-<em>Describe the steps with bullet points. Is there any external link that can be used to better test it or an example?</em> 
+<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->
 
 ## References
-<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  
+<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->
 
-<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
+<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->


### PR DESCRIPTION
Many PRs in faststore are being opened without changing or adding anything to the default template description and text. 

This PR moves the help from our default PR template to a mardown comment so we don't open PRs with the default template text, being more obvious when someone is writing something or not

