### PR TITLE
Creation of a new plugin for Renovate preset config

### DIFF
--- a/packages/renovate-config/README.md
+++ b/packages/renovate-config/README.md
@@ -1,0 +1,11 @@
+# `renovate-config`
+
+> TODO: description
+
+## Usage
+
+```
+const renovateConfig = require('renovate-config');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/renovate-config/README.md
+++ b/packages/renovate-config/README.md
@@ -1,11 +1,41 @@
-# `renovate-config`
+# @vtex/renovate-config
 
-> TODO: description
+> Renovate preset JSON config
+
+## Install
+
+`yarn add @vtex/renovate-config`
+
+Doesn't need to install as a dependency if used as a [GitHub-hosted Preset](https://docs.renovatebot.com/config-presets/#github-hosted-presets).
 
 ## Usage
 
-```
-const renovateConfig = require('renovate-config');
+In any store project, after [installing Renovate app inside your repository](https://docs.renovatebot.com/install-github-app/), insert the `extends` option inside `renovate.json`.
 
-// TODO: DEMONSTRATE API
+If used as a [GitHub-hosted Preset](https://docs.renovatebot.com/config-presets/#github-hosted-presets):
+
+```json
+// renovate.json
+
+{
+  ...,
+  "extends": ["git:vtex/faststore/packages/renovate-config"],
+  ...
+}
 ```
+
+If used as a [NPM-hosted preset](https://docs.renovatebot.com/config-presets/#npm-hosted-presets):
+
+```json
+// renovate.json
+
+{
+  ...
+  "extends": ["@vtex/renovate-config"],
+  ...
+}
+```
+
+## License
+
+MIT © [VTEX](https://github.com/vtex)

--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@vtex/renovate-config",
+  "version": "0.368.1",
+  "description": "A plugin that holds the Renovate preset config for updating VTEX dependencies in our stores",
+  "author": "VTEX",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vtex/faststore.git"
+  }
+}

--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -7,5 +7,54 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vtex/faststore.git"
+  },
+  "renovate-config": {
+    "default": {
+      "extends": [
+        "config:base",
+        ":timezone(America/Sao_Paulo)"
+      ],
+      "labels": [
+        "renovate",
+        "automerge",
+        "VTEX"
+      ],
+      "schedule": [
+        "after 9am and before 6pm every weekday"
+      ],
+      "reviewers": [
+        "vtex:faststore",
+        "vtex:store-framework"
+      ],
+      "pin": {
+        "automerge": true
+      },
+      "packageRules": [
+        {
+          "excludePackagePatterns": [
+            "*"
+          ],
+          "matchPackagePatterns": [
+            "^@vtex/"
+          ],
+          "matchUpdateTypes": [
+            "minor",
+            "patch",
+            "digest",
+            "pin"
+          ],
+          "groupName": "VTEX Dependencies",
+          "major": {
+            "automerge": false
+          },
+          "minor": {
+            "automerge": true
+          },
+          "patch": {
+            "automerge": true
+          }
+        }
+      ]
+    }
   }
 }

--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/renovate-config",
-  "version": "0.368.1",
+  "version": "0.368.2",
   "description": "A plugin that holds the Renovate preset config for updating VTEX dependencies in our stores",
   "author": "VTEX",
   "license": "MIT",

--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -17,7 +17,7 @@
       "labels": [
         "renovate",
         "automerge",
-        "VTEX"
+        "faststore"
       ],
       "schedule": [
         "after 9am and before 6pm every weekday"
@@ -43,7 +43,7 @@
             "digest",
             "pin"
           ],
-          "groupName": "VTEX Dependencies",
+          "groupName": "Faststore Dependencies",
           "major": {
             "automerge": false
           },

--- a/packages/renovate-config/renovate.json
+++ b/packages/renovate-config/renovate.json
@@ -1,0 +1,26 @@
+{
+  "extends": ["config:base", ":timezone(America/Sao_Paulo)"],
+  "labels": ["renovate", "automerge", "VTEX"],
+  "schedule": ["after 9am and before 6pm every weekday"],
+  "reviewers": ["vtex:faststore", "vtex:store-framework"],
+  "pin": {
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "excludePackagePatterns": ["*"],
+      "matchPackagePatterns": ["^@vtex/"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
+      "groupName": "VTEX Dependencies",
+      "major": {
+        "automerge": false
+      },
+      "minor": {
+        "automerge": true
+      },
+      "patch": {
+        "automerge": true
+      }
+    }
+  ]
+}

--- a/packages/renovate-config/renovate.json
+++ b/packages/renovate-config/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:base", ":timezone(America/Sao_Paulo)"],
-  "labels": ["renovate", "automerge", "VTEX"],
+  "labels": ["renovate", "automerge", "faststore"],
   "schedule": ["after 9am and before 6pm every weekday"],
   "reviewers": ["vtex:faststore", "vtex:store-framework"],
   "pin": {
@@ -11,7 +11,7 @@
       "excludePackagePatterns": ["*"],
       "matchPackagePatterns": ["^@vtex/"],
       "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
-      "groupName": "VTEX Dependencies",
+      "groupName": "Faststore Dependencies",
       "major": {
         "automerge": false
       },


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds a preset configuration for Renovate app, so our stores can use the same config source for their Renovate configuration.

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->
I'm testing yet inside [this test repository](https://github.com/vtex-sites/renovatetest.store), but I need this new package published somewhere.

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->

https://docs.renovatebot.com/configuration-options/
https://docs.renovatebot.com/config-presets/