### PR TITLE
Set store-framework team as reviewer when fail pipeline

### DIFF
--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -22,10 +22,7 @@
       "schedule": [
         "after 9am and before 6pm every weekday"
       ],
-      "reviewers": [
-        "vtex:faststore",
-        "vtex:store-framework"
-      ],
+      "reviewers": ["team:store-framework"],
       "pin": {
         "automerge": true
       },

--- a/packages/renovate-config/renovate.json
+++ b/packages/renovate-config/renovate.json
@@ -2,7 +2,7 @@
   "extends": ["config:base", ":timezone(America/Sao_Paulo)"],
   "labels": ["renovate", "automerge", "faststore"],
   "schedule": ["after 9am and before 6pm every weekday"],
-  "reviewers": ["vtex:faststore", "vtex:store-framework"],
+  "reviewers": ["team:store-framework"],
   "pin": {
     "automerge": true
   },


### PR DESCRIPTION
## What's the purpose of this pull request?
When the auto-merge of PR fails when pipeline fails, adds VTEX team to review the PR. 
