### PR TITLE
Fix orderfrom from being reset

### DIFF
--- a/packages/gatsby-theme-store/src/sdk/orderForm/controller/getOrderForm.ts
+++ b/packages/gatsby-theme-store/src/sdk/orderForm/controller/getOrderForm.ts
@@ -25,7 +25,8 @@ export const getOrderForm = async () => {
 
     return orderForm
   } catch (err) {
-    if (err.extensions?.exception?.status) {
+    // Check if checkout return status code is related to request or server errors
+    if (err.extensions?.exception?.status >= 400) {
       // If anything goes wrong on this step,
       // let's try to self heal by removing any cached orderForm
       clearOrderFormId()

--- a/packages/gatsby-theme-store/src/sdk/orderForm/controller/getOrderForm.ts
+++ b/packages/gatsby-theme-store/src/sdk/orderForm/controller/getOrderForm.ts
@@ -25,9 +25,11 @@ export const getOrderForm = async () => {
 
     return orderForm
   } catch (err) {
-    // If anything goes wrong on this step,
-    // let's try to self heal by removing any cached orderForm
-    clearOrderFormId()
+    if (err.extensions?.exception?.status) {
+      // If anything goes wrong on this step,
+      // let's try to self heal by removing any cached orderForm
+      clearOrderFormId()
+    }
 
     throw err
   }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR prevents resetting the orderFormId on localStorage when the request to get orderform is canceled after an error at the store occurs. 

## How it works? 

## How to test it?
Steps:
1. Add some product to your cart
2. Force to cause an error while the fetch of orderform
3. Check if the cart contains your products

Stores:
https://github.com/vtex-sites/carrefourbrfood.store/pull/858
https://github.com/vtex-sites/btglobal.store/pull/666
https://github.com/vtex-sites/marinbrasil.store/pull/537
https://github.com/vtex-sites/storecomponents.store/pull/1002

## References
