### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: 'Thanks for reporting a bug. In case this report is not related to the FastStore,
+  we recommend posting it on the VTEX community: https://community.vtex.com/'
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Current behavior**
+A clear and concise description of what is happening to cause the bug.
+
+**Steps to reproduce**
+A step-by-step on how to reproduce the bug behavior.
+1. ‘...’
+2. ‘...’
+3. ‘...’
+
+**Possible Solution**
+If applicable, describe a possible solution to fix the bug.
+
+**Workspace**
+Add a workspace where you tested the bug behavior.
+
+**Additional context**
+Add any other context, screenshots, or comments about the problem.

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -1,0 +1,18 @@
+---
+name: Documentation request
+about: 'Thanks for contributing. In case this request is not related to the FastStore,
+  we recommend posting it on the VTEX community: https://community.vtex.com/'
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+**Documentation description**
+A clear and concise description of what you'd like to see documented. 
+
+**Additional context**
+Add any other context or comment about the request.
+
+**References**
+Add a link or a list of helpful references to the documentation requested.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,10 +15,7 @@ A clear and concise description of what you want to happen.
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Additional context**
-Add any other context or comment about the request.
+Add any other context or screenshots about the feature request here.
 
 **References**
 Add a link or a list of references to the feature requested. 
-
-**Additional context**
-Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: 'Thanks for contributing. In case this request is not related to the FastStore,
+  we recommend posting it on the VTEX community: https://community.vtex.com/'
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Describe the feature you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or comment about the request.
+
+**References**
+Add a link or a list of references to the feature requested. 
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,18 @@
+---
+name: Question
+about: 'Thanks for your question. In case this question is not related to the FastStore,
+  we recommend posting it on the VTEX community: https://community.vtex.com/'
+title: ''
+labels: good first issue, question
+assignees: ''
+
+---
+
+**What are you trying to accomplish? Please describe.**
+A clear and concise description of what is your question and what you're trying to accomplish.
+
+**What have you tried so far?**
+A clear and concise description of what you tried to do already.
+
+**Additional context**
+Add any other context or comment about your question.


### PR DESCRIPTION
## What's the purpose of this pull request?

Currently, the FastStore repo does not have issue templates. Those templates are helpful to give guidance to contributors, better address the issue they want to communicate, and help receive the right resources for the request.

## How does it work?
When someone wants to open an issue, they will have the following template's options:

- Bug report
- Feature request
- Documentation request
- Question

## References:

[About issue and pull request templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates)