### PR TITLE
Chore: Adds modal overlay id and classnames props

### DIFF
--- a/packages/ui/src/molecules/Modal/Modal.tsx
+++ b/packages/ui/src/molecules/Modal/Modal.tsx
@@ -31,6 +31,14 @@ export interface ModalProps extends ModalContentProps {
    * Controls whether or not the dialog is open.
    */
   isOpen: boolean
+  /**
+   * ID to identify overlay
+   */
+  overlayId?: string
+  /**
+   * Returns the value of overlay's class attribute.
+   */
+  className?: string
 }
 
 /*
@@ -44,6 +52,8 @@ const Modal = ({
   children,
   onDismiss,
   testId = 'store-modal',
+  overlayId,
+  className,
   ...otherProps
 }: PropsWithChildren<ModalProps>) => {
   const handleBackdropClick = (event: MouseEvent) => {
@@ -67,9 +77,10 @@ const Modal = ({
   return isOpen
     ? createPortal(
         <Overlay
-          data-modal-overlay
+          data-modal-overlay={overlayId}
           onClick={handleBackdropClick}
           onKeyDown={handleBackdropKeyDown}
+          className={className}
         >
           <ModalContent {...otherProps} testId={testId}>
             {children}

--- a/packages/ui/src/molecules/Modal/Modal.tsx
+++ b/packages/ui/src/molecules/Modal/Modal.tsx
@@ -38,7 +38,7 @@ export interface ModalProps extends ModalContentProps {
   /**
    * Returns the value of overlay's class attribute.
    */
-  className?: string
+  overlayClassName?: string
 }
 
 /*
@@ -80,7 +80,7 @@ const Modal = ({
           data-modal-overlay={overlayId}
           onClick={handleBackdropClick}
           onKeyDown={handleBackdropKeyDown}
-          className={className}
+          className={overlayClassName}
         >
           <ModalContent {...otherProps} testId={testId}>
             {children}

--- a/packages/ui/src/molecules/Modal/Modal.tsx
+++ b/packages/ui/src/molecules/Modal/Modal.tsx
@@ -53,7 +53,7 @@ const Modal = ({
   onDismiss,
   testId = 'store-modal',
   overlayId,
-  className,
+  overlayClassName,
   ...otherProps
 }: PropsWithChildren<ModalProps>) => {
   const handleBackdropClick = (event: MouseEvent) => {

--- a/packages/ui/src/molecules/Modal/Modal.tsx
+++ b/packages/ui/src/molecules/Modal/Modal.tsx
@@ -35,10 +35,6 @@ export interface ModalProps extends ModalContentProps {
    * ID to identify overlay
    */
   overlayId?: string
-  /**
-   * Returns the value of overlay's class attribute.
-   */
-  overlayClassName?: string
 }
 
 /*
@@ -53,7 +49,6 @@ const Modal = ({
   onDismiss,
   testId = 'store-modal',
   overlayId,
-  overlayClassName,
   ...otherProps
 }: PropsWithChildren<ModalProps>) => {
   const handleBackdropClick = (event: MouseEvent) => {
@@ -78,9 +73,9 @@ const Modal = ({
     ? createPortal(
         <Overlay
           data-modal-overlay={overlayId}
+          data-modal-overlay-open={isOpen}
           onClick={handleBackdropClick}
           onKeyDown={handleBackdropKeyDown}
-          className={overlayClassName}
         >
           <ModalContent {...otherProps} testId={testId}>
             {children}


### PR DESCRIPTION
## What's the purpose of this pull request?

All the props were being applied to the `ModalContent` and it would be helpful to have something to identifier the overlay.
For example, I wanted to style different Modal's overlay and need an id to identify it.

- Adds `overlayId` : an ID to identify the modal's overlay 
- `data-modal-overlay-open={isOpen}`: data-attribute to too

