### PR TITLE
feat(api): Add additional property

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -251,6 +251,7 @@ export type StorePageInfo = {
 
 export type StoreProduct = {
   __typename?: 'StoreProduct';
+  additionalProperty: Array<StorePropertyValue>;
   aggregateRating: StoreAggregateRating;
   brand: StoreBrand;
   breadcrumbList: StoreBreadcrumbList;
@@ -284,6 +285,12 @@ export type StoreProductGroup = {
   hasVariant: Array<StoreProduct>;
   name: Scalars['String'];
   productGroupID: Scalars['String'];
+};
+
+export type StorePropertyValue = {
+  __typename?: 'StorePropertyValue';
+  name: Scalars['String'];
+  value: Scalars['String'];
 };
 
 export type StoreReview = {

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -282,6 +282,7 @@ export type StoreProductEdge = {
 
 export type StoreProductGroup = {
   __typename?: 'StoreProductGroup';
+  additionalProperty: Array<StorePropertyValue>;
   hasVariant: Array<StoreProduct>;
   name: Scalars['String'];
   productGroupID: Scalars['String'];

--- a/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
+++ b/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
@@ -90,7 +90,7 @@ export interface Product {
   timestamp: number
   product: string
   oldPrice: number
-  productSpecifications: any[]
+  productSpecifications: string[]
   url: string
   measurementUnit: string
   categoryIDS: string[]

--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -88,4 +88,27 @@ export const StoreProduct: Record<string, Resolver<Root>> = {
     return { ...simulation, product }
   },
   isVariantOf: ({ isVariantOf }) => isVariantOf,
+  additionalProperty: (root) => {
+    const {
+      isVariantOf: { textAttributes = [], productSpecifications },
+      attributes = [],
+    } = root
+
+    // Product specifications
+    const specs = new Set(productSpecifications)
+    const productAttributes = textAttributes
+      .filter((attribute) => specs.has(attribute.labelKey))
+      .map((attribute) => ({
+        name: attribute.labelKey,
+        value: attribute.labelValue,
+      }))
+
+    // Sku specifications
+    const skuAttributes = attributes.map((attribute) => ({
+      name: attribute.key,
+      value: attribute.value,
+    }))
+
+    return [...skuAttributes, ...productAttributes]
+  },
 }

--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -88,13 +88,9 @@ export const StoreProduct: Record<string, Resolver<Root>> = {
     return { ...simulation, product }
   },
   isVariantOf: ({ isVariantOf }) => isVariantOf,
-  additionalProperty: (root) => {
-    const { attributes = [] } = root
-
-    // Sku specifications
-    return attributes.map((attribute) => ({
+  additionalProperty: ({ attributes = [] }) =>
+    attributes.map((attribute) => ({
       name: attribute.key,
       value: attribute.value,
-    }))
-  },
+    })),
 }

--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -89,26 +89,12 @@ export const StoreProduct: Record<string, Resolver<Root>> = {
   },
   isVariantOf: ({ isVariantOf }) => isVariantOf,
   additionalProperty: (root) => {
-    const {
-      isVariantOf: { textAttributes = [], productSpecifications },
-      attributes = [],
-    } = root
-
-    // Product specifications
-    const specs = new Set(productSpecifications)
-    const productAttributes = textAttributes
-      .filter((attribute) => specs.has(attribute.labelKey))
-      .map((attribute) => ({
-        name: attribute.labelKey,
-        value: attribute.labelValue,
-      }))
+    const { attributes = [] } = root
 
     // Sku specifications
-    const skuAttributes = attributes.map((attribute) => ({
+    return attributes.map((attribute) => ({
       name: attribute.key,
       value: attribute.value,
     }))
-
-    return [...skuAttributes, ...productAttributes]
   },
 }

--- a/packages/api/src/platforms/vtex/resolvers/productGroup.ts
+++ b/packages/api/src/platforms/vtex/resolvers/productGroup.ts
@@ -6,10 +6,7 @@ export const StoreProductGroup: Record<string, Resolver<Product>> = {
   hasVariant: (root) => root.skus.map((sku) => enhanceSku(sku, root)),
   productGroupID: ({ product }) => product,
   name: ({ name }) => name,
-  additionalProperty: (root) => {
-    const { textAttributes = [], productSpecifications } = root
-
-    // Product specifications
+  additionalProperty: ({ textAttributes = [], productSpecifications = [] }) => {
     const specs = new Set(productSpecifications)
 
     return textAttributes

--- a/packages/api/src/platforms/vtex/resolvers/productGroup.ts
+++ b/packages/api/src/platforms/vtex/resolvers/productGroup.ts
@@ -6,4 +6,17 @@ export const StoreProductGroup: Record<string, Resolver<Product>> = {
   hasVariant: (root) => root.skus.map((sku) => enhanceSku(sku, root)),
   productGroupID: ({ product }) => product,
   name: ({ name }) => name,
+  additionalProperty: (root) => {
+    const { textAttributes = [], productSpecifications } = root
+
+    // Product specifications
+    const specs = new Set(productSpecifications)
+
+    return textAttributes
+      .filter((attribute) => specs.has(attribute.labelKey))
+      .map((attribute) => ({
+        name: attribute.labelKey,
+        value: attribute.labelValue,
+      }))
+  },
 }

--- a/packages/api/src/typeDefs/index.ts
+++ b/packages/api/src/typeDefs/index.ts
@@ -20,6 +20,7 @@ import Review from './review.graphql'
 import Seo from './seo.graphql'
 import Cart from './cart.graphql'
 import Status from './status.graphql'
+import PropertyValue from './propertyValue.graphql'
 
 export const typeDefs = [
   Query,
@@ -42,6 +43,7 @@ export const typeDefs = [
   Order,
   Cart,
   Status,
+  PropertyValue,
 ]
   .map(print)
   .join('\n')

--- a/packages/api/src/typeDefs/product.graphql
+++ b/packages/api/src/typeDefs/product.graphql
@@ -16,6 +16,7 @@ type StoreProduct {
   review: [StoreReview!]!
   aggregateRating: StoreAggregateRating!
   isVariantOf: StoreProductGroup!
+  additionalProperty: [StorePropertyValue!]!
 }
 
 input IStoreProduct {

--- a/packages/api/src/typeDefs/productGroup.graphql
+++ b/packages/api/src/typeDefs/productGroup.graphql
@@ -2,4 +2,5 @@ type StoreProductGroup {
   hasVariant: [StoreProduct!]!
   productGroupID: String!
   name: String!
+  additionalProperty: [StorePropertyValue!]!
 }

--- a/packages/api/src/typeDefs/propertyValue.graphql
+++ b/packages/api/src/typeDefs/propertyValue.graphql
@@ -1,0 +1,4 @@
+type StorePropertyValue {
+  value: String!
+  name: String!
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8432,11 +8432,6 @@
     "@types/eslint" "*"
     "@types/estree" "*"
 
-"@types/eslint-visitor-keys@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
-  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
-
 "@types/eslint@*", "@types/eslint@^7.2.6":
   version "7.2.7"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.7.tgz#f7ef1cf0dceab0ae6f9a976a0a9af14ab1baca26"
@@ -9064,17 +9059,7 @@
   resolved "https://registry.yarnpkg.com/@types/yoga-layout/-/yoga-layout-1.9.2.tgz#efaf9e991a7390dc081a0b679185979a83a9639a"
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
-"@typescript-eslint/eslint-plugin@^2.12.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
-  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    functional-red-black-tree "^1.0.1"
-    regexpp "^3.0.0"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/eslint-plugin@^4.28.1", "@typescript-eslint/eslint-plugin@^4.29.2":
+"@typescript-eslint/eslint-plugin@^2.12.0", "@typescript-eslint/eslint-plugin@^4", "@typescript-eslint/eslint-plugin@^4.28.1", "@typescript-eslint/eslint-plugin@^4.29.2":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
   integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
@@ -9087,16 +9072,6 @@
     regexpp "^3.1.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/experimental-utils@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
-  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
 
 "@typescript-eslint/experimental-utils@4.33.0":
   version "4.33.0"
@@ -9134,17 +9109,7 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^2.12.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
-  integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
-  dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/parser@^4.28.1", "@typescript-eslint/parser@^4.29.2":
+"@typescript-eslint/parser@^2.12.0", "@typescript-eslint/parser@^4", "@typescript-eslint/parser@^4.28.1", "@typescript-eslint/parser@^4.29.2":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
   integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
@@ -9192,19 +9157,6 @@
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
-
-"@typescript-eslint/typescript-estree@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
-  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.19.0":
   version "4.19.0"


### PR DESCRIPTION
## What's the purpose of this pull request?
[Schema.org](https://schema.org/Product) Product schema has a built-in field called [additionalProperty](https://schema.org/additionalProperty). The intent of this field is to provide an API for extending the fields of a product without defining a custom schema. As far as I can tell, this is analogous to VTEX's [specification fields](https://help.vtex.com/tutorial/what-are-fields-or-specifications--2lB4AgibEseceMggKE2k2m). 

This PR adds `additionalProperty` to type StoreProduct with the goal of having feature parity with VTEX's `productSpecification` API so developers can use these properties in their stores to create different UI's

## How it works? 
VTEX has two specifications. Product and SKU specifications. Luckily, schema.org has a very similar approach to the problem. Both `StoreProduct` (VTEX SKU) and `StoreProductGroup` (VTEX Product) have the  `additionalProperty` defined on schema.org. This PR adds both to the GraphQL schema and forwards the `attributes` and `productSpecifications` fields from Intelligent Search API respectively.

An example for the return of the API for the following query in account `decathlonproqa` is:
query:
```graphql
{
  allProducts(first: 1, after: "5") {
    edges {
      node {
        slug
        isVariantOf {
          additionalProperty {
            name
            value
          }
          hasVariant {
            additionalProperty {
              name
              value
            }
          }
        }
      }
    }
  }
}
``` 
result:
```json
{
  "data": {
    "allProducts": {
      "edges": [
        {
          "node": {
            "slug": "collant-de-danca-987",
            "isVariantOf": {
              "additionalProperty": [
                {
                  "name": "Gênero",
                  "value": "MENINA"
                },
                {
                  "name": "beneficiosDoProduto",
                  "value": "..."
                },
                {
                  "name": "conceitoTecnologia",
                  "value": "..."
                }
              ],
              "hasVariant": [
                {
                  "additionalProperty": [
                    {
                      "name": "Tamanho",
                      "value": "8 ANOS"
                    },
                    {
                      "name": "Cor",
                      "value": "rosa"
                    }
                  ]
                },
                {
                  "additionalProperty": [
                    {
                      "name": "Tamanho",
                      "value": "14 ANOS"
                    },
                    {
                      "name": "Cor",
                      "value": "rosa"
                    }
                  ]
                }
              ]
            }
          }
        }
      ]
    }
  }
}
```

These info should help creating UIs for extra fields for each product.
> Note that creating an SKU selector after these data would still require too much processing on the frontend and a better solution is still needed for this case.

## How to test it?
Use the base.store link below and make sure nothing has changed on the store, but now you can query these additionalProperty field
https://github.com/vtex-sites/base.store/pull/225