### PR TITLE
CI: Create official GitHub release

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,0 +1,33 @@
+name: Create GitHub release
+
+on:
+  create
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get semver number
+        id: get_semver
+        env:
+          TAG_NAME: ${{ github.ref }}
+        run: echo "::set-output name=pkg::${TAG_NAME:11}"
+
+      - name: Create release on GitHub API
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: "@${{ github.repository }}@${{ steps.get_semver.outputs.num }}"
+          body: |
+            :scroll: [Changelog](https://github.com/${{ github.repository }}/blob/v${{ steps.get_semver.outputs.num }}/CHANGELOG.md)
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## What's the purpose of this pull request?
<!--- Considering the context, what is the problem we'll solve? Where in VTEX's big picture our issue fits in? Write a tweet about the context and the problem itself. --->
Create GitHub release after each new version tag to properly support GitHub _watch > custom > releases_ feature.

## How it works? 
<!--- Tell us the role of the new feature, or component, in its context. --->
It creates new releases with name _@vtex/faststore@{semver}_ and changelog link on body (assuming the repository will have a `CHANGELOG.md` soon 😬 )

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->
New releases 😄 

## Considered alternatives
[Lerna can create](https://github.com/lerna/lerna/tree/main/commands/version#--create-release-type) the official GH release by itself and it would be a better solution I guess, but it requires using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), which is currently not the case here.

Eg.:

`lerna.json`
```json
"version": {
  "allowBranch": "master",
  "conventionalCommits": true,
  "createRelease": "github",
  "gitRemote": "origin",
  "message": "chore(release): publish :tada: [skip ci]"
}
```