### PR TITLE
fix(store-ui): Fix bullets iterator

### DIFF
--- a/packages/store-ui/src/atoms/Button/index.ts
+++ b/packages/store-ui/src/atoms/Button/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Button'
-export * from './Button'
+export type { ButtonProps } from './Button'

--- a/packages/store-ui/src/atoms/Checkbox/Checkbox.tsx
+++ b/packages/store-ui/src/atoms/Checkbox/Checkbox.tsx
@@ -1,13 +1,13 @@
 import React, { forwardRef } from 'react'
 import type { InputHTMLAttributes } from 'react'
 
-export interface Props
+export interface CheckboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   testId?: string
 }
 
-const Checkbox = forwardRef<HTMLInputElement, Props>(function Checkbox(
-  { testId = 'store-checkbox', ...props }: Props,
+const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  { testId = 'store-checkbox', ...props }: CheckboxProps,
   ref
 ) {
   return (

--- a/packages/store-ui/src/atoms/Checkbox/index.ts
+++ b/packages/store-ui/src/atoms/Checkbox/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Checkbox'
-export { Props as CheckboxProps } from './Checkbox'
+export type { CheckboxProps } from './Checkbox'

--- a/packages/store-ui/src/atoms/Icon/index.ts
+++ b/packages/store-ui/src/atoms/Icon/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Icon'
-export * from './Icon'
+export type { IconProps } from './Icon'

--- a/packages/store-ui/src/atoms/Input/index.ts
+++ b/packages/store-ui/src/atoms/Input/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Input'
-export * from './Input'
+export type { InputProps } from './Input'

--- a/packages/store-ui/src/atoms/Popover/index.ts
+++ b/packages/store-ui/src/atoms/Popover/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Popover'
-export * from './Popover'
+export type { PopoverProps } from './Popover'

--- a/packages/store-ui/src/atoms/Price/index.ts
+++ b/packages/store-ui/src/atoms/Price/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Price'
-export * from './Price'
+export type { PriceProps } from './Price'

--- a/packages/store-ui/src/atoms/TextArea/TextArea.tsx
+++ b/packages/store-ui/src/atoms/TextArea/TextArea.tsx
@@ -1,7 +1,7 @@
 import type { TextareaHTMLAttributes } from 'react'
 import React, { forwardRef } from 'react'
 
-export interface Props
+export interface TextAreaProps
   extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'children'> {
   /**
    * Current variant of the input.
@@ -13,24 +13,23 @@ export interface Props
   testId?: string
 }
 
-const TextArea = forwardRef<HTMLTextAreaElement, Props>(function TextArea(
-  { variant, testId = 'store-textarea', ...props },
-  ref
-) {
-  const variants = {
-    'data-success': variant === 'success' || undefined,
-    'data-error': variant === 'error' || undefined,
-  }
+const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  function TextArea({ variant, testId = 'store-textarea', ...props }, ref) {
+    const variants = {
+      'data-success': variant === 'success' || undefined,
+      'data-error': variant === 'error' || undefined,
+    }
 
-  return (
-    <textarea
-      ref={ref}
-      data-store-textarea
-      data-testid={testId}
-      {...variants}
-      {...props}
-    />
-  )
-})
+    return (
+      <textarea
+        ref={ref}
+        data-store-textarea
+        data-testid={testId}
+        {...variants}
+        {...props}
+      />
+    )
+  }
+)
 
 export default TextArea

--- a/packages/store-ui/src/atoms/TextArea/index.ts
+++ b/packages/store-ui/src/atoms/TextArea/index.ts
@@ -1,2 +1,2 @@
 export { default } from './TextArea'
-export type { Props as TextAreaProps } from './TextArea'
+export type { TextAreaProps } from './TextArea'

--- a/packages/store-ui/src/atoms/TextArea/stories/TextArea.stories.tsx
+++ b/packages/store-ui/src/atoms/TextArea/stories/TextArea.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import type { Story, Meta } from '@storybook/react'
 
 import Component from '../TextArea'
-import type { Props as TextAreaProps } from '../TextArea'
+import type { TextAreaProps } from '../TextArea'
 import mdx from './TextArea.mdx'
 import type { ComponentArgTypes } from '../../../typings/utils'
 

--- a/packages/store-ui/src/molecules/Bullets/Bullets.tsx
+++ b/packages/store-ui/src/molecules/Bullets/Bullets.tsx
@@ -61,13 +61,13 @@ function Bullets({
   testId = 'store-bullets',
   ariaLabelGenerator = defaultAriaLabel,
 }: BulletsProps) {
-  const bulletIndexes = useMemo(() => [...new Array(totalQuantity).keys()], [
+  const bulletIndexes = useMemo(() => Array(totalQuantity).fill(0), [
     totalQuantity,
   ])
 
   return (
     <ol data-store-bullets data-testid={testId}>
-      {bulletIndexes.map((idx) => {
+      {bulletIndexes.map((_, idx) => {
         const isActive = activeBullet === idx
 
         return (

--- a/packages/store-ui/src/molecules/Bullets/index.ts
+++ b/packages/store-ui/src/molecules/Bullets/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Bullets'
-export * from './Bullets'
+export type { BulletsProps } from './Bullets'

--- a/packages/store-ui/src/molecules/SearchInput/index.ts
+++ b/packages/store-ui/src/molecules/SearchInput/index.ts
@@ -1,2 +1,2 @@
 export { default } from './SearchInput'
-export * from './SearchInput'
+export type { SearchInputProps } from './SearchInput'


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes a bullets iterator on Server Side Rendering. Also, I took the time to make the types API uniform by making every component to export types the same way.

## How it works? 
I was getting this weird error when using the bullets component with Server Side Rendering. 
![image](https://user-images.githubusercontent.com/1753396/126006012-6af7b5b8-60cf-4e20-b3c5-5a6d8d254215.png)

I figured out this was beacuse of the `.keys()` method not having an uniform API across environments, a.k.a. Node.JS and the browser. By changing to using the index iterator the problem was solved.

## How to test it?
I'm using this component on the product image gallery at: 
https://github.com/vtex-sites/storecomponents.store/pull/1036
https://github.com/vtex-sites/btglobal.store/pull/712
https://github.com/vtex-sites/marinbrasil.store/pull/557/checks?check_run_id=3089658329