### PR TITLE
fix(gatsby-theme-store): complex plp navigation

### DIFF
--- a/packages/gatsby-theme-store/src/sdk/search/converter/useSearchParamsFromURL.ts
+++ b/packages/gatsby-theme-store/src/sdk/search/converter/useSearchParamsFromURL.ts
@@ -1,4 +1,3 @@
-import { useLocation } from '@reach/router'
 import { parseSearchParamsState } from '@vtex/store-sdk'
 import { useMemo } from 'react'
 import type { SearchParamsState } from '@vtex/store-sdk'
@@ -11,8 +10,5 @@ export interface SelectedFacets {
 /**
  * @description: Hydrates search context for dynamic search pages.
  */
-export const useSearchParamsFromUrl = (): SearchParamsState => {
-  const { href } = useLocation()
-
-  return useMemo(() => parseSearchParamsState(new URL(href)), [href])
-}
+export const useSearchParamsFromUrl = ({ href }: Location): SearchParamsState =>
+  useMemo(() => parseSearchParamsState(new URL(href)), [href])

--- a/packages/gatsby-theme-store/src/sdk/searchBar/controller/index.ts
+++ b/packages/gatsby-theme-store/src/sdk/searchBar/controller/index.ts
@@ -59,6 +59,7 @@ export const search = async (term: string) => {
   const path = `/${slugified}`
   const exists = await pathExists(path)
 
+  params.delete('map')
   if (exists) {
     // The page /slugified exists, let's navigate to this page
     pathname = `/${slugified}`

--- a/packages/gatsby-theme-store/src/templates/search.browser.tsx
+++ b/packages/gatsby-theme-store/src/templates/search.browser.tsx
@@ -21,9 +21,10 @@ const SearchPage: FC<PageProps> = (props) => {
   const {
     pageContext: { hideUnavailableItems },
     pageContext,
+    location,
   } = props
 
-  const searchParams = useSearchParamsFromUrl()
+  const searchParams = useSearchParamsFromUrl(location)
   const variables = useQueryVariablesFromSearchParams(searchParams)
   const redirecting = usePersonalizedSearchRedirect(searchParams)
 


### PR DESCRIPTION
## What's the purpose of this pull request?
When we have a brand or landing page, the search goes to this page with wrong parameters in the stores URL.

## How it works? 
This PR adds those parameters only if it's really a search page, not a brand or landing page.

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
