### PR TITLE
fix(gatsby-plugin-nginx): Spread routes support

### DIFF
--- a/packages/gatsby-plugin-nginx/src/headers.ts
+++ b/packages/gatsby-plugin-nginx/src/headers.ts
@@ -64,7 +64,7 @@ function cacheHeadersByPath(pages: Page[], manifest: Manifest): PathHeadersMap {
 }
 
 // removes trailing slash if possible
-function normalizePath(path: string) {
+export function normalizePath(path: string) {
   if (!path.endsWith('/') || path === '/') {
     return path
   }

--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -1,6 +1,7 @@
 import { posix } from 'path'
 
 import { INDEX_HTML, LOCATION_MODIFIERS } from './constants'
+import { normalizePath } from './headers'
 
 export {
   stringify,
@@ -192,7 +193,7 @@ function stringify(directives: NginxDirective[]): string {
     .join('\n')
 }
 
-const wildcard = /\/\*/g
+const wildcard = /\*/g
 const namedSegment = /:[^/]+/g
 
 // Converts a gatsby path to nginx location path
@@ -205,7 +206,9 @@ export function convertToRegExp(path: string) {
     .replace(wildcard, '(.*)') // replace * with (.*)
     .replace(namedSegment, '([^/]+)') // replace :param like with url component like regex ([^/]+)
 
-  return `^${converted}$`
+  const noTrailingSlashes = normalizePath(converted)
+
+  return `^${noTrailingSlashes}$`
 }
 
 function isRegExpMatch(path: string) {

--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -192,7 +192,7 @@ function stringify(directives: NginxDirective[]): string {
     .join('\n')
 }
 
-const wildcard = /\*/g
+const wildcard = /\/\*/g
 const namedSegment = /:[^/]+/g
 
 // Converts a gatsby path to nginx location path

--- a/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
+++ b/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
@@ -55,8 +55,9 @@ describe('convert Gatsby paths into nginx RegExp', () => {
   })
 
   it('handles wildcard (*)', () => {
-    expect(convertToRegExp('/*')).toEqual('^(.*)$')
-    expect(convertToRegExp('/pt/*')).toEqual('^/pt(.*)$')
+    expect(convertToRegExp('/*')).toEqual('^/(.*)$')
+    expect(convertToRegExp('/*/')).toEqual('^/(.*)$')
+    expect(convertToRegExp('/pt/*')).toEqual('^/pt/(.*)$')
   })
 })
 
@@ -104,11 +105,11 @@ describe('generateRewrites', () => {
       },
       {
         children: [{ cmd: ['rewrite', '.+', '/__client-side-search__'] }],
-        cmd: ['location', '~*', '"^(.*)$"'],
+        cmd: ['location', '~*', '"^/(.*)$"'],
       },
       {
         children: [{ cmd: ['rewrite', '.+', '/pt/__client-side-search__'] }],
-        cmd: ['location', '~*', '"^/pt(.*)$"'],
+        cmd: ['location', '~*', '"^/pt/(.*)$"'],
       },
       {
         children: [{ cmd: ['rewrite', '.+', '/foo-path'] }],
@@ -137,7 +138,7 @@ describe('generateRedirects', () => {
   it('correctly translates into NginxDirectives', () => {
     const expected = [
       {
-        cmd: ['location', '~*', '"^/api(.*)$"'],
+        cmd: ['location', '~*', '"^/api/(.*)$"'],
         children: [
           {
             cmd: [
@@ -149,7 +150,7 @@ describe('generateRedirects', () => {
         ],
       },
       {
-        cmd: ['location', '~*', '"^/graphql(.*)$"'],
+        cmd: ['location', '~*', '"^/graphql/(.*)$"'],
         children: [
           {
             cmd: [

--- a/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
+++ b/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
@@ -55,8 +55,8 @@ describe('convert Gatsby paths into nginx RegExp', () => {
   })
 
   it('handles wildcard (*)', () => {
-    expect(convertToRegExp('/*')).toEqual('^/(.*)$')
-    expect(convertToRegExp('/pt/*')).toEqual('^/pt/(.*)$')
+    expect(convertToRegExp('/*')).toEqual('^(.*)$')
+    expect(convertToRegExp('/pt/*')).toEqual('^/pt(.*)$')
   })
 })
 
@@ -104,11 +104,11 @@ describe('generateRewrites', () => {
       },
       {
         children: [{ cmd: ['rewrite', '.+', '/__client-side-search__'] }],
-        cmd: ['location', '~*', '"^/(.*)$"'],
+        cmd: ['location', '~*', '"^(.*)$"'],
       },
       {
         children: [{ cmd: ['rewrite', '.+', '/pt/__client-side-search__'] }],
-        cmd: ['location', '~*', '"^/pt/(.*)$"'],
+        cmd: ['location', '~*', '"^/pt(.*)$"'],
       },
       {
         children: [{ cmd: ['rewrite', '.+', '/foo-path'] }],
@@ -137,7 +137,7 @@ describe('generateRedirects', () => {
   it('correctly translates into NginxDirectives', () => {
     const expected = [
       {
-        cmd: ['location', '~*', '"^/api/(.*)$"'],
+        cmd: ['location', '~*', '"^/api(.*)$"'],
         children: [
           {
             cmd: [
@@ -149,7 +149,7 @@ describe('generateRedirects', () => {
         ],
       },
       {
-        cmd: ['location', '~*', '"^/graphql/(.*)$"'],
+        cmd: ['location', '~*', '"^/graphql(.*)$"'],
         children: [
           {
             cmd: [


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds support to spread routes only.

## How it works? 
Suppose we have the following taxonomy:
```
pages
...
│
├── {StoreCollection.slug}
│   └── [...].tsx
...
```

Currently, any page created will be available at, and only at: `/:slug/`. If the user enters in `/:slug` it will receive a 404. 
This PR solves this problem by making the route `/{StoreCollection.slug}/` also respond at `/:slug`.

Note that if the user has the following taxonomy:
```...
├── account.tsx
├── {StoreCollection.slug}
│   └── [...].tsx
│   └── index.tsx
...
```

Both account.tsx and index.tsx will still work because of route precedence. 
 
## How to test it?
Make sure no route was lost on either of these stores:

https://github.com/vtex-sites/storecomponents.store/pull/1124
https://github.com/vtex-sites/marinbrasil.store/pull/610
https://github.com/vtex-sites/btglobal.store/pull/789