### PR TITLE
refactor(sdk): Search serialization

### DIFF
--- a/packages/sdk/src/search/Provider.tsx
+++ b/packages/sdk/src/search/Provider.tsx
@@ -1,7 +1,6 @@
-import React, { createContext, useEffect, useMemo } from 'react'
+import React, { createContext, useMemo } from 'react'
 import type { FC } from 'react'
 
-import { format } from './serializer'
 import { useSearchInfiniteState } from './useInfiniteSearchState'
 import { useSearchState } from './useSearchState'
 import type { UseSearchInfiniteState } from './useInfiniteSearchState'
@@ -24,12 +23,8 @@ export const Provider: FC<Props> = ({
   onChange,
   ...rest
 }) => {
-  const { state, ...searchActions } = useSearchState(rest)
+  const { state, ...searchActions } = useSearchState(rest, onChange)
   const { pages, ...infiniteActions } = useSearchInfiniteState(state.page)
-
-  useEffect(() => {
-    onChange(format(state))
-  }, [onChange, state])
 
   const value = useMemo(
     (): SearchContext => ({

--- a/packages/sdk/src/search/serializer.ts
+++ b/packages/sdk/src/search/serializer.ts
@@ -1,85 +1,50 @@
-import { SDKError } from '../utils/error'
 import { initialize, reducer } from './useSearchState'
 import type { State as SearchState, SearchSort } from './useSearchState'
 
 export const format = (params: SearchState): URL => {
-  const map: string[] = []
-  const query: string[] = []
+  const url = new URL(params.base, 'http://localhost')
+  const { page, selectedFacets, sort, term } = params
 
-  if (params.term !== null) {
-    map.push('term')
-    query.push(params.term)
+  if (term !== null) {
+    url.searchParams.set('q', term)
   }
 
-  for (const facet of params.selectedFacets) {
-    map.push(facet.key)
-    query.push(facet.value)
+  const facets = new Set<string>()
+
+  for (const facet of selectedFacets) {
+    url.searchParams.append(facet.key, facet.value)
+    facets.add(facet.key)
   }
 
-  map.push('sort')
-  query.push(params.sort)
-
-  if (typeof params.page === 'number') {
-    map.push('page')
-    query.push(params.page.toString())
+  if (selectedFacets.length > 0) {
+    url.searchParams.set('facets', Array.from(facets).join(','))
   }
 
-  const url = new URL(`${params.base}${query.join('/')}`, 'http://localhost')
-
-  url.searchParams.set('map', map.join(','))
+  url.searchParams.set('sort', sort)
+  url.searchParams.set('page', page.toString())
 
   return url
 }
 
 export const parse = ({ pathname, searchParams }: URL): SearchState => {
-  const spath = pathname.split('/').slice(1)
-  const smap = searchParams.get('map')?.split(',')
-
-  if (smap === undefined) {
-    throw new SDKError(
-      `Cannot parse selected facets from window.location. Please add a 'map' querystring to the page`
-    )
-  }
-
-  if (smap.length > spath.length) {
-    throw new SDKError(
-      `Invalid map querystring. There are more map params than segments on the path: (map: ${smap.join(
-        ','
-      )}, pathname: ${pathname}). `
-    )
-  }
-
-  const nfacets = smap.length
-  const offset = spath.length - nfacets
   let state = initialize({
-    base: `/${spath.slice(0, offset).join('/')}`,
+    base: pathname,
+    term: searchParams.get('q') ?? null,
+    sort: (searchParams.get('sort') as SearchSort) ?? undefined,
+    page: Number(searchParams.get('page') ?? 0),
   })
 
-  for (let it = 0; it < nfacets; it++) {
-    const key = smap[it]
-    const value = spath[it + offset]
-    const action =
-      key === 'sort'
-        ? {
-            type: 'setSort' as const,
-            payload: value as SearchSort,
-          }
-        : key === 'term'
-        ? {
-            type: 'setTerm' as const,
-            payload: value,
-          }
-        : key === 'page'
-        ? {
-            type: 'setPage' as const,
-            payload: Number(value),
-          }
-        : {
-            type: 'setFacet' as const,
-            payload: { facet: { key, value }, unique: false },
-          }
+  const facets = searchParams.get('facets')?.split(',') ?? []
 
-    state = reducer(state, action)
+  for (const facet of facets) {
+    const values = searchParams.getAll(facet)
+
+    for (const value of values) {
+      state = reducer(state, {
+        type: 'setFacet' as const,
+        payload: { facet: { key: facet, value }, unique: false },
+      })
+    }
   }
 
   return state

--- a/packages/sdk/src/search/useInfiniteSearchState.ts
+++ b/packages/sdk/src/search/useInfiniteSearchState.ts
@@ -35,14 +35,15 @@ export const useSearchInfiniteState = (initialPage: number) => {
     initialPage,
   ])
 
-  return useMemo(
+  const actions = useMemo(
     () => ({
-      pages,
       addPrevPage: () => dispatch({ type: 'addPrev' }),
       addNextPage: () => dispatch({ type: 'addNext' }),
     }),
-    [pages]
+    []
   )
+
+  return { pages, ...actions }
 }
 
 export type UseSearchInfiniteState = ReturnType<typeof useSearchInfiniteState>

--- a/packages/sdk/test/search/serializer.test.ts
+++ b/packages/sdk/test/search/serializer.test.ts
@@ -4,7 +4,7 @@ test('Search State Serializer: Basic serialization', async () => {
   let state = initSearchState()
 
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/score_desc/0?map=sort%2Cpage'
+    'http://localhost/?sort=score_desc&page=0'
   )
 
   state = {
@@ -12,7 +12,7 @@ test('Search State Serializer: Basic serialization', async () => {
     term: 'Hello Wolrd',
   }
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/Hello%20Wolrd/score_desc/0?map=term%2Csort%2Cpage'
+    'http://localhost/?q=Hello+Wolrd&sort=score_desc&page=0'
   )
 
   state = {
@@ -23,7 +23,7 @@ test('Search State Serializer: Basic serialization', async () => {
     ],
   }
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/Hello%20Wolrd/10-to-100/score_desc/0?map=term%2CpriceRange%2Csort%2Cpage'
+    'http://localhost/?q=Hello+Wolrd&priceRange=10-to-100&facets=priceRange&sort=score_desc&page=0'
   )
 
   state = {
@@ -31,7 +31,7 @@ test('Search State Serializer: Basic serialization', async () => {
     sort: 'price_desc',
   }
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/Hello%20Wolrd/10-to-100/price_desc/0?map=term%2CpriceRange%2Csort%2Cpage'
+    'http://localhost/?q=Hello+Wolrd&priceRange=10-to-100&facets=priceRange&sort=price_desc&page=0'
   )
 })
 
@@ -41,7 +41,7 @@ test('Search State Serializer: serialization with base path', async () => {
   })
 
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/pt-br/sale/score_desc/0?map=sort%2Cpage'
+    'http://localhost/pt-br/sale/?sort=score_desc&page=0'
   )
 
   state = {
@@ -49,7 +49,7 @@ test('Search State Serializer: serialization with base path', async () => {
     term: 'Hello Wolrd',
   }
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/pt-br/sale/Hello%20Wolrd/score_desc/0?map=term%2Csort%2Cpage'
+    'http://localhost/pt-br/sale/?q=Hello+Wolrd&sort=score_desc&page=0'
   )
 
   state = {
@@ -60,7 +60,7 @@ test('Search State Serializer: serialization with base path', async () => {
     ],
   }
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/pt-br/sale/Hello%20Wolrd/10-to-100/score_desc/0?map=term%2CpriceRange%2Csort%2Cpage'
+    'http://localhost/pt-br/sale/?q=Hello+Wolrd&priceRange=10-to-100&facets=priceRange&sort=score_desc&page=0'
   )
 
   state = {
@@ -68,7 +68,7 @@ test('Search State Serializer: serialization with base path', async () => {
     sort: 'price_desc',
   }
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/pt-br/sale/Hello%20Wolrd/10-to-100/price_desc/0?map=term%2CpriceRange%2Csort%2Cpage'
+    'http://localhost/pt-br/sale/?q=Hello+Wolrd&priceRange=10-to-100&facets=priceRange&sort=price_desc&page=0'
   )
 })
 
@@ -76,7 +76,7 @@ test('Search State Serializer: Basic parsing', async () => {
   expect(
     parseSearchState(
       new URL(
-        'http://localhost/pt-br/sale/Hello%20Wolrd/10-to-100/score_desc/0?map=term%2CpriceRange%2Csort%2Cpage'
+        'http://localhost/pt-br/sale/?q=Hello+Wolrd&&sort=score_desc&priceRange=10-to-100&page=0&facets=priceRange'
       )
     )
   ).toEqual({
@@ -88,35 +88,33 @@ test('Search State Serializer: Basic parsing', async () => {
       },
     ],
     sort: 'score_desc',
-    term: 'Hello%20Wolrd',
+    term: 'Hello Wolrd',
     page: 0,
   })
 
   expect(
     parseSearchState(
       new URL(
-        'http://localhost/pt-br/sale/Hello%20Wolrd/score_desc/1?map=term%2Csort%2Cpage'
+        'http://localhost/pt-br/sale/?q=Hello+Wolrd&sort=score_desc&page=1'
       )
     )
   ).toEqual({
     base: '/pt-br/sale/',
     selectedFacets: [],
     sort: 'score_desc',
-    term: 'Hello%20Wolrd',
+    term: 'Hello Wolrd',
     page: 1,
   })
 
   expect(
     parseSearchState(
-      new URL(
-        'http://localhost/Hello%20Wolrd/score_desc/10?map=term%2Csort%2Cpage'
-      )
+      new URL('http://localhost/?q=Hello+Wolrd&sort=score_desc&page=10')
     )
   ).toEqual({
     base: '/',
     selectedFacets: [],
     sort: 'score_desc',
-    term: 'Hello%20Wolrd',
+    term: 'Hello Wolrd',
     page: 10,
   })
 })

--- a/packages/sdk/test/search/usePagination.test.tsx
+++ b/packages/sdk/test/search/usePagination.test.tsx
@@ -22,7 +22,7 @@ test('usePagination: paginates forwards', async () => {
   expect(result.current.prev).toBe(false)
   expect(result.current.next).toEqual({
     cursor: 1,
-    link: '/score_desc/1?map=sort%2Cpage',
+    link: '/?sort=score_desc&page=1',
   })
 })
 
@@ -45,6 +45,6 @@ test('usePagination: paginates backwards', async () => {
   expect(result.current.next).toBe(false)
   expect(result.current.prev).toEqual({
     cursor: 0,
-    link: '/score_desc/0?map=sort%2Cpage',
+    link: '/?sort=score_desc&page=0',
   })
 })


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR changes the search serialization strategy. With this new strategy, I hope to better use the CDN by re-using the same html template for all search filters in a given collection 

## How it works? 
Search state comes from the URL. This state contains which filters are applied, which sorting method is selected etc. To apply any change to this state, a navigation to a new URL is required. Serializing/Parsing is an important part of the search flow and can be done in multiple ways. Currently our state is totally serialized into the url using path segments. 
For instance, serializing the following search state
```json
{
   "base":  "",
   "selectedFacest": [{ "key": "category-1", "value": "women"}]
   "sort": "score_desc",
   "page": "0",
   "term": null
}
```
would give us `/women/score_desc/0?map=category-1%2Csort%2Cpage`.

The problem with this approach is that, for each filter we apply, we need to serve an html for that path. The solution proposed on this PR solves this problem by serializing the search state into querystring parameters instead of segments in the path. Serializing te aforementioned state with the proposed solution would gives us:
`/women/?category-1=women&facets=category-1&sort=score_desc&page=0`

## How to test it?
Take a look at base.store for these new change at: https://github.com/vtex-sites/base.store/pull/122