### PR TITLE
feat(sdk): add item generics to analytics types for easy customization

### DIFF
--- a/packages/sdk/src/analytics/events/add_payment_info.ts
+++ b/packages/sdk/src/analytics/events/add_payment_info.ts
@@ -1,14 +1,14 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface AddPaymentInfoParams {
+export interface AddPaymentInfoParams<T extends Item = Item> {
   currency?: CurrencyCode
   value?: number
   coupon?: string
   payment_type?: string
-  items?: Item[]
+  items?: T[]
 }
 
-export interface AddPaymentInfoEvent {
+export interface AddPaymentInfoEvent<T extends Item = Item> {
   name: 'add_payment_info'
-  params: AddPaymentInfoParams
+  params: AddPaymentInfoParams<T>
 }

--- a/packages/sdk/src/analytics/events/add_shipping_info.ts
+++ b/packages/sdk/src/analytics/events/add_shipping_info.ts
@@ -1,14 +1,14 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface AddShippingInfoParams {
+export interface AddShippingInfoParams<T extends Item = Item> {
   currency?: CurrencyCode
   value?: number
   coupon?: string
   shipping_tier?: string
-  items?: Item[]
+  items?: T[]
 }
 
-export interface AddShippingInfoEvent {
+export interface AddShippingInfoEvent<T extends Item = Item> {
   name: 'add_shipping_info'
-  params: AddShippingInfoParams
+  params: AddShippingInfoParams<T>
 }

--- a/packages/sdk/src/analytics/events/add_to_cart.ts
+++ b/packages/sdk/src/analytics/events/add_to_cart.ts
@@ -1,12 +1,12 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface AddToCartParams {
+export interface AddToCartParams<T extends Item = Item> {
   currency?: CurrencyCode
   value?: number
-  items?: Item[]
+  items?: T[]
 }
 
-export interface AddToCartEvent {
+export interface AddToCartEvent<T extends Item = Item> {
   name: 'add_to_cart'
-  params: AddToCartParams
+  params: AddToCartParams<T>
 }

--- a/packages/sdk/src/analytics/events/add_to_wishlist.ts
+++ b/packages/sdk/src/analytics/events/add_to_wishlist.ts
@@ -1,12 +1,12 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface AddToWishlistParams {
+export interface AddToWishlistParams<T extends Item = Item> {
   currency?: CurrencyCode
   value?: number
-  items?: Item[]
+  items?: T[]
 }
 
-export interface AddToWishlistEvent {
+export interface AddToWishlistEvent<T extends Item = Item> {
   name: 'add_to_wishlist'
-  params: AddToWishlistParams
+  params: AddToWishlistParams<T>
 }

--- a/packages/sdk/src/analytics/events/begin_checkout.ts
+++ b/packages/sdk/src/analytics/events/begin_checkout.ts
@@ -1,13 +1,13 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface BeginCheckoutParams {
+export interface BeginCheckoutParams<T extends Item = Item> {
   currency?: CurrencyCode
   value?: number
   coupon?: string
-  items?: Item[]
+  items?: T[]
 }
 
-export interface BeginCheckoutEvent {
+export interface BeginCheckoutEvent<T extends Item = Item> {
   name: 'begin_checkout'
-  params: BeginCheckoutParams
+  params: BeginCheckoutParams<T>
 }

--- a/packages/sdk/src/analytics/events/purchase.ts
+++ b/packages/sdk/src/analytics/events/purchase.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface PurchaseParams {
+export interface PurchaseParams<T extends Item = Item> {
   currency?: CurrencyCode
   transaction_id?: string
   value?: number
@@ -8,10 +8,10 @@ export interface PurchaseParams {
   coupon?: string
   shipping?: number
   tax?: number
-  items?: Item[]
+  items?: T[]
 }
 
-export interface PurchaseEvent {
+export interface PurchaseEvent<T extends Item = Item> {
   name: 'purchase'
-  params: PurchaseParams
+  params: PurchaseParams<T>
 }

--- a/packages/sdk/src/analytics/events/refund.ts
+++ b/packages/sdk/src/analytics/events/refund.ts
@@ -1,6 +1,6 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface RefundParams {
+export interface RefundParams<T extends Item = Item> {
   currency?: CurrencyCode
   transaction_id?: string
   value?: number
@@ -8,10 +8,10 @@ export interface RefundParams {
   coupon?: string
   shipping?: number
   tax?: number
-  items?: Item[]
+  items?: T[]
 }
 
-export interface RefundEvent {
+export interface RefundEvent<T extends Item = Item> {
   name: 'refund'
-  params: RefundParams
+  params: RefundParams<T>
 }

--- a/packages/sdk/src/analytics/events/remove_from_cart.ts
+++ b/packages/sdk/src/analytics/events/remove_from_cart.ts
@@ -1,12 +1,12 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface RemoveFromCartParams {
+export interface RemoveFromCartParams<T extends Item = Item> {
   currency?: CurrencyCode
   value?: number
-  items?: Item[]
+  items?: T[]
 }
 
-export interface RemoveFromCartEvent {
+export interface RemoveFromCartEvent<T extends Item = Item> {
   name: 'remove_from_cart'
-  params: RemoveFromCartParams
+  params: RemoveFromCartParams<T>
 }

--- a/packages/sdk/src/analytics/events/select_item.ts
+++ b/packages/sdk/src/analytics/events/select_item.ts
@@ -1,12 +1,12 @@
 import type { Item } from './common'
 
-export interface SelectItemParams {
+export interface SelectItemParams<T extends Item = Item> {
   item_list_id?: string
   item_list_name?: string
-  items?: Item[]
+  items?: T[]
 }
 
-export interface SelectItemEvent {
+export interface SelectItemEvent<T extends Item = Item> {
   name: 'select_item'
-  params: SelectItemParams
+  params: SelectItemParams<T>
 }

--- a/packages/sdk/src/analytics/events/select_promotion.ts
+++ b/packages/sdk/src/analytics/events/select_promotion.ts
@@ -1,12 +1,14 @@
 import type { PromotionItem, PromotionParams } from './common'
 
-export interface SelectPromotionItems {
-  items?: PromotionItem[]
+export interface SelectPromotionItems<T extends PromotionItem = PromotionItem> {
+  items?: T[]
 }
 
-export type SelectPromotionParams = PromotionParams & SelectPromotionItems
+export type SelectPromotionParams<
+  T extends PromotionItem = PromotionItem
+> = PromotionParams & SelectPromotionItems<T>
 
-export interface SelectPromotionEvent {
+export interface SelectPromotionEvent<T extends PromotionItem = PromotionItem> {
   name: 'select_promotion'
-  params: SelectPromotionParams
+  params: SelectPromotionParams<T>
 }

--- a/packages/sdk/src/analytics/events/view_cart.ts
+++ b/packages/sdk/src/analytics/events/view_cart.ts
@@ -1,12 +1,12 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface ViewCartParams {
+export interface ViewCartParams<T extends Item = Item> {
   currency?: CurrencyCode
   value?: number
-  items?: Item[]
+  items?: T[]
 }
 
-export interface ViewCartEvent {
+export interface ViewCartEvent<T extends Item = Item> {
   name: 'view_cart'
-  params: ViewCartParams
+  params: ViewCartParams<T>
 }

--- a/packages/sdk/src/analytics/events/view_item.ts
+++ b/packages/sdk/src/analytics/events/view_item.ts
@@ -1,12 +1,12 @@
 import type { CurrencyCode, Item } from './common'
 
-export interface ViewItemParams {
+export interface ViewItemParams<T extends Item = Item> {
   currency?: CurrencyCode
   value?: number
-  items?: Item[]
+  items?: T[]
 }
 
-export interface ViewItemEvent {
+export interface ViewItemEvent<T extends Item = Item> {
   name: 'view_item'
-  params: ViewItemParams
+  params: ViewItemParams<T>
 }

--- a/packages/sdk/src/analytics/events/view_item_list.ts
+++ b/packages/sdk/src/analytics/events/view_item_list.ts
@@ -1,12 +1,12 @@
 import type { Item } from './common'
 
-export interface ViewItemListParams {
+export interface ViewItemListParams<T extends Item = Item> {
   item_list_id?: string
   item_list_name?: string
-  items?: Item[]
+  items?: T[]
 }
 
-export interface ViewItemListEvent {
+export interface ViewItemListEvent<T extends Item = Item> {
   name: 'view_item_list'
-  params: ViewItemListParams
+  params: ViewItemListParams<T>
 }

--- a/packages/sdk/src/analytics/events/view_promotion.ts
+++ b/packages/sdk/src/analytics/events/view_promotion.ts
@@ -1,12 +1,14 @@
 import type { PromotionItem, PromotionParams } from './common'
 
-export interface ViewPromotionItems {
-  items?: PromotionItem[]
+export interface ViewPromotionItems<T extends PromotionItem = PromotionItem> {
+  items?: T[]
 }
 
-export type ViewPromotionParams = PromotionParams & ViewPromotionItems
+export type ViewPromotionParams<
+  T extends PromotionItem = PromotionItem
+> = PromotionParams & ViewPromotionItems<T>
 
-export interface ViewPromotionEvent {
+export interface ViewPromotionEvent<T extends PromotionItem = PromotionItem> {
   name: 'view_promotion'
-  params: ViewPromotionParams
+  params: ViewPromotionParams<T>
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds generics to the analytics events so users can control which type is used for the Item property. This makes it easier for additional properties to be included inside an item, which is a common use case.

## How it works? 

It defaults to the regular Item type but allows users to override it to include additional properties.

## How to test it?
it shouldn't affect how the code behaves, only the dev experience.

### `base.store` Deploy Preview
I'll link it here as soon as I have it
