### PR TITLE
fix(gatsby-plugin-cms): null cms nodes were preventing stores from building

### DIFF
--- a/packages/gatsby-plugin-cms/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-cms/src/gatsby-node.ts
@@ -96,7 +96,7 @@ export const sourceNodes = async (
   const nodes = await Promise.all([
     fetchAllRemoteNodes(gatsbyApi, options),
     fetchAllLocalNodes(gatsbyApi),
-  ]).then(([x, y]) => [...x, ...y])
+  ]).then(([x, y]) => [...x, ...y].filter(Boolean))
 
   createCmsSchemaCustomization(gatsbyApi, nodes)
 


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes stores breaking the build when remote nodes were null. We observed this can occur when a page of type Institutional Page is published with no sections on it.

The CMS team will discuss it to see if that's the API format they intend to keep or if they will change the null value to a page object with empty/null fields when that happens.

## How it works?
I just added a filter for null/undefined values
