### PR TITLE
fix(store-ui): Remove unnecessary ID and improve a11y

### DIFF
--- a/packages/store-ui/src/molecules/Carousel/Carousel.tsx
+++ b/packages/store-ui/src/molecules/Carousel/Carousel.tsx
@@ -86,12 +86,7 @@ function Carousel({
   const slides = preRenderedSlides.concat(children ?? [], postRenderedSlides)
 
   return (
-    <section
-      id="store-carousel"
-      data-store-carousel
-      data-testid={testId}
-      aria-label="carousel"
-    >
+    <section data-store-carousel data-testid={testId} aria-label="carousel">
       <div
         data-carousel-track-container
         style={{ overflow: 'hidden', width: '100%' }}

--- a/packages/store-ui/src/molecules/Carousel/Carousel.tsx
+++ b/packages/store-ui/src/molecules/Carousel/Carousel.tsx
@@ -24,6 +24,7 @@ const createTransformValues = (infinite: boolean, totalItems: number) => {
 }
 
 export interface CarouselProps extends SwipeableProps {
+  id: string
   testId?: string
   infiniteMode?: boolean
   controls?: 'complete' | 'navigationArrows' | 'paginationBullets'
@@ -44,6 +45,7 @@ function Carousel({
     property: 'transform',
   },
   children,
+  id = 'store-carousel',
   ...swipeableConfigOverrides
 }: PropsWithChildren<CarouselProps>) {
   const childrenArray = React.Children.toArray(children)
@@ -86,7 +88,12 @@ function Carousel({
   const slides = preRenderedSlides.concat(children ?? [], postRenderedSlides)
 
   return (
-    <section data-store-carousel data-testid={testId} aria-label="carousel">
+    <section
+      id={id}
+      data-store-carousel
+      data-testid={testId}
+      aria-label="carousel"
+    >
       <div
         data-carousel-track-container
         style={{ overflow: 'hidden', width: '100%' }}
@@ -150,7 +157,7 @@ function Carousel({
         <div data-carousel-controls>
           <Button
             data-left-arrow
-            aria-controls="store-carousel"
+            aria-controls={id}
             aria-label="previous"
             onClick={() => {
               if (sliderState.sliding) {
@@ -164,7 +171,7 @@ function Carousel({
           </Button>
           <Button
             data-right-arrow
-            aria-controls="store-carousel"
+            aria-controls={id}
             aria-label="next"
             onClick={() => {
               if (sliderState.sliding) {

--- a/packages/store-ui/src/molecules/Carousel/Carousel.tsx
+++ b/packages/store-ui/src/molecules/Carousel/Carousel.tsx
@@ -24,7 +24,7 @@ const createTransformValues = (infinite: boolean, totalItems: number) => {
 }
 
 export interface CarouselProps extends SwipeableProps {
-  id: string
+  id?: string
   testId?: string
   infiniteMode?: boolean
   controls?: 'complete' | 'navigationArrows' | 'paginationBullets'


### PR DESCRIPTION
## What's the purpose of this pull request?
When we use the Carousel twice in the same page, the ID label decreases our A11y points in Lighthouse.
