### PR TITLE
feat(store-sdk): Add session storage helper

### DIFF
--- a/packages/store-sdk/src/index.ts
+++ b/packages/store-sdk/src/index.ts
@@ -106,3 +106,4 @@ export type { Cart } from './cart/Optimistic'
 
 // Storage
 export { useStorage } from './storage/useStorage'
+export { useSessionStorage } from './storage/useSessionStorage'

--- a/packages/store-sdk/src/storage/useSessionStorage.ts
+++ b/packages/store-sdk/src/storage/useSessionStorage.ts
@@ -1,0 +1,45 @@
+/**
+ * Safe SessionStorage interface. These try..catch are usefull because
+ * some browsers may block accesss to these APIs due to security policies
+ *
+ */
+import { useState, useEffect } from 'react'
+
+import { isFunction } from './utils'
+
+const getItem = <T>(key: string): T | null => {
+  try {
+    const value = window.sessionStorage.getItem(key)
+
+    return value && JSON.parse(value)
+  } catch (err) {
+    return null
+  }
+}
+
+const setItem = <T>(key: string, value: T | null) => {
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(value))
+  } catch (err) {
+    // noop
+  }
+}
+
+export const useSessionStorage = <T>(
+  key: string,
+  initialValue: T | (() => T)
+) => {
+  const state = useState(
+    () =>
+      getItem<T>(key) ??
+      (isFunction(initialValue) ? initialValue() : initialValue)
+  )
+
+  const [data] = state
+
+  useEffect(() => {
+    setItem(key, data)
+  }, [key, data])
+
+  return state
+}

--- a/packages/store-sdk/src/storage/useStorage.ts
+++ b/packages/store-sdk/src/storage/useStorage.ts
@@ -9,6 +9,8 @@
 import { useState, useEffect, useMemo } from 'react'
 import { get, set } from 'idb-keyval'
 
+import { isFunction } from './utils'
+
 const getItem = async <T>(key: string) => {
   try {
     const value = await get<T>(key)
@@ -26,9 +28,6 @@ const setItem = async <T>(key: string, value: T | null) => {
     // noop
   }
 }
-
-const isFunction = <T>(x: T | (() => T)): x is () => T =>
-  typeof x === 'function'
 
 export const useStorage = <T>(key: string, initialValue: T | (() => T)) => {
   const [data, setData] = useState(() => ({

--- a/packages/store-sdk/src/storage/utils.ts
+++ b/packages/store-sdk/src/storage/utils.ts
@@ -1,0 +1,2 @@
+export const isFunction = <T>(x: T | (() => T)): x is () => T =>
+  typeof x === 'function'

--- a/packages/store-sdk/test/storage/useSessionStorage.test.ts
+++ b/packages/store-sdk/test/storage/useSessionStorage.test.ts
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useSessionStorage } from '../../src'
+
+test('useSessionStorage: Hydrate with initial value', async () => {
+  const hook = renderHook(() => useSessionStorage('k', { a: 1 }))
+
+  expect(hook.result.current[0].a).toBe(1)
+})
+
+test('useSessionStorage: Read value from sessionStorage', async () => {
+  const key = 'k'
+  const storedValue = { a: 4 }
+  const initialValue = { a: 2 }
+
+  sessionStorage.setItem(key, JSON.stringify(storedValue))
+
+  const run = renderHook(() => useSessionStorage(key, initialValue))
+
+  expect(run.result.current[0]).toEqual(storedValue)
+})

--- a/packages/store-sdk/test/storage/useStorage.test.ts
+++ b/packages/store-sdk/test/storage/useStorage.test.ts
@@ -9,7 +9,7 @@ test('useStorage: Hydrate with initial value', async () => {
   expect(hook.result.current[0].a).toBe(1)
 })
 
-test('useStorage: Read value from localStorage after hydration', async () => {
+test('useStorage: Read value from indexedDB after hydration', async () => {
   const key = 'k'
   const storedValue = { a: 1 }
   const initialValue = { a: 2 }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds a sessionStorage helper to store-sdk so we can use this hook on our stores. 

This hook can be used to store small, ephemeral values that respect the browser's session storage. 

> Note: SessionStorage can be disabled on certain browsers due to privacy settings. In this case, we store the value a React's state and the state can be entirely lost if the component is umounted.

## How to test it?
I need this hook to implement the search pagination. The idea is that our search uses infinite scroll and, every time the user scrolls down, we need to keep the state of the pagination so once the user navigates on the site and goes back to a search page, it sees exactly where he's left.

To test it:
https://github.com/vtex-sites/base.store/pull/37

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
