### PR TITLE
feat(core): Creates build scripts inside root package.json for themes and Storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "private": true,
   "scripts": {
     "build": "lerna run build",
+    "build-themes": "lerna run build --scope '@vtex/theme-*' || true",
+    "build-storybook": "yarn build-themes && yarn workspace @vtex/store-ui build-storybook",
     "clean": "lerna clean && lerna run clean",
     "format": "prettier --write \"packages/**/*.{ts,tsx,json}\"",
     "lint": "eslint packages/ --ext .ts,.tsx",


### PR DESCRIPTION
## What's the purpose of this pull request?
Store UI deploys are failing [in this PR](https://github.com/vtex/faststore/pull/828) because we need to build themes before building our Storybook. 

I'll change the Netlify build command after this merge.

## How it works? 
This PR creates one script for building all of our themes and other to build our Storybook inside root `package.json`. 

## How to test it?
Just run those scripts inside root path with `yarn build-themes` or `yarn build-storybook`
