### PR TITLE
Move faststore docs to a folder inside Store Framework

### DIFF
--- a/.github/workflows/internal-docs.yml
+++ b/.github/workflows/internal-docs.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: vtex/action-internal-docs@main
         with:
           repo-token: ${{ secrets.VTEX_GITHUB_BOT_TOKEN }}
-          docs-product: Store-Framework
+          docs-product: Store-Framework/faststore

--- a/.github/workflows/internal-docs.yml
+++ b/.github/workflows/internal-docs.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: vtex/action-internal-docs@main
         with:
           repo-token: ${{ secrets.VTEX_GITHUB_BOT_TOKEN }}
-          docs-product: Store-Framework/faststore
+          docs-product: Store-Framework/Jamstack/Store

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -9,7 +9,7 @@ In the Store Framework Jamstack (SFJ), end-to-end tests are developed with Cypre
 In the following section, you'll learn how to build your own E2E test with Cypress. Therefore, if you're not familiar with Cypress, we strongly encourage you to check [Cypress's documentation](https://docs.cypress.io/guides/overview/why-cypress.html) before proceeding any further.
 
 ## Step by step
-
+ 
 ### Step 1: Setting up your development environment
 
 1. Open up the terminal.


### PR DESCRIPTION
## What's the purpose of this pull request?
<!--- Considering the context, what is the problem we'll solve? Where in VTEX's big picture our issue fits in? Write a tweet about the context and the problem itself. --->
Currently, the faststore docs are spread over the Store Framework docs on the vtex-internal docs page. With the on-call protocol, we want to produce documentation for all the systems that the SF team takes care and keeping a folder for each one makes things more organized.
