### PR TITLE
feat: use activity timer to report on duration of building nginx config

### DIFF
--- a/packages/gatsby-plugin-nginx/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-nginx/src/gatsby-node.ts
@@ -74,6 +74,9 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async (
 ) => {
   const options = pluginOptions(opt)
 
+  const timer = reporter.activityTimer(`write out nginx configuration`)
+  timer.start()
+
   const { program, pages: pagesMap, redirects } = store.getState() as {
     pages: Map<string, Page>
     program: { directory: string }
@@ -137,5 +140,5 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async (
     })
   )
 
-  reporter.success('write out nginx configuration')
+  timer.end()
 }


### PR DESCRIPTION
I have a build that takes a long time in the post build stage, so I would like to know how long each plugin takes