### PR TITLE
Making CMS schema description optional

### DIFF
--- a/packages/gatsby-plugin-cms/src/index.ts
+++ b/packages/gatsby-plugin-cms/src/index.ts
@@ -2,7 +2,7 @@ import type { JSONSchema6 } from 'json-schema'
 
 export interface Schema extends JSONSchema6 {
   title: string
-  description: string
+  description?: string
 }
 
 export type Schemas = Record<string, Schema>


### PR DESCRIPTION
## What's the purpose of this pull request?
The CMS doesn't show descriptions for objects, only for internal properties. So we don't need this as required.
