### PR TITLE
Remove trailing slashes

### DIFF
--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -299,7 +299,7 @@ function generateErrorPageRewriteChildren({
 function generateRewriteChildren({ toPath }: Redirect) {
   return [
     {
-      cmd: ['rewrite', '.+', toPath],
+      cmd: ['rewrite', '.+', toPath.replace(/\/$/g, '')],
     },
   ]
 }

--- a/packages/gatsby-theme-store/src/sdk/seo/product/useMetadata.ts
+++ b/packages/gatsby-theme-store/src/sdk/seo/product/useMetadata.ts
@@ -27,7 +27,7 @@ export const useMetadata = (
   const price = product?.items[0].sellers?.[0].commercialOffer.spotPrice
   const title = product?.titleTag ?? siteMetadata.title
   const description = product?.metaTagDescription ?? siteMetadata.description
-  const pathname = path.slice(0, -1) // remove trailing slashes from pathname
+  const pathname = path[path.length - 1] === '/' ? path.slice(0, -1) : path // remove trailing slashes from pathname
   const canonical = host !== undefined ? `https://${host}${pathname}` : pathname
   const images = useMemo(
     () =>


### PR DESCRIPTION
## What's the purpose of this pull request?
Remove trailing slashes when generating redirects on the nginx plugin so paths like `[...].tsx` work just fine

## To test it
https://github.com/vtex-sites/marinbrasil.store/pull/595
https://github.com/vtex-sites/btglobal.store/pull/781
https://github.com/vtex-sites/storecomponents.store/pull/1101