### PR TITLE
fix(gatsby-source-vtex): page size

### DIFF
--- a/packages/gatsby-source-vtex/src/gatsby-node.ts
+++ b/packages/gatsby-source-vtex/src/gatsby-node.ts
@@ -60,9 +60,9 @@ export interface Options extends PluginOptions, VTEXOptions {
   ignorePaths?: string[]
   concurrency?: number
   /**
-   * @description max number of paths for getStaticPaths to generate
+   * @description minimum number of products to fetch from catalog
    * */
-  maxNumPaths?: number
+  minProducts?: number
 }
 
 const DEFAULT_PAGE_TYPES_WHITELIST = [
@@ -358,7 +358,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
       execute: run,
       gatsbyTypePrefix: `Store`,
       gatsbyNodeDefs: buildNodeDefinitions({ gatsbyNodeTypes, documents }),
-      paginationAdapters: [ProductPaginationAdapter],
+      paginationAdapters: [ProductPaginationAdapter(options)],
     }
 
     // Step5. Add explicit types to gatsby schema
@@ -569,5 +569,5 @@ export const pluginOptionsSchema = ({ Joi }: PluginOptionsSchemaArgs) =>
     getStaticPaths: Joi.function().arity(0),
     getRedirects: Joi.function().arity(0),
     pageTypes: Joi.array().items(Joi.string()),
-    maxNumPaths: Joi.number(),
+    minProducts: Joi.number(),
   })

--- a/packages/gatsby-source-vtex/src/graphql/pagination/product.ts
+++ b/packages/gatsby-source-vtex/src/graphql/pagination/product.ts
@@ -16,7 +16,7 @@ interface IPage {
 const PAGE_SIZE = 90
 
 // VTEX Search API hard limits us to 2500 products at most
-// Increasing this hard limit on the API may help us fetching more products
+// Increasing this hard limit on the API may help us fetch more products
 const MAX_PRODUCTS = 2500
 
 export const ProductPaginationAdapter = ({

--- a/packages/gatsby-source-vtex/src/graphql/pagination/product.ts
+++ b/packages/gatsby-source-vtex/src/graphql/pagination/product.ts
@@ -11,7 +11,7 @@ interface IPage {
 
 // Current max page size supported by VTEX API
 // TODO: Increasing this number could help on our build times
-const PAGE_SIZE = 100
+const PAGE_SIZE = 90
 
 export const ProductPaginationAdapter: IPaginationAdapter<IPage, IProduct> = {
   name: 'ProductPaginationAdapter',

--- a/packages/gatsby-source-vtex/src/graphql/pagination/product.ts
+++ b/packages/gatsby-source-vtex/src/graphql/pagination/product.ts
@@ -1,8 +1,5 @@
 import type { IPaginationAdapter } from 'gatsby-graphql-source-toolkit'
-
-interface Options {
-  minProducts?: number
-}
+import type { Options } from '../../../gatsby-node'
 
 // Define pagination adapters
 interface IProduct {

--- a/packages/gatsby-source-vtex/src/graphql/pagination/product.ts
+++ b/packages/gatsby-source-vtex/src/graphql/pagination/product.ts
@@ -1,5 +1,6 @@
 import type { IPaginationAdapter } from 'gatsby-graphql-source-toolkit'
-import type { Options } from '../../../gatsby-node'
+
+import type { Options } from '../../gatsby-node'
 
 // Define pagination adapters
 interface IProduct {


### PR DESCRIPTION
## What's the purpose of this pull request?
Fixes 404 errors while fetching products. Also, adds an option to fetch less products for testing purposes

## How it works? 
When we made builds on `carrefourbrfood`, we got a 404. This is because we were fetching too much products at once. Decreasing the number of products per fetch should solve this problem.

Also, this plugin adds a minProducts option to set the minimum amount of products to be fetched. This can help developing since we can fetch less products on "dev mode" and make a full build in production.

