### PR TITLE
chore: Move graphql generation to a single folder

### DIFF
--- a/packages/gatsby-plugin-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-graphql/src/gatsby-node.ts
@@ -36,7 +36,7 @@ export const onCreateWebpackConfig = async (
   const { schema: dirtySchema } = store.getState()
   const typeDefs = parse(printSchema(dirtySchema))
   const schema = makeExecutableSchema({ typeDefs })
-  const rootPath = join(process.cwd(), options.rootPath ?? '/__generated__')
+  const rootPath = join(process.cwd(), options.rootPath ?? '__generated__')
   const schemaPath = join(
     process.cwd(),
     options.schemaPath ?? '/src/typings/schema.graphql.d.ts'

--- a/packages/gatsby-plugin-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-graphql/src/gatsby-node.ts
@@ -2,21 +2,19 @@ import { join } from 'path'
 
 import { makeExecutableSchema } from '@graphql-tools/schema'
 import { parse, printSchema } from 'graphql'
-import type {
-  CreatePageArgs,
-  CreateWebpackConfigArgs,
-  PluginOptionsSchemaArgs,
-} from 'gatsby'
+import type { CreateWebpackConfigArgs, PluginOptionsSchemaArgs } from 'gatsby'
 
 import { WebpackPlugin } from './webpack'
 
 interface Options {
   schemaPath?: string
+  rootPath?: string
 }
 
 export const pluginOptionsSchema = ({ Joi }: PluginOptionsSchemaArgs) => {
   return Joi.object({
     schemaPath: Joi.string(),
+    rootPath: Joi.string(),
   })
 }
 
@@ -38,18 +36,13 @@ export const onCreateWebpackConfig = async (
   const { schema: dirtySchema } = store.getState()
   const typeDefs = parse(printSchema(dirtySchema))
   const schema = makeExecutableSchema({ typeDefs })
+  const rootPath = join(process.cwd(), options.rootPath ?? '/__generated__')
   const schemaPath = join(
     process.cwd(),
     options.schemaPath ?? '/src/typings/schema.graphql.d.ts'
   )
 
   setWebpackConfig({
-    plugins: [new WebpackPlugin(schema, { schemaPath })],
+    plugins: [new WebpackPlugin(schema, { schemaPath, rootPath })],
   })
-}
-
-export const onCreatePage = ({ page, actions }: CreatePageArgs) => {
-  if (page.component.endsWith('.graphql.ts')) {
-    actions.deletePage(page)
-  }
 }

--- a/packages/gatsby-plugin-graphql/src/webpack.ts
+++ b/packages/gatsby-plugin-graphql/src/webpack.ts
@@ -82,7 +82,7 @@ export class WebpackPlugin {
 
   constructor(
     public schema: GraphQLSchema,
-    public options: { schemaPath: string }
+    public options: { schemaPath: string; rootPath: string }
   ) {
     this.persistedPath = join(root, 'public', publicPath, persisted)
     this.queryInfoPath = join(root, 'public', publicPath, queryInfo)
@@ -235,12 +235,8 @@ export class WebpackPlugin {
 
         // write generated files
         await Promise.all([
-          ...operationNodes.map(async ({ value, filename: filepath, name }) => {
-            const filename = join(
-              dirname(filepath),
-              '__generated__',
-              `${name}.graphql.ts`
-            )
+          ...operationNodes.map(async ({ value, name }) => {
+            const filename = join(this.options.rootPath, `${name}.graphql.ts`)
 
             return outputFile(filename, value)
           }),

--- a/packages/gatsby-plugin-graphql/src/webpack.ts
+++ b/packages/gatsby-plugin-graphql/src/webpack.ts
@@ -238,6 +238,8 @@ export class WebpackPlugin {
           ...operationNodes.map(async ({ value, name }) => {
             const filename = join(this.options.rootPath, `${name}.graphql.ts`)
 
+            console.log('outputing', filename)
+
             return outputFile(filename, value)
           }),
           outputFile(this.options.schemaPath, schemaNode),

--- a/packages/gatsby-plugin-graphql/src/webpack.ts
+++ b/packages/gatsby-plugin-graphql/src/webpack.ts
@@ -238,8 +238,6 @@ export class WebpackPlugin {
           ...operationNodes.map(async ({ value, name }) => {
             const filename = join(this.options.rootPath, `${name}.graphql.ts`)
 
-            console.log('outputing', filename)
-
             return outputFile(filename, value)
           }),
           outputFile(this.options.schemaPath, schemaNode),

--- a/packages/gatsby-plugin-graphql/src/webpack.ts
+++ b/packages/gatsby-plugin-graphql/src/webpack.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'path'
+import { join } from 'path'
 
 import * as typeScriptPlugin from '@graphql-codegen/typescript'
 import * as typeScriptOperationsPlugin from '@graphql-codegen/typescript-operations'


### PR DESCRIPTION
## What's the purpose of this pull request?
gatsby-plugin-graphql generates artifacts on the same folder the reference file is located at. For instance, supose you have a file called `index.ts` inside the folder `pages`. Our graphql plugin will generate the following page structure:
```
| pages
|__ index.ts
|__ __generated__
     |__ MyQuery.graphql.ts
```

Where MyQuery is the name of the query you've written inside `index.ts`. This works really well, however the way Gatsby (and Next) was built doesn't allow you to have these kind of assets inside the `pages` folder. 

I fixes this issue by removing these pages. However, gatsby cloud breaks with this. 

This PR proposes a fix by moving all queries into a folder at the root of the projecct called `__generated__`. All queries are generated inside this folder and we don't need to bother with this ever again in our framework.

## How to test it?
To test it, please take a look at:
https://github.com/vtex-sites/base.store/pull/21
