### PR TITLE
Update url repository

### DIFF
--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -2,6 +2,11 @@
   "name": "@vtex/gatsby-plugin-cms",
   "version": "0.371.14",
   "description": "Gatsby plugin for building pages with VTEX CMS.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/gatsby-plugin-cms"
+  },
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vtex/gatsby-plugin-google-tag-manager",
   "version": "0.371.14",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/gatsby-plugin-google-tag-manager"
+  },
   "description": "Gatsby plugin for using Google Tag Manager with SFJ",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vtex/gatsby-plugin-graphql",
   "version": "0.371.14",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/gatsby-plugin-graphql"
+  },
   "description": "Gatsby plugin for unsing gatsby's grahpql on the client.",
   "main": "index.js",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vtex/gatsby-plugin-i18n",
   "version": "0.371.14",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/gatsby-plugin-i18n"
+  },
   "main": "index.js",
   "typings": "index.d.ts",
   "browser": "src/index.ts",

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -3,6 +3,11 @@
   "version": "0.371.14",
   "description": "Gatsby plugin to generate a nginx configuration template.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/gatsby-plugin-nginx"
+  },
   "main": "dist/index.js",
   "module": "dist/gatsby-plugin-nginx.esm.js",
   "typings": "dist/index.d.ts",

--- a/packages/gatsby-plugin-performance/package.json
+++ b/packages/gatsby-plugin-performance/package.json
@@ -3,6 +3,11 @@
   "author": "Tiago Gimenes",
   "version": "0.371.14",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/gatsby-plugin-performance"
+  },
   "main": "dist/index.js",
   "module": "dist/gatsby-plugin-performance.esm.js",
   "typings": "dist/index.d.ts",

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -2,6 +2,11 @@
   "name": "@vtex/gatsby-plugin-pixel-facebook",
   "version": "0.371.14",
   "description": "Gatsby plugin for using Facebook Pixel with Store Framework Jamstack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/gatsby-plugin-pixel-facebook"
+  },
   "main": "index.js",
   "browser": "src/index.ts",
   "scripts": {

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vtex/gatsby-plugin-theme-ui",
   "version": "0.371.14",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/gatsby-plugin-theme-ui"
+  },
   "main": "index.js",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/gatsby-plugin-thumbor/package.json
+++ b/packages/gatsby-plugin-thumbor/package.json
@@ -3,6 +3,11 @@
   "version": "0.371.14",
   "author": "Tiago Gimenes",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/gatsby-plugin-thumbor"
+  },
   "main": "index.js",
   "module": "dist/gatsby-plugin-thumbor.esm.js",
   "typings": "dist/index.d.ts",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -3,6 +3,11 @@
   "version": "0.371.14",
   "description": "Gatsby theme for building ecommerce websites",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/gatsby-theme-store"
+  },
   "module": "src/index.ts",
   "browser": "src/index.ts",
   "sideEffects": false,

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -3,7 +3,11 @@
   "version": "0.371.14",
   "author": "Emerson Laurentino",
   "license": "MIT",
-  "repository": "vtex/lighthouse-config",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/lighthouse-config"
+  },
   "main": "dist/index.js",
   "module": "dist/lighthouse-config.esm.js",
   "typings": "dist/index.d.ts",

--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vtex/faststore.git"
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/renovate-config"
   },
   "renovate-config": {
     "default": {

--- a/packages/store-sdk/package.json
+++ b/packages/store-sdk/package.json
@@ -3,6 +3,11 @@
   "version": "0.371.14",
   "description": "Hooks for creating your next component library",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/store-ui"
+  },
   "main": "dist/index.js",
   "module": "dist/store-sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/packages/store-sdk/package.json
+++ b/packages/store-sdk/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/vtex/faststore",
-    "directory": "packages/store-ui"
+    "directory": "packages/store-sdk"
   },
   "main": "dist/index.js",
   "module": "dist/store-sdk.esm.js",

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -4,7 +4,11 @@
   "description": "Next store component library",
   "author": "emersonlaurentino",
   "license": "MIT",
-  "repository": "vtex/gatsby-vtex",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vtex/faststore",
+    "directory": "packages/store-ui"
+  },
   "main": "dist/index.js",
   "module": "dist/store-ui.esm.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## What's the purpose of this pull request?
Add the "repository" field in package.json in `store-ui` package. Thus npm and gatsby can find plugins and their repos.

## How to test it?
1. Go to [faststore repo](https://github.com/vtex/faststore).
2. Click on **packages** > **store-ui** > **package.json**
3. In the field `repository` should have the following to specify the directory:
```
"repository": {
    "type": "git",
    "url": "https://github.com/vtex/faststore",
    "directory": "packages/store-ui"
  },
```

## References
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository
