### PR TITLE
fix(gatsby-plugin-graphql): Fix warnings and incremental builds

### DIFF
--- a/packages/gatsby-plugin-graphql/src/cache.ts
+++ b/packages/gatsby-plugin-graphql/src/cache.ts
@@ -1,0 +1,54 @@
+import type { QueryManager } from './manager'
+
+export const serialize = (manager: QueryManager): string => {
+  const state = {
+    queries: manager.queries,
+    fragments: manager.fragments,
+    fragmentsUsedByQuery: manager.fragmentsUsedByQuery,
+    fragmentsUsedByFragment: manager.fragmentsUsedByFragment,
+  }
+
+  return JSON.stringify(state, (_, value) => {
+    if (value instanceof Map) {
+      return {
+        dataType: 'Map',
+        value: Array.from(value.entries()),
+      }
+    }
+
+    if (value instanceof Set) {
+      return {
+        dataType: 'Set',
+        value: Array.from(value.keys()),
+      }
+    }
+
+    return value
+  })
+}
+
+export const hydrate = (
+  serialized: string,
+  manager: QueryManager
+): QueryManager => {
+  const state = JSON.parse(serialized, (_, value) => {
+    if (typeof value === 'object' && value != null) {
+      if (value.dataType === 'Map') {
+        return new Map(value.value)
+      }
+
+      if (value.dataType === 'Set') {
+        return new Set(value.value)
+      }
+    }
+
+    return value
+  })
+
+  manager.queries = state.queries
+  manager.fragments = state.fragments
+  manager.fragmentsUsedByQuery = state.fragmentsUsedByQuery
+  manager.fragmentsUsedByFragment = state.fragmentsUsedByFragment
+
+  return manager
+}

--- a/packages/gatsby-plugin-graphql/src/filesystem.ts
+++ b/packages/gatsby-plugin-graphql/src/filesystem.ts
@@ -6,24 +6,22 @@
  */
 import { createHash } from 'crypto'
 
-import { outputFile as fsExtraOutputFile } from 'fs-extra'
-
-const filesMap = new Map<string, string>()
+import { outputFile as fsExtraOutputFile, pathExists, readFile } from 'fs-extra'
 
 function hash(s: string) {
   return createHash('md5').update(s, 'utf8').digest().toString('hex')
 }
 
-export const outputFile = (file: string, data: any) => {
-  const newHash = hash(JSON.stringify(data))
-  const oldHash = filesMap.get(file)
+export const outputFile = async (file: string, data: string) => {
+  const exists = await pathExists(file)
 
-  // The files content are equal, don't do anything
-  if (oldHash === newHash) {
-    return
+  if (exists) {
+    const oldData = await readFile(file)
+
+    if (hash(oldData.toString()) === hash(data)) {
+      return
+    }
   }
-
-  filesMap.set(file, newHash)
 
   return fsExtraOutputFile(file, data)
 }

--- a/packages/gatsby-plugin-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-graphql/src/gatsby-node.ts
@@ -7,7 +7,12 @@ import { WebpackPlugin } from './webpack'
 export const onCreateWebpackConfig = async ({
   actions: { setWebpackConfig },
   store,
+  stage,
 }: CreateWebpackConfigArgs) => {
+  if (stage === 'build-html' || stage === 'develop-html') {
+    return
+  }
+
   /**
    * Here be Unicorns 🦄
    *

--- a/packages/gatsby-plugin-graphql/src/manager.ts
+++ b/packages/gatsby-plugin-graphql/src/manager.ts
@@ -93,7 +93,10 @@ export class QueryManager {
 
         const query = print(def).trim()
 
-        if (this.queries.get(queryName) !== undefined) {
+        if (
+          this.queries.has(queryName) &&
+          this.queries.get(queryName)!.filename !== filename
+        ) {
           console.warn(
             `Skipping query ${queryName} since it was already defined. If this wasn't the intended behavior please change your query operation name`
           )
@@ -113,7 +116,10 @@ export class QueryManager {
           'GraphQL Fragment should be named following the template <ComponentName>_<PropName>'
         )
 
-        if (this.fragments.get(fragmentName) !== undefined) {
+        if (
+          this.fragments.has(fragmentName) &&
+          this.fragments.get(fragmentName)!.filename !== filename
+        ) {
           console.warn(
             `Skipping query ${fragmentName} since it was already defined. If this wasn't the intended behavior please change your query operation name`
           )


### PR DESCRIPTION
## What's the purpose of this pull request?
When using this plugin, we get the warnings: 

```
success Rewriting compilation hashes - 0.019s
success Writing page-data.json files to public directory - 0.391s - 419/419 1070.34/s
warn Skipping query HomePageQuery since it was already defined. If this wasn't the intended
behavior please change your query operation name
warn Skipping query BrowserProductPageQuery since it was already defined. If this wasn't the
 intended behavior please change your query operation name
warn Skipping query BrowserSearchPageQuery since it was already defined. If this wasn't the
intended behavior please change your query operation name
warn Skipping query ServerSearchPageQuery since it was already defined. If this wasn't the
intended behavior please change your query operation name
warn Skipping query CollectionPageQuery since it was already defined. If this wasn't the
intended behavior please change your query operation name
warn Skipping query ServerProductPageQuery since it was already defined. If this wasn't the
intended behavior please change your query operation name
warn Skipping query BrowserCollectionPageQuery since it was already defined. If this wasn't
the intended behavior please change your query operation name
```

These warnings are there to prevent adding two different queries with the same name. When building the same query, this warning is fires by mistake. This PR fixes this issue by tracking the filename of the query and only warning when two queries of the same name in different files are created.

Another fix this PR brings is related to incremental builds. When building incrementally, not all files will go through babel and some queries/fragments may be missing, causing a "Missing Query" error. To fix this error, we serialize the plugin's state into te file system and hydrate the plugin when building incrementally. This should fix all errors.

## How to test it?
Make sure the warnings went away and incremental builds work just fine: Also, make sure queries are still generated correctly

https://github.com/vtex-sites/storecomponents.store/pull/1109
https://github.com/vtex-sites/btglobal.store/pull/785
https://github.com/vtex-sites/marinbrasil.store/pull/601