### PR TITLE
Uses application/json Content-Type as default for graphql requests

### DIFF
--- a/packages/gatsby-plugin-graphql/src/index.ts
+++ b/packages/gatsby-plugin-graphql/src/index.ts
@@ -68,10 +68,11 @@ export const request = async <V = any, D = any>(
   const response = await fetch(url, {
     method,
     body,
+    ...fetchOptions,
     headers: {
       'Content-Type': 'application/json',
+      ...fetchOptions?.headers,
     },
-    ...fetchOptions,
   })
 
   return response.json()


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR sets `application/json` as default `Content-Type` for graphql requests.

## How it works? 
It sets the `Content-Type: application/json` header at the request but let it be overwritten by the `fetchOptions` prop.

### `base.store` Deploy Preview
Gatsby Cloud preview: https://basestore-choreapplicationsjson.gtsb.io/
vtex-sites preview: https://preview-77--base.preview.vtex.app


<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->