### PR TITLE
fix: facets selection

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -34,16 +34,16 @@ export const IntelligentSearch = (
   ctx: Context
 ) => {
   const base = `http://portal.${environment}.com.br/search-api/v1/${account}`
+  const policyFacet = { key: 'trade-policy', value: ctx.storage.channel }
 
   const addDefaultFacets = (facets: SelectedFacet[]) => {
-    const facetsObj = Object.fromEntries(
-      facets.map(({ key, value }) => [key, value])
-    )
+    const facet = facets.find(({ key }) => key === policyFacet.key)
 
-    return Object.entries({
-      'trade-policy': ctx.storage.channel,
-      ...facetsObj,
-    }).map(([key, value]) => ({ key, value }))
+    if (facet === undefined) {
+      return [...facets, policyFacet]
+    }
+
+    return facets
   }
 
   const search = <T>({


### PR DESCRIPTION
## What's the purpose of this pull request?
API had a problem where it only accepted one type of facet being selected. When multiple were selected it chose one. 

## How it works? 
This PR fixes this issue by not merging the facets, but using another algorithm.

## How to test it?
Go to base.store and select multiple `sizes` in the plp for instance. Compare with both my preview and master. I my preview it should be working as expected.

https://github.com/vtex-sites/base.store/pull/113

Before after in the same path:
![image](https://user-images.githubusercontent.com/1753396/142212588-b9cab526-944c-400b-a522-7fcba1f7f9b6.png)

