### PR TITLE
fix: add fallback to prevent null facets attribute StoreSearchResult query

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/types/AttributeSearchResult.ts
+++ b/packages/api/src/platforms/vtex/clients/search/types/AttributeSearchResult.ts
@@ -7,7 +7,7 @@ export interface AttributeSearchResult {
   query: string
   operator: string
   fuzzy: string
-  attributes: Attribute[]
+  attributes: Attribute[] | null
 }
 
 export interface Attribute {

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -41,6 +41,6 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const facets = await is.facets(searchArgs)
 
-    return facets.attributes
+    return facets.attributes ?? []
   },
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes collection pages failing to load when they had no facets configured on the VTEX platform. The graphql schema expects a non-null facets array, so an exception was thrown when no facets were returned from the IS server.

## How it works? 
A fallback was added so even if IS returns null, the faststore API will return an empty array.

![Screen Shot 2021-12-06 at 14 35 18](https://user-images.githubusercontent.com/8127610/144894069-88da6083-83ef-43f6-9f8a-86221a179dfe.png)

