### PR TITLE
fix: users are unable to develop a store in an account without CMS pages

### DIFF
--- a/packages/gatsby-plugin-cms/src/node-api/cms/fetchNodes.ts
+++ b/packages/gatsby-plugin-cms/src/node-api/cms/fetchNodes.ts
@@ -107,7 +107,7 @@ export const fetchAllNodes = async (
       const { edges, pageInfo } = pages
       const nodes = edges.map((x: any) => x.node)
 
-      after = edges[edges.length - 1].cursor
+      after = edges[edges.length - 1]?.cursor
       hasNextPage = pageInfo.hasNextPage
       data = [...data, ...nodes]
     }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes an issue where users were unable to develop on a store that didn't have a CMS page yet

## How it works? 
I just checked if the edge existed before getting the cursor