### PR TITLE
Fix renovate config

### DIFF
--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -55,10 +55,10 @@
             "automerge": false
           },
           "minor": {
-            "automerge": true
+            "automerge": false
           },
           "patch": {
-            "automerge": true
+            "automerge": false
           }
         }
       ]

--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -31,9 +31,16 @@
       },
       "packageRules": [
         {
-          "excludePackagePatterns": [
+          "packagePatterns": [
             "*"
           ],
+          "excludePackagePatterns": [
+            "^@vtex/"
+          ],
+          "enabled": false
+        },
+        {
+          "enabled": true,
           "matchPackagePatterns": [
             "^@vtex/"
           ],

--- a/packages/renovate-config/renovate.json
+++ b/packages/renovate-config/renovate.json
@@ -8,7 +8,12 @@
   },
   "packageRules": [
     {
-      "excludePackagePatterns": ["*"],
+      "packagePatterns": ["*"],
+      "excludePackagePatterns": ["^@vtex/"],
+      "enabled": false
+    },
+    {
+      "enabled": true,
       "matchPackagePatterns": ["^@vtex/"],
       "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
       "groupName": "Faststore Dependencies",

--- a/packages/renovate-config/renovate.json
+++ b/packages/renovate-config/renovate.json
@@ -21,10 +21,10 @@
         "automerge": false
       },
       "minor": {
-        "automerge": true
+        "automerge": false
       },
       "patch": {
-        "automerge": true
+        "automerge": false
       }
     }
   ]


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes the Renovate config to update only VTEX/Faststore dependencies and disables the auto-merge feature (Temporarily until we setup a solid E2E in our stores). 
