### PR TITLE
fix(seo): Fix undefined host in canonical tags of product pages

### DIFF
--- a/packages/gatsby-theme-store/src/sdk/seo/product/useBreadcrumbJsonLd.ts
+++ b/packages/gatsby-theme-store/src/sdk/seo/product/useBreadcrumbJsonLd.ts
@@ -15,7 +15,7 @@ export const useBreadcrumbJsonLd = (
   options: Options
 ): BreadcrumbJSONLD | null => {
   const { product } = options
-  const { host, pathname } = useLocation()
+  const { pathname } = useLocation()
 
   return useMemo(() => {
     if (
@@ -31,7 +31,7 @@ export const useBreadcrumbJsonLd = (
     const itemListElements = categoryTree.map((item, index) => ({
       position: index + 1,
       name: item.name,
-      item: `https://${host}${item.href}`,
+      item: item.href,
     }))
 
     const len: number = itemListElements.length
@@ -39,11 +39,11 @@ export const useBreadcrumbJsonLd = (
     itemListElements.push({
       position: len + 1,
       name: productName!,
-      item: `https://${host}${pathname}`,
+      item: pathname,
     })
 
     return {
       itemListElements,
     }
-  }, [host, pathname, product])
+  }, [pathname, product])
 }

--- a/packages/gatsby-theme-store/src/sdk/seo/product/useMetadata.ts
+++ b/packages/gatsby-theme-store/src/sdk/seo/product/useMetadata.ts
@@ -27,7 +27,7 @@ export const useMetadata = (
   const price = product?.items[0].sellers?.[0].commercialOffer.spotPrice
   const title = product?.titleTag ?? siteMetadata.title
   const description = product?.metaTagDescription ?? siteMetadata.description
-  const canonical = `https://${host}${pathname}`
+  const canonical = host !== undefined ? `https://${host}${pathname}` : pathname
   const images = useMemo(
     () =>
       product?.items[0].images.map((image) => ({

--- a/packages/gatsby-theme-store/src/sdk/seo/product/useProductJsonLd.ts
+++ b/packages/gatsby-theme-store/src/sdk/seo/product/useProductJsonLd.ts
@@ -14,7 +14,7 @@ type ProductJSONLD = ComponentPropsWithoutRef<typeof ProductJsonLd>
 
 export const useProductJsonLd = (options: Options): ProductJSONLD | null => {
   const { product } = options
-  const { host, pathname } = useLocation()
+  const { pathname } = useLocation()
   const [currency] = useCurrency()
 
   return useMemo(() => {
@@ -35,7 +35,7 @@ export const useProductJsonLd = (options: Options): ProductJSONLD | null => {
     const offers = {
       price: `${seller.commercialOffer.spotPrice}`,
       priceCurrency: currency,
-      url: `https://${host}${pathname}`,
+      url: pathname,
       priceValidUntil: seller.commercialOffer.priceValidUntil?.slice(0, 10),
       availability:
         seller.commercialOffer.availableQuantity > 0
@@ -52,5 +52,5 @@ export const useProductJsonLd = (options: Options): ProductJSONLD | null => {
       gtin13: sku.ean,
       description,
     }
-  }, [currency, host, pathname, product])
+  }, [currency, pathname, product])
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
While SSR, we generated canonical tags with the SSR host. The SSR host was `undefined` which made us to generate canonical link tags like:
`https://undefined/<pathname>`

To prevent this problem, we generate relative canonical tags with `/<pathname>` during SSR and hydrate it with `https://<host>/<pathname>` once the React hydration kicks in.

With this I hope to solve the problem of product pages having invalid canonicals.

You may be wondering now why don't we just fix the `host` value during SSR to the same domain as we are going to serve the production server. The response to this question is that we use lighthouse to test these urls in a different domain, and if lighthouse sees that the canonical points to a different domain, it will break with an error. To circumvent this issue we do this hydration strategy

## How to test it?
https://github.com/vtex-sites/btglobal.store/pull/706
https://github.com/vtex-sites/marinbrasil.store/pull/549
https://github.com/vtex-sites/storecomponents.store/pull/1019