### PR TITLE
adding a image ratio parameter + tests

### DIFF
--- a/packages/gatsby-theme-store/src/sdk/img/fileManager.test.ts
+++ b/packages/gatsby-theme-store/src/sdk/img/fileManager.test.ts
@@ -1,0 +1,29 @@
+import { optimize } from './fileManager'
+
+describe('Image Optimization', () => {
+  it('return URL with the correct parameters', () => {
+    const imageSrc =
+      'https://storecomponents.vtexassets.com/assets/vtex.file-manager-graphql/images/f05e3621-d515-4dac-8c44-675f1ab36b66___3be6fb3cbcef0db2be3ad13631f2f356.jpg'
+
+    // Generate random values for parameters
+    const height = Math.floor(Math.random() * 1920) + 480
+    const width = Math.floor(Math.random() * 1920) + 480
+    const ratio = Math.floor(Math.random() * 5) + 1
+    const aspect = Math.random() < 0.5
+
+    // Run optimize API
+    const optimized = optimize(imageSrc, { width, height, aspect }, { ratio })
+
+    // Get optimized URL
+    const urlParams = new URL(optimized)
+
+    // Get parameters from URL
+    const heightFromURL = urlParams.searchParams.get('height')
+    const widthFromURL = urlParams.searchParams.get('width')
+    const aspectFromURL = urlParams.searchParams.get('aspect')
+
+    expect(heightFromURL).toBe(`${height * ratio}`)
+    expect(widthFromURL).toBe(`${width * ratio}`)
+    expect(aspectFromURL).toBe(`${aspect}`)
+  })
+})

--- a/packages/gatsby-theme-store/src/sdk/img/fileManager.ts
+++ b/packages/gatsby-theme-store/src/sdk/img/fileManager.ts
@@ -3,18 +3,31 @@
  * If this file in being added to your final bundle, please rethink your rendering strategy
  */
 
-interface Options {
+interface ImageParams {
   width?: number
   height?: number
   aspect?: boolean
   quality?: number
 }
+interface Options {
+  ratio: number
+}
 
-export const optimize = (src: string, opts: Options) => {
+export const optimize = (
+  src: string,
+  imageParams: ImageParams,
+  options: Options = { ratio: 1 }
+) => {
   const url = new URL(src)
 
-  for (const option of Object.keys(opts)) {
-    url.searchParams.append(option, `${opts[option as keyof Options]}`)
+  for (const option of Object.keys(imageParams)) {
+    let paramValue = imageParams[option as keyof ImageParams]
+
+    if (option === 'width' || option === 'height') {
+      paramValue = (paramValue as number) * options.ratio
+    }
+
+    url.searchParams.append(option, `${paramValue}`)
   }
 
   return url.toString()


### PR DESCRIPTION
## What's the purpose of this pull request?
We had some problems in mobile banners/carousel resolutions when optimizing them. 

## How it works? 
This PR adds an extra parameter in optimize function, so we can increase the width/height ratio.

## How to test it?
[Carrefour PR](https://github.com/vtex-sites/carrefourbrfood.store/pull/657)

