### PR TITLE
fix: synchronously reading regionId initial value

### DIFF
--- a/packages/gatsby-theme-store/src/sdk/region/Provider.tsx
+++ b/packages/gatsby-theme-store/src/sdk/region/Provider.tsx
@@ -14,9 +14,15 @@ export interface IContext {
 export const Context = createContext<IContext | undefined>(undefined)
 
 export const Provider: FC = ({ children }) => {
-  const [postalCode, setPostalCode] = useState<Maybe<string>>(null)
-  const [regionId, setRegionId] = useState<Maybe<string>>(null)
   const [isLoading, setLoading] = useState(true)
+
+  const [postalCode, setPostalCode] = useState<Maybe<string>>(
+    controller.postalCode.get()
+  )
+
+  const [regionId, setRegionId] = useState<Maybe<string>>(
+    controller.region.get()
+  )
 
   const value = useMemo(
     () => ({
@@ -36,8 +42,6 @@ export const Provider: FC = ({ children }) => {
   )
 
   useEffect(() => {
-    setPostalCode(controller.postalCode.get())
-    setRegionId(controller.region.get())
     setLoading(false)
   }, [])
 


### PR DESCRIPTION
## What's the purpose of this pull request?
This fixes an issue where `regionId` would be null on queries because it was being loaded lazily.
