### PR TITLE
Chore: Improves InputSearch usability

### DIFF
--- a/packages/ui/src/molecules/Banner/BannerContent.tsx
+++ b/packages/ui/src/molecules/Banner/BannerContent.tsx
@@ -1,8 +1,7 @@
 import type { HTMLAttributes } from 'react'
 import React, { forwardRef } from 'react'
 
-export interface BannerContentProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'role'> {
+export interface BannerContentProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
@@ -17,7 +16,6 @@ const BannerContent = forwardRef<HTMLDivElement, BannerContentProps>(
     return (
       <div
         ref={ref}
-        role="region"
         data-store-banner-content
         data-testid={testId}
         {...otherProps}

--- a/packages/ui/src/molecules/SearchInput/SearchInput.tsx
+++ b/packages/ui/src/molecules/SearchInput/SearchInput.tsx
@@ -77,6 +77,7 @@ const SearchInput = forwardRef<HTMLFormElement, SearchInputProps>(
         data-store-search-input
         data-testid={testId}
         onSubmit={handleSubmit}
+        role="search"
       >
         <Input ref={valueRef} aria-label={ariaLabel} {...otherProps} />
         <Button type="submit" aria-label="Submit Search">

--- a/packages/ui/src/molecules/SearchInput/SearchInput.tsx
+++ b/packages/ui/src/molecules/SearchInput/SearchInput.tsx
@@ -79,7 +79,7 @@ const SearchInput = forwardRef<HTMLFormElement, SearchInputProps>(
         onSubmit={handleSubmit}
       >
         <Input ref={valueRef} aria-label={ariaLabel} {...otherProps} />
-        <Button type="submit" aria-label={`button-${ariaLabel}`}>
+        <Button type="submit" aria-label="Submit Search">
           <Icon component={icon ?? <SearchIcon />} />
         </Button>
       </Form>


### PR DESCRIPTION
## What's the purpose of this pull request?

- I wanted to add `role=search` to the `Form` component inside the `InputSearch`, but I noticed that the `props` are being 
applied to the `<Input>`. So, I thought it might be good to add it directly to this `InputSearch` component.


- The word button was unnecessarily repetitive, so I changed it to be more contextual to provide a better experience.


https://user-images.githubusercontent.com/3356699/146251127-db8d13d5-788a-4286-839d-747bdf9097ea.mov

- Also took the opportunity to remove the misused `role=region` for the `BannerContent` component.

## How it works? 
<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### `base.store` Deploy Preview
<!--- Add a link to a deploy preview from `base.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References
- [ARIA: search role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/search_role)
