### PR TITLE
fix(gatsby-plugin-nginx): replaceAll crashing build with env vars

### DIFF
--- a/packages/gatsby-plugin-nginx/src/headers.ts
+++ b/packages/gatsby-plugin-nginx/src/headers.ts
@@ -177,7 +177,7 @@ export function getGlobalHeaders(
     // Normalizes header name. Headers with underscores are ignored by nginx anyway.
     const headerName = envVar
       .slice(ENV_VAR_HEADER_PREVIX.length)
-      .replaceAll('_', '-')
+      .replace(/_/g, '-')
 
     rawGlobalHeaders[headerName] = process.env[envVar]!
   })


### PR DESCRIPTION
## What's the purpose of this pull request?
Fixes an error at nginx plugin that prevented stores from building when using custom env var headers.

## How it works? 
Uses the replace method in replacement to the replaceAll method that's causing the error probably because the node version doesn't include it yet.