### PR TITLE
Replace $is_args usage and detect wheteher query is already present

### DIFF
--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -275,9 +275,11 @@ function generateProxyRewriteChildren({
   toPath,
   proxyHeaders,
 }: Redirect): NginxDirective['children'] {
+  const isArgs: string = toPath.includes('?') ? '&' : '?'
+
   return [
     ...formatProxyHeaders(proxyHeaders as Record<string, string> | undefined),
-    { cmd: ['proxy_pass', `${convertToPath(toPath)}$is_args$args`] },
+    { cmd: ['proxy_pass', `${convertToPath(toPath)}${isArgs}$args`] },
     { cmd: ['proxy_ssl_server_name', 'on'] },
   ]
 }

--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -275,7 +275,7 @@ function generateProxyRewriteChildren({
   toPath,
   proxyHeaders,
 }: Redirect): NginxDirective['children'] {
-  const isArgs: string = toPath.includes('?') ? '&' : '?'
+  const isArgs: string = toPath.includes('?') ? '&' : '$is_args'
 
   return [
     ...formatProxyHeaders(proxyHeaders as Record<string, string> | undefined),


### PR DESCRIPTION
## What's the purpose of this pull request?
`proxy_pass` already containing a querystring will be formatted wrong with a 2nd `?` instead of using `&`

## How it works? 
Detects whether a `?` is already present and switches to using a `&` directly in the string vs referencing the nginx variable
