### PR TITLE
fix(api): Breadcrumb data on collection pages

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/collection.ts
+++ b/packages/api/src/platforms/vtex/resolvers/collection.ts
@@ -15,11 +15,11 @@ const slugify = (root: Root) => {
   if (isBrand(root)) {
     return baseSlugify(root.name)
   }
-  
+
   if (isPortalPageType(root)) {
     return new URL(`https://${root.url}`).pathname.slice(1)
   }
-  
+
   return new URL(root.url).pathname.slice(1)
 }
 

--- a/packages/api/src/platforms/vtex/resolvers/collection.ts
+++ b/packages/api/src/platforms/vtex/resolvers/collection.ts
@@ -1,8 +1,8 @@
+import { slugify as baseSlugify } from '../utils/slugify'
 import type { Resolver } from '..'
 import type { Brand } from '../clients/commerce/types/Brand'
 import type { CategoryTree } from '../clients/commerce/types/CategoryTree'
 import type { PortalPagetype } from '../clients/commerce/types/Portal'
-import { slugify } from '../utils/slugify'
 
 type Root = Brand | (CategoryTree & { level: number }) | PortalPagetype
 
@@ -11,9 +11,16 @@ const isBrand = (x: any): x is Brand => x.type === 'brand'
 const isPortalPageType = (x: any): x is PortalPagetype =>
   typeof x.pageType === 'string'
 
+const slugify = (root: Root) =>
+  isBrand(root)
+    ? baseSlugify(root.name)
+    : isPortalPageType(root)
+    ? new URL(`https://${root.url}`).pathname.slice(1)
+    : new URL(root.url).pathname.slice(1)
+
 export const StoreCollection: Record<string, Resolver<Root>> = {
   id: ({ id }) => id.toString(),
-  slug: ({ name }) => slugify(name),
+  slug: (root) => slugify(root),
   seo: (root) =>
     isBrand(root) || isPortalPageType(root)
       ? {
@@ -35,7 +42,7 @@ export const StoreCollection: Record<string, Resolver<Root>> = {
   meta: (root) =>
     isBrand(root)
       ? {
-          selectedFacets: [{ key: 'brand', value: slugify(root.name) }],
+          selectedFacets: [{ key: 'brand', value: baseSlugify(root.name) }],
         }
       : {
           selectedFacets: new URL(
@@ -45,11 +52,38 @@ export const StoreCollection: Record<string, Resolver<Root>> = {
             .split('/')
             .map((segment, index) => ({
               key: `category-${index + 1}`,
-              value: slugify(segment),
+              value: baseSlugify(segment),
             })),
         },
-  breadcrumbList: () => ({
-    itemListElement: [],
-    numberOfItems: 0,
-  }),
+  breadcrumbList: async (root, _, ctx) => {
+    const {
+      clients: { commerce },
+    } = ctx
+
+    const slug = slugify(root)
+
+    /**
+     * Split slug into segments so we fetch all data for
+     * the breadcrumb. For instance, if we get `/foo/bar`
+     * we need all metadata for both `/foo` and `/bar` and
+     * thus we need to fetch pageType for `/foo` and `/bar`
+     */
+    const segments = slug.split('/').filter((segment) => Boolean(segment))
+    const slugs = segments.map((__, index) =>
+      segments.slice(0, index + 1).join('/')
+    )
+
+    const pageTypes = await Promise.all(
+      slugs.map((s) => commerce.catalog.portal.pagetype(s))
+    )
+
+    return {
+      itemListElement: pageTypes.map((pageType, index) => ({
+        item: new URL(`https://${pageType.url}`).pathname,
+        name: pageType.name,
+        position: index + 1,
+      })),
+      numberOfItems: pageTypes.length,
+    }
+  },
 }

--- a/packages/api/src/platforms/vtex/resolvers/collection.ts
+++ b/packages/api/src/platforms/vtex/resolvers/collection.ts
@@ -11,12 +11,17 @@ const isBrand = (x: any): x is Brand => x.type === 'brand'
 const isPortalPageType = (x: any): x is PortalPagetype =>
   typeof x.pageType === 'string'
 
-const slugify = (root: Root) =>
-  isBrand(root)
-    ? baseSlugify(root.name)
-    : isPortalPageType(root)
-    ? new URL(`https://${root.url}`).pathname.slice(1)
-    : new URL(root.url).pathname.slice(1)
+const slugify = (root: Root) => {
+  if (isBrand(root)) {
+    return baseSlugify(root.name)
+  }
+  
+  if (isPortalPageType(root)) {
+    return new URL(`https://${root.url}`).pathname.slice(1)
+  }
+  
+  return new URL(root.url).pathname.slice(1)
+}
 
 export const StoreCollection: Record<string, Resolver<Root>> = {
   id: ({ id }) => id.toString(),


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes an issue with breadcrumb data on PLPs. 

## How it works? 
Before this PR, we were just returning an empty list as the breadcrumb. After this PR, we use catalog data for filling the breadcrumb info.

## How to test it?
Use the base.store PR linked below and check that you can run both `allCollection` and `collection` fields.

### `base.store` Deploy Preview
https://github.com/vtex-sites/base.store/pull/216