### PR TITLE
fix: Removing automerge PR label from renovate config

### DIFF
--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -17,7 +17,6 @@
       ],
       "labels": [
         "renovate",
-        "automerge",
         "faststore"
       ],
       "schedule": [

--- a/packages/renovate-config/renovate.json
+++ b/packages/renovate-config/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:base", ":timezone(America/Sao_Paulo)"],
-  "labels": ["renovate", "automerge", "faststore"],
+  "labels": ["renovate", "faststore"],
   "schedule": ["after 9am and before 6pm every weekday"],
   "reviewers": ["team:store-framework"],
   "pin": {


### PR DESCRIPTION
## What's the purpose of this pull request?
Removing the automerge label from Renovate config, since we aren't doing automerge yet.
