### PR TITLE
feat(gatsby-plugin-graphql): Remove special case for the pages folder

### DIFF
--- a/packages/gatsby-plugin-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-graphql/src/gatsby-node.ts
@@ -1,6 +1,6 @@
 import { makeExecutableSchema } from '@graphql-tools/schema'
 import { parse, printSchema } from 'graphql'
-import type { CreateWebpackConfigArgs } from 'gatsby'
+import type { CreatePageArgs, CreateWebpackConfigArgs } from 'gatsby'
 
 import { WebpackPlugin } from './webpack'
 
@@ -27,4 +27,10 @@ export const onCreateWebpackConfig = async ({
   setWebpackConfig({
     plugins: [new WebpackPlugin(schema)],
   })
+}
+
+export const onCreatePage = ({ page, actions }: CreatePageArgs) => {
+  if (page.component.endsWith('.graphql.ts')) {
+    actions.deletePage(page)
+  }
 }

--- a/packages/gatsby-plugin-graphql/src/webpack.ts
+++ b/packages/gatsby-plugin-graphql/src/webpack.ts
@@ -205,7 +205,7 @@ export class WebpackPlugin {
               dirname(filepath),
               '__generated__',
               `${name}.graphql.ts`
-            ).replace('src/pages', 'src') // Do not generate a folder inside src/pages otherwise gatsby's build breaks
+            )
 
             return outputFile(filename, value)
           })


### PR DESCRIPTION
## What's the purpose of this pull request?
Our graphql plugin generates special graphql artifacts after the building process. These files are located under the `__generated__` folder. 
The problem with these `__generated__` files is that when they are created inside the `pages` folder, Gatsby thinks they are valid components and create pages for these files, which, in turn, breaks the build. 

To address this issue, this plugin had a special case where it would move file from the pages folder to the `src` folder. At frst, this worked fine. However, as the app grow and more queries where created we ended up  with many folder on the root `src` folder, creating a huge entropy.

This PR fixes this side effect by allowing the creation of `__generated__` files inside `pages` folder and removing them with the `onCreatePage` hook. This drastically removed the entropy of query autogeneration.

## Results
Before this changes, the filesystem looked like this on storecomponents:
```
./src/
├── @vtex
├── [slug]
├── __generated__
├── components
├── custom-sw-code.js
├── images
├── pages
├── s
├── sdk
├── views
├── {StoreCollection.slug}
└── {StoreProduct.slug}
```

After this change, we have:
```
./src/
├── @vtex
├── components
├── custom-sw-code.js
├── images
├── pages
├── sdk
└── views
```

## How to test it?
This is only an architectural change. Please make sure nothing has changed for the final user

https://github.com/vtex-sites/storecomponents.store/pull/1127
https://github.com/vtex-sites/marinbrasil.store/pull/612
https://github.com/vtex-sites/btglobal.store/pull/794

## References
