### PR TITLE
Feat | Thumbor plugin

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,5 @@
       "message": "Release: %v"
     }
   },
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }

--- a/packages/gatsby-plugin-thumbor/README.md
+++ b/packages/gatsby-plugin-thumbor/README.md
@@ -1,0 +1,100 @@
+# gatsby-plugin-thumbor
+
+A plugin for integrating gatsby-plugin-image with (thumbor)[http://thumbor.org/], an open-source smart on-demand image cropping, resizing and filters, so you can make your own smart image handling service.
+
+## Install
+```
+yarn add @vtex/gatsby-plugin-thumbor gatsby-plugin-image
+```
+
+## How to use 
+For using this plugin, you will need to add both `gatsby-plugin-image` and `gatsby-plugin-thumbor` to your `gatsby-config.js`.
+```js
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    // other plugins ...
+    {
+      resolve: 'gatsby-plugin-image'
+    },
+    {
+      resolve: `@vtex/gatsby-plugin-thumbor`
+      options: {
+        // Your thumbor server url
+        server: 'https://mythumborserver.com',
+      }
+    }
+  ],
+}
+```
+Then, in your react component you can simply use the hooks exported by `gatsby-plugin-thumbor` with the components exported by `gatsby-plugin-image`
+
+```tsx
+// In your React component
+import React, { FC } from 'react'
+import { useThumborImageData } from '@vtex/gatsby-plugin-thumbor'
+import { GatsbyImage } from 'gatsby-plugin-image'
+
+const MyComponent: FC = () => {
+  const image = useThumborImageData({
+    baseUrl: 'http://example.org/image.jpg',
+    options: {
+      // ...other thumbor options
+      fitIn: true,
+    }
+  })
+
+  return <GatsbyImage alt="example image" image={image} />
+}
+```
+
+## How it works
+Thumbor is an image processing service that enable you to process any image on the web. According to `gatsby-plugin-image` documentation, thumbor is a url-based image optimization service. This means that, for processing an image, we only need to generate an url with the right parameters and thumbor will do the heavy lifting for us.
+
+A thumbor compatible url can be splitted in two sections. The first one is a thumbor specific url with parameters for image resizing, postprocessing etc, and a second section containing a data source where thumbor must fetch the original image from. To illustrate. Let's supose your thumbor service is located at `mythumborserver.com` domain and that you need to resize to 250px/250px an image located at `example.com/image.png`. To resize `image.png` you can do the following request:
+```
+GET https://mythumborserver.com/unsafe/250x250/http://example.com/image.png
+```
+The aforementioned request returns the processed image. `gatsby-plugin-image` uses this url in html's `img` tag elements to add images to the final html.
+
+As mentioned before, Thumbor has lots of different parameters that tell it how to process and convert images. `gatsby-plugin-thumbor` tightly integrates with `gatsby-plugin-image` to give you control over these parameters in a simple interface, while generating a thumbor compatible urls. The interface chosen is the extra `options` parameters in `gatsby-plugin-image` functions.
+
+## Securing your thumbor service
+You may now be wondering why there is an `/unsafe` segment in thumbor's generated url. This is because, thumbor accepts requests from anyone on the internet to process and resize images. This makes the thumbor service prone to DDoS attacks.
+ 
+Thumbor has a solution for this on their docs. They say you should sign the urls so the thumbor service know when an image is from a reliable source or if it's someone messing with your server. This is the best way for protecting your thumbor server. 
+
+However, this plugin offers an alternative to this solution. 
+Usually, when serving gatsby, you are using a CDN (`gatsby-plugin-netlify`) or nginx (`@vtex/gatsby-plugin-nginx`). These services can be used as a reverse proxy server. Adding a reverse proxy to your thumbor service may protect it from malicous users because then we can only allow a small subset of all possible transformations to your images, decreasing the attack space on your thumbor service. 
+This protection is achieved with two parameters accepted by the plugin, `sizes` and `basePath`. A config using these parameters look like this:
+```js
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    // other plugins ...
+    {
+      resolve: 'gatsby-plugin-image'
+    },
+    {
+      resolve: `@vtex/gatsby-plugin-thumbor`
+      options: {
+        // Your thumbor server url
+        server: 'https://mythumborserver.com',
+        basePath: '/images',
+        sizes: [
+          '1080x1080',
+          '720x720',
+        ]
+      }
+    }
+  ],
+}
+```
+
+Now, instead of creating urls like `https://mythumborserver.com/unsafe/1080x1080/http://example.com/image.png`, the plugin will create urls for `{basePath}/1080x1080/http://example.com/image.png`, serve thumbor images on the same domain as your site and will only allow resizing to 1080x1080 and 720x720 images.
+
+Behind the scenes, what this plugin is doing is calling a `createRedirect` function between `/{basePath}/{size} => https://mythumborserver.com/unsafe/{size}` 
+
+## How to contribute
+
+Feel free to open issues in our repo. Also, there is a general contributing guidelines in there

--- a/packages/gatsby-plugin-thumbor/README.md
+++ b/packages/gatsby-plugin-thumbor/README.md
@@ -49,24 +49,24 @@ const MyComponent: FC = () => {
 ```
 
 ## How it works
-Thumbor is an image processing service that enable you to process any image on the web. According to `gatsby-plugin-image` documentation, thumbor is a url-based image optimization service. This means that, for processing an image, we only need to generate an url with the right parameters and thumbor will do the heavy lifting for us.
+Thumbor is an image processing service that enables you to process any image on the web. According to `gatsby-plugin-image` documentation, thumbor is a URL-based image optimization service. This means that, for processing an image, we only need to generate an URL with the right parameters, and thumbor will do the heavy lifting for us.
 
-A thumbor compatible url can be splitted in two sections. The first one is a thumbor specific url with parameters for image resizing, postprocessing etc, and a second section containing a data source where thumbor must fetch the original image from. To illustrate. Let's supose your thumbor service is located at `mythumborserver.com` domain and that you need to resize to 250px/250px an image located at `example.com/image.png`. To resize `image.png` you can do the following request:
+A thumbor compatible URL can be split into two sections. The first one is a thumbor specific URL with parameters for image resizing, postprocessing, etc, and a second section containing a data source where thumbor must fetch the original image from. To illustrate. Let's suppose your thumbor service is located at `mythumborserver.com` domain and that you need to resize to 250px/250px an image located at `example.com/image.png`. To resize `image.png` you can do the following request:
 ```
 GET https://mythumborserver.com/unsafe/250x250/http://example.com/image.png
 ```
-The aforementioned request returns the processed image. `gatsby-plugin-image` uses this url in html's `img` tag elements to add images to the final html.
+The aforementioned request returns the processed image. `gatsby-plugin-image` uses this URL in HTML's `img` tag elements to add images to the final HTML.
 
-As mentioned before, Thumbor has lots of different parameters that tell it how to process and convert images. `gatsby-plugin-thumbor` tightly integrates with `gatsby-plugin-image` to give you control over these parameters in a simple interface, while generating a thumbor compatible urls. The interface chosen is the extra `options` parameters in `gatsby-plugin-image` functions.
+As mentioned before, Thumbor has lots of different parameters that tell it how to process and convert images. `gatsby-plugin-thumbor` tightly integrates with `gatsby-plugin-image` to give you control over these parameters in a simple interface, while generating a thumbor compatible URLs. The interface chosen is the extra `options` parameters in `gatsby-plugin-image` functions.
 
 ## Securing your thumbor service
-You may now be wondering why there is an `/unsafe` segment in thumbor's generated url. This is because, thumbor accepts requests from anyone on the internet to process and resize images. This makes the thumbor service prone to DDoS attacks.
+You may now be wondering why there is an `/unsafe` segment in thumbor's generated URL. This is because thumbor accepts requests from anyone on the internet to process and resize images. This makes the thumbor service prone to DDoS attacks.
  
-Thumbor has a solution for this on their docs. They say you should sign the urls so the thumbor service know when an image is from a reliable source or if it's someone messing with your server. This is the best way for protecting your thumbor server. 
+Thumbor has a solution for this on their docs. They say you should sign the URLs so the thumbor service knows when an image is from a reliable source or if it's someone messing with your server. This is the best way for protecting your thumbor server. 
 
 However, this plugin offers an alternative to this solution. 
-Usually, when serving gatsby, you are using a CDN (`gatsby-plugin-netlify`) or nginx (`@vtex/gatsby-plugin-nginx`). These services can be used as a reverse proxy server. Adding a reverse proxy to your thumbor service may protect it from malicous users because then we can only allow a small subset of all possible transformations to your images, decreasing the attack space on your thumbor service. 
-This protection is achieved with two parameters accepted by the plugin, `sizes` and `basePath`. A config using these parameters look like this:
+Usually, when serving gatsby, you are using a CDN (`gatsby-plugin-netlify`) or Nginx (`@vtex/gatsby-plugin-nginx`). These services can be used as a reverse proxy server. Adding a reverse proxy to your thumbor service may protect it from malicious users because then we can only allow a small subset of all possible transformations to your images, decreasing the attack space on your thumbor service. 
+This protection is achieved with two parameters accepted by the plugin, `sizes` and `basePath`. A config using these parameters looks like this:
 ```js
 // In your gatsby-config.js
 module.exports = {
@@ -91,12 +91,12 @@ module.exports = {
 }
 ```
 
-Now, instead of creating urls like `https://mythumborserver.com/unsafe/1080x1080/http://example.com/image.png`, the plugin will create urls for `{basePath}/1080x1080/http://example.com/image.png`, serve thumbor images on the same domain as your site and will only allow resizing to 1080x1080 and 720x720 images.
+Now, instead of creating URLs like `https://mythumborserver.com/unsafe/1080x1080/http://example.com/image.png`, the plugin will create URLs for `{basePath}/1080x1080/http://example.com/image.png`, serve thumbor images on the same domain as your site, and will only allow resizing to 1080x1080 and 720x720 images.
 
 Behind the scenes, what this plugin is doing is calling a `createRedirect` function between `/{basePath}/{size} => https://mythumborserver.com/unsafe/{size}` 
 
 ## Examples
-Aside from `useThumborImageData`, this plugin exports `useUrlBuilder`, `useGetThumborImageData`, `getThumborImageData` and `urlBuilder`. These functions are thin wrappers to their counterparts on `gatsby-plugin-image` only adding the plugin's options, like the thumbor server url. You can use them normally in your react code. For instance, if you need the `getImageData` function you can:
+Aside from `useThumborImageData`, this plugin exports `useUrlBuilder`, `useGetThumborImageData`, `getThumborImageData` and `urlBuilder`. These functions are thin wrappers to their counterparts on `gatsby-plugin-image` only adding the plugin's options, like the thumbor server URL. You can use them normally in your react code. For instance, if you need the `getImageData` function you can:
 ```tsx
 // In your React component
 import React, { FC } from 'react'
@@ -120,4 +120,4 @@ const MyComponent: FC = () => {
 ```
 
 ## How to contribute
-Feel free to open issues in our repo. Also, there is a general contributing guidelines in there
+Feel free to open issues in our repo. Also, there is a general contributing guideline in there

--- a/packages/gatsby-plugin-thumbor/README.md
+++ b/packages/gatsby-plugin-thumbor/README.md
@@ -95,6 +95,29 @@ Now, instead of creating urls like `https://mythumborserver.com/unsafe/1080x1080
 
 Behind the scenes, what this plugin is doing is calling a `createRedirect` function between `/{basePath}/{size} => https://mythumborserver.com/unsafe/{size}` 
 
-## How to contribute
+## Extra APIs
+Aside from `useThumborImageData`, this plugin exports `useUrlBuilder`, `useGetThumborImageData`, `getThumborImageData` and `urlBuilder`. These functions are thin wrappers to their counterparts on `gatsby-plugin-image` only adding the plugin's options, like the thumbor server url. You can use them normally in your react code. For instance, if you need the `getImageData` function you can:
+```tsx
+// In your React component
+import React, { FC } from 'react'
+import { useGetThumborImageData } from '@vtex/gatsby-plugin-thumbor'
+import { GatsbyImage, withArtDirection } from 'gatsby-plugin-image'
 
+const MyComponent: FC = () => {
+  // gatsby-plugin-image's getImageData function
+  const getImageData = useGetThumborImageData()
+  const img1 = getImageData({baseUrl: 'http://example.org/img1.jpg'})
+  const img2 = getImageData({baseUrl: 'http://example.org/img2.jpg'})
+
+  // The images are totally compatible with gatsby-plugin-image
+  const image = withArtDirection(img1, {
+    media: '(max-width: 40em)',
+    image: img2
+  })
+
+  return <GatsbyImage alt="example image" image={image} />
+}
+```
+
+## How to contribute
 Feel free to open issues in our repo. Also, there is a general contributing guidelines in there

--- a/packages/gatsby-plugin-thumbor/README.md
+++ b/packages/gatsby-plugin-thumbor/README.md
@@ -95,7 +95,7 @@ Now, instead of creating urls like `https://mythumborserver.com/unsafe/1080x1080
 
 Behind the scenes, what this plugin is doing is calling a `createRedirect` function between `/{basePath}/{size} => https://mythumborserver.com/unsafe/{size}` 
 
-## Extra APIs
+## Examples
 Aside from `useThumborImageData`, this plugin exports `useUrlBuilder`, `useGetThumborImageData`, `getThumborImageData` and `urlBuilder`. These functions are thin wrappers to their counterparts on `gatsby-plugin-image` only adding the plugin's options, like the thumbor server url. You can use them normally in your react code. For instance, if you need the `getImageData` function you can:
 ```tsx
 // In your React component

--- a/packages/gatsby-plugin-thumbor/gatsby-browser.js
+++ b/packages/gatsby-plugin-thumbor/gatsby-browser.js
@@ -1,0 +1,8 @@
+import React from 'react'
+
+// Force webpack to resolve to the right (es-module) file
+import { Provider } from '@vtex/gatsby-plugin-thumbor'
+
+export const wrapRootElement = ({ element }, options) => (
+  <Provider options={options}>{element}</Provider>
+)

--- a/packages/gatsby-plugin-thumbor/gatsby-node.js
+++ b/packages/gatsby-plugin-thumbor/gatsby-node.js
@@ -1,0 +1,37 @@
+module.exports.pluginOptionsSchema = ({ Joi }) =>
+  Joi.object({
+    server: Joi.string().required(),
+    sizes: Joi.array().items(Joi.string().required()),
+    basePath: Joi.string(),
+  })
+
+module.exports.createPages = (
+  { actions: { createRedirect } },
+  { server, sizes, basePath }
+) => {
+  if (typeof basePath !== 'string') {
+    return
+  }
+
+  for (const size of sizes) {
+    createRedirect({
+      fromPath: `${basePath}/${size}/*`,
+      toPath: `${server}/unsafe/${size}/:splat`,
+    })
+
+    createRedirect({
+      fromPath: `${basePath}/:p1/${size}/*`,
+      toPath: `${server}/unsafe/:p1/${size}/:splat`,
+    })
+
+    createRedirect({
+      fromPath: `${basePath}/:p1/:p2/${size}/*`,
+      toPath: `${server}/unsafe/:p1/:p2/${size}/:splat`,
+    })
+
+    createRedirect({
+      fromPath: `${basePath}/:p1/:p2/:p3/${size}/*`,
+      toPath: `${server}/unsafe/:p1/:p2/:p3/${size}/:splat`,
+    })
+  }
+}

--- a/packages/gatsby-plugin-thumbor/gatsby-ssr.js
+++ b/packages/gatsby-plugin-thumbor/gatsby-ssr.js
@@ -1,0 +1,8 @@
+import React from 'react'
+
+// Force webpack to resolve to the right (es-module) file
+import { Provider } from '@vtex/gatsby-plugin-thumbor'
+
+export const wrapRootElement = ({ element }, options) => (
+  <Provider options={options}>{element}</Provider>
+)

--- a/packages/gatsby-plugin-thumbor/index.js
+++ b/packages/gatsby-plugin-thumbor/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist')

--- a/packages/gatsby-plugin-thumbor/package.json
+++ b/packages/gatsby-plugin-thumbor/package.json
@@ -47,6 +47,5 @@
     "tsdx": "^0.14.1",
     "tslib": "^2.2.0",
     "typescript": "^4.3.2"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/gatsby-plugin-thumbor/package.json
+++ b/packages/gatsby-plugin-thumbor/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@vtex/gatsby-plugin-thumbor",
+  "version": "0.1.0",
+  "author": "Tiago Gimenes",
+  "license": "MIT",
+  "main": "index.js",
+  "module": "dist/gatsby-plugin-thumbor.esm.js",
+  "typings": "dist/index.d.ts",
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "src",
+    "gatsby-*",
+    "index.js"
+  ],
+  "engines": {
+    "node": ">=10"
+  },
+  "scripts": {
+    "develop": "tsdx watch",
+    "build": "tsdx build",
+    "test": "tsdx test",
+    "lint": "tsdx lint",
+    "prepare": "tsdx build",
+    "size": "size-limit",
+    "analyze": "size-limit --why"
+  },
+  "size-limit": [
+    {
+      "path": "dist/gatsby-plugin-thumbor.cjs.production.min.js",
+      "limit": "10 KB"
+    },
+    {
+      "path": "dist/gatsby-plugin-thumbor.esm.js",
+      "limit": "10 KB"
+    }
+  ],
+  "peerDependencies": {
+    "gatsby-plugin-image": "^1.6.0",
+    "react": "^17.0.2"
+  },
+  "devDependencies": {
+    "@size-limit/preset-small-lib": "^4.11.0",
+    "gatsby-plugin-image": "^1.6.0",
+    "react": "^17.0.2",
+    "size-limit": "^4.11.0",
+    "tsdx": "^0.14.1",
+    "tslib": "^2.2.0",
+    "typescript": "^4.3.2"
+  },
+  "dependencies": {}
+}

--- a/packages/gatsby-plugin-thumbor/package.json
+++ b/packages/gatsby-plugin-thumbor/package.json
@@ -25,6 +25,13 @@
     "size": "size-limit",
     "analyze": "size-limit --why"
   },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "vtex",
+    "thumbor",
+    "gatsby-plugin-thumbor"
+  ],
   "size-limit": [
     {
       "path": "dist/gatsby-plugin-thumbor.cjs.production.min.js",

--- a/packages/gatsby-plugin-thumbor/src/Provider.tsx
+++ b/packages/gatsby-plugin-thumbor/src/Provider.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react'
 
 interface PluginOptions {
   server: string
-  sizes: string[]
+  sizes?: string[]
   basePath?: string
 }
 

--- a/packages/gatsby-plugin-thumbor/src/Provider.tsx
+++ b/packages/gatsby-plugin-thumbor/src/Provider.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext as reactUseContext } from 'react'
+import type { FC } from 'react'
+
+interface PluginOptions {
+  server: string
+  sizes: string[]
+  basePath?: string
+}
+
+const Context = createContext<PluginOptions | undefined>(undefined)
+
+export const useContext = () => {
+  const value = reactUseContext(Context)
+
+  if (value === undefined) {
+    throw new Error('[gatsby-plugin-thumbor]: Missing context in React tree')
+  }
+
+  return value
+}
+
+export const Provider: FC<{ options: PluginOptions }> = ({
+  children,
+  options,
+}) => <Context.Provider value={options}>{children}</Context.Provider>

--- a/packages/gatsby-plugin-thumbor/src/index.ts
+++ b/packages/gatsby-plugin-thumbor/src/index.ts
@@ -1,0 +1,8 @@
+export { urlBuilder } from './utils/urlBuilder'
+export { getThumborImageData } from './utils/getImageData'
+export type { ThumborImageDataOptions } from './utils/getImageData'
+
+export { Provider } from './Provider'
+export { useUrlBuilder } from './useUrlBuilder'
+export { useThumborImageData } from './useThumborImageData'
+export { useGetThumborImageData } from './useGetThumborImageData'

--- a/packages/gatsby-plugin-thumbor/src/useGetThumborImageData.ts
+++ b/packages/gatsby-plugin-thumbor/src/useGetThumborImageData.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react'
+
+import { useContext } from './Provider'
+import { getThumborImageData } from './utils/getImageData'
+import type { ThumborImageDataOptions } from './utils/getImageData'
+
+export const useGetThumborImageData = () => {
+  const { server, basePath } = useContext()
+
+  const getImageData = useCallback(
+    (options: ThumborImageDataOptions) =>
+      getThumborImageData({
+        ...options,
+        options: {
+          ...options.options,
+          server,
+          basePath,
+        },
+      }),
+    [server, basePath]
+  )
+
+  return getImageData
+}

--- a/packages/gatsby-plugin-thumbor/src/useThumborImageData.ts
+++ b/packages/gatsby-plugin-thumbor/src/useThumborImageData.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react'
+
+import { useContext } from './Provider'
+import { getThumborImageData } from './utils/getImageData'
+import type { ThumborImageDataOptions } from './utils/getImageData'
+
+export const useThumborImageData = (options: ThumborImageDataOptions) => {
+  const { server, basePath } = useContext()
+
+  const image = useMemo(
+    () =>
+      getThumborImageData({
+        ...options,
+        options: {
+          ...options.options,
+          server,
+          basePath,
+        },
+      }),
+    [server, basePath, options]
+  )
+
+  return image
+}

--- a/packages/gatsby-plugin-thumbor/src/useUrlBuilder.ts
+++ b/packages/gatsby-plugin-thumbor/src/useUrlBuilder.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react'
+import type { IUrlBuilderArgs } from 'gatsby-plugin-image'
+
+import { urlBuilder as thumborUrlBuilder } from './utils/urlBuilder'
+import { useContext } from './Provider'
+import type { ThumborProps } from './utils/urlBuilder'
+
+type Options = IUrlBuilderArgs<Omit<ThumborProps, 'server' | 'basePath'>>
+
+export const useUrlBuilder = () => {
+  const { server, basePath } = useContext()
+
+  const urlBuilder = useCallback(
+    (options: Options) =>
+      thumborUrlBuilder({
+        ...options,
+        options: {
+          ...options.options,
+          server,
+          basePath,
+        },
+      }),
+    [server, basePath]
+  )
+
+  return urlBuilder
+}

--- a/packages/gatsby-plugin-thumbor/src/utils/getImageData.ts
+++ b/packages/gatsby-plugin-thumbor/src/utils/getImageData.ts
@@ -1,0 +1,18 @@
+import { getImageData } from 'gatsby-plugin-image'
+import type { IGetImageDataArgs } from 'gatsby-plugin-image'
+
+import { urlBuilder } from './urlBuilder'
+import type { ThumborProps } from './urlBuilder'
+
+export type ThumborImageDataOptions = Omit<
+  IGetImageDataArgs<ThumborProps>,
+  'urlBuilder' | 'pluginName' | 'formats'
+>
+
+export const getThumborImageData = (options: ThumborImageDataOptions) =>
+  getImageData({
+    formats: ['auto'],
+    pluginName: 'gatsby-plugin-thumbor',
+    urlBuilder,
+    ...options,
+  })

--- a/packages/gatsby-plugin-thumbor/src/utils/urlBuilder.ts
+++ b/packages/gatsby-plugin-thumbor/src/utils/urlBuilder.ts
@@ -1,0 +1,109 @@
+import type { IUrlBuilderArgs } from 'gatsby-plugin-image'
+
+export type FilterValue = boolean | string | string[] | number[]
+
+export interface Box {
+  top: number
+  bottom: number
+  left: number
+  right: number
+}
+
+export interface ThumborProps {
+  basePath?: string
+  server: string
+  flipHorizontal?: boolean
+  flipVertical?: boolean
+  trim?: boolean
+  fitIn?: boolean
+  horizontalAlign?: 'left' | 'center' | 'right'
+  verticalAlign?: 'top' | 'middle' | 'bottom'
+  smart?: boolean
+  filters?: Record<string, FilterValue>
+  manualCrop?: Box | false
+}
+
+const cropSection = ({ left, top, right, bottom }: Box) =>
+  `${left}x${top}:${right}x${bottom}`
+
+function filtersURIComponent(filters: Record<string, FilterValue>) {
+  const elements = ['filters']
+
+  Object.keys(filters).forEach((name) => {
+    const parameters = filters[name]
+    let stringParameters
+
+    // If we have several parameters, they were passed as an array
+    // and now they need to be comma separated, otherwise there is just one to convert to a string
+    if (Array.isArray(parameters)) {
+      stringParameters = parameters.join(',')
+    }
+    // If true, we don't even need to do anything, we just have an empty string and insert ()
+    // Ex: {grayscale: true} => grayscale()
+    else if (parameters === true) {
+      stringParameters = ''
+    } else {
+      stringParameters = String(parameters)
+    }
+
+    elements.push(`${name}(${stringParameters})`)
+  })
+
+  return elements.join(':')
+}
+
+export const urlBuilder = (args: IUrlBuilderArgs<ThumborProps>) => {
+  const { options } = args
+
+  const urlComponents = [
+    options.basePath
+      ? options.basePath
+      : `${options.server}/unsafe`,
+  ]
+
+  // Add the trim parameter after unsafe if appliable
+  options.trim && urlComponents.push('trim')
+
+  // Add the crop parameter if any
+  options.manualCrop && urlComponents.push(cropSection(options.manualCrop))
+
+  // Add the fit-in parameter after crop if appliable
+  options.fitIn && urlComponents.push('fit-in')
+
+  // Adds the final size parameter
+  let finalSize = ''
+
+  if (options.flipHorizontal) {
+    finalSize += '-'
+  }
+
+  finalSize += `${args.width}x`
+
+  if (options.flipVertical) {
+    finalSize += '-'
+  }
+
+  finalSize += `${args.height}`
+  urlComponents.push(finalSize)
+
+  // Adds the horizontal alignement after the size
+  urlComponents.push(options.horizontalAlign ?? 'center')
+
+  // Adds the vertical alignement after the size
+  urlComponents.push(options.verticalAlign ?? 'middle')
+
+  // Adds the smart parameter if appliable
+  options.smart && urlComponents.push('smart')
+
+  // Compile the filters and add them right before the URI
+  const { filters } = options
+
+  filters && urlComponents.push(filtersURIComponent(filters))
+
+  // Finally, adds the real image uri
+  urlComponents.push(encodeURIComponent(args.baseUrl))
+
+  const url = urlComponents.join('/')
+
+  return url
+}

--- a/packages/gatsby-plugin-thumbor/src/utils/urlBuilder.ts
+++ b/packages/gatsby-plugin-thumbor/src/utils/urlBuilder.ts
@@ -56,9 +56,7 @@ export const urlBuilder = (args: IUrlBuilderArgs<ThumborProps>) => {
   const { options } = args
 
   const urlComponents = [
-    options.basePath
-      ? options.basePath
-      : `${options.server}/unsafe`,
+    options.basePath ? options.basePath : `${options.server}/unsafe`,
   ]
 
   // Add the trim parameter after unsafe if appliable

--- a/packages/gatsby-plugin-thumbor/test/urlBuilder.test.ts
+++ b/packages/gatsby-plugin-thumbor/test/urlBuilder.test.ts
@@ -1,0 +1,147 @@
+import type { IUrlBuilderArgs } from 'gatsby-plugin-image'
+
+import { urlBuilder } from '../src'
+import type { ThumborProps } from '../src/utils/urlBuilder'
+
+describe('Build thumbor url with gatsby-plugin-image', () => {
+  const DEFAULT_CONFIG: IUrlBuilderArgs<ThumborProps> = {
+    baseUrl: 'http://otherserver/img.jpg',
+    width: 100,
+    height: 100,
+    format: 'auto',
+    options: {
+      server: 'http://thumborserver.com',
+      basePath: '/assets',
+    },
+  } as const
+
+  it('should handle a basic url', () => {
+    expect(urlBuilder(DEFAULT_CONFIG)).toBe(
+      '/assets/100x100/center/middle/http%3A%2F%2Fotherserver%2Fimg.jpg'
+    )
+  })
+
+  it('should handle a basic url without base redirect', () => {
+    expect(
+      urlBuilder({
+        ...DEFAULT_CONFIG,
+        options: { ...DEFAULT_CONFIG.options, basePath: undefined },
+      })
+    ).toBe(
+      'http://thumborserver.com/unsafe/100x100/center/middle/http%3A%2F%2Fotherserver%2Fimg.jpg'
+    )
+  })
+
+  it('should handle flipping', () => {
+    expect(
+      urlBuilder({
+        ...DEFAULT_CONFIG,
+        options: { ...DEFAULT_CONFIG.options, flipHorizontal: true },
+      })
+    ).toBe('/assets/-100x100/center/middle/http%3A%2F%2Fotherserver%2Fimg.jpg')
+
+    expect(
+      urlBuilder({
+        ...DEFAULT_CONFIG,
+        options: { ...DEFAULT_CONFIG.options, flipVertical: true },
+      })
+    ).toBe('/assets/100x-100/center/middle/http%3A%2F%2Fotherserver%2Fimg.jpg')
+
+    expect(
+      urlBuilder({
+        ...DEFAULT_CONFIG,
+        options: {
+          ...DEFAULT_CONFIG.options,
+          flipHorizontal: true,
+          flipVertical: true,
+        },
+      })
+    ).toBe('/assets/-100x-100/center/middle/http%3A%2F%2Fotherserver%2Fimg.jpg')
+  })
+
+  it('should handle trim', () => {
+    expect(
+      urlBuilder({
+        ...DEFAULT_CONFIG,
+        options: { ...DEFAULT_CONFIG.options, trim: true },
+      })
+    ).toBe(
+      '/assets/trim/100x100/center/middle/http%3A%2F%2Fotherserver%2Fimg.jpg'
+    )
+  })
+
+  it('should handle fitIn', () => {
+    expect(
+      urlBuilder({
+        ...DEFAULT_CONFIG,
+        options: { ...DEFAULT_CONFIG.options, fitIn: true },
+      })
+    ).toBe(
+      '/assets/fit-in/100x100/center/middle/http%3A%2F%2Fotherserver%2Fimg.jpg'
+    )
+  })
+
+  it('should handle smart cropping', () => {
+    expect(
+      urlBuilder({
+        ...DEFAULT_CONFIG,
+        options: { ...DEFAULT_CONFIG.options, smart: true },
+      })
+    ).toBe(
+      '/assets/100x100/center/middle/smart/http%3A%2F%2Fotherserver%2Fimg.jpg'
+    )
+  })
+
+  it('should handle manual cropping', () => {
+    expect(
+      urlBuilder({
+        ...DEFAULT_CONFIG,
+        options: {
+          ...DEFAULT_CONFIG.options,
+          manualCrop: {
+            top: 10,
+            left: 20,
+            bottom: 60,
+            right: 120,
+          },
+        },
+      })
+    ).toBe(
+      '/assets/20x10:120x60/100x100/center/middle/http%3A%2F%2Fotherserver%2Fimg.jpg'
+    )
+  })
+
+  it('should handle other alignments', () => {
+    expect(
+      urlBuilder({
+        ...DEFAULT_CONFIG,
+        options: { ...DEFAULT_CONFIG.options, horizontalAlign: 'left' },
+      })
+    ).toBe('/assets/100x100/left/middle/http%3A%2F%2Fotherserver%2Fimg.jpg')
+
+    expect(
+      urlBuilder({
+        ...DEFAULT_CONFIG,
+        options: { ...DEFAULT_CONFIG.options, verticalAlign: 'top' },
+      })
+    ).toBe('/assets/100x100/center/top/http%3A%2F%2Fotherserver%2Fimg.jpg')
+  })
+
+  it('should handle filters', () => {
+    expect(
+      urlBuilder({
+        ...DEFAULT_CONFIG,
+        options: {
+          ...DEFAULT_CONFIG.options,
+          filters: {
+            fill: 'blue',
+            rgb: [20, 10, 40],
+            grayscale: true,
+          },
+        },
+      })
+    ).toBe(
+      '/assets/100x100/center/middle/filters:fill(blue):rgb(20,10,40):grayscale()/http%3A%2F%2Fotherserver%2Fimg.jpg'
+    )
+  })
+})

--- a/packages/gatsby-plugin-thumbor/tsconfig.json
+++ b/packages/gatsby-plugin-thumbor/tsconfig.json
@@ -1,6 +1,6 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
-  "include": ["src", "types", "test"],
+  "include": ["src", "types"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],
@@ -10,7 +10,7 @@
     // output .js.map sourcemap files for consumers
     "sourceMap": true,
     // match output dir to input dir. e.g. dist/index instead of dist/src/index
-    "rootDir": ".",
+    "rootDir": "./src",
     // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
     // linter checks for common issues

--- a/packages/gatsby-plugin-thumbor/tsconfig.json
+++ b/packages/gatsby-plugin-thumbor/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
+  "include": ["src", "types", "test"],
+  "compilerOptions": {
+    "module": "esnext",
+    "lib": ["dom", "esnext"],
+    "importHelpers": true,
+    // output .d.ts declaration files for consumers
+    "declaration": true,
+    // output .js.map sourcemap files for consumers
+    "sourceMap": true,
+    // match output dir to input dir. e.g. dist/index instead of dist/src/index
+    "rootDir": ".",
+    // stricter type-checking for stronger correctness. Recommended by TS
+    "strict": true,
+    // linter checks for common issues
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    // use Node's module resolution algorithm, instead of the legacy TS one
+    "moduleResolution": "node",
+    // transpile JSX to React.createElement
+    "jsx": "react",
+    // interop between ESM and CJS modules. Recommended by TS
+    "esModuleInterop": true,
+    // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
+    "skipLibCheck": true,
+    // error out if import and file system have a casing mismatch. Recommended by TS
+    "forceConsistentCasingInFileNames": true,
+    // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
+    "noEmit": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3703,6 +3703,13 @@
   dependencies:
     semver "7.3.5"
 
+"@size-limit/file@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@size-limit/file/-/file-4.11.0.tgz#d453ea543e4f4f1ba5e8b3bd517d1f27759b747d"
+  integrity sha512-GPQPcFHBa6U8Z7xEl42gB1RJxCDqUILL5/WzgWDC9Q9WujnKuZwq16+yoCxrvTQfbl4Ol+Z42M50FvvibFMy9w==
+  dependencies:
+    semver "7.3.5"
+
 "@size-limit/preset-small-lib@^4.10.2":
   version "4.10.2"
   resolved "https://registry.yarnpkg.com/@size-limit/preset-small-lib/-/preset-small-lib-4.10.2.tgz#9522f38fb091f88fcb7178735903b31ac9bf4f17"
@@ -3710,6 +3717,14 @@
   dependencies:
     "@size-limit/file" "4.10.2"
     "@size-limit/webpack" "4.10.2"
+
+"@size-limit/preset-small-lib@^4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@size-limit/preset-small-lib/-/preset-small-lib-4.11.0.tgz#1519907d55bb681e88faeb0901912e9523e3db61"
+  integrity sha512-+McnY9jHr5hNm9PoUkInzRIn9aNNW2BVmHaACLN892bkfaHmQ6lAj4qe6czuypq8xHJl2IdIFGu+CEsyEC1baA==
+  dependencies:
+    "@size-limit/file" "4.11.0"
+    "@size-limit/webpack" "4.11.0"
 
 "@size-limit/webpack@4.10.2":
   version "4.10.2"
@@ -3727,6 +3742,23 @@
     style-loader "^2.0.0"
     webpack "^4.44.1"
     webpack-bundle-analyzer "^4.4.0"
+
+"@size-limit/webpack@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@size-limit/webpack/-/webpack-4.11.0.tgz#ccc9e1e8418127e876ca659c27d605258b40ec7b"
+  integrity sha512-TzPESkF/sakw6qMadw+0X1yxOeTcttbm7qTDWvUf49mIoBlYa52Bu6BZUj3L6H7ZKhrieHLkyU7zqPyu7yPXjg==
+  dependencies:
+    css-loader "^5.2.5"
+    escape-string-regexp "^4.0.0"
+    file-loader "^6.2.0"
+    mkdirp "^1.0.4"
+    nanoid "^3.1.23"
+    optimize-css-assets-webpack-plugin "^6.0.0"
+    pnp-webpack-plugin "^1.6.4"
+    rimraf "^3.0.2"
+    style-loader "^2.0.0"
+    webpack "^4.44.1"
+    webpack-bundle-analyzer "^4.4.2"
 
 "@storybook/addon-actions@6.2.9", "@storybook/addon-actions@^6.2.9":
   version "6.2.9"
@@ -4991,7 +5023,7 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
+"@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
@@ -5386,30 +5418,30 @@
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
 "@typescript-eslint/eslint-plugin@^2.10.0", "@typescript-eslint/eslint-plugin@^2.12.0", "@typescript-eslint/eslint-plugin@^4", "@typescript-eslint/eslint-plugin@^4.15.2", "@typescript-eslint/eslint-plugin@^4.18.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.24.0.tgz#03801ffc25b2af9d08f3dc9bccfc0b7ce3780d0f"
-  integrity sha512-qbCgkPM7DWTsYQGjx9RTuQGswi+bEt0isqDBeo+CKV0953zqI0Tp7CZ7Fi9ipgFA6mcQqF4NOVNwS/f2r6xShw==
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.26.0.tgz#12bbd6ebd5e7fabd32e48e1e60efa1f3554a3242"
+  integrity sha512-yA7IWp+5Qqf+TLbd8b35ySFOFzUfL7i+4If50EqvjT6w35X8Lv0eBHb6rATeWmucks37w+zV+tWnOXI9JlG6Eg==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.24.0"
-    "@typescript-eslint/scope-manager" "4.24.0"
-    debug "^4.1.1"
+    "@typescript-eslint/experimental-utils" "4.26.0"
+    "@typescript-eslint/scope-manager" "4.26.0"
+    debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
-    lodash "^4.17.15"
-    regexpp "^3.0.0"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    lodash "^4.17.21"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.24.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.24.0.tgz#c23ead9de44b99c3a5fd925c33a106b00165e172"
-  integrity sha512-IwTT2VNDKH1h8RZseMH4CcYBz6lTvRoOLDuuqNZZoThvfHEhOiZPQCow+5El3PtyxJ1iDr6UXZwYtE3yZQjhcw==
+"@typescript-eslint/experimental-utils@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.26.0.tgz#ba7848b3f088659cdf71bce22454795fc55be99a"
+  integrity sha512-TH2FO2rdDm7AWfAVRB5RSlbUhWxGVuxPNzGT7W65zVfl8H/WeXTk1e69IrcEVsBslrQSTDKQSaJD89hwKrhdkw==
   dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.24.0"
-    "@typescript-eslint/types" "4.24.0"
-    "@typescript-eslint/typescript-estree" "4.24.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.26.0"
+    "@typescript-eslint/types" "4.26.0"
+    "@typescript-eslint/typescript-estree" "4.26.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
 "@typescript-eslint/experimental-utils@^4.0.1":
   version "4.19.0"
@@ -5436,14 +5468,14 @@
     eslint-utils "^2.0.0"
 
 "@typescript-eslint/parser@^2.10.0", "@typescript-eslint/parser@^2.12.0", "@typescript-eslint/parser@^4", "@typescript-eslint/parser@^4.15.2", "@typescript-eslint/parser@^4.18.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.24.0.tgz#2e5f1cc78ffefe43bfac7e5659309a92b09a51bd"
-  integrity sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.26.0.tgz#31b6b732c9454f757b020dab9b6754112aa5eeaf"
+  integrity sha512-b4jekVJG9FfmjUfmM4VoOItQhPlnt6MPOBUL0AQbiTmm+SSpSdhHYlwayOm4IW9KLI/4/cRKtQCmDl1oE2OlPg==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.24.0"
-    "@typescript-eslint/types" "4.24.0"
-    "@typescript-eslint/typescript-estree" "4.24.0"
-    debug "^4.1.1"
+    "@typescript-eslint/scope-manager" "4.26.0"
+    "@typescript-eslint/types" "4.26.0"
+    "@typescript-eslint/typescript-estree" "4.26.0"
+    debug "^4.3.1"
 
 "@typescript-eslint/scope-manager@4.19.0":
   version "4.19.0"
@@ -5461,13 +5493,13 @@
     "@typescript-eslint/types" "4.22.0"
     "@typescript-eslint/visitor-keys" "4.22.0"
 
-"@typescript-eslint/scope-manager@4.24.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz#38088216f0eaf235fa30ed8cabf6948ec734f359"
-  integrity sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==
+"@typescript-eslint/scope-manager@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.26.0.tgz#60d1a71df162404e954b9d1c6343ff3bee496194"
+  integrity sha512-G6xB6mMo4xVxwMt5lEsNTz3x4qGDt0NSGmTBNBPJxNsrTXJSm21c6raeYroS2OwQsOyIXqKZv266L/Gln1BWqg==
   dependencies:
-    "@typescript-eslint/types" "4.24.0"
-    "@typescript-eslint/visitor-keys" "4.24.0"
+    "@typescript-eslint/types" "4.26.0"
+    "@typescript-eslint/visitor-keys" "4.26.0"
 
 "@typescript-eslint/types@4.19.0":
   version "4.19.0"
@@ -5479,10 +5511,10 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.0.tgz#0ca6fde5b68daf6dba133f30959cc0688c8dd0b6"
   integrity sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==
 
-"@typescript-eslint/types@4.24.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.24.0.tgz#6d0cca2048cbda4e265e0c4db9c2a62aaad8228c"
-  integrity sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==
+"@typescript-eslint/types@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.26.0.tgz#7c6732c0414f0a69595f4f846ebe12616243d546"
+  integrity sha512-rADNgXl1kS/EKnDr3G+m7fB9yeJNnR9kF7xMiXL6mSIWpr3Wg5MhxyfEXy/IlYthsqwBqHOr22boFbf/u6O88A==
 
 "@typescript-eslint/typescript-estree@4.19.0":
   version "4.19.0"
@@ -5510,18 +5542,18 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@4.24.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.24.0.tgz#b49249679a98014d8b03e8d4b70864b950e3c90f"
-  integrity sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==
+"@typescript-eslint/typescript-estree@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.0.tgz#aea17a40e62dc31c63d5b1bbe9a75783f2ce7109"
+  integrity sha512-GHUgahPcm9GfBuy3TzdsizCcPjKOAauG9xkz9TR8kOdssz2Iz9jRCSQm6+aVFa23d5NcSpo1GdHGSQKe0tlcbg==
   dependencies:
-    "@typescript-eslint/types" "4.24.0"
-    "@typescript-eslint/visitor-keys" "4.24.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
+    "@typescript-eslint/types" "4.26.0"
+    "@typescript-eslint/visitor-keys" "4.26.0"
+    debug "^4.3.1"
+    globby "^11.0.3"
     is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/visitor-keys@4.19.0":
   version "4.19.0"
@@ -5539,12 +5571,12 @@
     "@typescript-eslint/types" "4.22.0"
     eslint-visitor-keys "^2.0.0"
 
-"@typescript-eslint/visitor-keys@4.24.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.24.0.tgz#a8fafdc76cad4e04a681a945fbbac4e35e98e297"
-  integrity sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==
+"@typescript-eslint/visitor-keys@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.0.tgz#26d2583169222815be4dcd1da4fe5459bc3bcc23"
+  integrity sha512-cw4j8lH38V1ycGBbF+aFiLUls9Z0Bw8QschP3mkth50BbWzgFS33ISIgBzUMuQ2IdahoEv/rXstr8Zhlz4B1Zg==
   dependencies:
-    "@typescript-eslint/types" "4.24.0"
+    "@typescript-eslint/types" "4.26.0"
     eslint-visitor-keys "^2.0.0"
 
 "@vtex-components/accordion@^0.2.3":
@@ -6764,6 +6796,11 @@ babel-jest@^25.5.1:
     graceful-fs "^4.2.4"
     slash "^3.0.0"
 
+babel-jsx-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-jsx-utils/-/babel-jsx-utils-1.1.0.tgz#304ce4fce0c86cbeee849551a45eb4ed1036381a"
+  integrity sha512-Mh1j/rw4xM9T3YICkw22aBQ78FhsHdsmlb9NEk4uVAFBOg+Ez9ZgXXHugoBPCZui3XLomk/7/JBBH4daJqTkQQ==
+
 babel-loader@8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.1.0.tgz#c611d5112bd5209abe8b9fa84c3e4da25275f1c3"
@@ -6987,6 +7024,11 @@ babel-plugin-remove-graphql-queries@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-3.5.0.tgz#980b683dad1c4f9345312cdf68e4e4743dae3ec5"
   integrity sha512-JGVMfrPk7TwRSDxs8Rro748SbSrj+5h4iQvbE5dfUIUOELVoPm9FrhiEn/kIMvwd+nMgn8td9sg0Pp24HtjZlQ==
+
+babel-plugin-remove-graphql-queries@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-3.6.0.tgz#20b8094ae319920fb925b1604e837e5f6a987e2f"
+  integrity sha512-8BEpm4gnHJhAcQ/K+yvY+/LINPljBgzncYnpLLhXa4rHa5SGsD0EIjWC0yzcP6WtMlIAqUf2cWz2itGci7FrvA==
 
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
@@ -7501,7 +7543,7 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.12.2, browserslist@^4
     escalade "^3.1.1"
     node-releases "^1.1.70"
 
-browserslist@^4.16.0:
+browserslist@^4.16.0, browserslist@^4.16.6:
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
   integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
@@ -8339,6 +8381,11 @@ color@^3.0.0, color@^3.1.1:
     color-convert "^1.9.1"
     color-string "^1.5.4"
 
+colord@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/colord/-/colord-2.0.1.tgz#1e7fb1f9fa1cf74f42c58cb9c20320bab8435aa0"
+  integrity sha512-vm5YpaWamD0Ov6TSG0GGmUIwstrWcfKQV/h2CmbR7PbNu41+qdB5PW9lpzhjedrpm08uuYvcXi0Oel1RLZIJuA==
+
 colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
@@ -9033,6 +9080,13 @@ css-declaration-sorter@^4.0.1:
     postcss "^7.0.1"
     timsort "^0.3.0"
 
+css-declaration-sorter@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-6.0.3.tgz#9dfd8ea0df4cc7846827876fafb52314890c21a9"
+  integrity sha512-52P95mvW1SMzuRZegvpluT6yEv0FqQusydKQPZsNN5Q7hh8EwQvN8E2nwuJ16BBvNN6LcoIZXu/Bk58DAhrrxw==
+  dependencies:
+    timsort "^0.3.0"
+
 css-has-pseudo@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz#3c642ab34ca242c59c41a125df9105841f6966ee"
@@ -9105,6 +9159,22 @@ css-loader@^5.2.0:
     icss-utils "^5.1.0"
     loader-utils "^2.0.0"
     postcss "^8.2.10"
+    postcss-modules-extract-imports "^3.0.0"
+    postcss-modules-local-by-default "^4.0.0"
+    postcss-modules-scope "^3.0.0"
+    postcss-modules-values "^4.0.0"
+    postcss-value-parser "^4.1.0"
+    schema-utils "^3.0.0"
+    semver "^7.3.5"
+
+css-loader@^5.2.5:
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-5.2.6.tgz#c3c82ab77fea1f360e587d871a6811f4450cc8d1"
+  integrity sha512-0wyN5vXMQZu6BvjbrPdUJvkCzGEO24HC7IS7nW4llc6BBFC+zwR9CKtYGv63Puzsg10L/o12inMY5/2ByzfD6w==
+  dependencies:
+    icss-utils "^5.1.0"
+    loader-utils "^2.0.0"
+    postcss "^8.2.15"
     postcss-modules-extract-imports "^3.0.0"
     postcss-modules-local-by-default "^4.0.0"
     postcss-modules-scope "^3.0.0"
@@ -9315,6 +9385,41 @@ cssnano-preset-default@^5.0.1:
     postcss-svgo "^5.0.0"
     postcss-unique-selectors "^5.0.0"
 
+cssnano-preset-default@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-5.1.2.tgz#5d4877a91769823c5da6bcebd54996ecdf8aca12"
+  integrity sha512-spilp8LRw0sacuxiN9A/dyyPr6G/WISKMBKcBD4NMoPV0ENx4DeuWvIIrSx9PII2nJIDCO3kywkqTPreECBVOg==
+  dependencies:
+    css-declaration-sorter "^6.0.3"
+    cssnano-utils "^2.0.1"
+    postcss-calc "^8.0.0"
+    postcss-colormin "^5.2.0"
+    postcss-convert-values "^5.0.1"
+    postcss-discard-comments "^5.0.1"
+    postcss-discard-duplicates "^5.0.1"
+    postcss-discard-empty "^5.0.1"
+    postcss-discard-overridden "^5.0.1"
+    postcss-merge-longhand "^5.0.2"
+    postcss-merge-rules "^5.0.2"
+    postcss-minify-font-values "^5.0.1"
+    postcss-minify-gradients "^5.0.1"
+    postcss-minify-params "^5.0.1"
+    postcss-minify-selectors "^5.1.0"
+    postcss-normalize-charset "^5.0.1"
+    postcss-normalize-display-values "^5.0.1"
+    postcss-normalize-positions "^5.0.1"
+    postcss-normalize-repeat-style "^5.0.1"
+    postcss-normalize-string "^5.0.1"
+    postcss-normalize-timing-functions "^5.0.1"
+    postcss-normalize-unicode "^5.0.1"
+    postcss-normalize-url "^5.0.1"
+    postcss-normalize-whitespace "^5.0.1"
+    postcss-ordered-values "^5.0.1"
+    postcss-reduce-initial "^5.0.1"
+    postcss-reduce-transforms "^5.0.1"
+    postcss-svgo "^5.0.2"
+    postcss-unique-selectors "^5.0.1"
+
 cssnano-util-get-arguments@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz#ed3a08299f21d75741b20f3b81f194ed49cc150f"
@@ -9342,6 +9447,11 @@ cssnano-utils@^2.0.0:
   resolved "https://registry.yarnpkg.com/cssnano-utils/-/cssnano-utils-2.0.0.tgz#b04baaa312aa3dd5a854b7f61d76b9d94be07f74"
   integrity sha512-xvxmTszdrvSyTACdPe8VU5J6p4sm3egpgw54dILvNqt5eBUv6TFjACLhSxtRuEsxYrgy8uDy269YjScO5aKbGA==
 
+cssnano-utils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/cssnano-utils/-/cssnano-utils-2.0.1.tgz#8660aa2b37ed869d2e2f22918196a9a8b6498ce2"
+  integrity sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==
+
 cssnano@^4.1.10:
   version "4.1.10"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-4.1.10.tgz#0ac41f0b13d13d465487e111b778d42da631b8b2"
@@ -9359,6 +9469,15 @@ cssnano@^5.0.0:
   dependencies:
     cosmiconfig "^7.0.0"
     cssnano-preset-default "^5.0.1"
+    is-resolvable "^1.1.0"
+
+cssnano@^5.0.2:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-5.0.5.tgz#6b8787123bf4cd5a220a2fa6cb5bc036b0854b48"
+  integrity sha512-L2VtPXnq6rmcMC9vkBOP131sZu3ccRQI27ejKZdmQiPDpUlFkUbpXHgKN+cibeO1U4PItxVZp1zTIn5dHsXoyg==
+  dependencies:
+    cosmiconfig "^7.0.0"
+    cssnano-preset-default "^5.1.2"
     is-resolvable "^1.1.0"
 
 csso@^4.0.2, csso@^4.2.0:
@@ -10816,6 +10935,13 @@ eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
@@ -12024,6 +12150,20 @@ gatsby-core-utils@^2.5.0:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
+gatsby-core-utils@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-2.6.0.tgz#4653995f3640b56fe218a20da6458cfe0bffcdfb"
+  integrity sha512-d8a/iblc3wIrLEOWTUcoK5uYE2DrvlQmeulx6DK3NY49KD8jet8ozB6T5GA1CftsvowWeO6aaDnoWDbTxIxTRA==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    file-type "^16.2.0"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-graphiql-explorer@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-1.1.0.tgz#00e4cfcad769363e6ea97cf6e36ff618c5e31923"
@@ -12115,6 +12255,24 @@ gatsby-plugin-bundle-stats@^2.7.2:
   integrity sha512-vbmejOdU4qx3eOJUBKGv+IGx8SYDPwJ5mPfhcRJWF5uM2FVo4tR5O0DNko7Y72hT7XXnKK6A5bLjaSqlgagxYQ==
   dependencies:
     bundle-stats-webpack-plugin "^2.7.2"
+
+gatsby-plugin-image@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-image/-/gatsby-plugin-image-1.6.0.tgz#a6b2ed58179475d2f92c374af2f946d9f0aea784"
+  integrity sha512-AYNSer+Cj78anY8EDprw0BbAMLA0+8fEomRFpPcBh/TxN/b74q8jIfsjOUj43TmrIKEmtDiaCh8Z3i/4ZWFD5A==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/parser" "^7.12.5"
+    "@babel/traverse" "^7.12.5"
+    babel-jsx-utils "^1.1.0"
+    babel-plugin-remove-graphql-queries "^3.6.0"
+    camelcase "^5.3.1"
+    chokidar "^3.5.1"
+    common-tags "^1.8.0"
+    fs-extra "^8.1.0"
+    gatsby-core-utils "^2.6.0"
+    objectFitPolyfill "^2.3.0"
+    prop-types "^15.7.2"
 
 gatsby-plugin-next-seo@^1.7.0:
   version "1.7.0"
@@ -17681,9 +17839,6 @@ minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
-  dependencies:
-    minipass "^3.0.0"
-    yallist "^4.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -18388,6 +18543,11 @@ object.values@^1.1.0, object.values@^1.1.1, object.values@^1.1.3:
     es-abstract "^1.18.0-next.2"
     has "^1.0.3"
 
+objectFitPolyfill@^2.3.0:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/objectFitPolyfill/-/objectFitPolyfill-2.3.5.tgz#be8c83064aabfa4e88780f776c2013c48ce1f745"
+  integrity sha512-8Quz071ZmGi0QWEG4xB3Bv5Lpw6K0Uca87FLoLMKMWjB6qIq9IyBegP3b/VLNxv2WYvIMGoeUQ+c6ibUkNa8TA==
+
 objectorarray@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/objectorarray/-/objectorarray-1.0.4.tgz#d69b2f0ff7dc2701903d308bb85882f4ddb49483"
@@ -18481,6 +18641,15 @@ optimize-css-assets-webpack-plugin@^5.0.4:
   dependencies:
     cssnano "^4.1.10"
     last-call-webpack-plugin "^3.0.0"
+
+optimize-css-assets-webpack-plugin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-6.0.0.tgz#00acd99d420715ad96ed3d8ad65a8a4df1be233b"
+  integrity sha512-XKVxJuCBSslP1Eyuf1uVtZT3Pkp6jEIkmg7BMcNU/pq6XAnDXTINkYFWmiQWt8+j//FO4dIDd4v+gn0m5VWJIw==
+  dependencies:
+    cssnano "^5.0.2"
+    last-call-webpack-plugin "^3.0.0"
+    postcss "^8.2.1"
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
@@ -19326,6 +19495,16 @@ postcss-colormin@^5.0.0:
     color "^3.1.1"
     postcss-value-parser "^4.1.0"
 
+postcss-colormin@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-5.2.0.tgz#2b620b88c0ff19683f3349f4cf9e24ebdafb2c88"
+  integrity sha512-+HC6GfWU3upe5/mqmxuqYZ9B2Wl4lcoUUNkoaX59nEWV4EtADCMiBqui111Bu8R8IvaZTmqmxrqOAqjbHIwXPw==
+  dependencies:
+    browserslist "^4.16.6"
+    caniuse-api "^3.0.0"
+    colord "^2.0.1"
+    postcss-value-parser "^4.1.0"
+
 postcss-convert-values@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz#ca3813ed4da0f812f9d43703584e449ebe189a7f"
@@ -19338,6 +19517,13 @@ postcss-convert-values@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-5.0.0.tgz#cd77e1d23ebe8fcf508640551eed08e232784cba"
   integrity sha512-V5kmYm4xoBAjNs+eHY/6XzXJkkGeg4kwNf2ocfqhLb1WBPEa4oaSmoi1fnVO7Dkblqvus9h+AenDvhCKUCK7uQ==
+  dependencies:
+    postcss-value-parser "^4.1.0"
+
+postcss-convert-values@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-5.0.1.tgz#4ec19d6016534e30e3102fdf414e753398645232"
+  integrity sha512-C3zR1Do2BkKkCgC0g3sF8TS0koF2G+mN8xxayZx3f10cIRmTaAnpgpRQZjNekTZxM2ciSPoh2IWJm0VZx8NoQg==
   dependencies:
     postcss-value-parser "^4.1.0"
 
@@ -19384,6 +19570,11 @@ postcss-discard-comments@^5.0.0:
   resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-5.0.0.tgz#6c27310e0657c0b9e38a6175ad001b5aa28964bc"
   integrity sha512-Umig6Gxs8m20RihiXY6QkePd6mp4FxkA1Dg+f/Kd6uw0gEMfKRjDeQOyFkLibexbJJGHpE3lrN/Q0R9SMrUMbQ==
 
+postcss-discard-comments@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz#9eae4b747cf760d31f2447c27f0619d5718901fe"
+  integrity sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==
+
 postcss-discard-duplicates@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz#3fe133cd3c82282e550fc9b239176a9207b784eb"
@@ -19395,6 +19586,11 @@ postcss-discard-duplicates@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.0.tgz#6a2c4f779e8d20da6781e90730f234f9e650c51c"
   integrity sha512-vEJJ+Y3pFUnO1FyCBA6PSisGjHtnphL3V6GsNvkASq/VkP3OX5/No5RYXXLxHa2QegStNzg6HYrYdo71uR4caQ==
+
+postcss-discard-duplicates@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz#68f7cc6458fe6bab2e46c9f55ae52869f680e66d"
+  integrity sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==
 
 postcss-discard-empty@^4.0.1:
   version "4.0.1"
@@ -19408,6 +19604,11 @@ postcss-discard-empty@^5.0.0:
   resolved "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-5.0.0.tgz#0f0a9baee415f5f7be4ae046ba235e98626ba821"
   integrity sha512-+wigy099Y1xZxG36WG5L1f2zeH1oicntkJEW4TDIqKKDO2g9XVB3OhoiHTu08rDEjLnbcab4rw0BAccwi2VjiQ==
 
+postcss-discard-empty@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz#ee136c39e27d5d2ed4da0ee5ed02bc8a9f8bf6d8"
+  integrity sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==
+
 postcss-discard-overridden@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz#652aef8a96726f029f5e3e00146ee7a4e755ff57"
@@ -19419,6 +19620,11 @@ postcss-discard-overridden@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-5.0.0.tgz#ac00f695a60001eda52135a11fac87376b8da9ee"
   integrity sha512-hybnScTaZM2iEA6kzVQ6Spozy7kVdLw+lGw8hftLlBEzt93uzXoltkYp9u0tI8xbfhxDLTOOzHsHQCkYdmzRUg==
+
+postcss-discard-overridden@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz#454b41f707300b98109a75005ca4ab0ff2743ac6"
+  integrity sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==
 
 postcss-double-position-gradients@^1.0.0:
   version "1.0.0"
@@ -19579,6 +19785,15 @@ postcss-merge-longhand@^5.0.1:
     postcss-value-parser "^4.1.0"
     stylehacks "^5.0.0"
 
+postcss-merge-longhand@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-5.0.2.tgz#277ada51d9a7958e8ef8cf263103c9384b322a41"
+  integrity sha512-BMlg9AXSI5G9TBT0Lo/H3PfUy63P84rVz3BjCFE9e9Y9RXQZD3+h3YO1kgTNsNJy7bBc1YQp8DmSnwLIW5VPcw==
+  dependencies:
+    css-color-names "^1.0.1"
+    postcss-value-parser "^4.1.0"
+    stylehacks "^5.0.1"
+
 postcss-merge-rules@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz#362bea4ff5a1f98e4075a713c6cb25aefef9a650"
@@ -19602,6 +19817,17 @@ postcss-merge-rules@^5.0.0:
     postcss-selector-parser "^6.0.4"
     vendors "^1.0.3"
 
+postcss-merge-rules@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-5.0.2.tgz#d6e4d65018badbdb7dcc789c4f39b941305d410a"
+  integrity sha512-5K+Md7S3GwBewfB4rjDeol6V/RZ8S+v4B66Zk2gChRqLTCC8yjnHQ601omj9TKftS19OPGqZ/XzoqpzNQQLwbg==
+  dependencies:
+    browserslist "^4.16.6"
+    caniuse-api "^3.0.0"
+    cssnano-utils "^2.0.1"
+    postcss-selector-parser "^6.0.5"
+    vendors "^1.0.3"
+
 postcss-minify-font-values@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz#cd4c344cce474343fac5d82206ab2cbcb8afd5a6"
@@ -19614,6 +19840,13 @@ postcss-minify-font-values@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-5.0.0.tgz#fee5d0fa192fae8757cb744870a0ad02be5f402e"
   integrity sha512-zi2JhFaMOcIaNxhndX5uhsqSY1rexKDp23wV8EOmC9XERqzLbHsoRye3aYF716Zm+hkcR4loqKDt8LZlmihwAg==
+  dependencies:
+    postcss-value-parser "^4.1.0"
+
+postcss-minify-font-values@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-5.0.1.tgz#a90cefbfdaa075bd3dbaa1b33588bb4dc268addf"
+  integrity sha512-7JS4qIsnqaxk+FXY1E8dHBDmraYFWmuL6cgt0T1SWGRO5bzJf8sUoelwa4P88LEWJZweHevAiDKxHlofuvtIoA==
   dependencies:
     postcss-value-parser "^4.1.0"
 
@@ -19633,6 +19866,15 @@ postcss-minify-gradients@^5.0.0:
   integrity sha512-/jPtNgs6JySMwgsE5dPOq8a2xEopWTW3RyqoB9fLqxgR+mDUNLSi7joKd+N1z7FXWgVkc4l/dEBMXHgNAaUbvg==
   dependencies:
     cssnano-utils "^2.0.0"
+    is-color-stop "^1.1.0"
+    postcss-value-parser "^4.1.0"
+
+postcss-minify-gradients@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-minify-gradients/-/postcss-minify-gradients-5.0.1.tgz#2dc79fd1a1afcb72a9e727bc549ce860f93565d2"
+  integrity sha512-odOwBFAIn2wIv+XYRpoN2hUV3pPQlgbJ10XeXPq8UY2N+9ZG42xu45lTn/g9zZ+d70NKSQD6EOi6UiCMu3FN7g==
+  dependencies:
+    cssnano-utils "^2.0.1"
     is-color-stop "^1.1.0"
     postcss-value-parser "^4.1.0"
 
@@ -19659,6 +19901,17 @@ postcss-minify-params@^5.0.0:
     postcss-value-parser "^4.1.0"
     uniqs "^2.0.0"
 
+postcss-minify-params@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-5.0.1.tgz#371153ba164b9d8562842fdcd929c98abd9e5b6c"
+  integrity sha512-4RUC4k2A/Q9mGco1Z8ODc7h+A0z7L7X2ypO1B6V8057eVK6mZ6xwz6QN64nHuHLbqbclkX1wyzRnIrdZehTEHw==
+  dependencies:
+    alphanum-sort "^1.0.2"
+    browserslist "^4.16.0"
+    cssnano-utils "^2.0.1"
+    postcss-value-parser "^4.1.0"
+    uniqs "^2.0.0"
+
 postcss-minify-selectors@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz#e2e5eb40bfee500d0cd9243500f5f8ea4262fbd8"
@@ -19676,6 +19929,14 @@ postcss-minify-selectors@^5.0.0:
   dependencies:
     alphanum-sort "^1.0.2"
     postcss-selector-parser "^3.1.2"
+
+postcss-minify-selectors@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-5.1.0.tgz#4385c845d3979ff160291774523ffa54eafd5a54"
+  integrity sha512-NzGBXDa7aPsAcijXZeagnJBKBPMYLaJJzB8CQh6ncvyl2sIndLVWfbcDi0SBjRWk5VqEjXvf8tYwzoKf4Z07og==
+  dependencies:
+    alphanum-sort "^1.0.2"
+    postcss-selector-parser "^6.0.5"
 
 postcss-modules-extract-imports@^2.0.0:
   version "2.0.0"
@@ -19757,6 +20018,11 @@ postcss-normalize-charset@^5.0.0:
   resolved "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-5.0.0.tgz#59e1fe2094fb2e3371cc5b054cbc39828a41a710"
   integrity sha512-pqsCkgo9KmQP0ew6DqSA+uP9YN6EfsW20pQ3JU5JoQge09Z6Too4qU0TNDsTNWuEaP8SWsMp+19l15210MsDZQ==
 
+postcss-normalize-charset@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz#121559d1bebc55ac8d24af37f67bd4da9efd91d0"
+  integrity sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==
+
 postcss-normalize-display-values@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz#0dbe04a4ce9063d4667ed2be476bb830c825935a"
@@ -19774,6 +20040,14 @@ postcss-normalize-display-values@^5.0.0:
     cssnano-utils "^2.0.0"
     postcss-value-parser "^4.1.0"
 
+postcss-normalize-display-values@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.1.tgz#62650b965981a955dffee83363453db82f6ad1fd"
+  integrity sha512-uupdvWk88kLDXi5HEyI9IaAJTE3/Djbcrqq8YgjvAVuzgVuqIk3SuJWUisT2gaJbZm1H9g5k2w1xXilM3x8DjQ==
+  dependencies:
+    cssnano-utils "^2.0.1"
+    postcss-value-parser "^4.1.0"
+
 postcss-normalize-positions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz#05f757f84f260437378368a91f8932d4b102917f"
@@ -19788,6 +20062,13 @@ postcss-normalize-positions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-normalize-positions/-/postcss-normalize-positions-5.0.0.tgz#fe1d9a8122dd385b9c6908bd2008140dea17750d"
   integrity sha512-0o6/qU5ky74X/eWYj/tv4iiKCm3YqJnrhmVADpIMNXxzFZywsSQxl8F7cKs8jQEtF3VrJBgcDHTexZy1zgDoYg==
+  dependencies:
+    postcss-value-parser "^4.1.0"
+
+postcss-normalize-positions@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-positions/-/postcss-normalize-positions-5.0.1.tgz#868f6af1795fdfa86fbbe960dceb47e5f9492fe5"
+  integrity sha512-rvzWAJai5xej9yWqlCb1OWLd9JjW2Ex2BCPzUJrbaXmtKtgfL8dBMOOMTX6TnvQMtjk3ei1Lswcs78qKO1Skrg==
   dependencies:
     postcss-value-parser "^4.1.0"
 
@@ -19809,6 +20090,14 @@ postcss-normalize-repeat-style@^5.0.0:
     cssnano-utils "^2.0.0"
     postcss-value-parser "^4.1.0"
 
+postcss-normalize-repeat-style@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.1.tgz#cbc0de1383b57f5bb61ddd6a84653b5e8665b2b5"
+  integrity sha512-syZ2itq0HTQjj4QtXZOeefomckiV5TaUO6ReIEabCh3wgDs4Mr01pkif0MeVwKyU/LHEkPJnpwFKRxqWA/7O3w==
+  dependencies:
+    cssnano-utils "^2.0.1"
+    postcss-value-parser "^4.1.0"
+
 postcss-normalize-string@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz#cd44c40ab07a0c7a36dc5e99aace1eca4ec2690c"
@@ -19822,6 +20111,13 @@ postcss-normalize-string@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-normalize-string/-/postcss-normalize-string-5.0.0.tgz#2ea08ff4cb8817ce160755e9fdc7e6ef6d495002"
   integrity sha512-wSO4pf7GNcDZpmelREWYADF1+XZWrAcbFLQCOqoE92ZwYgaP/RLumkUTaamEzdT2YKRZAH8eLLKGWotU/7FNPw==
+  dependencies:
+    postcss-value-parser "^4.1.0"
+
+postcss-normalize-string@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-string/-/postcss-normalize-string-5.0.1.tgz#d9eafaa4df78c7a3b973ae346ef0e47c554985b0"
+  integrity sha512-Ic8GaQ3jPMVl1OEn2U//2pm93AXUcF3wz+OriskdZ1AOuYV25OdgS7w9Xu2LO5cGyhHCgn8dMXh9bO7vi3i9pA==
   dependencies:
     postcss-value-parser "^4.1.0"
 
@@ -19842,6 +20138,14 @@ postcss-normalize-timing-functions@^5.0.0:
     cssnano-utils "^2.0.0"
     postcss-value-parser "^4.1.0"
 
+postcss-normalize-timing-functions@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.1.tgz#8ee41103b9130429c6cbba736932b75c5e2cb08c"
+  integrity sha512-cPcBdVN5OsWCNEo5hiXfLUnXfTGtSFiBU9SK8k7ii8UD7OLuznzgNRYkLZow11BkQiiqMcgPyh4ZqXEEUrtQ1Q==
+  dependencies:
+    cssnano-utils "^2.0.1"
+    postcss-value-parser "^4.1.0"
+
 postcss-normalize-unicode@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz#841bd48fdcf3019ad4baa7493a3d363b52ae1cfb"
@@ -19855,6 +20159,14 @@ postcss-normalize-unicode@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.0.tgz#aa46a89c86ae51a01cbca13e73c1ed7b0b38807e"
   integrity sha512-2CpVoz/67rXU5s9tsPZDxG1YGS9OFHwoY9gsLAzrURrCxTAb0H7Vp87/62LvVPgRWTa5ZmvgmqTp2rL8tlm72A==
+  dependencies:
+    browserslist "^4.16.0"
+    postcss-value-parser "^4.1.0"
+
+postcss-normalize-unicode@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.1.tgz#82d672d648a411814aa5bf3ae565379ccd9f5e37"
+  integrity sha512-kAtYD6V3pK0beqrU90gpCQB7g6AOfP/2KIPCVBKJM2EheVsBQmx/Iof+9zR9NFKLAx4Pr9mDhogB27pmn354nA==
   dependencies:
     browserslist "^4.16.0"
     postcss-value-parser "^4.1.0"
@@ -19878,6 +20190,15 @@ postcss-normalize-url@^5.0.0:
     normalize-url "^4.5.0"
     postcss-value-parser "^4.1.0"
 
+postcss-normalize-url@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-url/-/postcss-normalize-url-5.0.1.tgz#ffa9fe545935d8b57becbbb7934dd5e245513183"
+  integrity sha512-hkbG0j58Z1M830/CJ73VsP7gvlG1yF+4y7Fd1w4tD2c7CaA2Psll+pQ6eQhth9y9EaqZSLzamff/D0MZBMbYSg==
+  dependencies:
+    is-absolute-url "^3.0.3"
+    normalize-url "^4.5.0"
+    postcss-value-parser "^4.1.0"
+
 postcss-normalize-whitespace@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz#bf1d4070fe4fcea87d1348e825d8cc0c5faa7d82"
@@ -19890,6 +20211,13 @@ postcss-normalize-whitespace@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.0.tgz#1faf147a4f8d3d93a3c75109d120b4eefa00589b"
   integrity sha512-KRnxQvQAVkJfaeXSz7JlnD9nBN9sFZF9lrk9452Q2uRoqrRSkinqifF8Iex7wZGei2DZVG/qpmDFDmRvbNAOGA==
+  dependencies:
+    postcss-value-parser "^4.1.0"
+
+postcss-normalize-whitespace@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.1.tgz#b0b40b5bcac83585ff07ead2daf2dcfbeeef8e9a"
+  integrity sha512-iPklmI5SBnRvwceb/XH568yyzK0qRVuAG+a1HFUsFRf11lEJTiQQa03a4RSCQvLKdcpX7XsI1Gen9LuLoqwiqA==
   dependencies:
     postcss-value-parser "^4.1.0"
 
@@ -19919,6 +20247,14 @@ postcss-ordered-values@^5.0.0:
   integrity sha512-dPr+SRObiHueCIc4IUaG0aOGQmYkuNu50wQvdXTGKy+rzi2mjmPsbeDsheLk5WPb9Zyf2tp8E+I+h40cnivm6g==
   dependencies:
     cssnano-utils "^2.0.0"
+    postcss-value-parser "^4.1.0"
+
+postcss-ordered-values@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-ordered-values/-/postcss-ordered-values-5.0.1.tgz#79ef6e2bd267ccad3fc0c4f4a586dfd01c131f64"
+  integrity sha512-6mkCF5BQ25HvEcDfrMHCLLFHlraBSlOXFnQMHYhSpDO/5jSR1k8LdEXOkv+7+uzW6o6tBYea1Km0wQSRkPJkwA==
+  dependencies:
+    cssnano-utils "^2.0.1"
     postcss-value-parser "^4.1.0"
 
 postcss-overflow-shorthand@^2.0.0:
@@ -20012,6 +20348,14 @@ postcss-reduce-initial@^5.0.0:
     browserslist "^4.16.0"
     caniuse-api "^3.0.0"
 
+postcss-reduce-initial@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-5.0.1.tgz#9d6369865b0f6f6f6b165a0ef5dc1a4856c7e946"
+  integrity sha512-zlCZPKLLTMAqA3ZWH57HlbCjkD55LX9dsRyxlls+wfuRfqCi5mSlZVan0heX5cHr154Dq9AfbH70LyhrSAezJw==
+  dependencies:
+    browserslist "^4.16.0"
+    caniuse-api "^3.0.0"
+
 postcss-reduce-transforms@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz#17efa405eacc6e07be3414a5ca2d1074681d4e29"
@@ -20028,6 +20372,14 @@ postcss-reduce-transforms@^5.0.0:
   integrity sha512-iHdGODW4YzM3WjVecBhPQt6fpJC4lGQZxJKjkBNHpp2b8dzmvj0ogKThqya+IRodQEFzjfXgYeESkf172FH5Lw==
   dependencies:
     cssnano-utils "^2.0.0"
+    postcss-value-parser "^4.1.0"
+
+postcss-reduce-transforms@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.1.tgz#93c12f6a159474aa711d5269923e2383cedcf640"
+  integrity sha512-a//FjoPeFkRuAguPscTVmRQUODP+f3ke2HqFNgGPwdYnpeC29RZdCBvGRGTsKpMURb/I3p6jdKoBQ2zI+9Q7kA==
+  dependencies:
+    cssnano-utils "^2.0.1"
     postcss-value-parser "^4.1.0"
 
 postcss-replace-overflow-wrap@^3.0.0:
@@ -20088,6 +20440,14 @@ postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2, postcss-selector
     uniq "^1.0.1"
     util-deprecate "^1.0.2"
 
+postcss-selector-parser@^6.0.5:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
+  integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
 postcss-svgo@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-4.0.2.tgz#17b997bc711b333bab143aaed3b8d3d6e3d38258"
@@ -20102,6 +20462,14 @@ postcss-svgo@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-5.0.0.tgz#c8d806e573394ab24f1e233cac5be4c199e9f1b2"
   integrity sha512-M3/VS4sFI1Yp9g0bPL+xzzCNz5iLdRUztoFaugMit5a8sMfkVzzhwqbsOlD8IFFymCdJDmXmh31waYHWw1K4BA==
+  dependencies:
+    postcss-value-parser "^4.1.0"
+    svgo "^2.3.0"
+
+postcss-svgo@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-5.0.2.tgz#bc73c4ea4c5a80fbd4b45e29042c34ceffb9257f"
+  integrity sha512-YzQuFLZu3U3aheizD+B1joQ94vzPfE6BNUcSYuceNxlVnKKsOtdo6hL9/zyC168Q8EwfLSgaDSalsUGa9f2C0A==
   dependencies:
     postcss-value-parser "^4.1.0"
     svgo "^2.3.0"
@@ -20122,6 +20490,15 @@ postcss-unique-selectors@^5.0.0:
   dependencies:
     alphanum-sort "^1.0.2"
     postcss-selector-parser "^6.0.2"
+    uniqs "^2.0.0"
+
+postcss-unique-selectors@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-5.0.1.tgz#3be5c1d7363352eff838bd62b0b07a0abad43bfc"
+  integrity sha512-gwi1NhHV4FMmPn+qwBNuot1sG1t2OmacLQ/AX29lzyggnjd+MnVD5uqQmpXO3J17KGL2WAxQruj1qTd3H0gG/w==
+  dependencies:
+    alphanum-sort "^1.0.2"
+    postcss-selector-parser "^6.0.5"
     uniqs "^2.0.0"
 
 postcss-value-parser@^3.0.0:
@@ -20169,6 +20546,15 @@ postcss@^7, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, po
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^8.2.1, postcss@^8.2.15:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.0.tgz#b1a713f6172ca427e3f05ef1303de8b65683325f"
+  integrity sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==
+  dependencies:
+    colorette "^1.2.2"
+    nanoid "^3.1.23"
+    source-map-js "^0.6.2"
 
 postcss@^8.2.10:
   version "8.2.14"
@@ -22482,6 +22868,20 @@ size-limit@^4.10.2:
     ora "^5.4.0"
     read-pkg-up "^7.0.1"
 
+size-limit@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/size-limit/-/size-limit-4.11.0.tgz#61b325752e1978615ff9acc0745438ee3272172b"
+  integrity sha512-vguQEHxnBt0ldv4Q1gMkjSKNpCtH5/eXLbVqUumMvUOcA2BI/I82wTe7Ag3it5hKdbZYebDmRutDizxNsvpUAw==
+  dependencies:
+    bytes-iec "^3.1.1"
+    chokidar "^3.5.1"
+    ci-job-number "^1.2.2"
+    colorette "^1.2.2"
+    globby "^11.0.3"
+    lilconfig "^2.0.2"
+    ora "^5.4.0"
+    read-pkg-up "^7.0.1"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -22695,6 +23095,11 @@ source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"
@@ -23333,6 +23738,14 @@ stylehacks@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.0.0.tgz#c49b0b2cf9917fe37dc030b96a4c34698b932933"
   integrity sha512-QOWm6XivDLb+fqffTZP8jrmPmPITVChl2KCY2R05nsCWwLi3VGhCdVc3IVGNwd1zzTt1jPd67zIKjpQfxzQZeA==
+  dependencies:
+    browserslist "^4.16.0"
+    postcss-selector-parser "^6.0.4"
+
+stylehacks@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.0.1.tgz#323ec554198520986806388c7fdaebc38d2c06fb"
+  integrity sha512-Es0rVnHIqbWzveU1b24kbw92HsebBepxfcqe5iix7t9j0PQqhs0IxXVXv0pY2Bxa08CgMkzD6OWql7kbGOuEdA==
   dependencies:
     browserslist "^4.16.0"
     postcss-selector-parser "^6.0.4"
@@ -24122,7 +24535,7 @@ tslib@~2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
   integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
-tsutils@^3.17.1:
+tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
@@ -24249,6 +24662,11 @@ typescript@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+
+typescript@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
+  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
 
 ua-parser-js@^0.7.18:
   version "0.7.25"
@@ -24924,6 +25342,21 @@ webpack-bundle-analyzer@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.1.tgz#c71fb2eaffc10a4754d7303b224adb2342069da1"
   integrity sha512-j5m7WgytCkiVBoOGavzNokBOqxe6Mma13X1asfVYtKWM3wxBiRRu1u1iG0Iol5+qp9WgyhkMmBAcvjEfJ2bdDw==
+  dependencies:
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    chalk "^4.1.0"
+    commander "^6.2.0"
+    gzip-size "^6.0.0"
+    lodash "^4.17.20"
+    opener "^1.5.2"
+    sirv "^1.0.7"
+    ws "^7.3.1"
+
+webpack-bundle-analyzer@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.2.tgz#39898cf6200178240910d629705f0f3493f7d666"
+  integrity sha512-PIagMYhlEzFfhMYOzs5gFT55DkUdkyrJi/SxJp8EF3YMWhS+T9vvs2EoTetpk5qb6VsCq02eXTlRDOydRhDFAQ==
   dependencies:
     acorn "^8.0.4"
     acorn-walk "^8.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds the thumbor plugin to the monorepo. 

## How it works? 
Thumbor plugin is basically an integration (urlBuilder) with `gatsby-plugin-image` that does all the heavy lifting for reponsive images. More info on how it works on the plugin's README.

## How to test it?
It's still in wip, but boti already has a version running it 
https://github.com/vtex-sites/btglobal.store/pull/583