### PR TITLE
fix(gatsby-theme-store): Use Window instead of globalThis for browser support

### DIFF
--- a/packages/gatsby-theme-store/gatsby-browser.js
+++ b/packages/gatsby-theme-store/gatsby-browser.js
@@ -61,5 +61,5 @@ export const wrapRootElement = ({ element }) => {
 }
 
 export const onInitialClientRender = () => {
-  globalThis.__REACT_HYDRATED__ = true
+  window.__REACT_HYDRATED__ = true
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Stores were breaking when running in older browsers because we're using `globalThis` instead of `window`.

It's happening only in 0.x because it's inside `gatsby-theme-store`.