### PR TITLE
Drop file-manager in metadata

### DIFF
--- a/packages/gatsby-theme-store/src/views/product/SEO/useMetadata.ts
+++ b/packages/gatsby-theme-store/src/views/product/SEO/useMetadata.ts
@@ -4,9 +4,7 @@ import { useMemo } from 'react'
 import type { GatsbySeo } from 'gatsby-plugin-next-seo'
 import type { ComponentPropsWithoutRef } from 'react'
 
-import { scaleImage } from '../../../sdk/img/arquivos/scale'
 import { useLocale } from '../../../sdk/localization/useLocale'
-import { IMAGE_DEFAULT } from '../../../sdk/product/constants'
 import type { ProductPageSeoQueryQuery } from './__generated__/ProductPageSEOQuery.graphql'
 import type { ProductViewProps } from '../index'
 
@@ -16,8 +14,6 @@ import type { ProductViewProps } from '../index'
 * This deduplicates pages so our pages rank higher in Google
 */
 type Options = ProductViewProps
-
-const IMAGE_SIZE = 720
 
 export const useMetadata = (
   options: Options
@@ -54,13 +50,7 @@ export const useMetadata = (
   const images = useMemo(
     () =>
       product?.items?.[0]?.images?.map((image) => ({
-        url: scaleImage(
-          image?.imageUrl ?? IMAGE_DEFAULT,
-          IMAGE_SIZE,
-          IMAGE_SIZE
-        ),
-        width: IMAGE_SIZE,
-        height: IMAGE_SIZE,
+        url: image?.imageUrl,
         alt: image?.imageText,
       })),
     [product]


### PR DESCRIPTION
## What's the purpose of this pull request?
Removes image rescaling in metadata generation since we don't really need to rescale the images in metadata. Removing this should improve and help performance a little bit
