### PR TITLE
Adds data-testid to accordion Header

### DIFF
--- a/packages/store-ui/src/deprecated/SearchFilter/Accordion.tsx
+++ b/packages/store-ui/src/deprecated/SearchFilter/Accordion.tsx
@@ -53,6 +53,7 @@ const SearchFilterAccordion: FC<Props> = ({
     >
       {filters.map((filter, index) => (
         <BaseAccordion.Section
+          data-testid="collapsibleHeader"
           key={`${filter.name}:${index}`}
           header={filter.name}
           isActive={isActiveFn(index)}


### PR DESCRIPTION
## What's the purpose of this pull request?
The data-testid from `@vtex-components/accordion`'s header is not rendering on storecomponents. This fixes the issue.