### PR TITLE
fix(ui): removing aria-labelledby from payment methods component

### DIFF
--- a/packages/ui/src/molecules/PaymentMethods/PaymentMethods.tsx
+++ b/packages/ui/src/molecules/PaymentMethods/PaymentMethods.tsx
@@ -45,7 +45,6 @@ const PaymentMethods = forwardRef<HTMLDivElement, PaymentMethodsProps>(
         {!!title && <div id="payment-methods">{title}</div>}
         <div
           data-payment-methods-flags
-          aria-labelledby={title ? 'payment-methods' : undefined}
           aria-label={title ? undefined : ariaLabel}
         >
           {children}

--- a/packages/ui/src/molecules/PaymentMethods/PaymentMethods.tsx
+++ b/packages/ui/src/molecules/PaymentMethods/PaymentMethods.tsx
@@ -42,7 +42,7 @@ const PaymentMethods = forwardRef<HTMLDivElement, PaymentMethodsProps>(
         data-testid={testId}
         {...otherProps}
       >
-        {!!title && <div id="payment-methods">{title}</div>}
+        {!!title && <div>{title}</div>}
         <div
           data-payment-methods-flags
           aria-label={title ? undefined : ariaLabel}


### PR DESCRIPTION
## What's the purpose of this pull request?
The payment methods component was returning an accessibility error on storybook:
![image](https://user-images.githubusercontent.com/22377378/147774831-d9176deb-498d-455f-8d95-97830d5cde72.png)

To solve it, `aria-labelledby` was removed.
