### PR TITLE
fix(codesandbox): Prevent building twice

### DIFF
--- a/packages/gatsby-plugin-cms/package.json
+++ b/packages/gatsby-plugin-cms/package.json
@@ -11,8 +11,7 @@
   "browser": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
-    "prepare": "cross-env NODE_ENV=production yarn run build",
+    "build": "cross-env NODE_ENV=production tsc",
     "develop": "tsc --watch"
   },
   "keywords": [

--- a/packages/gatsby-plugin-google-tag-manager/package.json
+++ b/packages/gatsby-plugin-google-tag-manager/package.json
@@ -10,8 +10,7 @@
   "main": "index.js",
   "browser": "src/index.ts",
   "scripts": {
-    "build": "tsc",
-    "prepare": "cross-env NODE_ENV=production yarn run build",
+    "build": "cross-env NODE_ENV=production tsc",
     "develop": "tsc --watch"
   },
   "keywords": [

--- a/packages/gatsby-plugin-graphql/package.json
+++ b/packages/gatsby-plugin-graphql/package.json
@@ -11,8 +11,7 @@
   "browser": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
-    "prepare": "cross-env NODE_ENV=production yarn run build",
+    "build": "cross-env NODE_ENV=production tsc",
     "develop": "tsc --watch"
   },
   "keywords": [

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -12,8 +12,7 @@
   "sideEffects": false,
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
-    "prepare": "cross-env NODE_ENV=production yarn run build",
+    "build": "cross-env NODE_ENV=production tsc",
     "develop": "tsc --watch"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-nginx/package.json
+++ b/packages/gatsby-plugin-nginx/package.json
@@ -23,8 +23,7 @@
     "develop": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",
-    "lint": "tsdx lint",
-    "prepare": "tsdx build"
+    "lint": "tsdx lint"
   },
   "keywords": [
     "gatsby",

--- a/packages/gatsby-plugin-pixel-facebook/package.json
+++ b/packages/gatsby-plugin-pixel-facebook/package.json
@@ -10,8 +10,7 @@
   "main": "index.js",
   "browser": "src/index.ts",
   "scripts": {
-    "build": "tsc",
-    "prepare": "cross-env NODE_ENV=production yarn run build",
+    "build": "cross-env NODE_ENV=production tsc",
     "develop": "tsc --watch"
   },
   "keywords": [

--- a/packages/gatsby-plugin-theme-ui/package.json
+++ b/packages/gatsby-plugin-theme-ui/package.json
@@ -10,8 +10,7 @@
   "browser": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
-    "prepare": "cross-env NODE_ENV=production yarn run build",
+    "build": "cross-env NODE_ENV=production tsc",
     "develop": "tsc --watch"
   },
   "keywords": [

--- a/packages/gatsby-plugin-thumbor/package.json
+++ b/packages/gatsby-plugin-thumbor/package.json
@@ -26,7 +26,6 @@
     "build": "tsdx build",
     "test": "tsdx test",
     "lint": "tsdx lint",
-    "prepare": "tsdx build",
     "size": "size-limit",
     "analyze": "size-limit --why"
   },

--- a/packages/gatsby-source-vtex/package.json
+++ b/packages/gatsby-source-vtex/package.json
@@ -25,8 +25,7 @@
     "develop": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",
-    "lint": "tsdx lint",
-    "prepare": "tsdx build"
+    "lint": "tsdx lint"
   },
   "dependencies": {
     "@graphql-tools/delegate": "^7.1.5",

--- a/packages/gatsby-theme-store/package.json
+++ b/packages/gatsby-theme-store/package.json
@@ -12,7 +12,7 @@
   "browser": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
+    "build": "cross-env NODE_ENV=production tsc",
     "develop": "tsc --watch",
     "test": "tsdx test"
   },


### PR DESCRIPTION
## What's the purpose of this pull request?
Prevent codesandbox bot to build the packages twice

## How it works? 
Basically, Codesandbox's bot does the following commands:

```sh
lerna run build && lerna exec pack
```

The first command runs the build script for each package, whereas the second packs the built packages into a tarball. 
The problem with this approach is that while running `pack`, npm calls the `prepare` script. The prepare script was running `yarn build`, which rebuilt all packages again. This lead to longer than necessary build times in codesandbox CI and also caused inconsistencies since the `pack` command was run in parallel, not respecting the package's inter dependencies. This PR solves this problem by removing all `prepare` scripts. This is ok because our workflow on github actions do not use the prepare and runs build too.

## How to test it?
Make sure codesandbox CI is working as intended