### PR TITLE
chore: Use browserslist in api/ui/sdk

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,8 +9,9 @@
     "dist",
     "src"
   ],
+  "browserslist": "node 12",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "develop": "concurrently \"yarn generate -w\" \"tsdx watch\"",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/vtex/faststore",
     "directory": "packages/sdk"
   },
-  "browserslist": "last 2 chrome version",
+  "browserslist": "supports es6-module and not dead and last 2 version",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/vtex/faststore",
     "directory": "packages/sdk"
   },
+  "browserslist": "last 2 chrome version",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -2,7 +2,7 @@
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "include": ["src", "types"],
   "compilerOptions": {
-    "target": "es2019",
+    "target": "esnext",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/vtex/faststore",
     "directory": "packages/ui"
   },
-  "browserslist": "last 2 chrome version",
+  "browserslist": "supports es6-module and not dead and last 2 version",
   "main": "dist/index.js",
   "module": "dist/ui.esm.js",
   "typings": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/vtex/faststore",
     "directory": "packages/ui"
   },
+  "browserslist": "last 2 chrome version",
   "main": "dist/index.js",
   "module": "dist/ui.esm.js",
   "typings": "dist/index.d.ts",

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,8 +1,36 @@
 {
-  "extends": "@vtex/tsconfig",
-  "include": ["src"],
+  // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
+  "include": ["src", "types"],
   "compilerOptions": {
-    "module": "ESNext"
-  },
-  "exclude": ["node_modules", "dist"]
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["dom", "esnext"],
+    "importHelpers": true,
+    // output .d.ts declaration files for consumers
+    "declaration": true,
+    // output .js.map sourcemap files for consumers
+    "sourceMap": true,
+    // match output dir to input dir. e.g. dist/index instead of dist/src/index
+    "rootDir": "./src",
+    // stricter type-checking for stronger correctness. Recommended by TS
+    "strict": true,
+    // linter checks for common issues
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    // use Node's module resolution algorithm, instead of the legacy TS one
+    "moduleResolution": "node",
+    // transpile JSX to React.createElement
+    "jsx": "react",
+    // interop between ESM and CJS modules. Recommended by TS
+    "esModuleInterop": true,
+    // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
+    "skipLibCheck": true,
+    // error out if import and file system have a casing mismatch. Recommended by TS
+    "forceConsistentCasingInFileNames": true,
+    // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
+    "noEmit": true
+  }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR uses tsdx's `browserslist` capabilities to target newer browsers on all `store-*` packages. This way, we hope to remove the need of unnecessary polyfills in our dependencies, like regenerator runtime etc.

By having our deps with newer es versions, we can transpile our dependencies when building the stores, so we can do better browser targeting and differential serving in our infrastructure. If you want to know more about this topic visit https://web.dev/publish-modern-javascript/

## How it works? 
The table below shows some improvements while targeting newer browsers:
| Package | Before(Kb) | After(Kb) |
|:-------:|:----------:|:---------:|
|   SDK   |    6.78    |    3.11   |
|    UI   |    10.29   |    9.89   |

### `base.store` Deploy Preview
https://github.com/vtex-sites/base.store/pull/112

Also, for base.store, we had the following change in bundle sizes: ~2.5% improvement
![image](https://user-images.githubusercontent.com/1753396/142052732-05d09885-a6d7-49f8-b1c8-cca0109bf9e1.png)


## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
