### PR TITLE
Fix/schema of analytics events

### DIFF
--- a/packages/sdk/src/analytics/events/add_payment_info.ts
+++ b/packages/sdk/src/analytics/events/add_payment_info.ts
@@ -9,6 +9,6 @@ export interface AddPaymentInfoData {
 }
 
 export interface AddPaymentInfoEvent {
-  type: 'add_payment_info'
-  data: AddPaymentInfoData
+  name: 'add_payment_info'
+  params: AddPaymentInfoData
 }

--- a/packages/sdk/src/analytics/events/add_payment_info.ts
+++ b/packages/sdk/src/analytics/events/add_payment_info.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface AddPaymentInfoData {
+export interface AddPaymentInfoParams {
   currency?: CurrencyCode
   value?: number
   coupon?: string
@@ -10,5 +10,5 @@ export interface AddPaymentInfoData {
 
 export interface AddPaymentInfoEvent {
   name: 'add_payment_info'
-  params: AddPaymentInfoData
+  params: AddPaymentInfoParams
 }

--- a/packages/sdk/src/analytics/events/add_shipping_info.ts
+++ b/packages/sdk/src/analytics/events/add_shipping_info.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface AddShippingInfoData {
+export interface AddShippingInfoParams {
   currency?: CurrencyCode
   value?: number
   coupon?: string
@@ -10,5 +10,5 @@ export interface AddShippingInfoData {
 
 export interface AddShippingInfoEvent {
   name: 'add_shipping_info'
-  params: AddShippingInfoData
+  params: AddShippingInfoParams
 }

--- a/packages/sdk/src/analytics/events/add_shipping_info.ts
+++ b/packages/sdk/src/analytics/events/add_shipping_info.ts
@@ -9,6 +9,6 @@ export interface AddShippingInfoData {
 }
 
 export interface AddShippingInfoEvent {
-  type: 'add_shipping_info'
-  data: AddShippingInfoData
+  name: 'add_shipping_info'
+  params: AddShippingInfoData
 }

--- a/packages/sdk/src/analytics/events/add_to_cart.ts
+++ b/packages/sdk/src/analytics/events/add_to_cart.ts
@@ -7,6 +7,6 @@ export interface AddToCartData {
 }
 
 export interface AddToCartEvent {
-  type: 'add_to_cart'
-  data: AddToCartData
+  name: 'add_to_cart'
+  params: AddToCartData
 }

--- a/packages/sdk/src/analytics/events/add_to_cart.ts
+++ b/packages/sdk/src/analytics/events/add_to_cart.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface AddToCartData {
+export interface AddToCartParams {
   currency?: CurrencyCode
   value?: number
   items?: Item[]
@@ -8,5 +8,5 @@ export interface AddToCartData {
 
 export interface AddToCartEvent {
   name: 'add_to_cart'
-  params: AddToCartData
+  params: AddToCartParams
 }

--- a/packages/sdk/src/analytics/events/add_to_wishlist.ts
+++ b/packages/sdk/src/analytics/events/add_to_wishlist.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface AddToWishlistData {
+export interface AddToWishlistParams {
   currency?: CurrencyCode
   value?: number
   items?: Item[]
@@ -8,5 +8,5 @@ export interface AddToWishlistData {
 
 export interface AddToWishlistEvent {
   name: 'add_to_wishlist'
-  params: AddToWishlistData
+  params: AddToWishlistParams
 }

--- a/packages/sdk/src/analytics/events/add_to_wishlist.ts
+++ b/packages/sdk/src/analytics/events/add_to_wishlist.ts
@@ -7,6 +7,6 @@ export interface AddToWishlistData {
 }
 
 export interface AddToWishlistEvent {
-  type: 'add_to_wishlist'
-  data: AddToWishlistData
+  name: 'add_to_wishlist'
+  params: AddToWishlistData
 }

--- a/packages/sdk/src/analytics/events/begin_checkout.ts
+++ b/packages/sdk/src/analytics/events/begin_checkout.ts
@@ -8,6 +8,6 @@ export interface BeginCheckoutData {
 }
 
 export interface BeginCheckoutEvent {
-  type: 'begin_checkout'
-  data: BeginCheckoutData
+  name: 'begin_checkout'
+  params: BeginCheckoutData
 }

--- a/packages/sdk/src/analytics/events/begin_checkout.ts
+++ b/packages/sdk/src/analytics/events/begin_checkout.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface BeginCheckoutData {
+export interface BeginCheckoutParams {
   currency?: CurrencyCode
   value?: number
   coupon?: string
@@ -9,5 +9,5 @@ export interface BeginCheckoutData {
 
 export interface BeginCheckoutEvent {
   name: 'begin_checkout'
-  params: BeginCheckoutData
+  params: BeginCheckoutParams
 }

--- a/packages/sdk/src/analytics/events/common.ts
+++ b/packages/sdk/src/analytics/events/common.ts
@@ -132,7 +132,7 @@ export interface ItemWithoutIdentifier {
 
 export type Item = ItemUniqueIdentifier & ItemWithoutIdentifier
 
-export interface PromotionProperties {
+export interface PromotionParams {
   creative_name?: string
   creative_slot?: string
   location_id?: string
@@ -140,7 +140,7 @@ export interface PromotionProperties {
   promotion_name?: string
 }
 
-export type PromotionItem = Item & PromotionProperties
+export type PromotionItem = Item & PromotionParams
 
 /**
  * The values for this type were taken from https://github.com/freeall/currency-codes/blob/master/iso-4217-list-one.xml

--- a/packages/sdk/src/analytics/events/login.ts
+++ b/packages/sdk/src/analytics/events/login.ts
@@ -1,10 +1,10 @@
 // This isn't an ecommerce exclusive event, but it makes sense to include it in stores
 
-export interface LoginData {
+export interface LoginParams {
   method?: string
 }
 
 export interface LoginEvent {
   name: 'login'
-  params: LoginData
+  params: LoginParams
 }

--- a/packages/sdk/src/analytics/events/login.ts
+++ b/packages/sdk/src/analytics/events/login.ts
@@ -5,6 +5,6 @@ export interface LoginData {
 }
 
 export interface LoginEvent {
-  type: 'login'
-  data: LoginData
+  name: 'login'
+  params: LoginData
 }

--- a/packages/sdk/src/analytics/events/purchase.ts
+++ b/packages/sdk/src/analytics/events/purchase.ts
@@ -12,6 +12,6 @@ export interface PurchaseData {
 }
 
 export interface PurchaseEvent {
-  type: 'purchase'
-  data: PurchaseData
+  name: 'purchase'
+  params: PurchaseData
 }

--- a/packages/sdk/src/analytics/events/purchase.ts
+++ b/packages/sdk/src/analytics/events/purchase.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface PurchaseData {
+export interface PurchaseParams {
   currency?: CurrencyCode
   transaction_id?: string
   value?: number
@@ -13,5 +13,5 @@ export interface PurchaseData {
 
 export interface PurchaseEvent {
   name: 'purchase'
-  params: PurchaseData
+  params: PurchaseParams
 }

--- a/packages/sdk/src/analytics/events/refund.ts
+++ b/packages/sdk/src/analytics/events/refund.ts
@@ -12,6 +12,6 @@ export interface RefundData {
 }
 
 export interface RefundEvent {
-  type: 'refund'
-  data: RefundData
+  name: 'refund'
+  params: RefundData
 }

--- a/packages/sdk/src/analytics/events/refund.ts
+++ b/packages/sdk/src/analytics/events/refund.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface RefundData {
+export interface RefundParams {
   currency?: CurrencyCode
   transaction_id?: string
   value?: number
@@ -13,5 +13,5 @@ export interface RefundData {
 
 export interface RefundEvent {
   name: 'refund'
-  params: RefundData
+  params: RefundParams
 }

--- a/packages/sdk/src/analytics/events/remove_from_cart.ts
+++ b/packages/sdk/src/analytics/events/remove_from_cart.ts
@@ -7,6 +7,6 @@ export interface RemoveFromCartData {
 }
 
 export interface RemoveFromCartEvent {
-  type: 'remove_from_cart'
-  data: RemoveFromCartData
+  name: 'remove_from_cart'
+  params: RemoveFromCartData
 }

--- a/packages/sdk/src/analytics/events/remove_from_cart.ts
+++ b/packages/sdk/src/analytics/events/remove_from_cart.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface RemoveFromCartData {
+export interface RemoveFromCartParams {
   currency?: CurrencyCode
   value?: number
   items?: Item[]
@@ -8,5 +8,5 @@ export interface RemoveFromCartData {
 
 export interface RemoveFromCartEvent {
   name: 'remove_from_cart'
-  params: RemoveFromCartData
+  params: RemoveFromCartParams
 }

--- a/packages/sdk/src/analytics/events/search.ts
+++ b/packages/sdk/src/analytics/events/search.ts
@@ -5,6 +5,6 @@ export interface SearchData {
 }
 
 export interface SearchEvent {
-  type: 'search'
-  data: SearchData
+  name: 'search'
+  params: SearchData
 }

--- a/packages/sdk/src/analytics/events/search.ts
+++ b/packages/sdk/src/analytics/events/search.ts
@@ -1,10 +1,10 @@
 // This isn't an ecommerce exclusive event, but it makes sense to include it in stores
 
-export interface SearchData {
+export interface SearchParams {
   search_term: string
 }
 
 export interface SearchEvent {
   name: 'search'
-  params: SearchData
+  params: SearchParams
 }

--- a/packages/sdk/src/analytics/events/select_item.ts
+++ b/packages/sdk/src/analytics/events/select_item.ts
@@ -1,6 +1,6 @@
 import type { Item } from './common'
 
-export interface SelectItemData {
+export interface SelectItemParams {
   item_list_id?: string
   item_list_name?: string
   items?: Item[]
@@ -8,5 +8,5 @@ export interface SelectItemData {
 
 export interface SelectItemEvent {
   name: 'select_item'
-  params: SelectItemData
+  params: SelectItemParams
 }

--- a/packages/sdk/src/analytics/events/select_item.ts
+++ b/packages/sdk/src/analytics/events/select_item.ts
@@ -7,6 +7,6 @@ export interface SelectItemData {
 }
 
 export interface SelectItemEvent {
-  type: 'select_item'
-  data: SelectItemData
+  name: 'select_item'
+  params: SelectItemData
 }

--- a/packages/sdk/src/analytics/events/select_promotion.ts
+++ b/packages/sdk/src/analytics/events/select_promotion.ts
@@ -7,6 +7,6 @@ export interface SelectPromotionItems {
 export type SelectPromotionData = PromotionProperties & SelectPromotionItems
 
 export interface SelectPromotionEvent {
-  type: 'select_promotion'
-  data: SelectPromotionData
+  name: 'select_promotion'
+  params: SelectPromotionData
 }

--- a/packages/sdk/src/analytics/events/select_promotion.ts
+++ b/packages/sdk/src/analytics/events/select_promotion.ts
@@ -1,12 +1,12 @@
-import type { PromotionItem, PromotionProperties } from './common'
+import type { PromotionItem, PromotionParams } from './common'
 
 export interface SelectPromotionItems {
   items?: PromotionItem[]
 }
 
-export type SelectPromotionData = PromotionProperties & SelectPromotionItems
+export type SelectPromotionParams = PromotionParams & SelectPromotionItems
 
 export interface SelectPromotionEvent {
   name: 'select_promotion'
-  params: SelectPromotionData
+  params: SelectPromotionParams
 }

--- a/packages/sdk/src/analytics/events/share.ts
+++ b/packages/sdk/src/analytics/events/share.ts
@@ -1,6 +1,6 @@
 // This isn't an ecommerce exclusive event, but it makes sense to include it in stores
 
-export interface ShareData {
+export interface ShareParams {
   method?: string
   content_type?: string
   item_id?: string
@@ -8,5 +8,5 @@ export interface ShareData {
 
 export interface ShareEvent {
   name: 'share'
-  params: ShareData
+  params: ShareParams
 }

--- a/packages/sdk/src/analytics/events/share.ts
+++ b/packages/sdk/src/analytics/events/share.ts
@@ -7,6 +7,6 @@ export interface ShareData {
 }
 
 export interface ShareEvent {
-  type: 'share'
-  data: ShareData
+  name: 'share'
+  params: ShareData
 }

--- a/packages/sdk/src/analytics/events/signup.ts
+++ b/packages/sdk/src/analytics/events/signup.ts
@@ -5,6 +5,6 @@ export interface SignupData {
 }
 
 export interface SignupEvent {
-  type: 'signup'
-  data: SignupData
+  name: 'signup'
+  params: SignupData
 }

--- a/packages/sdk/src/analytics/events/signup.ts
+++ b/packages/sdk/src/analytics/events/signup.ts
@@ -1,10 +1,10 @@
 // This isn't an ecommerce exclusive event, but it makes sense to include it in stores
 
-export interface SignupData {
+export interface SignupParams {
   method?: string
 }
 
 export interface SignupEvent {
   name: 'signup'
-  params: SignupData
+  params: SignupParams
 }

--- a/packages/sdk/src/analytics/events/view_cart.ts
+++ b/packages/sdk/src/analytics/events/view_cart.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface ViewCartData {
+export interface ViewCartParams {
   currency?: CurrencyCode
   value?: number
   items?: Item[]
@@ -8,5 +8,5 @@ export interface ViewCartData {
 
 export interface ViewCartEvent {
   name: 'view_cart'
-  params: ViewCartData
+  params: ViewCartParams
 }

--- a/packages/sdk/src/analytics/events/view_cart.ts
+++ b/packages/sdk/src/analytics/events/view_cart.ts
@@ -7,6 +7,6 @@ export interface ViewCartData {
 }
 
 export interface ViewCartEvent {
-  type: 'view_cart'
-  data: ViewCartData
+  name: 'view_cart'
+  params: ViewCartData
 }

--- a/packages/sdk/src/analytics/events/view_item.ts
+++ b/packages/sdk/src/analytics/events/view_item.ts
@@ -7,6 +7,6 @@ export interface ViewItemData {
 }
 
 export interface ViewItemEvent {
-  type: 'view_item'
-  data: ViewItemData
+  name: 'view_item'
+  params: ViewItemData
 }

--- a/packages/sdk/src/analytics/events/view_item.ts
+++ b/packages/sdk/src/analytics/events/view_item.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface ViewItemData {
+export interface ViewItemParams {
   currency?: CurrencyCode
   value?: number
   items?: Item[]
@@ -8,5 +8,5 @@ export interface ViewItemData {
 
 export interface ViewItemEvent {
   name: 'view_item'
-  params: ViewItemData
+  params: ViewItemParams
 }

--- a/packages/sdk/src/analytics/events/view_item_list.ts
+++ b/packages/sdk/src/analytics/events/view_item_list.ts
@@ -1,6 +1,6 @@
 import type { Item } from './common'
 
-export interface ViewItemListData {
+export interface ViewItemListParams {
   item_list_id?: string
   item_list_name?: string
   items?: Item[]
@@ -8,5 +8,5 @@ export interface ViewItemListData {
 
 export interface ViewItemListEvent {
   name: 'view_item_list'
-  params: ViewItemListData
+  params: ViewItemListParams
 }

--- a/packages/sdk/src/analytics/events/view_item_list.ts
+++ b/packages/sdk/src/analytics/events/view_item_list.ts
@@ -7,6 +7,6 @@ export interface ViewItemListData {
 }
 
 export interface ViewItemListEvent {
-  type: 'view_item_list'
-  data: ViewItemListData
+  name: 'view_item_list'
+  params: ViewItemListData
 }

--- a/packages/sdk/src/analytics/events/view_promotion.ts
+++ b/packages/sdk/src/analytics/events/view_promotion.ts
@@ -1,12 +1,12 @@
-import type { PromotionItem, PromotionProperties } from './common'
+import type { PromotionItem, PromotionParams } from './common'
 
 export interface ViewPromotionItems {
   items?: PromotionItem[]
 }
 
-export type ViewPromotionData = PromotionProperties & ViewPromotionItems
+export type ViewPromotionParams = PromotionParams & ViewPromotionItems
 
 export interface ViewPromotionEvent {
   name: 'view_promotion'
-  params: ViewPromotionData
+  params: ViewPromotionParams
 }

--- a/packages/sdk/src/analytics/events/view_promotion.ts
+++ b/packages/sdk/src/analytics/events/view_promotion.ts
@@ -7,6 +7,6 @@ export interface ViewPromotionItems {
 export type ViewPromotionData = PromotionProperties & ViewPromotionItems
 
 export interface ViewPromotionEvent {
-  type: 'view_promotion'
-  data: ViewPromotionData
+  name: 'view_promotion'
+  params: ViewPromotionData
 }

--- a/packages/sdk/src/analytics/useAnalyticsEvent.ts
+++ b/packages/sdk/src/analytics/useAnalyticsEvent.ts
@@ -9,7 +9,7 @@ export const useAnalyticsEvent = <T extends UnknownEvent = UnknownEvent>(
   const callback = useCallback(
     (message: MessageEvent) => {
       try {
-        if (message.data.type !== ANALYTICS_EVENT_TYPE) {
+        if ((message.data as UnknownEvent).name !== ANALYTICS_EVENT_TYPE) {
           return
         }
 

--- a/packages/sdk/src/analytics/wrap.ts
+++ b/packages/sdk/src/analytics/wrap.ts
@@ -41,22 +41,22 @@ export type AnalyticsEvent =
   | ShareEvent
 
 export interface UnknownEvent {
-  type: string
-  data: unknown
+  name: string
+  params: unknown
 }
 
 export type WrappedAnalyticsEventData<T extends UnknownEvent> = Omit<
   T,
-  'type'
+  'name'
 > & {
   // Sadly tsdx doesn't support typescript 4.x yet. We should change this type to this when it does:
-  // type: `store:${T['type']}`
-  type: string
+  // name: `store:${T['name']}`
+  name: string
 }
 
 export interface WrappedAnalyticsEvent<T extends UnknownEvent> {
-  type: 'AnalyticsEvent'
-  data: WrappedAnalyticsEventData<T>
+  name: 'AnalyticsEvent'
+  params: WrappedAnalyticsEventData<T>
 }
 
 export const STORE_EVENT_PREFIX = 'store:'
@@ -66,10 +66,10 @@ export const wrap = <T extends UnknownEvent>(
   event: T
 ): WrappedAnalyticsEvent<T> =>
   ({
-    type: ANALYTICS_EVENT_TYPE,
-    data: {
+    name: ANALYTICS_EVENT_TYPE,
+    params: {
       ...event,
-      type: `${STORE_EVENT_PREFIX}${event.type}`,
+      name: `${STORE_EVENT_PREFIX}${event.name}`,
     },
   } as WrappedAnalyticsEvent<T>)
 
@@ -77,10 +77,10 @@ export const unwrap = <T extends UnknownEvent>(
   event: WrappedAnalyticsEvent<T>
 ): T => {
   return {
-    ...event.data,
-    type: event.data.type.slice(
+    ...event.params,
+    name: event.params.name.slice(
       STORE_EVENT_PREFIX.length,
-      event.data.type.length
+      event.params.name.length
     ),
   } as T
 }

--- a/packages/sdk/src/analytics/wrap.ts
+++ b/packages/sdk/src/analytics/wrap.ts
@@ -45,7 +45,7 @@ export interface UnknownEvent {
   params: unknown
 }
 
-export type WrappedAnalyticsEventData<T extends UnknownEvent> = Omit<
+export type WrappedAnalyticsEventParams<T extends UnknownEvent> = Omit<
   T,
   'name'
 > & {
@@ -56,7 +56,7 @@ export type WrappedAnalyticsEventData<T extends UnknownEvent> = Omit<
 
 export interface WrappedAnalyticsEvent<T extends UnknownEvent> {
   name: 'AnalyticsEvent'
-  params: WrappedAnalyticsEventData<T>
+  params: WrappedAnalyticsEventParams<T>
 }
 
 export const STORE_EVENT_PREFIX = 'store:'

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,52 +1,58 @@
-export type { ShareEvent, ShareData } from './analytics/events/share'
-export type { SearchEvent, SearchData } from './analytics/events/search'
-export type { SignupEvent, SignupData } from './analytics/events/signup'
-export type { LoginEvent, LoginData } from './analytics/events/login'
-export type { RefundEvent, RefundData } from './analytics/events/refund'
-export type { PurchaseEvent, PurchaseData } from './analytics/events/purchase'
+export type { ShareEvent, ShareParams } from './analytics/events/share'
+export type { SearchEvent, SearchParams } from './analytics/events/search'
+export type { SignupEvent, SignupParams } from './analytics/events/signup'
+export type { LoginEvent, LoginParams } from './analytics/events/login'
+export type { RefundEvent, RefundParams } from './analytics/events/refund'
+export type { PurchaseEvent, PurchaseParams } from './analytics/events/purchase'
 export type {
   AddShippingInfoEvent,
-  AddShippingInfoData,
+  AddShippingInfoParams,
 } from './analytics/events/add_shipping_info'
 export type {
   AddPaymentInfoEvent,
-  AddPaymentInfoData,
+  AddPaymentInfoParams,
 } from './analytics/events/add_payment_info'
 export type {
   BeginCheckoutEvent,
-  BeginCheckoutData,
+  BeginCheckoutParams,
 } from './analytics/events/begin_checkout'
-export type { ViewCartEvent, ViewCartData } from './analytics/events/view_cart'
+export type {
+  ViewCartEvent,
+  ViewCartParams,
+} from './analytics/events/view_cart'
 export type {
   RemoveFromCartEvent,
-  RemoveFromCartData,
+  RemoveFromCartParams,
 } from './analytics/events/remove_from_cart'
 export type {
   AddToCartEvent,
-  AddToCartData,
+  AddToCartParams,
 } from './analytics/events/add_to_cart'
 export type {
   SelectItemEvent,
-  SelectItemData,
+  SelectItemParams,
 } from './analytics/events/select_item'
 export type {
   AddToWishlistEvent,
-  AddToWishlistData,
+  AddToWishlistParams,
 } from './analytics/events/add_to_wishlist'
 export type {
   SelectPromotionEvent,
-  SelectPromotionData,
+  SelectPromotionParams,
   SelectPromotionItems,
 } from './analytics/events/select_promotion'
 export type {
   ViewPromotionEvent,
-  ViewPromotionData,
+  ViewPromotionParams,
   ViewPromotionItems,
 } from './analytics/events/view_promotion'
-export type { ViewItemEvent, ViewItemData } from './analytics/events/view_item'
+export type {
+  ViewItemEvent,
+  ViewItemParams,
+} from './analytics/events/view_item'
 export type {
   ViewItemListEvent,
-  ViewItemListData,
+  ViewItemListParams,
 } from './analytics/events/view_item_list'
 export type {
   ItemId,
@@ -54,14 +60,14 @@ export type {
   ItemUniqueIdentifier,
   ItemWithoutIdentifier,
   Item,
-  PromotionProperties,
+  PromotionParams,
   PromotionItem,
   CurrencyCode,
 } from './analytics/events/common'
 export type {
   AnalyticsEvent,
   WrappedAnalyticsEvent,
-  WrappedAnalyticsEventData,
+  WrappedAnalyticsEventParams,
   UnknownEvent,
 } from './analytics/wrap'
 export { STORE_EVENT_PREFIX, ANALYTICS_EVENT_TYPE } from './analytics/wrap'

--- a/packages/sdk/test/analytics/__fixtures__/EventSamples.ts
+++ b/packages/sdk/test/analytics/__fixtures__/EventSamples.ts
@@ -2,44 +2,44 @@ import type { AddToCartEvent } from '../../../src/analytics/events/add_to_cart'
 import type { WrappedAnalyticsEvent } from '../../../src/analytics/wrap'
 
 export interface CustomEvent {
-  type: 'custom_event'
-  data: {
-    customDataProperty: string
+  name: 'custom_event'
+  params: {
+    customParam: string
   }
   customProperty: string
 }
 
 export const CUSTOM_EVENT_SAMPLE: CustomEvent = {
-  type: 'custom_event',
-  data: {
-    customDataProperty: 'value',
+  name: 'custom_event',
+  params: {
+    customParam: 'value',
   },
   customProperty: 'value',
 }
 
 export const WRAPPED_CUSTOM_EVENT_SAMPLE: WrappedAnalyticsEvent<CustomEvent> = {
-  type: 'AnalyticsEvent',
-  data: {
-    type: 'store:custom_event',
-    data: {
-      customDataProperty: 'value',
+  name: 'AnalyticsEvent',
+  params: {
+    name: 'store:custom_event',
+    params: {
+      customParam: 'value',
     },
     customProperty: 'value',
   },
 }
 
 export const ADD_TO_CART_SAMPLE: AddToCartEvent = {
-  type: 'add_to_cart',
-  data: {
+  name: 'add_to_cart',
+  params: {
     items: [{ item_id: 'PRODUCT_ID' }],
   },
 }
 
 export const WRAPPED_ADD_TO_CART_SAMPLE: WrappedAnalyticsEvent<AddToCartEvent> = {
-  type: 'AnalyticsEvent',
-  data: {
-    type: 'store:add_to_cart',
-    data: {
+  name: 'AnalyticsEvent',
+  params: {
+    name: 'store:add_to_cart',
+    params: {
       items: [{ item_id: 'PRODUCT_ID' }],
     },
   },

--- a/packages/sdk/test/analytics/useAnalyticsEvent.test.ts
+++ b/packages/sdk/test/analytics/useAnalyticsEvent.test.ts
@@ -31,7 +31,7 @@ describe('useAnalyticsEvent', () => {
       if (typeof fn === 'function') {
         fn(
           new MessageEvent('message', {
-            data: { ...wrap(ADD_TO_CART_SAMPLE), type: 'OtherEventType' },
+            data: { ...wrap(ADD_TO_CART_SAMPLE), name: 'OtherEventType' },
           })
         )
       }

--- a/packages/sdk/test/analytics/wrap.test.ts
+++ b/packages/sdk/test/analytics/wrap.test.ts
@@ -2,24 +2,24 @@ import { wrap, unwrap } from '../../src/analytics/wrap'
 import { ADD_TO_CART_SAMPLE } from './__fixtures__/EventSamples'
 
 describe('wrap and unwrap functions', () => {
-  it('wrap function wraps event with AnalyticsEvent type', () => {
-    const { type } = wrap(ADD_TO_CART_SAMPLE)
+  it('wrap function wraps event with AnalyticsEvent name', () => {
+    const { name } = wrap(ADD_TO_CART_SAMPLE)
 
-    expect(type).toBe('AnalyticsEvent')
+    expect(name).toBe('AnalyticsEvent')
   })
 
-  it('wrap function prefixes the event type', () => {
+  it('wrap function prefixes the event name', () => {
     const wrappedEvent = wrap(ADD_TO_CART_SAMPLE)
-    const { type: wrappedEventType } = wrappedEvent.data
-    const { type: originalType } = ADD_TO_CART_SAMPLE
+    const { name: wrappedEventType } = wrappedEvent.params
+    const { name: originalType } = ADD_TO_CART_SAMPLE
 
     expect(wrappedEventType).toBe(`store:${originalType}`)
   })
 
-  it('wrap function preserves all event data but the type', () => {
+  it('wrap function preserves all event properties but the name', () => {
     const wrappedEvent = wrap(ADD_TO_CART_SAMPLE)
-    const { type: _, ...wrappedEventRest } = wrappedEvent.data
-    const { type: __, ...originalEventRest } = ADD_TO_CART_SAMPLE
+    const { name: _, ...wrappedEventRest } = wrappedEvent.params
+    const { name: __, ...originalEventRest } = ADD_TO_CART_SAMPLE
 
     expect(wrappedEventRest).toStrictEqual(originalEventRest)
   })


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR makes the top level types and schemas match the nomenclature of GA's [measurement protocol](https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag).

## How it works? 
The `type` and `data` properties were renamed to `name` and `params` respectively. All the references to those names and variables were also updated.

## How to test it?
The tests from the base.store is a great validation, but if you want to go deeper, I recommend you to check the `window.dataLayer` array for the events that live there.

### `base.store` Deploy Preview
https://github.com/vtex-sites/base.store/pull/129

## References
[Measurement Protocol](https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag)