### PR TITLE
fix: remove aria label from slider

### DIFF
--- a/packages/store-ui/src/atoms/Slider/Slider.test.tsx
+++ b/packages/store-ui/src/atoms/Slider/Slider.test.tsx
@@ -12,8 +12,7 @@ describe('Slider', () => {
   })
 
   describe('Accessibility', () => {
-    // Fix the Slider component
-    it.skip('should have no violations', async () => {
+    it('should have no violations', async () => {
       const { getByTestId } = render(<Slider min={0} max={100} />)
 
       expect(await axe(getByTestId('store-slider'))).toHaveNoViolations()

--- a/packages/store-ui/src/atoms/Slider/Slider.tsx
+++ b/packages/store-ui/src/atoms/Slider/Slider.tsx
@@ -24,10 +24,6 @@ export type SliderProps = {
    */
   onChange?: (value: { min: number; max: number }) => void
   /**
-   * Set a human-readable name for the slider.
-   */
-  ariaLabel?: string
-  /**
    * A function used to set a human-readable value text based on the slider's current value.
    */
   getAriaValueText?(value: number, thumb?: 'min' | 'max'): string
@@ -42,7 +38,6 @@ const Slider = ({
   max,
   onChange,
   testId = 'store-slider',
-  ariaLabel,
   getAriaValueText,
   className,
 }: SliderProps) => {
@@ -84,14 +79,7 @@ const Slider = ({
   }, [minVal, maxVal, onChange])
 
   return (
-    <div
-      data-store-slider
-      data-testid={testId}
-      aria-label={ariaLabel}
-      // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
-      role="slider"
-      className={className}
-    >
+    <div data-store-slider data-testid={testId} className={className}>
       <div ref={range} data-store-slider-range />
       <input
         type="range"


### PR DESCRIPTION
## What's the purpose of this pull request?
`role="slider"` can't be used by div, because he must be used by the focused component and input is already, for that we need remove it. So, once the role was removed, `aria-label` is no more need.

## How it works? 
<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
