### PR TITLE
fix(store-ui): lint problem in useSlider

### DIFF
--- a/packages/store-ui/src/hooks/useSlider/useSlider.ts
+++ b/packages/store-ui/src/hooks/useSlider/useSlider.ts
@@ -69,7 +69,9 @@ function reducer(state: SliderState, action: Action): SliderState {
     case 'NEXT_PAGE': {
       // If `state.infinite` is true, we need to take into account an extra
       // page in the calculation. This extra page is a clone of the first page.
-      const adjustedTotalPages = state.totalPages + Number(state.infinite)
+      const adjustedTotalPages = state.infinite
+        ? state.totalPages + 1
+        : state.totalPages
 
       const nextPageIndex = nextPage(state.currentPage, adjustedTotalPages)
 
@@ -88,9 +90,11 @@ function reducer(state: SliderState, action: Action): SliderState {
     case 'PREVIOUS_PAGE': {
       // If `state.infinite` is true, we need to take into account an extra
       // page in the calculation. This extra page is a clone of the first page.
-      const adjustedTotalPages = state.totalPages + Number(state.infinite)
+      const adjustedTotalPages = state.infinite
+        ? state.totalPages + 1
+        : state.totalPages
 
-      // If `state.infinite` is true and we're currently in page 0, we need to
+      // If `state.infinite` is true and we're currently on page 0, we need to
       // let the slider go to page -1. This -1 page is a clone of the last page.
       const shouldGoToClone = state.infinite && state.currentPage === 0
       const previousPageIndex = shouldGoToClone


### PR DESCRIPTION
## What's the purpose of this pull request?

fix the lint problem in useSlider. For some reason turn a boolean in a number using the Number function trigger the eslint rule `@typescript-eslint/restrict-plus-operands`. So, as `Number(true)` always 1, I check if the prop is true and add +1

![Screen Shot 2021-08-18 at 17 52 58](https://user-images.githubusercontent.com/10627086/129970655-c3b019dc-c721-46de-8b9d-640c8736b389.png)
## How it works? 
<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
