### PR TITLE
Support to augment the nginx rewrites

### DIFF
--- a/packages/gatsby-plugin-nginx/src/typings/types.d.ts
+++ b/packages/gatsby-plugin-nginx/src/typings/types.d.ts
@@ -8,9 +8,21 @@ import {
 declare global {
   type Manifest = Record<string, string[]>
 
-  type Redirect = Actions['createRedirect'] extends (redirect: infer R) => any
-    ? R
-    : never
+  interface NginxDirective {
+    cmd: string[]
+    children?: NginxDirective[]
+  }
+
+  type NginxRewriteType = 'proxy' | 'rewrite' | 'redirect' | 'error_page'
+
+  type RedirectNginxOptions = {
+    onGenerateNginxRewrites?: (
+      commands: NginxDirective[],
+      type: NginxRewriteType
+    ) => NginxDirective[]
+  }
+
+  type Redirect = Parameters<Actions['createRedirect']>[0] & RedirectNginxOptions
 
   type Page = PageProps['pageResources']['page']
 

--- a/packages/gatsby-plugin-nginx/src/utils/functions.ts
+++ b/packages/gatsby-plugin-nginx/src/utils/functions.ts
@@ -1,0 +1,1 @@
+export const identity = <T>(value: T) => value

--- a/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
+++ b/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
@@ -132,6 +132,41 @@ describe('generateRewrites', () => {
       ])
     ).toEqual(expected)
   })
+
+  it('uses onGenerateNginxRewrites to augment the children commands', () => {
+    const expected = [
+      {
+        children: [
+          {
+            cmd: [
+              'proxy_pass',
+              'https://other-domain.com/api/auth/$1$is_args$args',
+            ],
+          },
+          { cmd: ['proxy_ssl_server_name', 'on'] },
+          { cmd: ['proxy_cookie_domain', 'other-domain.com', '$host'] },
+          { cmd: ['proxy_cookie_path', '/api/auth', '/'] },
+        ],
+        cmd: ['location', '~*', '"^/api/auth/(.*)$"'],
+      },
+    ]
+
+    expect(
+      generateRewrites([
+        {
+          fromPath: '/api/auth/*',
+          toPath: 'https://other-domain.com/api/auth/:splat',
+          onGenerateNginxRewrites: (commands) => {
+            return [
+              ...commands,
+              { cmd: ['proxy_cookie_domain', 'other-domain.com', '$host'] },
+              { cmd: ['proxy_cookie_path', '/api/auth', '/'] },
+            ]
+          },
+        },
+      ])
+    ).toEqual(expected)
+  })
 })
 
 describe('generateRedirects', () => {


### PR DESCRIPTION
## What's the purpose of this pull request? / How it works? 

- Enables support to augment the generate nginx locations by passing the value by the function `onGenerateNginxRewrites` which can augment the generated commands to nginx

## How to test it?

Just run the tests or write more of them