### PR TITLE
Opt-in to CORS while registering rc.js script

### DIFF
--- a/packages/gatsby-theme-store/src/sdk/lazyScript/useLazyScript.ts
+++ b/packages/gatsby-theme-store/src/sdk/lazyScript/useLazyScript.ts
@@ -6,7 +6,12 @@ interface Options extends Partial<HTMLScriptElement> {
   timeout?: number
 }
 
-const registerScript = ({ id, timeout, ...scriptTagAttributes }: Options) => {
+const registerScript = ({
+  id,
+  timeout,
+  async = true,
+  ...scriptTagAttributes
+}: Options) => {
   const maybeElement = document.getElementById(id)
 
   // Script already added to page
@@ -25,6 +30,10 @@ const registerScript = ({ id, timeout, ...scriptTagAttributes }: Options) => {
       (scriptTagAttributes as any)[attributeName]
     )
   })
+
+  if (async) {
+    script.setAttribute('async', '')
+  }
 
   script.setAttribute('id', id)
 

--- a/packages/gatsby-theme-store/src/sdk/lazyScript/useLazyScript.ts
+++ b/packages/gatsby-theme-store/src/sdk/lazyScript/useLazyScript.ts
@@ -21,6 +21,7 @@ const registerScript = ({ id, src }: Options) => {
   script.setAttribute('type', 'application/javascript')
   script.setAttribute('id', id)
   script.setAttribute('src', src)
+  script.setAttribute('crossorigin', 'anonymous')
   document.getElementsByTagName('head')[0].appendChild(script)
 }
 

--- a/packages/gatsby-theme-store/src/sdk/lazyScript/useLazyScript.ts
+++ b/packages/gatsby-theme-store/src/sdk/lazyScript/useLazyScript.ts
@@ -26,6 +26,8 @@ const registerScript = ({ id, timeout, ...scriptTagAttributes }: Options) => {
     )
   })
 
+  script.setAttribute('id', id)
+
   document.getElementsByTagName('head')[0].appendChild(script)
 }
 

--- a/packages/gatsby-theme-store/src/sdk/lazyScript/useLazyScript.ts
+++ b/packages/gatsby-theme-store/src/sdk/lazyScript/useLazyScript.ts
@@ -3,11 +3,12 @@ import { useIdleEffect } from '@vtex/store-ui'
 interface Options {
   src: string
   id: string
+  useCors?: boolean
   // add script to the page after timeout ms after idleCallback fired
   timeout?: number
 }
 
-const registerScript = ({ id, src }: Options) => {
+const registerScript = ({ id, src, useCors }: Options) => {
   const maybeElement = document.getElementById(id)
 
   // Script already added to page
@@ -17,11 +18,15 @@ const registerScript = ({ id, src }: Options) => {
 
   const script = document.createElement('script')
 
+  if (useCors) {
+    script.setAttribute('crossorigin', 'anonymous')
+  }
+
   script.setAttribute('async', '')
   script.setAttribute('type', 'application/javascript')
   script.setAttribute('id', id)
   script.setAttribute('src', src)
-  script.setAttribute('crossorigin', 'anonymous')
+
   document.getElementsByTagName('head')[0].appendChild(script)
 }
 

--- a/packages/gatsby-theme-store/src/sdk/lazyScript/useLazyScript.ts
+++ b/packages/gatsby-theme-store/src/sdk/lazyScript/useLazyScript.ts
@@ -1,14 +1,12 @@
 import { useIdleEffect } from '@vtex/store-ui'
 
-interface Options {
-  src: string
+interface Options extends Partial<HTMLScriptElement> {
   id: string
-  useCors?: boolean
   // add script to the page after timeout ms after idleCallback fired
   timeout?: number
 }
 
-const registerScript = ({ id, src, useCors }: Options) => {
+const registerScript = ({ id, timeout, ...scriptTagAttributes }: Options) => {
   const maybeElement = document.getElementById(id)
 
   // Script already added to page
@@ -17,15 +15,16 @@ const registerScript = ({ id, src, useCors }: Options) => {
   }
 
   const script = document.createElement('script')
+  const attributes = Object.keys(scriptTagAttributes) as Array<
+    keyof HTMLScriptElement
+  >
 
-  if (useCors) {
-    script.setAttribute('crossorigin', 'anonymous')
-  }
-
-  script.setAttribute('async', '')
-  script.setAttribute('type', 'application/javascript')
-  script.setAttribute('id', id)
-  script.setAttribute('src', src)
+  attributes.forEach((attributeName) => {
+    script.setAttribute(
+      attributeName,
+      (scriptTagAttributes as any)[attributeName]
+    )
+  })
 
   document.getElementsByTagName('head')[0].appendChild(script)
 }

--- a/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/Provider.tsx
+++ b/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/Provider.tsx
@@ -33,7 +33,7 @@ export const Provider: FC = ({ children }) => {
     src: 'https://io.vtex.com.br/rc/rc.js',
     id: 'async-vtex-rc',
     timeout: 5500,
-    useCors: true,
+    crossOrigin: 'anonymous',
   })
 
   usePixelEvent(handler)

--- a/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/Provider.tsx
+++ b/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/Provider.tsx
@@ -34,7 +34,6 @@ export const Provider: FC = ({ children }) => {
     id: 'async-vtex-rc',
     timeout: 5500,
     crossOrigin: 'anonymous',
-    async: true,
     type: 'application/javascript',
   })
 

--- a/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/Provider.tsx
+++ b/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/Provider.tsx
@@ -33,6 +33,7 @@ export const Provider: FC = ({ children }) => {
     src: 'https://io.vtex.com.br/rc/rc.js',
     id: 'async-vtex-rc',
     timeout: 5500,
+    useCors: true,
   })
 
   usePixelEvent(handler)

--- a/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/Provider.tsx
+++ b/packages/gatsby-theme-store/src/sdk/pixel/vtexrc/Provider.tsx
@@ -34,6 +34,8 @@ export const Provider: FC = ({ children }) => {
     id: 'async-vtex-rc',
     timeout: 5500,
     crossOrigin: 'anonymous',
+    async: true,
+    type: 'application/javascript',
   })
 
   usePixelEvent(handler)


### PR DESCRIPTION
## What's the purpose of this pull request?
<!--- Considering the context, what is the problem we'll solve? Where in VTEX's big picture our issue fits in? Write a tweet about the context and the problem itself. --->

This PR makes it possible to add any attribute to `script` tags being added to our pages by the `useLazyScript` hook. 

It also enables CORS when we're adding our RC script to solve a more specific issue.

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

You can check [this deploy preview](https://sfj-a9656ef--storecomponents.preview.vtex.app/). There should be no issues pointed out in the console. Also, if you check the cache storage, specifically the `gatsby-plugin-offline-runtime-...` one, you should be able to find an entry for `rc/rc.js`, with a Response-Type set to `cors`. Before this PR, this value would be set to `opaque`.

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

- https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests
- https://fetch.spec.whatwg.org/#concept-request-mode
- https://developer.mozilla.org/en-US/docs/Web/API/Response/type
- https://stackoverflow.com/questions/39109789/what-limitations-apply-to-opaque-responses

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
