### PR TITLE
chore(gatsby-plugin-nginx): Try local files before returning 404

### DIFF
--- a/packages/gatsby-plugin-nginx/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-nginx/src/gatsby-node.ts
@@ -89,7 +89,12 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async (
   const pageRewrites: Redirect[] = pages
     .filter(
       (page) =>
-        typeof page.matchPath === 'string' && page.matchPath !== page.path
+        typeof page.matchPath === 'string' &&
+        page.matchPath !== page.path &&
+        // Remove DSG and SSR from nginx config.
+        // TODO: in the future allow adding a custom rule for these pages
+        page.mode !== 'DSG' &&
+        page.mode !== 'SSR'
     )
     .map((page) => ({
       fromPath: page.matchPath!,

--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -12,6 +12,30 @@ export {
   generateNginxConfiguration,
 }
 
+// Try fetching files from local filesystem. If nothing is found, return =404
+const catchAllLocation = {
+  cmd: ['location', '/'],
+  children: [
+    {
+      cmd: [
+        'add_header',
+        'Cache-Control',
+        '"public, max-age=0, must-revalidate"',
+      ],
+    },
+    {
+      cmd: [
+        'try_files',
+        '$uri',
+        '$uri/',
+        '$uri/index.html',
+        '$uri.html',
+        '=404',
+      ],
+    },
+  ],
+}
+
 function generateNginxConfiguration({
   rewrites,
   headersMap,
@@ -42,6 +66,7 @@ function generateNginxConfiguration({
         }
       ),
     ...generateRewrites(rewrites),
+    catchAllLocation,
   ]
 
   const brotliConf = disableBrotliEncoding

--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -12,30 +12,6 @@ export {
   generateNginxConfiguration,
 }
 
-// Try fetching files from local filesystem. If nothing is found, return =404
-const catchAllLocation = {
-  cmd: ['location', '/'],
-  children: [
-    {
-      cmd: [
-        'add_header',
-        'Cache-Control',
-        '"public, max-age=0, must-revalidate"',
-      ],
-    },
-    {
-      cmd: [
-        'try_files',
-        '$uri',
-        '$uri/',
-        '$uri/index.html',
-        '$uri.html',
-        '=404',
-      ],
-    },
-  ],
-}
-
 function generateNginxConfiguration({
   rewrites,
   headersMap,
@@ -66,7 +42,6 @@ function generateNginxConfiguration({
         }
       ),
     ...generateRewrites(rewrites),
-    catchAllLocation,
   ]
 
   const brotliConf = disableBrotliEncoding

--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -28,6 +28,10 @@ function generateNginxConfiguration({
     writeOnlyLocations,
     serverOptions,
     httpOptions,
+    locations: {
+      append: appendLocations = [],
+      prepend: prependLocations = [],
+    } = {},
   } = options
 
   const filesSet = new Set(files)
@@ -168,7 +172,9 @@ function generateNginxConfiguration({
                   ],
                 },
 
+                ...prependLocations,
                 ...locations,
+                ...appendLocations,
               ],
             },
           ],

--- a/packages/gatsby-plugin-nginx/src/pluginOptions.ts
+++ b/packages/gatsby-plugin-nginx/src/pluginOptions.ts
@@ -12,6 +12,10 @@ const defaultOptions: PluginOptions = {
   plugins: [],
   httpOptions: [['proxy_http_version', '1.1']],
   serverOptions: [['resolver', '8.8.8.8']],
+  locations: {
+    append: [],
+    prepend: [],
+  },
 }
 
 export function pluginOptions(options: Partial<PluginOptions>): PluginOptions {
@@ -37,6 +41,10 @@ export function pluginOptions(options: Partial<PluginOptions>): PluginOptions {
     plugins: options.plugins ?? defaultOptions.plugins,
     httpOptions: options.httpOptions ?? defaultOptions.httpOptions,
     serverOptions: options.serverOptions ?? defaultOptions.serverOptions,
+    locations: {
+      prepend: options.locations?.prepend ?? [],
+      append: options.locations?.append ?? [],
+    },
   }
 }
 

--- a/packages/gatsby-plugin-nginx/src/typings/types.d.ts
+++ b/packages/gatsby-plugin-nginx/src/typings/types.d.ts
@@ -22,9 +22,12 @@ declare global {
     ) => NginxDirective[]
   }
 
-  type Redirect = Parameters<Actions['createRedirect']>[0] & RedirectNginxOptions
+  type Redirect = Parameters<Actions['createRedirect']>[0] &
+    RedirectNginxOptions
 
-  type Page = PageProps['pageResources']['page']
+  type Page = PageProps['pageResources']['page'] & {
+    mode?: 'SSG' | 'SSR' | 'DSG'
+  }
 
   interface Header {
     name: string

--- a/packages/gatsby-plugin-nginx/src/typings/types.d.ts
+++ b/packages/gatsby-plugin-nginx/src/typings/types.d.ts
@@ -89,5 +89,41 @@ declare global {
      * * @default [['proxy_http_version', '1.1']]
      */
     httpOptions: string[][]
+    /**
+     * Add attributes to nginx's locations
+     *
+     * @example
+     * // Serve local files by url
+     * locations: {
+     *    append: {
+     *      cmd: ['location', '/'],
+     *      children: [
+     *        {
+     *          cmd: [
+     *            'add_header',
+     *            'Cache-Control',
+     *            '"public, max-age=0, must-revalidate"',
+     *          ],
+     *        },
+     *        {
+     *          cmd: [
+     *            'try_files',
+     *            '$uri',
+     *            '$uri/',
+     *            '$uri/index.html',
+     *            '$uri.html',
+     *            '=404',
+     *          ],
+     *        },
+     *      ],
+     *    },
+     *  },
+     *
+     * * @default { append: [], prepend: [] }
+     */
+    locations: {
+      append: NginxDirective[]
+      prepend: NginxDirective[]
+    }
   }
 }

--- a/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
+++ b/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
@@ -318,6 +318,10 @@ describe('generateNginxConfiguration', () => {
             add_header a \\"b\\";
             try_files /bar/index.html =404;
           }
+          location / {
+            add_header Cache-Control \\"public, max-age=0, must-revalidate\\";
+            try_files $uri $uri/ $uri/index.html $uri.html =404;
+          }
         }
       }"
     `)

--- a/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
+++ b/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
@@ -259,6 +259,10 @@ describe('generateNginxConfiguration', () => {
       writeOnlyLocations: false,
       serverOptions: [],
       httpOptions: [],
+      locations: {
+        prepend: [],
+        append: [],
+      },
     }
 
     expect(
@@ -353,6 +357,10 @@ describe('generateNginxConfiguration', () => {
       writeOnlyLocations: false,
       serverOptions: [],
       httpOptions: [],
+      locations: {
+        prepend: [],
+        append: [],
+      },
     }
 
     const start = performance.now()

--- a/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
+++ b/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
@@ -318,10 +318,6 @@ describe('generateNginxConfiguration', () => {
             add_header a \\"b\\";
             try_files /bar/index.html =404;
           }
-          location / {
-            add_header Cache-Control \\"public, max-age=0, must-revalidate\\";
-            try_files $uri $uri/ $uri/index.html $uri.html =404;
-          }
         }
       }"
     `)


### PR DESCRIPTION
## What's the purpose of this pull request?
Our current nginx config is generated for serving files that were touched by the Gatsby build. This is ok when you build the whole thing at once. However, when you do incremental builds you need be able to patch the build and serve these newly generated files. 
This PR addresses this issue by adding a hard coded rule in the end of `nginx.confg` that try for local files before returning a 404. The final rule is:
```
location / {
  add_header Cache-Control "public, max-age=0, must-revalidate";
  try_files $uri $uri/ $uri/index.html $uri.html =404;
}
```

Possible drawbacks of this solution is generating a security whole by serving files that should not be served. However, if the file should not be served, it should not be on the filesystem of the server in the first place.

## How to test it?
Make sure everything works at the base deploy preview:
https://github.com/vtex-sites/base.store/pull/120
