### PR TITLE
fix: use origin vtex

### DIFF
--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -310,6 +310,8 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
                 from: $from,
                 to: $to
                 simulationBehavior: skip
+                # Product data like spotPrice in IS is not reliable. Let's use portal
+                productOriginVtex: true
               ){
                 products {
                   ..._ProductFragment_


### PR DESCRIPTION
## What's the purpose of this pull request?
Intelligent search data is still not reliable. Some fields, like spotPrice and image alt text are not resolved correctly. This PR uses the productOriginVtex option in search query to source product changes with the right values

## How to test it?
Check that the spotPrice is correctly rendered by the store now on this product for marinbrasil. For this, open the product page at:
`/estante-para-livros-com-5-prateleiras-modulare-natural-tramontina-91620018/p`

Now, inspect source and look for the meta field "product:price:amount". Note that this property is now fixed with the value `130,66` instead of `139,00 `