### PR TITLE
fix(store-ui): Fix story title when CamelCase

### DIFF
--- a/packages/ui/src/molecules/LoadingButton/stories/LoadingButton.stories.tsx
+++ b/packages/ui/src/molecules/LoadingButton/stories/LoadingButton.stories.tsx
@@ -16,6 +16,7 @@ const LoadingButtonTemplate: Story<LoadingButtonProps> = ({
 )
 
 export const LoadingButton = LoadingButtonTemplate.bind({})
+LoadingButton.storyName = 'LoadingButton'
 
 const argTypes: ComponentArgTypes<LoadingButtonProps> = {
   loading: {

--- a/packages/ui/src/molecules/PriceRange/stories/PriceRange.stories.tsx
+++ b/packages/ui/src/molecules/PriceRange/stories/PriceRange.stories.tsx
@@ -11,6 +11,7 @@ const PriceRangeTemplate: Story<PriceRangeProps> = (props) => (
 )
 
 export const PriceRange = PriceRangeTemplate.bind({})
+PriceRange.storyName = 'PriceRange'
 
 function formatter(price: number) {
   return new Intl.NumberFormat('en-US', {


### PR DESCRIPTION
## What's the purpose of this pull request?
Every story that has only one default story and have two words in your name with CamelCase, like `PriceRange`, was displaying the story with a sub-story, when it has only one default story and it doesn't need a sub-story. Examples below:

Before: 

<img width="245" alt="Screen Shot 2021-11-12 at 7 46 55 AM" src="https://user-images.githubusercontent.com/42946693/141455174-6815df15-046a-4f7d-aeff-d7e95d720efe.png">

After: 

<img width="238" alt="Screen Shot 2021-11-12 at 7 28 13 AM" src="https://user-images.githubusercontent.com/42946693/141455145-7d78c652-c13e-4605-9dc0-b8b8163ba462.png">

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
