### PR TITLE
fix: check if window is available before accessing it

### DIFF
--- a/packages/gatsby-theme-store/src/sdk/region/controller.ts
+++ b/packages/gatsby-theme-store/src/sdk/region/controller.ts
@@ -1,5 +1,8 @@
 const postalCode = {
-  get: () => window?.localStorage?.getItem('vtex:postalCode'),
+  get: () =>
+    typeof window !== 'undefined'
+      ? window?.localStorage?.getItem('vtex:postalCode')
+      : null,
   set: (value: Maybe<string>) => {
     if (value) {
       localStorage.setItem('vtex:postalCode', value)
@@ -10,7 +13,10 @@ const postalCode = {
 }
 
 const region = {
-  get: () => window?.localStorage?.getItem('vtex:regionId'),
+  get: () =>
+    typeof window !== 'undefined'
+      ? window?.localStorage?.getItem('vtex:regionId')
+      : null,
   set: (value: Maybe<string>) => {
     if (value) {
       localStorage.setItem('vtex:regionId', value)


### PR DESCRIPTION
## What's the purpose of this pull request?
Check if `window` is available before accessing it
