### PR TITLE
Fix `warn export <type> was not found in <file>`

### DIFF
--- a/packages/store-ui/src/index.ts
+++ b/packages/store-ui/src/index.ts
@@ -78,16 +78,23 @@ export type {
 
 // All atomic components
 // Atoms
-export { default as Button, ButtonProps } from './atoms/Button'
-export { default as Input, InputProps } from './atoms/Input'
-export { default as Icon, IconProps } from './atoms/Icon'
-export { default as Popover, PopoverProps } from './atoms/Popover'
-export { default as Price, PriceProps } from './atoms/Price'
+export { default as Button } from './atoms/Button'
+export type { ButtonProps } from './atoms/Button'
+
+export { default as Input } from './atoms/Input'
+export type { InputProps } from './atoms/Input'
+
+export { default as Icon } from './atoms/Icon'
+export type { IconProps } from './atoms/Icon'
+
+export { default as Popover } from './atoms/Popover'
+export type { PopoverProps } from './atoms/Popover'
+
+export { default as Price } from './atoms/Price'
+export type { PriceProps } from './atoms/Price'
 // Molecules
-export {
-  default as SearchInput,
-  SearchInputProps,
-} from './molecules/SearchInput'
+export { default as SearchInput } from './molecules/SearchInput'
+export type { SearchInputProps } from './molecules/SearchInput'
 
 // The default Spinner from theme-ui, at the time of writing,
 // is under-performant in terms of CPU usage


### PR DESCRIPTION
## What's the purpose of this pull request?
While building stores, we would get the following warnings:

```
warn export 'ButtonProps' (reexported as 'ButtonProps') was not found in './atoms/Button'
(possible exports: default)
warn export 'InputProps' (reexported as 'InputProps') was not found in './atoms/Input'
(possible exports: default)
warn export 'IconProps' (reexported as 'IconProps') was not found in './atoms/Icon'
(possible exports: default)
warn export 'PopoverProps' (reexported as 'PopoverProps') was not found in './atoms/Popover'
 (possible exports: default)
warn export 'SearchInputProps' (reexported as 'SearchInputProps') was not found in
'./molecules/SearchInput' (possible exports: default)
warn export 'SearchFilterItem' (reexported as 'SearchFilterItem') was not found in
'./deprecated/SearchFilter/Accordion' (possible exports: default)
```

This is because we were exporting the type without the `export type` syntax and somehow our build tools thought it wasn't just a type but tried to import the whole thing. Explicitly `export type` solves this issue

