### PR TITLE
Chore | Improve gatsby-plugin-nginx configurability

### DIFF
--- a/packages/gatsby-plugin-nginx/README.md
+++ b/packages/gatsby-plugin-nginx/README.md
@@ -45,7 +45,7 @@ module.exports = {
   plugins: [
     // [...]
     {
-      resolve: require.resolve('@vtex/gatsby-plugin-nginx'),
+      resolve: '@vtex/gatsby-plugin-nginx',
       options: {
         transformHeaders: (headers, path) => {
           const DEFAULT_SECURITY_HEADERS = [
@@ -180,3 +180,33 @@ This location finally handles pages with mismatching *path* and *matchPath*.
 
 `createRedirect` with relative paths are not yet implemented. 
 
+### Adding custom blocks to nginx config
+Our default nginx config may not be suited for all use cases. For those use cases where you need to enable/disable some extra flags in the `server` and `http` block you can use the `serverOptions` and `httpOptions` params respectively. 
+
+For instance, say we don't want to use Google's dns server, but use the AWS one instead. One could configure the plugin like:
+```js
+// gatsby-config.js
+module.exports = {
+  // [...]
+  plugins: [
+    // [...]
+    {
+      resolve: '@vtex/gatsby-plugin-nginx',
+      options: {
+        // other options
+        serverOptions: [['resolver', '169.254.169.253']],
+      }
+    },
+  ],
+}
+```
+
+This will create an `nginx.conf` file similar to: 
+```
+...
+ server {
+    resolver 169.254.169.253;
+    ...
+ }
+...
+```

--- a/packages/gatsby-plugin-nginx/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-nginx/src/gatsby-node.ts
@@ -75,6 +75,7 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async (
   const options = pluginOptions(opt)
 
   const timer = reporter.activityTimer(`write out nginx configuration`)
+
   timer.start()
 
   const { program, pages: pagesMap, redirects } = store.getState() as {

--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -154,7 +154,6 @@ function generateNginxConfiguration({
                 'image/svg+xml',
               ],
             },
-            { cmd: ['proxy_http_version', '1.1'] },
             {
               cmd: ['server'],
               children: [

--- a/packages/gatsby-plugin-nginx/src/pluginOptions.ts
+++ b/packages/gatsby-plugin-nginx/src/pluginOptions.ts
@@ -10,6 +10,8 @@ const defaultOptions: PluginOptions = {
   disableBrotliEncoding: false,
   serveFileDirective: ['try_files', '/$file', '=404'],
   plugins: [],
+  httpOptions: [],
+  serverOptions: [['resolver', '8.8.8.8']],
 }
 
 export function pluginOptions(options: Partial<PluginOptions>): PluginOptions {
@@ -33,6 +35,8 @@ export function pluginOptions(options: Partial<PluginOptions>): PluginOptions {
       options.serveFileDirective ??
       defaultOptions.serveFileDirective,
     plugins: options.plugins ?? defaultOptions.plugins,
+    httpOptions: options.httpOptions ?? defaultOptions.httpOptions,
+    serverOptions: options.serverOptions ?? defaultOptions.serverOptions,
   }
 }
 

--- a/packages/gatsby-plugin-nginx/src/pluginOptions.ts
+++ b/packages/gatsby-plugin-nginx/src/pluginOptions.ts
@@ -10,7 +10,7 @@ const defaultOptions: PluginOptions = {
   disableBrotliEncoding: false,
   serveFileDirective: ['try_files', '/$file', '=404'],
   plugins: [],
-  httpOptions: [],
+  httpOptions: [['proxy_http_version', '1.1']],
   serverOptions: [['resolver', '8.8.8.8']],
 }
 

--- a/packages/gatsby-plugin-nginx/src/typings/types.d.ts
+++ b/packages/gatsby-plugin-nginx/src/typings/types.d.ts
@@ -71,7 +71,7 @@ declare global {
      * // Disable merge_slashes nginx config
      * httpOptions: [['merge_slashes', 'off']]
      *
-     * * @default []
+     * * @default [['proxy_http_version', '1.1']]
      */
     httpOptions: string[][]
   }

--- a/packages/gatsby-plugin-nginx/src/typings/types.d.ts
+++ b/packages/gatsby-plugin-nginx/src/typings/types.d.ts
@@ -1,3 +1,4 @@
+import { NginxDirective } from './../../dist/nginx-generator.d'
 import {
   PageProps,
   Actions,
@@ -53,5 +54,25 @@ declare global {
      * @default false
      */
     disableBrotliEncoding: boolean
+    /**
+     * Add attributes to nginx's server block options
+     *
+     * @example
+     * // Add Google dns server
+     * serverOptions: [['resolver', '8.8.8.8']]
+     *
+     * @default [['resolver', '8.8.8.8']]
+     */
+    serverOptions: string[][]
+    /**
+     * Add attributes to nginx's http block options
+     *
+     * @example
+     * // Disable merge_slashes nginx config
+     * httpOptions: [['merge_slashes', 'off']]
+     *
+     * * @default []
+     */
+    httpOptions: string[][]
   }
 }

--- a/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
+++ b/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
@@ -43,9 +43,9 @@ describe('stringify', () => {
 
 describe('convert Gatsby paths into nginx RegExp', () => {
   it('handles :slug', () => {
-    expect(convertToRegExp('/:slug/p')).toEqual('^/[^/]+/p$')
-    expect(convertToRegExp('/:slug')).toEqual('^/[^/]+$')
-    expect(convertToRegExp('/pt/:slug/p')).toEqual('^/pt/[^/]+/p$')
+    expect(convertToRegExp('/:slug/p')).toEqual('^/([^/]+)/p$')
+    expect(convertToRegExp('/:slug')).toEqual('^/([^/]+)$')
+    expect(convertToRegExp('/pt/:slug/p')).toEqual('^/pt/([^/]+)/p$')
   })
 
   it('handles wildcard (*)', () => {
@@ -90,11 +90,11 @@ describe('generateRewrites', () => {
             cmd: ['rewrite', '.+', '/__client-side-product__/p'],
           },
         ],
-        cmd: ['location', '~*', '"^/[^/]+/p$"'],
+        cmd: ['location', '~*', '"^/([^/]+)/p$"'],
       },
       {
         children: [{ cmd: ['rewrite', '.+', '/pt/__client-side-product__/p'] }],
-        cmd: ['location', '~*', '"^/pt/[^/]+/p$"'],
+        cmd: ['location', '~*', '"^/pt/([^/]+)/p$"'],
       },
       {
         children: [{ cmd: ['rewrite', '.+', '/__client-side-search__'] }],
@@ -184,6 +184,8 @@ describe('generateNginxConfiguration', () => {
       serveFileDirective: ['try_files', '/$file', '=404'],
       transformHeaders: undefined,
       writeOnlyLocations: false,
+      serverOptions: [],
+      httpOptions: [],
     }
 
     expect(
@@ -228,9 +230,9 @@ describe('generateNginxConfiguration', () => {
         brotli_types text/xml image/svg+xml application/x-font-ttf image/vnd.microsoft.icon application/x-font-opentype application/json font/eot application/vnd.ms-fontobject application/javascript font/otf application/xml application/xhtml+xml text/javascript application/x-javascript text/plain application/x-font-truetype application/xml+rss image/x-icon font/opentype text/css image/x-win-bitmap;
         gzip on;
         gzip_types text/plain text/css text/xml application/javascript application/x-javascript application/xml application/xml+rss application/emacscript application/json image/svg+xml;
+        proxy_http_version 1.1;
         server {
           listen 0.0.0.0:$PORT default_server;
-          resolver 8.8.8.8;
           error_page 404 /404.html;
           location /nginx.conf {
             deny all;
@@ -277,6 +279,8 @@ describe('generateNginxConfiguration', () => {
           .filter((h) => !h.includes(`Cache-Control`))
           .concat(`Cache-Control: public`),
       writeOnlyLocations: false,
+      serverOptions: [],
+      httpOptions: [],
     }
 
     const start = performance.now()

--- a/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
+++ b/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
@@ -48,6 +48,12 @@ describe('convert Gatsby paths into nginx RegExp', () => {
     expect(convertToRegExp('/pt/:slug/p')).toEqual('^/pt/([^/]+)/p$')
   })
 
+  it('handles multiple params', () => {
+    expect(convertToRegExp('/:p1/:p2/p')).toEqual('^/([^/]+)/([^/]+)/p$')
+    expect(convertToRegExp('/base/:p1/:p2')).toEqual('^/base/([^/]+)/([^/]+)$')
+    expect(convertToRegExp('/:p1/foo/:p2')).toEqual('^/([^/]+)/foo/([^/]+)$')
+  })
+
   it('handles wildcard (*)', () => {
     expect(convertToRegExp('/*')).toEqual('^/(.*)$')
     expect(convertToRegExp('/pt/*')).toEqual('^/pt/(.*)$')
@@ -104,6 +110,14 @@ describe('generateRewrites', () => {
         children: [{ cmd: ['rewrite', '.+', '/pt/__client-side-search__'] }],
         cmd: ['location', '~*', '"^/pt/(.*)$"'],
       },
+      {
+        children: [{ cmd: ['rewrite', '.+', '/foo-path'] }],
+        cmd: ['location', '~*', '"^/([^/]+)/([^/]+)/foo$"'],
+      },
+      {
+        children: [{ cmd: ['rewrite', '.+', '/bar-path'] }],
+        cmd: ['location', '~*', '"^/([^/]+)/bar/([^/]+)$"'],
+      },
     ]
 
     expect(
@@ -112,6 +126,8 @@ describe('generateRewrites', () => {
         { fromPath: '/pt/:slug/p', toPath: '/pt/__client-side-product__/p' },
         { fromPath: '/*', toPath: '/__client-side-search__' },
         { fromPath: '/pt/*', toPath: '/pt/__client-side-search__' },
+        { fromPath: '/:p1/:p2/foo', toPath: '/foo-path' },
+        { fromPath: '/:p1/bar/:p2', toPath: '/bar-path' },
       ])
     ).toEqual(expected)
   })
@@ -230,7 +246,6 @@ describe('generateNginxConfiguration', () => {
         brotli_types text/xml image/svg+xml application/x-font-ttf image/vnd.microsoft.icon application/x-font-opentype application/json font/eot application/vnd.ms-fontobject application/javascript font/otf application/xml application/xhtml+xml text/javascript application/x-javascript text/plain application/x-font-truetype application/xml+rss image/x-icon font/opentype text/css image/x-win-bitmap;
         gzip on;
         gzip_types text/plain text/css text/xml application/javascript application/x-javascript application/xml application/xml+rss application/emacscript application/json image/svg+xml;
-        proxy_http_version 1.1;
         server {
           listen 0.0.0.0:$PORT default_server;
           error_page 404 /404.html;


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR improves gatsby-plugin-nginx configurability by allowing it to:
1. Add custom server block options
2. Add custom http block options
3. Create redirects with more than one variable

## How it works? 
The first and second improvements are easy to understand. Basically, there is a new option to add custom nginx rules to the http and server block options. This gives people using this plugin more flexibility in terms of how they use the plugin and their nginx in their infrastructure.

The third point is more interesting. Before this PR, one could only write redirects like this:
```
createRedirect('/foo/*', '/bar/:splat')
```

Note that `:splat` had to be written exactly like this. Creating redirects with a different name, say: `/bar/:rest` broke the plugin. This PR fixes this problem. Also, another problem we are fixing is being able to use variables. Before, one could write:
```
createRedirect('/foo/:slug', '/bar/:slug')
```

Also, the `:slug` variable name mattered. Now, we can write redirects like:
```
createRedirect('/foo/:p1/:p2', '/bar/:p2/:p1')
```

## How to test it?
There is a jest that I added some cases like this to test it.

