### PR TITLE
feat: improve nginx config generation by orders of magnitude

### DIFF
--- a/packages/gatsby-plugin-nginx/tsconfig.json
+++ b/packages/gatsby-plugin-nginx/tsconfig.json
@@ -1,6 +1,6 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
-  "include": ["src", "types"],
+  "include": ["src", "types", "test"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],
@@ -30,6 +30,6 @@
     // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true,
     // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
-    "noEmit": true,
+    "noEmit": true
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Nginx config generation for my site was taking **5 minutes**

After this patch its **2 seconds**

## How it works? 

Uses a `set` instead of an `array` and does `set.has` instead of `array.find` in `storagePassTemplate`

## How to test it?

`yarn workspace @vtex/gatsby-plugin-nginx test`

Has a performance regression test when generates a config with 10k files which used to take 25s to run and after the patch its 23ms

I also added a inline snapshot test for 'correctly generates basic nginx configuration'