### PR TITLE
fix(gatsby-plugin-nginx): Fix proxy pass when toPath has port numbers on it

### DIFF
--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -222,7 +222,14 @@ function convertToPath(path: string) {
 
   return path.replace(
     new RegExp(`${wildcard.source}|${namedSegment.source}`, 'g'),
-    () => {
+    (match) => {
+      const isMatchANumber = !Number.isNaN(parseInt(match.substr(1), 10))
+      const isMatchAPortNumber = it === 0 && isMatchANumber
+
+      if (isMatchAPortNumber) {
+        return match
+      }
+
       it += 1
 
       return `$${it}`

--- a/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
+++ b/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
@@ -160,6 +160,20 @@ describe('generateRedirects', () => {
           { cmd: ['proxy_ssl_server_name', 'on'] },
         ],
       },
+      {
+        cmd: ['location', '=', '"/logs"'],
+        children: [
+          {
+            cmd: [
+              'proxy_pass',
+              'https://mylogs-proxy.endpoint.com:8088/logs$is_args$args',
+            ],
+          },
+          {
+            cmd: ['proxy_ssl_server_name', 'on'],
+          },
+        ],
+      },
     ]
 
     expect(
@@ -177,6 +191,13 @@ describe('generateRedirects', () => {
           isPermanent: false,
           redirectInBrowser: false,
           toPath: 'https://master--storecomponents.myvtex.com/graphql/:splat',
+          statusCode: 200,
+        },
+        {
+          fromPath: '/logs',
+          isPermanent: false,
+          redirectInBrowser: false,
+          toPath: 'https://mylogs-proxy.endpoint.com:8088/logs',
           statusCode: 200,
         },
       ])


### PR DESCRIPTION
## What's the purpose of this pull request?

Before this fix the new test would broke with:

    -           "https://mylogs-proxy.endpoint.com:8088/logs$is_args$args",
    +           "https://mylogs-proxy.endpoint.com$1/logs$is_args$args",

Meaning that this nginx plugin is replacing port number and not only `:splat` or `:*` values

## How to test it?

Running yarn test on gatsby-plugin-nginx package
