### PR TITLE
Reload at most twice

### DIFF
--- a/packages/gatsby-theme-store/src/components/Error/ErrorBoundary.tsx
+++ b/packages/gatsby-theme-store/src/components/Error/ErrorBoundary.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-types */
 import React, { Component } from 'react'
 import type { ErrorInfo } from 'react'
 

--- a/packages/gatsby-theme-store/src/components/Error/ErrorBoundary.tsx
+++ b/packages/gatsby-theme-store/src/components/Error/ErrorBoundary.tsx
@@ -1,15 +1,21 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import React, { Component } from 'react'
+import type { ErrorInfo } from 'react'
 
 import ErrorHandler from './ErrorHandler'
 
 class ErrorBoundary extends Component {
   public state = { hasError: false, error: null }
 
-  public static getDerivedStateFromError(error: any) {
+  public static getDerivedStateFromError(error: Error) {
     return {
       hasError: true,
       error,
     }
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(`React Error: ${error.message} ${errorInfo.componentStack}`)
   }
 
   public render() {

--- a/packages/gatsby-theme-store/src/components/Error/ErrorHandler.tsx
+++ b/packages/gatsby-theme-store/src/components/Error/ErrorHandler.tsx
@@ -14,10 +14,19 @@ interface Props {
   errorId?: string
 }
 
-export const handleError = ({ error, errorId }: Props) => {
-  console.error(error)
-  console.error(errorId)
+const getReloads = () =>
+  Number(window.sessionStorage.getItem('store:reloads') ?? '0')
 
+const setReloads = (reloads: number) =>
+  window.sessionStorage.setItem('store:reloads', `${reloads}`)
+
+const canRecover = () => getReloads() < 2
+
+const isFrameworkLevelError = (error: Error) => error?.name === 'ChunkLoadError'
+
+window.setInterval(() => setReloads(0), 30e3)
+
+export const handleError = ({ error, errorId }: Props) => {
   // prevent infinite loop
   if (
     window.location.pathname.startsWith('/404') ||
@@ -31,20 +40,20 @@ export const handleError = ({ error, errorId }: Props) => {
 
   const isOffline = !window.navigator.onLine
   const is404 = error?.extensions?.exception?.status === 404
-  const isFrameworkLevelError = error.name === 'ChunkLoadError'
 
-  if (isFrameworkLevelError) {
+  if (isFrameworkLevelError(error) && canRecover()) {
+    setReloads(getReloads() + 1)
     window.location.reload()
   } else if (isOffline) {
     window.location.href = `/offline?from=${from}`
   } else if (is404) {
     window.location.href = `/404?from=${from}`
   } else {
-    window.location.href = `/500?from=${from}&errorId=${errorId ?? uuidv4()}`
+    window.location.href = `/500?from=${from}&errorId=${errorId}`
   }
 }
 
-const ErrorHandler: FC<Props> = ({ error, errorId }) => {
+const ErrorHandler: FC<Props> = ({ error, errorId = uuidv4() }) => {
   useEffect(() => {
     handleError({ error, errorId })
   }, [error, errorId])

--- a/packages/gatsby-theme-store/src/gatsby-browser.tsx
+++ b/packages/gatsby-theme-store/src/gatsby-browser.tsx
@@ -6,7 +6,7 @@ import 'requestidlecallback-polyfill'
 import React, { StrictMode } from 'react'
 import { UIProvider } from '@vtex/store-sdk'
 import ReactDOM from 'react-dom'
-import type { RouteUpdateArgs, WrapRootElementBrowserArgs } from 'gatsby'
+import type { WrapRootElementBrowserArgs } from 'gatsby'
 import type { ReactChild } from 'react'
 
 import ErrorBoundary from './components/Error/ErrorBoundary'
@@ -84,19 +84,3 @@ export const wrapPageElement = ({
 export const onRouteUpdate = () => {
   progressOnRouteUpdate()
 }
-
-let nextRoute: string | undefined
-
-export const onPreRouteUpdate = ({ location }: RouteUpdateArgs) => {
-  nextRoute = location.pathname
-}
-
-window.addEventListener('unhandledrejection', (event) => {
-  if (event.reason.name === 'ChunkLoadError') {
-    if (nextRoute) {
-      window.location.pathname = nextRoute
-    } else {
-      window.location.reload()
-    }
-  }
-})


### PR DESCRIPTION
## What's the purpose of this pull request?
There was a bug when handling errors.

When a user entered in an invalid page, the [React error handler](https://github.com/vtex/faststore/blob/a796a8c3629a0378fc6220ecdfef5749978134e4/packages/gatsby-theme-store/src/components/Error/ErrorHandler.tsx#L43) takes the user to /500. However, if we do it too fast, webpack throws a ChunkLoad error. This error was caught in our [error handler](https://github.com/vtex/faststore/blob/a796a8c3629a0378fc6220ecdfef5749978134e4/packages/gatsby-theme-store/src/gatsby-browser.tsx#L94)  that made the page to reload.

This PR fixes this issue by only reloading the page in the react tree and only allowing at most 2 reloads. If all reloads fail, we redirect the user to the /500 page.

The reload count is keep using session storage and is cleared after 30 seconds.

## How to test it?
Block any JS file in DevTools. Verify that we will try to reload 3 times. Also, try reloading multiple times and verify we don't redirect the user to /500

