### PR TITLE
Fix | Source products using intelligent search (IS) 

### DIFF
--- a/packages/gatsby-source-vtex/src/api.ts
+++ b/packages/gatsby-source-vtex/src/api.ts
@@ -1,6 +1,31 @@
-import type { Sort } from './types'
+interface SearchOptions {
+  query?: string
+  page: number
+  count: number
+  sort: 'orders:desc'
+  operator: 'and' | 'or'
+  fuzzy?: string
+  locale?: string
+  bgy_leap?: boolean
+  'hide-unavailable-items'?: boolean
+}
 
 export const api = {
+  is: {
+    search: (params: SearchOptions) => {
+      const searchParams = new URLSearchParams()
+
+      Object.keys(params).forEach((key) => {
+        const value = params[key as keyof SearchOptions]
+
+        if (value) {
+          searchParams.set(key, `${value}`)
+        }
+      })
+
+      return `/api/split/product_search/trade-policy/1?${searchParams}`
+    },
+  },
   catalog: {
     brand: {
       list: ({ page, pageSize }: { page: number; pageSize: number }) =>
@@ -12,16 +37,6 @@ export const api = {
     },
     category: {
       tree: (depth: number) => `/api/catalog_system/pub/category/tree/${depth}`,
-      search: ({
-        sort = '',
-        from,
-        to,
-      }: {
-        sort?: Sort
-        from: number
-        to: number
-      }) =>
-        `/api/catalog_system/pub/products/search?O=${sort}&_from=${from}&_to=${to}`,
     },
   },
   tenants: {

--- a/packages/gatsby-source-vtex/src/fetch.ts
+++ b/packages/gatsby-source-vtex/src/fetch.ts
@@ -53,3 +53,24 @@ export const fetchVTEX = async <T>(
     throw err
   }
 }
+
+export const fetchIS = async <T>(
+  path: string,
+  options: VTEXOptions,
+  init?: RequestInit
+): Promise<T> => {
+  try {
+    const url = `https://search.biggylabs.com.br/search-api/v1/${options.tenant}${path}`
+
+    return await fetchRetry(url, {
+      ...init,
+      headers: {
+        ...headers,
+        ...init?.headers,
+      },
+    })
+  } catch (err) {
+    console.error(err)
+    throw err
+  }
+}

--- a/packages/gatsby-source-vtex/src/fetch.ts
+++ b/packages/gatsby-source-vtex/src/fetch.ts
@@ -15,7 +15,7 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 async function fetchRetry<T>(
   path: string,
-  init: RequestInit,
+  init?: RequestInit,
   retryCount = 3
 ): Promise<T> {
   try {
@@ -29,8 +29,47 @@ async function fetchRetry<T>(
 
     await delay(300) // wait for 300ms
 
+    console.error(
+      `[gatsby-source-vtex]: Error while fetching. Retrying...`,
+      err
+    )
+
     return fetchRetry(path, init, retryCount - 1)
   }
+}
+
+export const fetchGraphQL = async <T>(
+  path: string,
+  init?: RequestInit
+): Promise<{ data: T; errors: any[] }> => {
+  let retryCount = 0
+  let response: { data: T; errors: any[] } | undefined
+
+  while (retryCount !== 3) {
+    response = await fetchRetry<{ data: T; errors: any[] }>(path, init)
+
+    if (!response.errors || response.errors.length === 0) {
+      return response
+    }
+
+    retryCount += 1
+    console.error(
+      `[gatsby-source-vtex]: Error while fetching graphql data. Retry ${retryCount}`,
+      response.errors
+    )
+  }
+
+  if (response) {
+    for (const error of response.errors) {
+      console.error(error)
+    }
+
+    throw new Error(
+      `[gatsby-source-vtex]: GraphQL Error\n\n: ${response.errors}`
+    )
+  }
+
+  throw new Error('[gatsby-source-vtex]: Error while fetching graphql data')
 }
 
 export const fetchVTEX = async <T>(

--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -11,7 +11,7 @@ import type {
   GatsbyNode,
   PluginOptions,
   SourceNodesArgs,
-  CreatePageArgs,
+  CreatePagesArgs,
   PluginOptionsSchemaArgs,
 } from 'gatsby'
 
@@ -76,179 +76,235 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
     reporter,
   } = args
 
-  let activity = reporter.activityTimer(
-    '[gatsby-source-vtex]: adding VTEX GraphQL Schema'
-  )
-
-  activity.start()
+  const promisses = [] as Array<() => Promise<void>>
 
   /**
-   * VTEX GraphQL API
-   * */
+   * Add VTEX GraphQL API as 3p schema
+   */
+  promisses.push(async () => {
+    const activity = reporter.activityTimer(
+      '[gatsby-source-vtex]: adding VTEX GraphQL Schema'
+    )
 
-  // Create executor to run queries against schema
-  const url = getGraphQLUrl(tenant, workspace)
+    activity.start()
 
-  const executor: AsyncExecutor = async ({ document, variables }) => {
-    const query = print(document)
-    const fetchResult = await fetch(url, {
-      method: 'POST',
-      headers: {
-        accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ query, variables }),
-    })
+    // Create executor to run queries against schema
+    const url = getGraphQLUrl(tenant, workspace)
 
-    const result = await fetchResult.json()
-
-    /**
-     * We've chosen to ignore the 404 errors on build time.
-     * This allows us to complete builds with slightly old slugs and
-     * to handle this type of error on the client, where we will make
-     * some redirects.
-     */
-    if (result.errors && result.errors.length > 0) {
-      result.errors = result.errors.filter((error: any) => {
-        console.warn(error)
-        const status = error.extensions?.exception?.status
-
-        return !status || status !== 404
+    const executor: AsyncExecutor = async ({ document, variables }) => {
+      const query = print(document)
+      const fetchResult = await fetch(url, {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query, variables }),
       })
 
-      if (result.errors.length === 0) {
-        delete result.errors
+      const result = await fetchResult.json()
+
+      /**
+       * We've chosen to ignore the 404 errors on build time.
+       * This allows us to complete builds with slightly old slugs and
+       * to handle this type of error on the client, where we will make
+       * some redirects.
+       */
+      if (result.errors && result.errors.length > 0) {
+        result.errors = result.errors.filter((error: any) => {
+          console.warn(error)
+          const status = error.extensions?.exception?.status
+
+          return !status || status !== 404
+        })
+
+        if (result.errors.length === 0) {
+          delete result.errors
+        }
       }
+
+      return result
     }
 
-    return result
-  }
+    const schema = wrapSchema(
+      {
+        schema: await introspectSchema(executor),
+        executor,
+      },
+      [
+        // Filter CMS fields so people use the VTEX CMS plugin instead of this one
+        new FilterObjectFields(
+          (typeName, fieldName) => typeName !== 'VTEX' || fieldName !== 'pages'
+        ),
+        new PruneSchema({}),
+      ]
+    )
 
-  const schema = wrapSchema(
-    {
-      schema: await introspectSchema(executor),
-      executor,
-    },
-    [
-      // Filter CMS fields so people use the VTEX CMS plugin instead of this one
-      new FilterObjectFields(
-        (typeName, fieldName) => typeName !== 'VTEX' || fieldName !== 'pages'
-      ),
-      new PruneSchema({}),
-    ]
-  )
+    addThirdPartySchema({ schema })
 
-  addThirdPartySchema({ schema })
-
-  activity.end()
+    activity.end()
+  })
 
   /**
-   * VTEX HTTP API fetches
-   * */
+   * Add VTEX bindings
+   */
+  promisses.push(async () => {
+    const activity = reporter.activityTimer(
+      '[gatsby-source-vtex]: fetching VTEX Bindings'
+    )
 
-  // Bindings
-  activity = reporter.activityTimer(
-    '[gatsby-source-vtex]: fetching VTEX Bindings'
-  )
-  activity.start()
+    activity.start()
 
-  const { bindings } = await fetchVTEX<Tenant>(
-    api.tenants.tenant(tenant),
-    options
-  )
+    const { bindings } = await fetchVTEX<Tenant>(
+      api.tenants.tenant(tenant),
+      options
+    )
 
-  for (const binding of bindings) {
-    createChannelNode(args, binding)
-  }
+    for (const binding of bindings) {
+      createChannelNode(args, binding)
+    }
 
-  activity.end()
+    activity.end()
+  })
 
-  // Catetgories
-  activity = reporter.activityTimer(
-    '[gatsby-source-vtex]: fetching VTEX Departments'
-  )
-  activity.start()
+  /**
+   * Add VTEX categories
+   */
+  promisses.push(async () => {
+    const activity = reporter.activityTimer(
+      '[gatsby-source-vtex]: fetching VTEX Departments'
+    )
 
-  const departments = await fetchVTEX<Category[]>(
-    api.catalog.category.tree(1),
-    options
-  )
+    activity.start()
 
-  for (const department of departments) {
-    createDepartmentNode(args, department)
-  }
+    const departments = await fetchVTEX<Category[]>(
+      api.catalog.category.tree(1),
+      options
+    )
 
-  activity.end()
+    for (const department of departments) {
+      createDepartmentNode(args, department)
+    }
+
+    activity.end()
+  })
 
   /**
    * Static Paths used to generate pages
    */
-
-  activity = reporter.activityTimer(
-    '[gatsby-source-vtex]: fetching StaticPaths'
-  )
-
-  activity.start()
-
-  const staticPaths = (typeof getStaticPaths === 'function'
-    ? await getStaticPaths()
-    : await defaultStaticPaths(options)
-  )
-    .map(normalizePath)
-    .filter((path) => !ignorePaths.includes(path))
-
-  const fetchPageTypes = async (path: string): Promise<PageType> => {
-    const isProduct = /\/(.)+\/p$/g
-
-    // When the page is a product page, we skip calling the pageType backend to speedup the process considerably.
-    // This makes us have to synthetically generate some data. However, it shouldn't be a problem since we don't
-    // use these synthetic attributes
-    if (isProduct.test(path)) {
-      return {
-        id: md5(path),
-        name: path.split('/p')[0],
-        url: path,
-        title: '',
-        metaTagDescription: '',
-        pageType: 'Product',
-      }
-    }
-
-    return fetchVTEX<PageType>(api.catalog.portal.pageType(path), options)
-  }
-
-  const pageTypes = await pMap(staticPaths, fetchPageTypes, { concurrency })
-
-  if (pageTypes.length !== staticPaths.length) {
-    reporter.panicOnBuild(
-      '[gatsby-source-vtex]: Length of PageTypes and staticPaths do not agree. No static path will be generated'
+  promisses.push(async () => {
+    let activity = reporter.activityTimer(
+      '[gatsby-source-vtex]: fetching StaticPaths'
     )
 
-    return
-  }
+    activity.start()
 
-  for (let it = 0; it < pageTypes.length; it++) {
-    const pageType = pageTypes[it]
-    const staticPath = staticPaths[it]
+    const staticPaths = (typeof getStaticPaths === 'function'
+      ? await getStaticPaths()
+      : await defaultStaticPaths(options)
+    )
+      .map(normalizePath)
+      .filter((path) => !ignorePaths.includes(path))
 
-    if (!pageTypesWhitelist.includes(pageType.pageType)) {
-      reporter.warn(
-        `[gatsby-source-vtex]: Dropping path. Reason: PageType API reported ${pageType.pageType} for path: ${staticPath}`
-      )
+    activity.end()
 
-      continue
+    activity = reporter.activityTimer(
+      '[gatsby-source-vtex]: fetching PageTypes'
+    )
+
+    activity.start()
+
+    const fetchPageTypes = async (path: string): Promise<PageType> => {
+      const isProduct = /\/(.)+\/p$/g
+
+      // When the page is a product page, we skip calling the pageType backend to speedup the process considerably.
+      // This makes us have to synthetically generate some data. However, it shouldn't be a problem since we don't
+      // use these synthetic attributes
+      if (isProduct.test(path)) {
+        return {
+          id: md5(path),
+          name: path.split('/p')[0],
+          url: path,
+          title: '',
+          metaTagDescription: '',
+          pageType: 'Product',
+        }
+      }
+
+      return fetchVTEX<PageType>(api.catalog.portal.pageType(path), options)
     }
 
-    createStaticPathNode(args, pageType, staticPath)
-  }
+    const pageTypes = await pMap(staticPaths, fetchPageTypes, { concurrency })
 
-  activity.end()
+    if (pageTypes.length !== staticPaths.length) {
+      reporter.panicOnBuild(
+        '[gatsby-source-vtex]: Length of PageTypes and staticPaths do not agree. No static path will be generated'
+      )
+
+      return
+    }
+
+    for (let it = 0; it < pageTypes.length; it++) {
+      const pageType = pageTypes[it]
+      const staticPath = staticPaths[it]
+
+      if (!pageTypesWhitelist.includes(pageType.pageType)) {
+        reporter.warn(
+          `[gatsby-source-vtex]: Dropping path. Reason: PageType API reported ${pageType.pageType} for path: ${staticPath}`
+        )
+
+        continue
+      }
+
+      createStaticPathNode(args, pageType, staticPath)
+    }
+
+    activity.end()
+  })
+
+  await Promise.all(promisses.map((x) => x()))
 }
 
 export const createPages = async (
-  { actions: { createRedirect }, reporter }: CreatePageArgs,
+  { actions: { createRedirect }, graphql, reporter }: CreatePagesArgs,
   { tenant, workspace, environment, getRedirects }: Options
 ) => {
+  /**
+   * Report available PDPs and PLPs
+   */
+  const {
+    data: {
+      searches: { nodes: searches },
+      products: { nodes: products },
+    },
+  } = await graphql<any>(`
+    query GetAllStaticPaths {
+      searches: allStaticPath(
+        filter: {
+          pageType: { in: ["Department", "Category", "Brand", "SubCategory"] }
+        }
+      ) {
+        nodes {
+          ...staticPath
+        }
+      }
+      products: allStaticPath(filter: { pageType: { eq: "Product" } }) {
+        nodes {
+          ...staticPath
+        }
+      }
+    }
+
+    fragment staticPath on StaticPath {
+      id
+      path
+      pageType
+    }
+  `)
+
+  reporter.info(`[gatsby-source-vtex]: Available pdps: ${products.length}`)
+  reporter.info(`[gatsby-source-vtex]: Available plps: ${searches.length}`)
+
   /**
    * Create all proxy rules for VTEX Store
    * If adding a new rule, don't forget to modify ./gatsby-config.ts dev proxy


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR:
1. Fixes products sourcing 
2. Add retries to graphql queries so we don't break the whole build if something goes wrong on our infra.

## How it works? 
1. We were using Solr API for sourcing our products. Basically we make a search and fetch at about 2500 products. To speedup the fetching, we paginate the search and fetch the pages in parallel. Somehow, this API is not reliable for doing such pagination because it would return duplicated products among pages. This caused an unreliable build where consecutive builds would generate a different amount of pages. We fix this problem by using Inteligent Search (IS) instead of Solr.
2. We add retries to graphql's executor when a non empty `errors` array is returned or when an http level error occurs. 

## How to test it?
https://github.com/vtex-sites/marinbrasil.store/pull/510
https://github.com/vtex-sites/btglobal.store/pull/569
https://github.com/vtex-sites/carrefourbrfood.store/pull/712
https://github.com/vtex-sites/storecomponents.store/pull/936

