### PR TITLE
fix(gatsby-theme-store): useBuyButton only redirects users to the checkout when product is added successfully

### DIFF
--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -67,7 +67,7 @@
     "@theme-ui/match-media": "^0.3.1",
     "@vtex/gatsby-plugin-graphql": "^0.372.18",
     "@vtex/gatsby-plugin-theme-ui": "^0.372.18",
-    "@vtex/order-items": "^0.6.1",
+    "@vtex/order-items": "^0.6.3",
     "@vtex/order-manager": "^0.5.2",
     "gatsby-plugin-bundle-stats": "^2.7.2",
     "html-loader": "^2.1.2",

--- a/packages/gatsby-theme-store/src/sdk/orderForm/useOrderItems.tsx
+++ b/packages/gatsby-theme-store/src/sdk/orderForm/useOrderItems.tsx
@@ -10,14 +10,8 @@ import type { UpdateQuantityWithPixel } from './useUpdateQuantityWithPixel'
 import { useUpdateQuantityWithPixel } from './useUpdateQuantityWithPixel'
 
 export interface UseOrderItemsWithPixel {
-  updateQuantity: UpdateQuantityWithPixel<
-    Parameters<UpdateQuantityFn>[0],
-    ReturnType<UpdateQuantityFn>
-  >
-  removeItem: RemoveItemWithPixel<
-    Parameters<RemoveItemFn>[0],
-    ReturnType<RemoveItemFn>
-  >
+  updateQuantity: UpdateQuantityWithPixel<Parameters<UpdateQuantityFn>[0], void>
+  removeItem: RemoveItemWithPixel<Parameters<RemoveItemFn>[0], void>
 }
 
 export type UseOrderItems = Omit<
@@ -25,6 +19,12 @@ export type UseOrderItems = Omit<
   'updateQuantity' | 'removeItem'
 > &
   UseOrderItemsWithPixel
+
+const nonBlockingWrapper = <T extends any[]>(fn: (...args: T) => any) => {
+  return (...args: T): void => {
+    fn(...args)
+  }
+}
 
 export function useOrderItems(): UseOrderItems {
   const { updateQuantity, removeItem, ...rawOrderItems } = useRawOrderItems()
@@ -36,7 +36,7 @@ export function useOrderItems(): UseOrderItems {
 
   return {
     ...rawOrderItems,
-    updateQuantity: updateQuantityWithPixel,
+    updateQuantity: nonBlockingWrapper(updateQuantityWithPixel),
     removeItem: removeItemWithPixel,
   }
 }

--- a/packages/store-ui/src/deprecated/Minicart/Drawer/Content/ItemInfo.tsx
+++ b/packages/store-ui/src/deprecated/Minicart/Drawer/Content/ItemInfo.tsx
@@ -9,7 +9,7 @@ interface Props<T> {
   item: T
   variant: string
   removeItem: (item: T) => Promise<void> | void
-  updateItem: (item: T, oldItem?: T) => Promise<void> | void
+  updateItem: (item: T, oldItem?: T) => PromiseLike<unknown> | unknown
   numberFormat: (num: number) => string
   formatMessage: (obj: { id: string }) => string
 }

--- a/packages/store-ui/src/deprecated/Minicart/Drawer/Content/Quantity.tsx
+++ b/packages/store-ui/src/deprecated/Minicart/Drawer/Content/Quantity.tsx
@@ -10,7 +10,7 @@ interface Props<T extends Item> {
   item: T
   variant: string
   disabled?: boolean
-  updateItem: (item: T, oldItem?: T) => Promise<void> | void
+  updateItem: (item: T, oldItem?: T) => PromiseLike<unknown> | unknown
 }
 
 const MinicartDrawerQuantity = <T extends Item>({

--- a/packages/store-ui/src/deprecated/Minicart/Drawer/Content/index.tsx
+++ b/packages/store-ui/src/deprecated/Minicart/Drawer/Content/index.tsx
@@ -10,7 +10,7 @@ export interface Props<T> {
   items: T[]
   variant: string
   removeItem: (item: T) => Promise<void> | void
-  updateItem: (item: T, oldItem?: T) => Promise<void> | void
+  updateItem: (item: T, oldItem?: T) => PromiseLike<unknown> | unknown
   numberFormat: (num: number) => string
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5810,10 +5810,10 @@
   resolved "https://registry.yarnpkg.com/@vtex-components/drawer/-/drawer-0.2.4.tgz#682e627135c8f6cb134ffcc6661206163de6d7e8"
   integrity sha512-bv39LunQ9q+mtMN9eGzZSfRUx8VgJkOrMr5LDt8kdlA1+NemohiROTshj0RUwLGxCD6HcOOsQE25imIklKc1FQ==
 
-"@vtex/order-items@^0.6.1":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@vtex/order-items/-/order-items-0.6.2.tgz#47c497ed58e03152a73c904e102b7f1ee0c3164e"
-  integrity sha512-Bx1PUT1Z8LJYhaT7if8b5ma1iOv5eNB0OXvP3PLS2+9RRV2XvgT6sxQ5jNbZAL6qnwgFTD4t6VxYdqYKwmQftQ==
+"@vtex/order-items@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@vtex/order-items/-/order-items-0.6.3.tgz#cf21ff9df864b08dd49e7fff90f4a99dc5afbdc2"
+  integrity sha512-04dcwFeWtV7gk0lw5vnq1/YF7EAV3Ve+4zK10bU6osNHQxZZJ2HAN2tVUc5PfSEvfF/FwONDdInTCkYdf2Ip0A==
   dependencies:
     "@types/uuid" "^8.3.0"
     "@vtex/order-manager" "^0.5.0"


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes an issue where users are redirected to checkout before the `AddToCartMutation` is completed. If the request was to be successful, users would only see the product after a page refresh. If it wasn't going to be successful, users would be redirected to the checkout and never see their product on the cart. If the request fails, users are not going to be redirected and they can try again by just clicking one more time.

## How it works?
This PR allows the cart to remain async when making operations that don't redirect the users to the checkout, such as adding products to the cart and seeing them on the minicart.

## How to test it?
https://github.com/vtex-sites/marinbrasil.store/pull/556
