### PR TITLE
fix: Use new key for collection pages

### DIFF
--- a/packages/gatsby-plugin-cms/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-cms/src/gatsby-node.ts
@@ -19,6 +19,7 @@ import {
 } from './node-api/cms/sourceNode'
 import { fetchAllNodes as fetchAllLocalNodes } from './node-api/cms/sourceLocalNodes'
 import {
+  getCollectionRemoteId,
   getCollectionsFromPageContent,
   splitCollections,
 } from './node-api/catalog'
@@ -133,7 +134,7 @@ export const sourceNodes = async (
   for (const cluster of Object.values(splitted.clusters)) {
     const node: StoreCollection = {
       id: `${cluster.clusterId}:${cluster.seo.slug}`,
-      remoteId: cluster.clusterId,
+      remoteId: getCollectionRemoteId(cluster),
       slug: cluster.seo.slug,
       seo: {
         title: cluster.seo.title,

--- a/packages/gatsby-plugin-cms/src/node-api/catalog/index.ts
+++ b/packages/gatsby-plugin-cms/src/node-api/catalog/index.ts
@@ -47,23 +47,47 @@ export const getCollectionsFromPageContent = (
   return collectionBlocks
 }
 
+export const getCollectionRemoteId = (cluster: IClusterCollection) =>
+  `${cluster.clusterId}:${cluster.seo.slug}`
+
 export const splitCollections = (collections: Array<WithPLP<ICollection>>) => ({
   categories: collections
     .filter((x): x is WithPLP<ICategoryCollection> => isCategoryCollection(x))
-    .reduce(
-      (acc, curr) => ({ ...acc, [curr.categoryId]: curr }),
-      {} as Record<string, WithPLP<ICategoryCollection>>
-    ),
+    .reduce((acc, curr) => {
+      const id = curr.categoryId
+
+      if (acc[id]) {
+        console.warn(
+          `[gatsby-plugin-cms]: You have two or more pages on your cms pointing to the same Category(${id}). Delete one of them to avoid conflicts`
+        )
+      }
+
+      return { ...acc, [id]: curr }
+    }, {} as Record<string, WithPLP<ICategoryCollection>>),
   brands: collections
     .filter((x): x is WithPLP<IBrandCollection> => isBrandCollection(x))
-    .reduce(
-      (acc, curr) => ({ ...acc, [curr.brandId]: curr }),
-      {} as Record<string, WithPLP<IBrandCollection>>
-    ),
+    .reduce((acc, curr) => {
+      const id = curr.brandId
+
+      if (acc[id]) {
+        console.warn(
+          `[gatsby-plugin-cms]: You have two or more pages on your cms pointing to the same Brand(${id}). Delete one of them to avoid conflicts`
+        )
+      }
+
+      return { ...acc, [id]: curr }
+    }, {} as Record<string, WithPLP<IBrandCollection>>),
   clusters: collections
     .filter((x): x is WithPLP<IClusterCollection> => isClusterCollection(x))
-    .reduce(
-      (acc, curr) => ({ ...acc, [curr.clusterId]: curr }),
-      {} as Record<string, WithPLP<IClusterCollection>>
-    ),
+    .reduce((acc, curr) => {
+      const id = getCollectionRemoteId(curr)
+
+      if (acc[id]) {
+        console.warn(
+          `[gatsby-plugin-cms]: You have two or more pages on your cms pointing to the same Collection(${id}). Delete one of them to avoid conflicts`
+        )
+      }
+
+      return { ...acc, [id]: curr }
+    }, {} as Record<string, WithPLP<IClusterCollection>>),
 })


### PR DESCRIPTION
## What's the purpose of this pull request?
This [thread](https://vtex.slack.com/archives/C01HV0HTZ70/p1635427529001300) made me figure out that, if we have the same collection saved for two different PLPs on the CMS, one would override the other and we would end up with only one of the pages.

This PR fixes the aforementioned problem by not only using the PLP's cluster id as key, but a concatenation of the PLP's cluster id with the PLP's path as key. This solved the problem and the pages are now showing up as intended.

Also, I added a warning when an override happens so we keep track of this problem

## How to test it?
Make sure the pages described on that thread appear correctly

### `btglobal.store` Deploy Preview
https://github.com/vtex-sites/btglobal.store/pull/900

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
