### PR TITLE
fix: expose JS files only

### DIFF
--- a/packages/graphql-utils/package.json
+++ b/packages/graphql-utils/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "main": "dist/index.js",
-  "browser": "src/index.ts",
+  "browser": "dist/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "scripts": {

--- a/packages/ui/src/utils/toHaveNoIncomplete.ts
+++ b/packages/ui/src/utils/toHaveNoIncomplete.ts
@@ -65,7 +65,7 @@ export const toHaveNoIncompletes = {
 declare global {
   // eslint-disable-next-line
   namespace jest {
-    interface Matchers<R, T> {
+    interface Matchers<R> {
       toHaveNoIncompletes(): R
     }
   }


### PR DESCRIPTION
## What's the purpose of this pull request?
Make graphql-utils compatible with other frameworks

## How it works? 
graphql-utils was exposign the index file via typescript. This is ok when using Gatsby, however, other frameworks like Next.JS do not compile node_modules and may break when using this package. To solve this problem I'm just exposing the js file only

