### PR TITLE
Chore: Uses section instead of aria role on CardContent component

### DIFF
--- a/packages/ui/src/organisms/Card/CardContent.tsx
+++ b/packages/ui/src/organisms/Card/CardContent.tsx
@@ -1,38 +1,27 @@
-import type { HTMLAttributes, AriaAttributes } from 'react'
+import type { HTMLAttributes } from 'react'
 import React, { forwardRef } from 'react'
 
-export interface CardContentProps extends HTMLAttributes<HTMLDivElement> {
+export interface CardContentProps extends HTMLAttributes<HTMLElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
   testId?: string
-  /**
-   * Defines a string value that labels the current element.
-   */
-  'aria-label'?: AriaAttributes['aria-label']
 }
 
-const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
+const CardContent = forwardRef<HTMLElement, CardContentProps>(
   function CardContent(
-    {
-      testId = 'store-card-content',
-      'aria-label': ariaLabel = 'Card content',
-      children,
-      ...otherProps
-    },
+    { testId = 'store-card-content', children, ...otherProps },
     ref
   ) {
     return (
-      <div
+      <section
         ref={ref}
-        role="region"
-        aria-label={ariaLabel}
         data-store-card-content
         data-testid={testId}
         {...otherProps}
       >
         {children}
-      </div>
+      </section>
     )
   }
 )


### PR DESCRIPTION
## What's the purpose of this pull request?

- Changes `CardContent` component to `<section>` instead of using `role=region`

> Using the `<section>` element will automatically communicate a section has a role of region if it is given an accessible name. Developers should always prefer using the correct semantic HTML element, in this case `<section>`, over using ARIA ([role=region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role)).

I thought about 3 approaches that we could use to improve the accessibility of this component:
1. Removes the default `'aria-label': ariaLabel = 'Card content'`
- The ideal would be the user pass a different string here, but we aren't ensuring it. Typically a heading will be use inside it.
- Why not keep the default string? Considering that we are using this Card component in a list with other cards, we will probably get [landmark-unique issue](https://dequeuniversity.com/rules/axe/4.1/landmark-unique?application=RuleDescription) 

2. Make sure to pass an `aria-label` string when using the component in the application:
But it could sound very wordy for someone using the screen reader, for example. 🤔

https://user-images.githubusercontent.com/3356699/147280185-ff8f6598-9fe0-4988-a23a-6ed8a3cd9dcc.mov

3. So, I'm proposing to replace it with `<section>` to avoid these problems, and whoever is using it choose to use it the better way (Trust to be trusted)

In the future, we should add a `Component Guidelines` section giving more details about it.

## How it works? 
<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### `base.store` Deploy Preview
<!--- Add a link to a deploy preview from `base.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

- https://dequeuniversity.com/rules/axe/4.1/landmark-unique?application=RuleDescription
- https://www.w3.org/TR/wai-aria-practices/examples/landmarks/region.html
- https://stackoverflow.com/questions/65721709/why-is-there-no-htmlsectionelement-and-no-htmlarticleelement-in-javascript



