### PR TITLE
Fix ordering of breadcrumbList

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -26,7 +26,7 @@ export const StoreProduct: Record<string, Resolver<Root>> = {
   brand: ({ isVariantOf: { brand } }) => ({ name: brand }),
   breadcrumbList: ({ isVariantOf: { categoryTrees, name, link }, id }) => ({
     itemListElement: [
-      ...categoryTrees.map(({ categoryNames }, index) => ({
+      ...categoryTrees.reverse().map(({ categoryNames }, index) => ({
         name: categoryNames[categoryNames.length - 1],
         item: `/${categoryNames.join('/').toLowerCase()}`,
         position: index + 1,


### PR DESCRIPTION
## What's the purpose of this pull request?
After integrating the Breadcrumb component onto base.store, @israelswf and @lucasfp13 realized that the ordering of the categories on the breadcrumbs is reversed based on what comes from the API and what shows up on GraphQL. This PR reverts the `categoryTrees` before resolving the query.

Current API result:

```
...
  "categoryTrees":[
    {
      "categoryNames":[
        "Computer and Software",
        "Gadgets"
      ],
      "categoryIds":[
        "9286",
        "9292"
      ]
    },
    {
      "categoryNames":[
        "Computer and Software"
      ],
      "categoryIds":[
        "9286"
      ]
    }
  ],
  "images":[
    {
      "name":"deleniti",
      "value":"http://storeframework.vteximg.com.br/arquivos/ids/187078/in.jpg?v=637755572312800000"
    }
  ],
  "name":"Licensed Rubber Salad Handcrafted"
...
```

Current GraphQL result:

```
{
  "data": {
    "storeProduct": {
      "breadcrumbList": {
        "itemListElement": [
          {
            "item": "/computer and software/gadgets",
            "name": "Gadgets",
            "position": 1,
            "remoteTypeName": "StoreListItem"
          },
          {
            "item": "/computer and software",
            "name": "Computer and Software",
            "position": 2,
            "remoteTypeName": "StoreListItem"
          },
          {
            "item": "/licensed-rubber-salad-handcrafted-48361956/p",
            "name": "Licensed Rubber Salad Handcrafted",
            "position": 3,
            "remoteTypeName": "StoreListItem"
          }
        ]
      }
    }
  },
  "extensions": {
    "enableRefresh": "true"
  }
}
```

After the changes made in this PR we will process the categoryTrees in the reverse order and the GraphQL result should be:

````
{
  "data": {
    "storeProduct": {
      "breadcrumbList": {
        "itemListElement": [
          {
            "item": "/computer and software",
            "name": "Computer and Software",
            "position": 1,
            "remoteTypeName": "StoreListItem"
          },
          {
            "item": "/computer and software/gadgets",
            "name": "Gadgets",
            "position": 2,
            "remoteTypeName": "StoreListItem"
          },
          {
            "item": "/licensed-rubber-salad-handcrafted-48361956/p",
            "name": "Licensed Rubber Salad Handcrafted",
            "position": 3,
            "remoteTypeName": "StoreListItem"
          }
        ]
      }
    }
  },
  "extensions": {
    "enableRefresh": "true"
  }
}
```

I've checked with another production account and this also happens.