### PR TITLE
fix: Thumbor options

### DIFF
--- a/packages/gatsby-plugin-thumbor/src/index.ts
+++ b/packages/gatsby-plugin-thumbor/src/index.ts
@@ -1,8 +1,8 @@
 export { urlBuilder } from './utils/urlBuilder'
 export { getThumborImageData } from './utils/getImageData'
-export type { ThumborImageDataOptions } from './utils/getImageData'
 
 export { Provider } from './Provider'
 export { useUrlBuilder } from './useUrlBuilder'
 export { useThumborImageData } from './useThumborImageData'
 export { useGetThumborImageData } from './useGetThumborImageData'
+export type { ThumborImageOptions } from './useThumborImageData'

--- a/packages/gatsby-plugin-thumbor/src/useGetThumborImageData.ts
+++ b/packages/gatsby-plugin-thumbor/src/useGetThumborImageData.ts
@@ -2,13 +2,13 @@ import { useCallback } from 'react'
 
 import { useContext } from './Provider'
 import { getThumborImageData } from './utils/getImageData'
-import type { ThumborImageDataOptions } from './utils/getImageData'
+import type { ThumborImageOptions } from './useThumborImageData'
 
 export const useGetThumborImageData = () => {
   const { server, basePath } = useContext()
 
   const getImageData = useCallback(
-    (options: ThumborImageDataOptions) =>
+    (options: ThumborImageOptions) =>
       getThumborImageData({
         ...options,
         options: {

--- a/packages/gatsby-plugin-thumbor/src/useThumborImageData.ts
+++ b/packages/gatsby-plugin-thumbor/src/useThumborImageData.ts
@@ -2,9 +2,15 @@ import { useMemo } from 'react'
 
 import { useContext } from './Provider'
 import { getThumborImageData } from './utils/getImageData'
+import type { ThumborProps } from './utils/urlBuilder'
 import type { ThumborImageDataOptions } from './utils/getImageData'
 
-export const useThumborImageData = (options: ThumborImageDataOptions) => {
+export interface ThumborImageOptions
+  extends Omit<ThumborImageDataOptions, 'options'> {
+  options?: Omit<ThumborProps, 'server'>
+}
+
+export const useThumborImageData = (options: ThumborImageOptions) => {
   const { server, basePath } = useContext()
 
   const image = useMemo(


### PR DESCRIPTION
## What's the purpose of this pull request?
The typings of thumbor were not correct, since we don't accept the `server` as option from thumbor. This PR fixes this typing and export the right one

