### PR TITLE
chore(store-ui): Remove '@storybook/addon-storysource'

### DIFF
--- a/packages/store-ui/.storybook/main.js
+++ b/packages/store-ui/.storybook/main.js
@@ -7,13 +7,5 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     'storybook-addon-themes',
-    {
-      name: '@storybook/addon-storysource',
-      options: {
-        loaderOptions: {
-          injectStoryParameters: false,
-        },
-      },
-    },
   ],
 }

--- a/packages/store-ui/package.json
+++ b/packages/store-ui/package.json
@@ -65,7 +65,6 @@
     "@storybook/addon-docs": "^6.3.7",
     "@storybook/addon-essentials": "^6.3.7",
     "@storybook/addon-links": "^6.3.7",
-    "@storybook/addon-storysource": "^6.3.7",
     "@storybook/addons": "^6.3.7",
     "@storybook/react": "^6.3.7",
     "@testing-library/jest-dom": "^5.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4794,26 +4794,6 @@
   resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-2.0.0.tgz#c40bbe91bacd3f795963dc1ee6ff86be87deeda9"
   integrity sha512-ZhdT++cX+L9LwjhGYggvYUUVQH/MGn2rwbrAwCMzA/f2QTFvkjxzX8nDgMxIhaLCDC+gHIxfJG2wrWN0jkBr3g==
 
-"@storybook/addon-storysource@^6.3.7":
-  version "6.3.7"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-storysource/-/addon-storysource-6.3.7.tgz#7818f2402e19453747274d2c1e8e0a99f24fc2ab"
-  integrity sha512-cb1F47aD/c5TQDMmYwuKz608YeLWYSYQXGtCdijzjznYVSMJ4eAFnd38AiF2Ax1EM79BEMqzqH1SrveibAaQlA==
-  dependencies:
-    "@storybook/addons" "6.3.7"
-    "@storybook/api" "6.3.7"
-    "@storybook/client-logger" "6.3.7"
-    "@storybook/components" "6.3.7"
-    "@storybook/router" "6.3.7"
-    "@storybook/source-loader" "6.3.7"
-    "@storybook/theming" "6.3.7"
-    core-js "^3.8.2"
-    estraverse "^5.2.0"
-    loader-utils "^2.0.0"
-    prettier "~2.2.1"
-    prop-types "^15.7.2"
-    react-syntax-highlighter "^13.5.3"
-    regenerator-runtime "^0.13.7"
-
 "@storybook/addon-toolbars@6.3.7":
   version "6.3.7"
   resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-6.3.7.tgz#acd0c9eea7fad056d995a821e34abddd5b065b9b"


### PR DESCRIPTION
## What's the purpose of this pull request?

Remove the Storybook add-on `@storybook/addon-storysource`. We are already using the `@storybook/addon-docs` add-on, which is already capable of generating the same code snippets we need, and these two packages being used at the same time caused some sort of conflict, as described in this issue: https://github.com/storybookjs/storybook/issues/13362.

This issue came to light after @igorbrasileiro spotted a bug in the Table component stories: https://github.com/vtex/faststore/pull/987#issuecomment-942640022.

## How to test it?

The bug mentioned above should be solved in the deploy preview below. And the source code for all other stories should be working the same way as before.

## References

https://github.com/storybookjs/storybook/issues/13362
