### PR TITLE
feat(gatsby-theme-store): fix product click event

### DIFF
--- a/packages/gatsby-plugin-google-tag-manager/src/pixel/handler.ts
+++ b/packages/gatsby-plugin-google-tag-manager/src/pixel/handler.ts
@@ -55,8 +55,7 @@ const getDataFromEvent = (event: PixelEvent) => {
 
     case 'vtex:productClick': {
       // TODO: Add brand, categories and sku
-      const { productName, items } = event.data.product
-      const price = items?.[0]?.sellers?.[0]?.commercialOffer?.price
+      const { productName, price } = event.data.product
 
       return {
         event: 'productClick',

--- a/packages/gatsby-theme-store/src/components/ProductSummary/index.tsx
+++ b/packages/gatsby-theme-store/src/components/ProductSummary/index.tsx
@@ -8,6 +8,7 @@ import type { ProductSummary_ProductFragment } from './__generated__/ProductSumm
 export interface Props {
   product: ProductSummary_ProductFragment
   loading?: 'lazy' | 'eager'
+  position?: number
   variant?: string
 }
 

--- a/packages/gatsby-theme-store/src/components/Search/List/Page.tsx
+++ b/packages/gatsby-theme-store/src/components/Search/List/Page.tsx
@@ -54,8 +54,13 @@ const Page: FC<Props> = ({ display, cursor, initialData, columns }) => {
 
   return (
     <Grid variant="search" columns={columns}>
-      {data.vtex.productSearch?.products?.map((product) => (
-        <ProductSummary loading="lazy" key={product!.id!} product={product!} />
+      {data.vtex.productSearch?.products?.map((product, index) => (
+        <ProductSummary
+          loading="lazy"
+          key={product!.id!}
+          product={product!}
+          position={cursor * pageInfo.size + index + 1}
+        />
       ))}
     </Grid>
   )

--- a/packages/gatsby-theme-store/src/sdk/buyButton/useBuyButton.ts
+++ b/packages/gatsby-theme-store/src/sdk/buyButton/useBuyButton.ts
@@ -4,42 +4,164 @@ import { sendPixelEvent } from '../pixel/usePixelSendEvent'
 import { useOrderItems } from '../orderForm/useOrderItems'
 import { useOrderForm } from '../orderForm/useOrderForm'
 import { useBestSeller } from '../product/useBestSeller'
-import type { PixelProduct } from '../pixel/events'
+import type { CartPixelProduct } from '../pixel/events'
 
 interface Seller {
+  /**
+   * Seller id.
+   *
+   * @type {string}
+   * @memberof Seller
+   */
   sellerId: string
+  /**
+   * Seller's commercial offer. It contains price and availability information.
+   *
+   * @type {object}
+   * @memberof Seller
+   */
   commercialOffer: {
+    /**
+     * Available quantity of a seller's SKU.
+     *
+     * @type {number}
+     */
     availableQuantity: number
+    /**
+     * Price of a seller's SKU.
+     *
+     * @type {number}
+     */
     price: number
   }
 }
 
 export interface SKU {
+  /**
+   * SKU id.
+   *
+   * @type {string}
+   * @memberof SKU
+   */
   itemId: string
+  /**
+   * SKU sellers.
+   *
+   * @type {Seller[]}
+   * @memberof SKU
+   */
   sellers: Seller[]
+  /**
+   * SKU reference id. May be an array of objects with possibly `null` value properties.
+   *
+   * @type {Maybe<Array<{ value: Maybe<string> }>>}
+   * @memberof SKU
+   */
   referenceId: Maybe<Array<{ value: Maybe<string> }>>
+  /**
+   * SKU name. Doesn't include the product name.
+   *
+   * @type {string}
+   * @memberof SKU
+   */
   name: string
+  /**
+   * SKU images. May be an array of objects with possibly `undefined` imageUrl properties.
+   *
+   * @type {Array<{ imageUrl?: string }>}
+   * @memberof SKU
+   */
   images?: Array<{
-    imageUrl: string
+    imageUrl?: string
   }>
 }
 
 export interface Product {
+  /**
+   * Product id.
+   *
+   * @type {string}
+   * @memberof Product
+   */
   id: string
+  /**
+   * Product name. Doesn't include the SKU name.
+   *
+   * @type {string}
+   * @memberof Product
+   */
   productName: string
+  /**
+   * Product brand.
+   *
+   * @type {string}
+   * @memberof Product
+   */
   brand: string
+  /**
+   * Product's category tree. Each category must have a name.
+   *
+   * @type {Array<{ name: string }>}
+   * @memberof Product
+   */
   categoryTree: Array<{ name: string }>
+  /**
+   * Product reference id.
+   *
+   * @type {Maybe<string>}
+   * @memberof Product
+   */
   productReference: Maybe<string>
 }
 
 export interface Props {
+  /**
+   * Target SKU for add to cart operations. ´disabled´ is returned as false if `sku` is null or undefined.
+   *
+   * @type {Maybe<SKU>}
+   * @memberof Props
+   */
   sku: Maybe<SKU>
+  /**
+   * Target Product for add to cart operations. Properties are used for optimistic cart behavior and pixel events. ´disabled´ is returned as false if `sku` is null or undefined.
+   *
+   * @type {Maybe<Product>}
+   * @memberof Props
+   */
   product: Maybe<Product>
+  /**
+   * Product quantity to be added to the cart after each click.
+   *
+   * @type {number}
+   * @memberof Props
+   */
   quantity: number
+  /**
+   * Toggle that signals if users should be redirected to the checkout (`true`) or not (`false`) after a click.
+   *
+   * @type {boolean}
+   * @memberof Props
+   */
   oneClickBuy?: boolean
+  /**
+   * Toggle that signals if minicart should be opened (`true`) or not (`false`) after a click.
+   *
+   * @type {boolean}
+   * @memberof Props
+   */
   openMinicart?: boolean
 }
 
+/**
+ * Utility to simplify add to cart operations. Given a product and a SKU, returns common properties to manage the behavior of an add to cart button.
+ *
+ * @param {Maybe<SKU>} [sku] Target SKU for add to cart operations. ´disabled´ is returned as false if `sku` is null or undefined.
+ * @param {Maybe<Product>} [product] Target Product for add to cart operations. Properties are used for optimistic cart behavior and pixel events. ´disabled´ is returned as false if `sku` is null or undefined.
+ * @param {number} quantity Product quantity to be added to the cart after each click.
+ * @param {boolean} [oneClickBuy=false] Toggle that signals if users should be redirected to the checkout (`true`) or not (`false`) after a click.
+ * @param {boolean} [openMinicart=true] Toggle that signals if minicart should be opened (`true`) or not (`false`) after a click.
+ * @returns `disabled` and `onClick` properties to be passed on to a button component. `loading` state to be managed by the button.
+ */
 export const useBuyButton = ({
   sku,
   product,
@@ -48,7 +170,7 @@ export const useBuyButton = ({
   openMinicart: shouldOpenMinicart = true,
 }: Props) => {
   const { openMinicart } = useGlobalUIState()
-  const seller = useBestSeller(sku)
+  const seller = useBestSeller(sku) as Seller
   const { orderForm, loading } = useOrderForm()
   const { addItems } = useOrderItems()
   const disabled =
@@ -79,7 +201,7 @@ export const useBuyButton = ({
       skuId: sku?.itemId,
       skuName: sku?.name,
       skuReferenceId: sku?.referenceId,
-    } as PixelProduct
+    } as CartPixelProduct
 
     // Item to be updated into the orderForm
     const orderFormItem = {

--- a/packages/gatsby-theme-store/src/sdk/orderForm/useUpdateQuantityWithPixel.ts
+++ b/packages/gatsby-theme-store/src/sdk/orderForm/useUpdateQuantityWithPixel.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 
 import { sendPixelEvent } from '../pixel/usePixelSendEvent'
-import type { PixelProduct } from '../pixel/events'
+import type { CartPixelProduct } from '../pixel/events'
 
 export interface UpdateQuantityWithPixelParams<T, R> {
   updateQuantity: (item: T) => R
@@ -37,7 +37,7 @@ export interface MinimalOrderFormItem {
 
 export function orderFormItemToPixelProduct(
   orderFormItem: MinimalOrderFormItem
-): PixelProduct {
+): CartPixelProduct {
   return {
     productId: orderFormItem.productId,
     productReferenceId: orderFormItem.productRefId,
@@ -54,7 +54,7 @@ export function orderFormItemToPixelProduct(
     skuId: orderFormItem.id,
     skuReferenceId: [{ value: orderFormItem.refId }],
     skuName: orderFormItem.skuName,
-  } as PixelProduct
+  } as CartPixelProduct
 }
 
 export function updateQuantityWithPixel<T, R>({

--- a/packages/gatsby-theme-store/src/sdk/pixel/events.ts
+++ b/packages/gatsby-theme-store/src/sdk/pixel/events.ts
@@ -89,6 +89,9 @@ export interface ProductViewData {
 }
 
 export interface ProductClickData {
+  pageType: PageType
+  term?: string | undefined | null
+  position?: number | undefined | null
   product: PixelProduct
 }
 
@@ -301,3 +304,5 @@ export interface MinimalProduct {
    */
   items: MinimalSKU[]
 }
+
+export type PageType = 'fullTextSearch' | 'nonFullTextSearch' | 'other'

--- a/packages/gatsby-theme-store/src/sdk/product/useBestSeller.ts
+++ b/packages/gatsby-theme-store/src/sdk/product/useBestSeller.ts
@@ -1,15 +1,10 @@
-interface Seller {
-  commercialOffer: {
-    availableQuantity: number
-    price: number
-  }
+interface SKU<T> {
+  sellers: T[]
 }
 
-interface SKU {
-  sellers: Seller[]
-}
+export const getBestSeller = <T>(sku: Maybe<SKU<T>>): T | undefined =>
+  sku?.sellers?.[0]
 
 // TODO: This could be sent to the backend since only marketplaces
 // require this feature
-export const useBestSeller = <T extends SKU>(sku: Maybe<T>) =>
-  sku?.sellers?.[0] as ArrayItem<T['sellers']>
+export const useBestSeller = getBestSeller

--- a/packages/gatsby-theme-store/src/sdk/product/useLink.ts
+++ b/packages/gatsby-theme-store/src/sdk/product/useLink.ts
@@ -52,7 +52,7 @@ export interface UseLinkProduct extends MinimalProduct {
  * @param {UseLinkOptions} [options] Hook options. Include pixel-related data whenever possible. This is specially useful on shelves or product listing pages.
  * @returns `to` and `onClick` properties to be passed on to a link component.
  */
-export const useLink = (product: UseLinkProduct, options: UseLinkOptions) => {
+export const useLink = (product: UseLinkProduct, options?: UseLinkOptions) => {
   const [sku] = useSku(product)
   const { pixelData = {} } = options ?? {}
 

--- a/packages/gatsby-theme-store/src/sdk/product/useLink.ts
+++ b/packages/gatsby-theme-store/src/sdk/product/useLink.ts
@@ -1,19 +1,69 @@
 import type { MouseEvent } from 'react'
 
+import { minimalToPixelProduct } from '../pixel/events'
+import type { MinimalProduct } from '../pixel/events'
 import { sendPixelEvent } from '../pixel/usePixelSendEvent'
 import { useSku } from './useSku'
-import type { ProductSummary_ProductFragment } from '../../components/ProductSummary/__generated__/ProductSummary_product.graphql'
 
-export const useLink = (product: ProductSummary_ProductFragment) => {
-  const [{ itemId }] = useSku(product as any)
+export type SearchMap = 'ft' | 'c' | 'b'
+
+export interface UseLinkPixelData {
+  /**
+   * Type of product listing page query that's being made.
+   *
+   * @type {SearchMap}
+   * @memberof UseLinkPixelData
+   */
+  map?: SearchMap
+  /**
+   * Main term that's being used at the product listing page query.
+   *
+   * @type {string}
+   * @memberof UseLinkPixelData
+   */
+  query?: string
+  /**
+   * The item's position on a list, usually a shelf or a product listing page.
+   *
+   * @type {number}
+   * @memberof UseLinkPixelData
+   */
+  position?: number
+}
+
+export interface UseLinkOptions {
+  /**
+   * Pixel-related data to be used by the hook to fire events with proper analytics data.
+   *
+   * @type {UseLinkPixelData}
+   * @memberof UseLinkOptions
+   */
+  pixelData?: UseLinkPixelData
+}
+
+export interface UseLinkProduct extends MinimalProduct {
+  linkText: string
+}
+
+/**
+ * Given a product, returns the necessary properties for a component to link to the page of the product.
+ *
+ * @param {MinimalProduct} product The product to be used to extract the link.
+ * @param {UseLinkOptions} [options] Hook options. Include pixel-related data whenever possible. This is specially useful on shelves or product listing pages.
+ * @returns `to` and `onClick` properties to be passed on to a link component.
+ */
+export const useLink = (product: UseLinkProduct, options: UseLinkOptions) => {
+  const [sku] = useSku(product)
+  const { pixelData = {} } = options ?? {}
 
   return {
-    to: `/${product.linkText}/p?skuId=${itemId}`,
+    to: `/${product.linkText}/p?skuId=${sku.itemId}`,
     onClick: (_: MouseEvent<HTMLAnchorElement>) =>
       sendPixelEvent({
         type: 'vtex:productClick',
         data: {
-          product,
+          ...pixelData,
+          product: minimalToPixelProduct(product, sku),
         },
       }),
   }

--- a/packages/gatsby-theme-store/src/sdk/search/useSearch.tsx
+++ b/packages/gatsby-theme-store/src/sdk/search/useSearch.tsx
@@ -11,3 +11,5 @@ export const useSearch = () => {
 
   return context
 }
+
+export const useUnprotectedSearch = () => useContext(Context)

--- a/packages/store-ui/src/deprecated/SearchSuggestions/Products.tsx
+++ b/packages/store-ui/src/deprecated/SearchSuggestions/Products.tsx
@@ -14,7 +14,10 @@ interface Item {
   key: string
 }
 
-export type SummaryComponent = ComponentType<{ product: Item }>
+export type SummaryComponent = ComponentType<{
+  product: Item
+  position: number
+}>
 
 interface Props {
   SummaryComponent: SummaryComponent
@@ -37,11 +40,11 @@ const SearchSuggestionsProduct: FC<Required<Props>> = ({
 
   return (
     <>
-      <SearchSuggestionsList items={items as any} variant={variant}>
-        {({ item, variant: v }: any) => (
+      <SearchSuggestionsList items={items} variant={variant}>
+        {({ item, index, variant: v }) => (
           <Box data-testid="searchSuggestionsItem" variant={v}>
             <Suspense fallback={null}>
-              <SummaryComponent product={item} />
+              <SummaryComponent product={item} position={Number(index) + 1} />
             </Suspense>
           </Box>
         )}

--- a/packages/store-ui/src/deprecated/Shelf/Page.tsx
+++ b/packages/store-ui/src/deprecated/Shelf/Page.tsx
@@ -10,11 +10,16 @@ export interface Product {
   id: string
 }
 
-export type ProductSummary<T extends Product> = ComponentType<{ product: T }>
+export type ProductSummary<T extends Product> = ComponentType<{
+  product: T
+  position: number
+}>
 
 interface Props<T extends Product>
   extends ComponentPropsWithoutRef<typeof Grid> {
   items: T[]
+  page: number
+  pageSize: number
   pageSizes?: number[]
   variant: string
   ProductSummary: ProductSummary<T>
@@ -22,6 +27,8 @@ interface Props<T extends Product>
 
 const ShelfPage = <T extends Product>({
   items,
+  page,
+  pageSize,
   pageSizes,
   variant,
   ProductSummary,
@@ -35,8 +42,12 @@ const ShelfPage = <T extends Product>({
     columns={pageSizes}
     sx={{ width: '100%' }}
   >
-    {items.map((item) => (
-      <ProductSummary product={item} key={item.id} />
+    {items.map((item, index) => (
+      <ProductSummary
+        product={item}
+        position={page * pageSize + index + 1}
+        key={item.id}
+      />
     ))}
   </Grid>
 )

--- a/packages/store-ui/src/deprecated/Shelf/index.tsx
+++ b/packages/store-ui/src/deprecated/Shelf/index.tsx
@@ -43,6 +43,7 @@ const Shelf = <T extends Product>({
 }: PropsWithChildren<Props<T>>) => {
   const {
     page,
+    pageSize,
     items,
     totalPages,
     setPage,
@@ -71,6 +72,8 @@ const Shelf = <T extends Product>({
           ProductSummary={Component}
           variant={variant}
           items={items}
+          page={page}
+          pageSize={pageSize}
           pageSizes={pageSizes}
         />
         {withArrows === true && (


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes the data sent by the product click event and makes it ready to serve accurate SAE and GTM events.

## How it works? 
The event data is handled by the `useLink` hook. There are default values, but people can override them whenever necessary.

## How to test it?
https://github.com/vtex-sites/storecomponents.store/pull/1049