### PR TITLE
Size limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: Build
-        run: yarn build --ci
+        run: yarn build --scope "@vtex/gatsby-plugin-thumbor" --scope "@vtex/store-ui" --scope "@vtex/store-sdk" --ci
 
       - name: Size Limit
         run: yarn size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,22 @@ jobs:
 
       - name: Test
         run: yarn test --ci --maxWorkers=2
+
+  test:
+    name: Size Limit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Use Node 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      - name: Install deps and build (with cache)
+        uses: bahmutov/npm-install@v1
+
+      - name: Size Limit
+        run: yarn size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: Build
-        run: yarn build --ci --maxWorkers=2
+        run: yarn build --ci
 
       - name: Size Limit
         run: yarn size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,8 @@ jobs:
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1
 
+      - name: Build
+        run: yarn build --ci --maxWorkers=2
+
       - name: Size Limit
         run: yarn size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Test
         run: yarn test --ci --maxWorkers=2
 
-  test:
+  size:
     name: Size Limit
     runs-on: ubuntu-latest
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint packages/ --ext .ts,.tsx",
     "test": "lerna run test --",
     "bootstrap": "lerna bootstrap",
-    "release": "lerna version minor --yes && lerna publish from-git --yes"
+    "release": "lerna version minor --yes && lerna publish from-git --yes",
+    "size": "lerna run size"
   },
   "workspaces": [
     "packages/*"

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -19,9 +19,7 @@
     "build": "tsdx build",
     "test": "tsdx test",
     "lint": "tsdx lint",
-    "prepare": "tsdx build",
-    "size": "size-limit",
-    "analyze": "size-limit --why"
+    "prepare": "tsdx build"
   },
   "keywords": [
     "gatsby",
@@ -29,16 +27,6 @@
     "vtex",
     "nginx",
     "gatsby-plugin-nginx"
-  ],
-  "size-limit": [
-    {
-      "path": "dist/gatsby-plugin-nginx.cjs.production.min.js",
-      "limit": "10 KB"
-    },
-    {
-      "path": "dist/gatsby-plugin-nginx.esm.js",
-      "limit": "10 KB"
-    }
   ],
   "peerDependencies": {
     "gatsby": "^3.5.0"

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -21,7 +21,9 @@
     "build": "tsdx build",
     "test": "tsdx test --passWithNoTests",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "size": "size-limit",
+    "analyze": "size-limit --why"
   },
   "jest": {
     "collectCoverageFrom": [
@@ -34,6 +36,16 @@
       "<rootDir>/src"
     ]
   },
+  "size-limit": [
+    {
+      "path": "dist/store-ui.cjs.production.min.js",
+      "limit": "100 KB"
+    },
+    {
+      "path": "dist/store-ui.esm.js",
+      "limit": "100 KB"
+    }
+  ],
   "dependencies": {
     "@reach/popover": "^0.15.0",
     "@reach/router": "^1.3.4",
@@ -57,6 +69,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
+    "@size-limit/preset-small-lib": "^4.11.0",
     "@babel/core": "^7.13.16",
     "@storybook/addon-actions": "^6.2.9",
     "@storybook/addon-essentials": "^6.2.9",
@@ -70,6 +83,7 @@
     "@types/testing-library__jest-dom": "^5.9.5",
     "@types/unorm": "^1.3.28",
     "@vtex/tsconfig": "^0.5.0",
+    "size-limit": "^4.11.0",
     "babel-loader": "^8.2.2",
     "gatsby-link": "^3.5.0",
     "react": "^17.0.2",


### PR DESCRIPTION
## What's the purpose of this pull request?
Add Bot for `size-limit`. 

## How it works? 
`size-limit` is a tool for evaluating the size of packages. The ideia is to not explode the size of libs we use. 
We already have some packages that support this, however we don't really have a bot for checking `size-limit`. This PR adds this bot

## Future work
We need eventually to remove all theme-ui related code from store-ui and than decrease the threshold that is really high (100Kb min + gzipped) 