### PR TITLE
feat(store-api): Add cart to store-api

### DIFF
--- a/packages/store-api/package.json
+++ b/packages/store-api/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "@graphql-tools/schema": "^8.2.0",
-    "graphql": "^15.5.3",
+    "dataloader": "^2.0.0",
+    "fast-deep-equal": "^3.1.3",
     "isomorphic-unfetch": "^3.1.0",
     "rollup-plugin-graphql": "^0.1.0",
     "slugify": "^1.6.0"
@@ -36,5 +37,8 @@
     "tsdx": "^0.14.1",
     "tslib": "^2.3.1",
     "typescript": "^4.4.2"
+  },
+  "peerDependencies": {
+    "graphql": "^15.6.0"
   }
 }

--- a/packages/store-api/src/__generated__/schema.ts
+++ b/packages/store-api/src/__generated__/schema.ts
@@ -11,6 +11,48 @@ export type Scalars = {
   Float: number;
 };
 
+export type IStoreCart = {
+  order: IStoreOrder;
+};
+
+export type IStoreImage = {
+  alternateName: Scalars['String'];
+  url: Scalars['String'];
+};
+
+export type IStoreOffer = {
+  itemOffered: IStoreProduct;
+  listPrice: Scalars['Float'];
+  price: Scalars['Float'];
+  quantity: Scalars['Int'];
+  seller: IStoreOrganization;
+};
+
+export type IStoreOrder = {
+  acceptedOffer: Array<IStoreOffer>;
+  orderNumber: Scalars['String'];
+};
+
+export type IStoreOrganization = {
+  identifier: Scalars['String'];
+};
+
+export type IStoreProduct = {
+  image: Array<IStoreImage>;
+  name: Scalars['String'];
+  sku: Scalars['String'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  validateCart?: Maybe<StoreCart>;
+};
+
+
+export type MutationValidateCartArgs = {
+  cart: IStoreCart;
+};
+
 export type Query = {
   __typename?: 'Query';
   allCollections: StoreCollectionConnection;
@@ -74,6 +116,18 @@ export type StoreBreadcrumbList = {
   __typename?: 'StoreBreadcrumbList';
   itemListElement: Array<StoreListItem>;
   numberOfItems: Scalars['Int'];
+};
+
+export type StoreCart = {
+  __typename?: 'StoreCart';
+  messages: Array<StoreCartMessage>;
+  order: StoreOrder;
+};
+
+export type StoreCartMessage = {
+  __typename?: 'StoreCartMessage';
+  status: StoreStatus;
+  text: Scalars['String'];
 };
 
 export type StoreCollection = {
@@ -154,12 +208,20 @@ export type StoreOffer = {
   __typename?: 'StoreOffer';
   availability: Scalars['String'];
   itemCondition: Scalars['String'];
+  itemOffered: StoreProduct;
   listPrice: Scalars['Float'];
   price: Scalars['Float'];
   priceCurrency: Scalars['String'];
   priceValidUntil: Scalars['String'];
+  quantity: Scalars['Int'];
   seller: StoreOrganization;
   sellingPrice: Scalars['Float'];
+};
+
+export type StoreOrder = {
+  __typename?: 'StoreOrder';
+  acceptedOffer: Array<StoreOffer>;
+  orderNumber: Scalars['String'];
 };
 
 export type StoreOrganization = {
@@ -263,4 +325,10 @@ export const enum StoreSort {
   PriceDesc = 'price_desc',
   ReleaseDesc = 'release_desc',
   ScoreDesc = 'score_desc'
+};
+
+export const enum StoreStatus {
+  Error = 'ERROR',
+  Info = 'INFO',
+  Warning = 'WARNING'
 };

--- a/packages/store-api/src/platforms/vtex/clients/commerce/types/OrderForm.ts
+++ b/packages/store-api/src/platforms/vtex/clients/commerce/types/OrderForm.ts
@@ -1,0 +1,371 @@
+export interface OrderFormInputItem {
+  id: string
+  quantity: number
+  seller: string
+  index?: number
+}
+
+export interface OrderFormItem {
+  id: string
+  name: string
+  detailUrl: string
+  imageUrl: string
+  skuName: string
+  quantity: number
+  uniqueId: string
+  productId: string
+  refId: string
+  ean: string
+  priceValidUntil: string
+  price: number
+  tax: number
+  listPrice: number
+  sellingPrice: number
+  rewardValue: number
+  isGift: boolean
+  parentItemIndex: number | null
+  parentAssemblyBinding: string | null
+  productCategoryIds: string
+  priceTags: string[]
+  manualPrice: number
+  measurementUnit: string
+  additionalInfo: {
+    brandName: string
+    brandId: string
+    offeringInfo: any | null
+    offeringType: any | null
+    offeringTypeId: any | null
+  }
+  productCategories: Record<string, string>
+  productRefId: string
+  seller: string
+  sellerChain: string[]
+  availability: string
+  unitMultiplier: number
+  skuSpecifications: SKUSpecification[]
+  priceDefinition: {
+    calculatedSellingPrice: number
+    sellingPrices: SellingPrice[]
+    total: number
+  }
+}
+
+interface SKUSpecification {
+  fieldName: string
+  fieldValues: string[]
+}
+
+export interface AdditionalInfo {
+  dimension: null
+  brandName: string
+  brandId: string
+  offeringInfo: null
+  offeringType: null
+  offeringTypeId: null
+}
+
+export interface PriceDefinition {
+  calculatedSellingPrice: number
+  total: number
+  sellingPrices: SellingPrice[]
+}
+
+export interface SellingPrice {
+  value: number
+  quantity: number
+}
+
+export interface PriceTag {
+  name: string
+  value: number
+  rawValue: number
+  isPercentual: boolean
+  identifier: string
+}
+
+export interface OrderForm {
+  orderFormId: string
+  salesChannel: string
+  loggedIn: boolean
+  isCheckedIn: boolean
+  storeId: string | null
+  checkedInPickupPointId: string | null
+  allowManualPrice: boolean
+  canEditData: boolean
+  userProfileId: string | null
+  userType: string | null
+  ignoreProfileData: boolean
+  value: number
+  messages: any[]
+  items: OrderFormItem[]
+  selectableGifts: any[]
+  totalizers: Array<{
+    id: string
+    name: string
+    value: number
+  }>
+  shippingData: ShippingData | null
+  clientProfileData: ClientProfileData | null
+  paymentData: PaymentData
+  marketingData: OrderFormMarketingData | null
+  sellers: Array<{
+    id: string
+    name: string
+    logo: string
+  }>
+  clientPreferencesData: {
+    locale: string
+    optinNewsLetter: any | null
+  }
+  commercialConditionData: any | null
+  storePreferencesData: {
+    countryCode: string
+    currencyCode: string
+    currencyFormatInfo: {
+      currencyDecimalDigits: number
+      currencyDecimalSeparator: string
+      currencyGroupSeparator: string
+      currencyGroupSize: number
+      startsWithCurrencySymbol: boolean
+    }
+    currencyLocale: string
+    currencySymbol: string
+    saveUserData: boolean
+    timeZone: string
+  }
+  giftRegistryData: any | null
+  openTextField: any | null
+  invoiceData: any | null
+  customData: any | null
+  itemMetadata: {
+    items: MetadataItem[]
+  }
+  hooksData: any | null
+  ratesAndBenefitsData: {
+    rateAndBenefitsIdentifiers: any[]
+    teaser: any[]
+  }
+  subscriptionData: SubscriptionData | null
+  itemsOrdination: any | null
+}
+
+interface OrderFormMarketingData {
+  utmCampaign?: string
+  utmMedium?: string
+  utmSource?: string
+  utmiCampaign?: string
+  utmiPart?: string
+  utmipage?: string
+  marketingTags?: string
+  coupon?: string
+}
+
+interface PaymentData {
+  installmentOptions: Array<{
+    paymentSystem: string
+    bin: string | null
+    paymentName: string | null
+    paymentGroupName: string | null
+    value: number
+    installments: Array<{
+      count: number
+      hasInterestRate: false
+      interestRate: number
+      value: number
+      total: number
+      sellerMerchantInstallments: Array<{
+        count: number
+        hasInterestRate: false
+        interestRate: number
+        value: number
+        total: number
+      }>
+    }>
+  }>
+  paymentSystems: Array<{
+    id: string
+    name: string
+    groupName: string
+    validator: {
+      regex: string
+      mask: string
+      cardCodeRegex: string
+      cardCodeMask: string
+      weights: number[]
+      useCvv: boolean
+      useExpirationDate: boolean
+      useCardHolderName: boolean
+      useBillingAddress: boolean
+    }
+    stringId: string
+    template: string
+    requiresDocument: boolean
+    isCustom: boolean
+    description: string | null
+    requiresAuthentication: boolean
+    dueDate: string
+    availablePayments: any | null
+  }>
+  payments: any[]
+  giftCards: any[]
+  giftCardMessages: any[]
+  availableAccounts: any[]
+  availableTokens: any[]
+}
+
+interface ClientProfileData {
+  email: string
+  firstName: string
+  lastName: string
+  document: string
+  documentType: string
+  phone: string
+  corporateName: string
+  tradeName: string
+  corporateDocument: string
+  stateInscription: string
+  corporatePhone: string
+  isCorporate: boolean
+  profileCompleteOnLoading: boolean
+  profileErrorOnLoading: boolean
+  customerClass: string
+}
+
+interface ShippingData {
+  address: CheckoutAddress | null
+  logisticsInfo: LogisticsInfo[]
+  selectedAddresses: CheckoutAddress[]
+  availableAddresses: CheckoutAddress[]
+  pickupPoints: PickupPoint[]
+}
+
+interface PickupPoint {
+  friendlyName: string
+  address: CheckoutAddress
+  additionalInfo: string
+  id: string
+  businessHours: BusinessHour[]
+}
+
+interface BusinessHour {
+  DayOfWeek: number
+  ClosingTime: string
+  OpeningTime: string
+}
+
+interface LogisticsInfo {
+  addressId: string | null
+  deliveryChannels: DeliveryChannel[]
+  itemId: string
+  itemIndex: number
+  shipsTo: string[]
+  slas: SLA[]
+  selectedDeliveryChannel: string | null
+  selectedSla: string | null
+}
+
+interface SLA {
+  id: string
+  deliveryChannel: string
+  name: string
+  deliveryIds: DeliveryId[]
+  shippingEstimate: string
+  shippingEstimateDate: string | null
+  lockTTL: string | null
+  availableDeliveryWindows: any[]
+  deliveryWindow: string | null
+  price: number
+  listPrice: number
+  tax: number
+  pickupStoreInfo: {
+    isPickupStore: boolean
+    friendlyName: string | null
+    address: CheckoutAddress | null
+    additionalInfo: any | null
+    dockId: string | null
+  }
+  pickupPointId: string | null
+  pickupDistance: number | null
+  polygonName: string | null
+  transitTime: string | null
+}
+
+interface DeliveryId {
+  courierId: string
+  warehouseId: string
+  dockId: string
+  courierName: string
+  quantity: number
+}
+
+interface DeliveryChannel {
+  id: string
+}
+
+interface CheckoutAddress {
+  addressId: string
+  addressType: string
+  city: string | null
+  complement: string | null
+  country: string
+  geoCoordinates: number[]
+  neighborhood: string | null
+  number: string | null
+  postalCode: string | null
+  receiverName: string | null
+  reference: string | null
+  state: string | null
+  street: string | null
+  isDisposable: boolean
+}
+
+interface MetadataItem {
+  id: string
+  name: string
+  imageUrl: string
+  detailUrl: string
+  seller: string
+  assemblyOptions: AssemblyOption[]
+  skuName: string
+  productId: string
+  refId: string
+  ean: string | null
+}
+
+interface AssemblyOption {
+  id: string
+  name: string
+  composition: Composition | null
+}
+
+interface SubscriptionDataEntry {
+  executionCount: number
+  itemIndex: number
+  plan: {
+    frequency: {
+      interval: number
+      periodicity: 'YEAR' | 'MONTH' | 'WEEK' | 'DAY'
+    }
+    type: string
+    validity: unknown
+  }
+}
+
+interface CompositionItem {
+  id: string
+  minQuantity: number
+  maxQuantity: number
+  initialQuantity: number
+  priceTable: string
+  seller: string
+}
+
+interface Composition {
+  minQuantity: number
+  maxQuantity: number
+  items: CompositionItem[]
+}
+
+interface SubscriptionData {
+  subscriptions: SubscriptionDataEntry[]
+}

--- a/packages/store-api/src/platforms/vtex/clients/commerce/types/OrderForm.ts
+++ b/packages/store-api/src/platforms/vtex/clients/commerce/types/OrderForm.ts
@@ -50,7 +50,7 @@ export interface OrderFormItem {
   }
 }
 
-interface SKUSpecification {
+export interface SKUSpecification {
   fieldName: string
   fieldValues: string[]
 }
@@ -149,7 +149,7 @@ export interface OrderForm {
   itemsOrdination: any | null
 }
 
-interface OrderFormMarketingData {
+export interface OrderFormMarketingData {
   utmCampaign?: string
   utmMedium?: string
   utmSource?: string
@@ -160,7 +160,7 @@ interface OrderFormMarketingData {
   coupon?: string
 }
 
-interface PaymentData {
+export interface PaymentData {
   installmentOptions: Array<{
     paymentSystem: string
     bin: string | null
@@ -213,7 +213,7 @@ interface PaymentData {
   availableTokens: any[]
 }
 
-interface ClientProfileData {
+export interface ClientProfileData {
   email: string
   firstName: string
   lastName: string
@@ -231,7 +231,7 @@ interface ClientProfileData {
   customerClass: string
 }
 
-interface ShippingData {
+export interface ShippingData {
   address: CheckoutAddress | null
   logisticsInfo: LogisticsInfo[]
   selectedAddresses: CheckoutAddress[]
@@ -239,7 +239,7 @@ interface ShippingData {
   pickupPoints: PickupPoint[]
 }
 
-interface PickupPoint {
+export interface PickupPoint {
   friendlyName: string
   address: CheckoutAddress
   additionalInfo: string
@@ -247,13 +247,13 @@ interface PickupPoint {
   businessHours: BusinessHour[]
 }
 
-interface BusinessHour {
+export interface BusinessHour {
   DayOfWeek: number
   ClosingTime: string
   OpeningTime: string
 }
 
-interface LogisticsInfo {
+export interface LogisticsInfo {
   addressId: string | null
   deliveryChannels: DeliveryChannel[]
   itemId: string
@@ -264,7 +264,7 @@ interface LogisticsInfo {
   selectedSla: string | null
 }
 
-interface SLA {
+export interface SLA {
   id: string
   deliveryChannel: string
   name: string
@@ -290,7 +290,7 @@ interface SLA {
   transitTime: string | null
 }
 
-interface DeliveryId {
+export interface DeliveryId {
   courierId: string
   warehouseId: string
   dockId: string
@@ -298,11 +298,11 @@ interface DeliveryId {
   quantity: number
 }
 
-interface DeliveryChannel {
+export interface DeliveryChannel {
   id: string
 }
 
-interface CheckoutAddress {
+export interface CheckoutAddress {
   addressId: string
   addressType: string
   city: string | null
@@ -319,7 +319,7 @@ interface CheckoutAddress {
   isDisposable: boolean
 }
 
-interface MetadataItem {
+export interface MetadataItem {
   id: string
   name: string
   imageUrl: string
@@ -332,13 +332,13 @@ interface MetadataItem {
   ean: string | null
 }
 
-interface AssemblyOption {
+export interface AssemblyOption {
   id: string
   name: string
   composition: Composition | null
 }
 
-interface SubscriptionDataEntry {
+export interface SubscriptionDataEntry {
   executionCount: number
   itemIndex: number
   plan: {
@@ -351,7 +351,7 @@ interface SubscriptionDataEntry {
   }
 }
 
-interface CompositionItem {
+export interface CompositionItem {
   id: string
   minQuantity: number
   maxQuantity: number
@@ -360,12 +360,12 @@ interface CompositionItem {
   seller: string
 }
 
-interface Composition {
+export interface Composition {
   minQuantity: number
   maxQuantity: number
   items: CompositionItem[]
 }
 
-interface SubscriptionData {
+export interface SubscriptionData {
   subscriptions: SubscriptionDataEntry[]
 }

--- a/packages/store-api/src/platforms/vtex/clients/commerce/types/Simulation.ts
+++ b/packages/store-api/src/platforms/vtex/clients/commerce/types/Simulation.ts
@@ -21,7 +21,7 @@ export interface SimulationArgs {
 }
 
 export interface SimulationOptions {
-  sc: string
+  salesChannel: string
 }
 
 export interface Simulation {

--- a/packages/store-api/src/platforms/vtex/clients/common.ts
+++ b/packages/store-api/src/platforms/vtex/clients/common.ts
@@ -9,6 +9,5 @@ export const fetchAPI = async (info: RequestInfo, init?: RequestInit) => {
 
   const text = await response.text()
 
-  console.error(text)
   throw new Error(text)
 }

--- a/packages/store-api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/store-api/src/platforms/vtex/clients/search/index.ts
@@ -33,16 +33,17 @@ export interface ProductLocator {
   value: string
 }
 
-// TODO: change here once supporting sales channel
-const defaultFacets = [
-  {
-    key: 'trade-policy',
-    value: '1',
-  },
-]
+export const IntelligentSearch = (options: Options) => {
+  const { channel } = options
+  const base = `http://search.biggylabs.com.br/search-api/v1/${options.account}`
 
-export const IntelligentSearch = (opts: Options) => {
-  const base = `http://search.biggylabs.com.br/search-api/v1/${opts.account}`
+  // TODO: change here once supporting sales channel
+  const defaultFacets = [
+    {
+      key: 'trade-policy',
+      value: channel,
+    },
+  ]
 
   const search = <T>({
     query = '',

--- a/packages/store-api/src/platforms/vtex/index.ts
+++ b/packages/store-api/src/platforms/vtex/index.ts
@@ -1,26 +1,32 @@
-import { StoreSearchResult } from './resolvers/searchResult'
 import { getClients } from './clients'
+import { getLoaders } from './loaders'
 import { StoreAggregateOffer } from './resolvers/aggregateOffer'
 import { StoreAggregateRating } from './resolvers/aggregateRating'
 import { StoreCollection } from './resolvers/collection'
 import { StoreFacet } from './resolvers/facet'
 import { StoreFacetValue } from './resolvers/facetValue'
+import { Mutation } from './resolvers/mutation'
 import { StoreOffer } from './resolvers/offer'
 import { StoreProduct } from './resolvers/product'
 import { StoreProductGroup } from './resolvers/productGroup'
 import { Query } from './resolvers/query'
 import { StoreReview } from './resolvers/review'
+import { StoreSearchResult } from './resolvers/searchResult'
 import { StoreSeo } from './resolvers/seo'
+import type { Loaders } from './loaders'
 import type { Clients } from './clients'
 
 export interface Options {
   platform: 'vtex'
   account: string
   environment: 'vtexcommercestable' | 'vtexcommercebeta'
+  // Default sales channel to use for fetching products
+  channel: string
 }
 
 export interface Context {
   clients: Clients
+  loaders: Loaders
 }
 
 export type Resolver<R = unknown, A = unknown> = (
@@ -43,10 +49,12 @@ const Resolvers = {
   StoreProductGroup,
   StoreSearchResult,
   Query,
+  Mutation,
 }
 
 export const getContextFactory = (options: Options) => (ctx: any) => {
   ctx.clients = getClients(options)
+  ctx.loaders = getLoaders(options, ctx.clients)
 
   return ctx
 }

--- a/packages/store-api/src/platforms/vtex/loaders/index.ts
+++ b/packages/store-api/src/platforms/vtex/loaders/index.ts
@@ -1,0 +1,16 @@
+import { getSimulationLoader } from './simulation'
+import { getSkuLoader } from './sku'
+import type { Options } from '..'
+import type { Clients } from '../clients'
+
+export type Loaders = ReturnType<typeof getLoaders>
+
+export const getLoaders = (options: Options, clients: Clients) => {
+  const skuLoader = getSkuLoader(options, clients)
+  const simulationLoader = getSimulationLoader(options, clients)
+
+  return {
+    skuLoader,
+    simulationLoader,
+  }
+}

--- a/packages/store-api/src/platforms/vtex/loaders/simulation.ts
+++ b/packages/store-api/src/platforms/vtex/loaders/simulation.ts
@@ -1,0 +1,42 @@
+import DataLoader from 'dataloader'
+
+import type {
+  PayloadItem,
+  Simulation,
+} from '../clients/commerce/types/Simulation'
+import type { Options } from '..'
+import type { Clients } from '../clients'
+
+export const getSimulationLoader = (_: Options, clients: Clients) => {
+  const loader = async (items: readonly PayloadItem[][]) => {
+    const simulated = await clients.commerce.checkout.simulation({
+      items: [...items.flat()],
+    })
+
+    const itemsIndices = items.reduce(
+      (acc, curr) => [...acc, curr.length + acc[acc.length - 1]],
+      [0]
+    )
+
+    if (simulated.items.length !== itemsIndices[itemsIndices.length - 1]) {
+      const askedItems = itemsIndices[itemsIndices.length - 1]
+      const returnedItems = simulated.items.length
+
+      throw new Error(
+        `Simulation asked for ${askedItems}, but received ${returnedItems} items`
+      )
+    }
+
+    return items.map((__, index) => ({
+      ...simulated,
+      items: simulated.items.slice(
+        itemsIndices[index],
+        itemsIndices[index + 1]
+      ),
+    }))
+  }
+
+  return new DataLoader<PayloadItem[], Simulation>(loader, {
+    maxBatchSize: 20,
+  })
+}

--- a/packages/store-api/src/platforms/vtex/loaders/sku.ts
+++ b/packages/store-api/src/platforms/vtex/loaders/sku.ts
@@ -1,0 +1,48 @@
+import DataLoader from 'dataloader'
+
+import { enhanceSku } from '../utils/enhanceSku'
+import type { EnhancedSku } from '../utils/enhanceSku'
+import type { Options } from '..'
+import type { Clients } from '../clients'
+
+export const getSkuLoader = (_: Options, clients: Clients) => {
+  const loader = async (skuIds: readonly string[]) => {
+    const indexById = skuIds.reduce(
+      (acc, id, index) => ({ ...acc, [id]: index }),
+      {} as Record<string, number>
+    )
+
+    const { products } = await clients.search.products({
+      query: `sku:${skuIds.join(';')}`,
+      page: 0,
+      count: skuIds.length,
+    })
+
+    if (products.length !== skuIds.length) {
+      throw new Error(
+        `Sku batching went wrong. Asked for ${skuIds.length} sku(s) but search api returned ${products.length} sku(s)`
+      )
+    }
+
+    const sorted = new Array<EnhancedSku>(products.length)
+
+    // O(n*m) sort, where n = skuIds.length and m is the number of skus per product
+    for (const product of products) {
+      const sku = product.skus.find((item) => indexById[item.id] != null)
+
+      if (sku == null) {
+        throw new Error(`Could not find sku for product ${product.id}`)
+      }
+
+      const index = indexById[sku.id]
+
+      sorted[index] = enhanceSku(sku, product)
+    }
+
+    return sorted
+  }
+
+  return new DataLoader<string, EnhancedSku>(loader, {
+    maxBatchSize: 50, // Warning: Don't change this value, this the max allowed batch size of Search API
+  })
+}

--- a/packages/store-api/src/platforms/vtex/resolvers/aggregateOffer.ts
+++ b/packages/store-api/src/platforms/vtex/resolvers/aggregateOffer.ts
@@ -1,6 +1,7 @@
-import type { Simulation } from '../clients/commerce/types/Checkout'
+import type { EnhancedSku } from '../utils/enhanceSku'
+import type { Simulation } from '../clients/commerce/types/Simulation'
 
-type Resolvers = (root: Simulation) => unknown
+type Resolvers = (root: Simulation & { product: EnhancedSku }) => unknown
 
 export const StoreAggregateOffer: Record<string, Resolvers> = {
   highPrice: ({ items }) =>
@@ -15,5 +16,5 @@ export const StoreAggregateOffer: Record<string, Resolvers> = {
     ) / 1e2,
   offerCount: ({ items }) => items.length,
   priceCurrency: () => '',
-  offers: ({ items }) => items,
+  offers: ({ items, product }) => items.map((item) => ({ ...item, product })),
 }

--- a/packages/store-api/src/platforms/vtex/resolvers/mutation.ts
+++ b/packages/store-api/src/platforms/vtex/resolvers/mutation.ts
@@ -1,0 +1,5 @@
+import { validateCart } from './validateCart'
+
+export const Mutation = {
+  validateCart,
+}

--- a/packages/store-api/src/platforms/vtex/resolvers/offer.ts
+++ b/packages/store-api/src/platforms/vtex/resolvers/offer.ts
@@ -1,7 +1,13 @@
+import type { EnhancedSku } from '../utils/enhanceSku'
 import type { Resolver } from '..'
-import type { Item } from '../clients/commerce/types/Checkout'
+import type { Item } from '../clients/commerce/types/Simulation'
+import type { OrderFormItem } from '../clients/commerce/types/OrderForm'
 
-export const StoreOffer: Record<string, Resolver<Item>> = {
+type Root =
+  | (Item & { product: EnhancedSku }) // when querying search/product
+  | (OrderFormItem & { product: Promise<EnhancedSku> }) // when querying order
+
+export const StoreOffer: Record<string, Resolver<Root>> = {
   priceCurrency: () => '',
   priceValidUntil: ({ priceValidUntil }) => priceValidUntil ?? '',
   itemCondition: () => 'https://schema.org/NewCondition',
@@ -15,4 +21,6 @@ export const StoreOffer: Record<string, Resolver<Item>> = {
   price: ({ sellingPrice }) => sellingPrice / 1e2, // TODO add spot price calculation
   sellingPrice: ({ sellingPrice }) => sellingPrice / 1e2,
   listPrice: ({ listPrice }) => listPrice / 1e2,
+  itemOffered: ({ product }) => product,
+  quantity: ({ quantity }) => quantity,
 }

--- a/packages/store-api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/store-api/src/platforms/vtex/resolvers/product.ts
@@ -52,10 +52,12 @@ export const StoreProduct: Record<string, Resolver<Root>> = {
   gtin: ({ reference }) => reference ?? '',
   review: () => [],
   aggregateRating: () => ({}),
-  offers: async ({ sellers, id }, _, ctx) => {
+  offers: async (product, _, ctx) => {
     const {
-      clients: { commerce },
+      loaders: { simulationLoader },
     } = ctx
+
+    const { sellers, id } = product
 
     // Unique seller ids
     const sellerIds = sellers.map((seller) => seller.id)
@@ -65,9 +67,9 @@ export const StoreProduct: Record<string, Resolver<Root>> = {
       id,
     }))
 
-    return commerce.checkout.simulation({
-      items,
-    })
+    const simulation = await simulationLoader.load(items)
+
+    return { ...simulation, product }
   },
   isVariantOf: ({ isVariantOf }) => isVariantOf,
 }

--- a/packages/store-api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/store-api/src/platforms/vtex/resolvers/query.ts
@@ -32,7 +32,7 @@ export const Query = {
     ctx: Context
   ) => {
     const {
-      clients: { search },
+      loaders: { skuLoader },
     } = ctx
 
     const skuId =
@@ -40,19 +40,7 @@ export const Query = {
         ? locator.value
         : locator.value.split('-').reverse()[0]
 
-    const {
-      products: [product],
-    } = await search.products({ query: `sku:${skuId}`, page: 0, count: 1 })
-
-    const sku = product.skus.find((x) => x.id === skuId)
-
-    if (sku == null) {
-      throw new Error(
-        `Could not find sku of id: ${skuId} for locator field: ${locator.field}, value: ${locator.value}`
-      )
-    }
-
-    return enhanceSku(sku, product)
+    return skuLoader.load(skuId)
   },
   search: async (
     _: unknown,

--- a/packages/store-api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/store-api/src/platforms/vtex/resolvers/validateCart.ts
@@ -76,7 +76,7 @@ const equals = (of1: OrderForm, of2: OrderForm) => {
  * The algoritm is something like:
  * 1. Fetch orderForm from VTEX
  * 2. Compute delta changes between the orderForm and the UI's cart
- * 3. Update the orderForm accordingly
+ * 3. Update the orderForm in VTEX platform accordingly
  * 4. If any chages were made, send to the UI the new cart. Null otherwise
  */
 export const validateCart = async (

--- a/packages/store-api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/store-api/src/platforms/vtex/resolvers/validateCart.ts
@@ -1,0 +1,166 @@
+import deepEquals from 'fast-deep-equal'
+
+import type { IStoreCart, IStoreOffer } from '../../../__generated__/schema'
+import type {
+  OrderForm,
+  OrderFormItem,
+  OrderFormInputItem,
+} from '../clients/commerce/types/OrderForm'
+import type { Context } from '..'
+
+type Indexed<T> = T & { index?: number }
+
+const getId = (item: IStoreOffer) =>
+  [item.itemOffered.sku, item.seller.identifier, item.price].join('::')
+
+const orderFormItemToOffer = (
+  item: OrderFormItem,
+  index?: number
+): Indexed<IStoreOffer> => ({
+  listPrice: item.listPrice / 100,
+  price: item.sellingPrice / 100,
+  quantity: item.quantity,
+  seller: { identifier: item.seller },
+  itemOffered: {
+    sku: item.id,
+    image: [],
+    name: item.name,
+  },
+  index,
+})
+
+const offerToOrderItemInput = (
+  offer: Indexed<IStoreOffer>
+): OrderFormInputItem => ({
+  quantity: offer.quantity,
+  seller: offer.seller.identifier,
+  id: offer.itemOffered.sku,
+  index: offer.index,
+})
+
+const groupById = (offers: IStoreOffer[]): Map<string, IStoreOffer> =>
+  offers.reduce((acc, item) => {
+    const id = getId(item)
+
+    acc.set(id, acc.get(id) ?? item)
+
+    return acc
+  }, new Map<string, IStoreOffer>())
+
+const equals = (of1: OrderForm, of2: OrderForm) => {
+  const pick = ({ orderFormId, messages, items, salesChannel }: OrderForm) => ({
+    orderFormId,
+    messages,
+    salesChannel,
+    items: items.map(
+      ({ uniqueId, quantity, seller, sellingPrice, availability }) => ({
+        uniqueId,
+        quantity,
+        seller,
+        sellingPrice,
+        availability,
+      })
+    ),
+  })
+
+  return deepEquals(pick(of1), pick(of2))
+}
+
+/**
+ * This resolver implements the optimistic cart behavior. The main idea in here
+ * is that we receive a cart from the UI (as query params) and we validate it with
+ * the commerce platform. If the cart is valid, we return null, if the cart is
+ * invalid according to the commerce platform, we return the new cart the UI should use
+ * instead
+ *
+ * The algoritm is something like:
+ * 1. Fetch orderForm from VTEX
+ * 2. Compute delta changes between the orderForm and the UI's cart
+ * 3. Update the orderForm accordingly
+ * 4. If any chages were made, send to the UI the new cart. Null otherwise
+ */
+export const validateCart = async (
+  _: unknown,
+  {
+    cart: {
+      order: { orderNumber, acceptedOffer },
+    },
+  }: { cart: IStoreCart },
+  ctx: Context
+) => {
+  const {
+    clients: { commerce },
+    loaders: { skuLoader },
+  } = ctx
+
+  // Step1: Get OrderForm from VTEX Commerce
+  const orderForm = await commerce.checkout.orderForm({
+    id: orderNumber,
+  })
+
+  // Step2: Process items from both browser and checkout so they have the same shape
+  const browserItemsById = groupById(acceptedOffer)
+  const originItemsById = groupById(orderForm.items.map(orderFormItemToOffer))
+  const browserItems = Array.from(browserItemsById.values()) // items on the user's browser
+  const originItems = Array.from(originItemsById.values()) // items on the VTEX platform backend
+
+  // Step3: Compute delta changes
+  const { itemsToAdd, itemsToUpdate } = browserItems.reduce(
+    (acc, item) => {
+      const maybeOriginItem = originItemsById.get(getId(item))
+
+      if (!maybeOriginItem) {
+        acc.itemsToAdd.push(item)
+      } else {
+        acc.itemsToUpdate.push({
+          ...maybeOriginItem,
+          quantity: item.quantity,
+        })
+      }
+
+      return acc
+    },
+    {
+      itemsToAdd: [] as IStoreOffer[],
+      itemsToUpdate: [] as IStoreOffer[],
+    }
+  )
+
+  const itemsToDelete = originItems
+    .filter((item) => !browserItemsById.has(getId(item)))
+    .map((item) => ({ ...item, quantity: 0 }))
+
+  const changes = [...itemsToAdd, ...itemsToUpdate, ...itemsToDelete].map(
+    offerToOrderItemInput
+  )
+
+  if (changes.length === 0) {
+    return null
+  }
+
+  // Step4: Apply delta changes to order form
+  const updatedOrderForm = await commerce.checkout.updateOrderFormItems({
+    id: orderForm.orderFormId,
+    orderItems: changes,
+  })
+
+  // Step5: If no changes detected before/after updating orderForm, the order is validated
+  if (equals(orderForm, updatedOrderForm)) {
+    return null
+  }
+
+  // Step6: There were changes, convert orderForm to StoreOrder
+  return {
+    order: {
+      orderNumber: updatedOrderForm.orderFormId,
+      acceptedOffer: updatedOrderForm.items.map((item) => ({
+        ...item,
+        product: skuLoader.load(item.id),
+      })),
+    },
+    messages: updatedOrderForm.messages.map(({ text, status }) => ({
+      text,
+      status: status.toUpperCase(),
+    })),
+  }
+}

--- a/packages/store-api/src/typeDefs/cart.graphql
+++ b/packages/store-api/src/typeDefs/cart.graphql
@@ -1,0 +1,13 @@
+type StoreCartMessage {
+  text: String!
+  status: StoreStatus!
+}
+
+type StoreCart {
+  order: StoreOrder!
+  messages: [StoreCartMessage!]!
+}
+
+input IStoreCart {
+  order: IStoreOrder!
+}

--- a/packages/store-api/src/typeDefs/image.graphql
+++ b/packages/store-api/src/typeDefs/image.graphql
@@ -2,3 +2,8 @@ type StoreImage {
   url: String!
   alternateName: String!
 }
+
+input IStoreImage {
+  url: String!
+  alternateName: String!
+}

--- a/packages/store-api/src/typeDefs/index.ts
+++ b/packages/store-api/src/typeDefs/index.ts
@@ -8,7 +8,9 @@ import Breadcrumb from './breadcrumb.graphql'
 import Collection from './collection.graphql'
 import Facet from './facet.graphql'
 import Image from './image.graphql'
+import Mutation from './mutation.graphql'
 import Offer from './offer.graphql'
+import Order from './order.graphql'
 import Organization from './organization.graphql'
 import PageInfo from './pageInfo.graphql'
 import Product from './product.graphql'
@@ -16,9 +18,12 @@ import ProductGroup from './productGroup.graphql'
 import Query from './query.graphql'
 import Review from './review.graphql'
 import Seo from './seo.graphql'
+import Cart from './cart.graphql'
+import Status from './status.graphql'
 
 export const typeDefs = [
   Query,
+  Mutation,
   Brand,
   Breadcrumb,
   Collection,
@@ -34,6 +39,9 @@ export const typeDefs = [
   ProductGroup,
   Organization,
   AggregateOffer,
+  Order,
+  Cart,
+  Status,
 ]
   .map(print)
   .join('\n')

--- a/packages/store-api/src/typeDefs/mutation.graphql
+++ b/packages/store-api/src/typeDefs/mutation.graphql
@@ -1,0 +1,4 @@
+type Mutation {
+  # Returns the order if anything changed with the order. Null if the order is valid
+  validateCart(cart: IStoreCart!): StoreCart
+}

--- a/packages/store-api/src/typeDefs/offer.graphql
+++ b/packages/store-api/src/typeDefs/offer.graphql
@@ -8,4 +8,14 @@ type StoreOffer {
   itemCondition: String!
   availability: String!
   seller: StoreOrganization!
+  itemOffered: StoreProduct!
+  quantity: Int!
+}
+
+input IStoreOffer {
+  price: Float!
+  listPrice: Float!
+  seller: IStoreOrganization!
+  itemOffered: IStoreProduct!
+  quantity: Int!
 }

--- a/packages/store-api/src/typeDefs/order.graphql
+++ b/packages/store-api/src/typeDefs/order.graphql
@@ -1,0 +1,9 @@
+type StoreOrder {
+  orderNumber: String!
+  acceptedOffer: [StoreOffer!]!
+}
+
+input IStoreOrder {
+  orderNumber: String!
+  acceptedOffer: [IStoreOffer!]!
+}

--- a/packages/store-api/src/typeDefs/organization.graphql
+++ b/packages/store-api/src/typeDefs/organization.graphql
@@ -1,3 +1,7 @@
 type StoreOrganization {
   identifier: String!
 }
+
+input IStoreOrganization {
+  identifier: String!
+}

--- a/packages/store-api/src/typeDefs/product.graphql
+++ b/packages/store-api/src/typeDefs/product.graphql
@@ -17,3 +17,9 @@ type StoreProduct {
   aggregateRating: StoreAggregateRating!
   isVariantOf: StoreProductGroup!
 }
+
+input IStoreProduct {
+  sku: String!
+  name: String!
+  image: [IStoreImage!]!
+}

--- a/packages/store-api/src/typeDefs/status.graphql
+++ b/packages/store-api/src/typeDefs/status.graphql
@@ -1,0 +1,5 @@
+enum StoreStatus {
+  INFO
+  WARNING
+  ERROR
+}

--- a/packages/store-api/test/index.test.ts
+++ b/packages/store-api/test/index.test.ts
@@ -6,6 +6,7 @@ describe('Schema', () => {
       platform: 'vtex',
       account: 'storecomponents',
       environment: 'vtexcommercestable',
+      channel: '1',
     })
 
     expect(schema).not.toBeNull()

--- a/yarn.lock
+++ b/yarn.lock
@@ -6456,27 +6456,28 @@
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
 "@typescript-eslint/eslint-plugin@^2.12.0", "@typescript-eslint/eslint-plugin@^4", "@typescript-eslint/eslint-plugin@^4.28.1", "@typescript-eslint/eslint-plugin@^4.29.2":
-  version "4.31.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.1.tgz#e938603a136f01dcabeece069da5fb2e331d4498"
-  integrity sha512-UDqhWmd5i0TvPLmbK5xY3UZB0zEGseF+DHPghZ37Sb83Qd3p8ujhvAtkU4OF46Ka5Pm5kWvFIx0cCTBFKo0alA==
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.32.0.tgz#46d2370ae9311092f2a6f7246d28357daf2d4e89"
+  integrity sha512-+OWTuWRSbWI1KDK8iEyG/6uK2rTm3kpS38wuVifGUTDB6kjEuNrzBI1MUtxnkneuWG/23QehABe2zHHrj+4yuA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.31.1"
-    "@typescript-eslint/scope-manager" "4.31.1"
+    "@typescript-eslint/experimental-utils" "4.32.0"
+    "@typescript-eslint/scope-manager" "4.32.0"
     debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
+    ignore "^5.1.8"
     regexpp "^3.1.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.31.1":
-  version "4.31.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.1.tgz#0c900f832f270b88e13e51753647b02d08371ce5"
-  integrity sha512-NtoPsqmcSsWty0mcL5nTZXMf7Ei0Xr2MT8jWjXMVgRK0/1qeQ2jZzLFUh4QtyJ4+/lPUyMw5cSfeeME+Zrtp9Q==
+"@typescript-eslint/experimental-utils@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.32.0.tgz#53a8267d16ca5a79134739129871966c56a59dc4"
+  integrity sha512-WLoXcc+cQufxRYjTWr4kFt0DyEv6hDgSaFqYhIzQZ05cF+kXfqXdUh+//kgquPJVUBbL3oQGKQxwPbLxHRqm6A==
   dependencies:
     "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.31.1"
-    "@typescript-eslint/types" "4.31.1"
-    "@typescript-eslint/typescript-estree" "4.31.1"
+    "@typescript-eslint/scope-manager" "4.32.0"
+    "@typescript-eslint/types" "4.32.0"
+    "@typescript-eslint/typescript-estree" "4.32.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -6505,13 +6506,13 @@
     eslint-utils "^3.0.0"
 
 "@typescript-eslint/parser@^2.12.0", "@typescript-eslint/parser@^4", "@typescript-eslint/parser@^4.28.1", "@typescript-eslint/parser@^4.29.2":
-  version "4.31.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.31.1.tgz#8f9a2672033e6f6d33b1c0260eebdc0ddf539064"
-  integrity sha512-dnVZDB6FhpIby6yVbHkwTKkn2ypjVIfAR9nh+kYsA/ZL0JlTsd22BiDjouotisY3Irmd3OW1qlk9EI5R8GrvRQ==
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.32.0.tgz#751ecca0e2fecd3d44484a9b3049ffc1871616e5"
+  integrity sha512-lhtYqQ2iEPV5JqV7K+uOVlPePjClj4dOw7K4/Z1F2yvjIUvyr13yJnDzkK6uon4BjHYuHy3EG0c2Z9jEhFk56w==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.31.1"
-    "@typescript-eslint/types" "4.31.1"
-    "@typescript-eslint/typescript-estree" "4.31.1"
+    "@typescript-eslint/scope-manager" "4.32.0"
+    "@typescript-eslint/types" "4.32.0"
+    "@typescript-eslint/typescript-estree" "4.32.0"
     debug "^4.3.1"
 
 "@typescript-eslint/scope-manager@4.19.0":
@@ -6530,13 +6531,13 @@
     "@typescript-eslint/types" "4.29.2"
     "@typescript-eslint/visitor-keys" "4.29.2"
 
-"@typescript-eslint/scope-manager@4.31.1":
-  version "4.31.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.31.1.tgz#0c21e8501f608d6a25c842fcf59541ef4f1ab561"
-  integrity sha512-N1Uhn6SqNtU2XpFSkD4oA+F0PfKdWHyr4bTX0xTj8NRx1314gBDRL1LUuZd5+L3oP+wo6hCbZpaa1in6SwMcVQ==
+"@typescript-eslint/scope-manager@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.32.0.tgz#e03c8668f8b954072b3f944d5b799c0c9225a7d5"
+  integrity sha512-DK+fMSHdM216C0OM/KR1lHXjP1CNtVIhJ54kQxfOE6x8UGFAjha8cXgDMBEIYS2XCYjjCtvTkjQYwL3uvGOo0w==
   dependencies:
-    "@typescript-eslint/types" "4.31.1"
-    "@typescript-eslint/visitor-keys" "4.31.1"
+    "@typescript-eslint/types" "4.32.0"
+    "@typescript-eslint/visitor-keys" "4.32.0"
 
 "@typescript-eslint/types@4.19.0":
   version "4.19.0"
@@ -6548,10 +6549,10 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.2.tgz#fc0489c6b89773f99109fb0aa0aaddff21f52fcd"
   integrity sha512-K6ApnEXId+WTGxqnda8z4LhNMa/pZmbTFkDxEBLQAbhLZL50DjeY0VIDCml/0Y3FlcbqXZrABqrcKxq+n0LwzQ==
 
-"@typescript-eslint/types@4.31.1":
-  version "4.31.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.1.tgz#5f255b695627a13401d2fdba5f7138bc79450d66"
-  integrity sha512-kixltt51ZJGKENNW88IY5MYqTBA8FR0Md8QdGbJD2pKZ+D5IvxjTYDNtJPDxFBiXmka2aJsITdB1BtO1fsgmsQ==
+"@typescript-eslint/types@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.32.0.tgz#52c633c18da47aee09449144bf59565ab36df00d"
+  integrity sha512-LE7Z7BAv0E2UvqzogssGf1x7GPpUalgG07nGCBYb1oK4mFsOiFC/VrSMKbZQzFJdN2JL5XYmsx7C7FX9p9ns0w==
 
 "@typescript-eslint/typescript-estree@4.19.0":
   version "4.19.0"
@@ -6579,13 +6580,13 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@4.31.1":
-  version "4.31.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.1.tgz#4a04d5232cf1031232b7124a9c0310b577a62d17"
-  integrity sha512-EGHkbsUvjFrvRnusk6yFGqrqMBTue5E5ROnS5puj3laGQPasVUgwhrxfcgkdHNFECHAewpvELE1Gjv0XO3mdWg==
+"@typescript-eslint/typescript-estree@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.32.0.tgz#db00ccc41ccedc8d7367ea3f50c6994b8efa9f3b"
+  integrity sha512-tRYCgJ3g1UjMw1cGG8Yn1KzOzNlQ6u1h9AmEtPhb5V5a1TmiHWcRyF/Ic+91M4f43QeChyYlVTcf3DvDTZR9vw==
   dependencies:
-    "@typescript-eslint/types" "4.31.1"
-    "@typescript-eslint/visitor-keys" "4.31.1"
+    "@typescript-eslint/types" "4.32.0"
+    "@typescript-eslint/visitor-keys" "4.32.0"
     debug "^4.3.1"
     globby "^11.0.3"
     is-glob "^4.0.1"
@@ -6608,12 +6609,12 @@
     "@typescript-eslint/types" "4.29.2"
     eslint-visitor-keys "^2.0.0"
 
-"@typescript-eslint/visitor-keys@4.31.1":
-  version "4.31.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.1.tgz#f2e7a14c7f20c4ae07d7fc3c5878c4441a1da9cc"
-  integrity sha512-PCncP8hEqKw6SOJY+3St4LVtoZpPPn+Zlpm7KW5xnviMhdqcsBty4Lsg4J/VECpJjw1CkROaZhH4B8M1OfnXTQ==
+"@typescript-eslint/visitor-keys@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.32.0.tgz#455ba8b51242f2722a497ffae29313f33b14cb7f"
+  integrity sha512-e7NE0qz8W+atzv3Cy9qaQ7BTLwWsm084Z0c4nIO2l3Bp6u9WIgdqCgyPyV5oSPDMIW3b20H59OOCmVk3jw3Ptw==
   dependencies:
-    "@typescript-eslint/types" "4.31.1"
+    "@typescript-eslint/types" "4.32.0"
     eslint-visitor-keys "^2.0.0"
 
 "@vtex/prettier-config@^0.3.5":
@@ -10345,7 +10346,7 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-dataloader@2.0.0:
+dataloader@2.0.0, dataloader@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
   integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
@@ -14270,11 +14271,6 @@ graphql@^15.4.0:
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
   integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
 
-graphql@^15.5.3:
-  version "15.5.3"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.3.tgz#c72349017d5c9f5446a897fe6908b3186db1da00"
-  integrity sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==
-
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -14924,7 +14920,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4:
+ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds an optimistic cart implementation to store-api.

## How it works? 
The optimistic cart we have works via state validation. This means that, we build a state of the cart on the browser, and then, the backend validates this state. If this state is valid, the backend signalizes this state is ok and nothing changes on the frontend. If, however, this state is not valid, a.k.a, this product is unavailable, a promotion was applied, etc, the backend sends the new cart state to the frontend. An example of this process can be seen below: 

![image](https://user-images.githubusercontent.com/1753396/134071242-86b2e100-408b-4b85-81f7-85438d4774e5.png)

To implement the cart, I used the schema.org's type `Order`. Also, another thing this PR brings is `input` fields. We didn't really use them before, but now I needed a standard for writing them. I added an `I` prefix to them, so writing an `input` for a `type` can be achieved by:
`type StoreProduct` -> `type IStoreProduct`.

Also, another thing this PR brings is the usage of [dataloaders](https://github.com/graphql/dataloader). This was necessary for loading skus and simulations without overwhelming the search/checkout API.

## How to test it?
To test it, open our PR on base.store and check that all promotions are applied correctly. Also, if you want you can change the base account name to `carrefourbrfood` and check all edge cases in there. 

https://github.com/vtex-sites/base.store/pull/36