### PR TITLE
Fix: Offset search API pagination params

### DIFF
--- a/packages/gatsby-source-vtex/src/staticPaths.ts
+++ b/packages/gatsby-source-vtex/src/staticPaths.ts
@@ -100,8 +100,10 @@ const staticPaths = async ({
       fetchVTEX<Array<{ linkText?: string }>>(
         api.catalog.category.search({
           sort: 'OrderByTopSaleDESC',
-          from: pageIndex * itemsPerPage,
-          to: pageIndex * itemsPerPage + itemsPerPage,
+          from: pageIndex ? pageIndex * itemsPerPage + 1 : pageIndex,
+          to: pageIndex
+            ? pageIndex * itemsPerPage + itemsPerPage
+            : itemsPerPage,
         }),
         options
       ),

--- a/packages/gatsby-source-vtex/src/staticPaths.ts
+++ b/packages/gatsby-source-vtex/src/staticPaths.ts
@@ -101,10 +101,7 @@ const staticPaths = async ({
         api.catalog.category.search({
           sort: 'OrderByTopSaleDESC',
           from: pageIndex * itemsPerPage,
-          to: pageIndex * itemsPerPage + itemsPerPage - 1,
-          to: pageIndex
-            ? pageIndex * itemsPerPage + itemsPerPage
-            : itemsPerPage,
+          to: pageIndex * itemsPerPage + itemsPerPage - 1
         }),
         options
       ),

--- a/packages/gatsby-source-vtex/src/staticPaths.ts
+++ b/packages/gatsby-source-vtex/src/staticPaths.ts
@@ -100,7 +100,8 @@ const staticPaths = async ({
       fetchVTEX<Array<{ linkText?: string }>>(
         api.catalog.category.search({
           sort: 'OrderByTopSaleDESC',
-          from: pageIndex ? pageIndex * itemsPerPage + 1 : pageIndex,
+          from: pageIndex * itemsPerPage,
+          to: pageIndex * itemsPerPage + itemsPerPage - 1,
           to: pageIndex
             ? pageIndex * itemsPerPage + itemsPerPage
             : itemsPerPage,


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix paginating Search API for products static paths.

Related to: #726