### PR TITLE
Fix: Adds back missing css imports

### DIFF
--- a/themes/theme-b2c-tailwind/src/molecules/index.css
+++ b/themes/theme-b2c-tailwind/src/molecules/index.css
@@ -11,3 +11,5 @@
 @import './payment-methods.css';
 @import './price-range.css';
 @import './radio-group.css';
+@import './search-input.css';
+@import './table.css';


### PR DESCRIPTION
## What's the purpose of this pull request?
Sorry! I probably made a mistake while merging [this](https://github.com/vtex/faststore/pull/1048/files#diff-bcac487ddf0a40be314da14a715f3226436d8d07cd6433fc4359ec4cadfe3f16L1)!  😓

This PR is to put back missing css imports on `/theme-b2c-tailwind/src/molecules/index.css`

## How it works? 
<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### `base.store` Deploy Preview
<!--- Add a link to a deploy preview from `base.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
