### PR TITLE
chore(ui): Add prefixId attribute to AccordionItem

### DIFF
--- a/packages/ui/src/molecules/Accordion/Accordion.test.tsx
+++ b/packages/ui/src/molecules/Accordion/Accordion.test.tsx
@@ -94,6 +94,38 @@ describe('Accordion', () => {
     expect(panelsMock[1]).toBeVisible()
   })
 
+  it('should prevent duplicate IDs when using the `prefixID` attribute', () => {
+    const { getAllByTestId } = render(
+      <>
+        <Accordion indices={[]} onChange={() => {}}>
+          <AccordionItem prefixId="filter">
+            <AccordionButton testId="data-accordion-button" />
+            <AccordionPanel testId="data-accordion-panel" />
+          </AccordionItem>
+        </Accordion>
+        <Accordion indices={[]} onChange={() => {}}>
+          <AccordionItem prefixId="footer">
+            <AccordionButton testId="data-accordion-button" />
+            <AccordionPanel testId="data-accordion-panel" />
+          </AccordionItem>
+        </Accordion>
+      </>
+    )
+
+    const allPanels = getAllByTestId('data-accordion-panel')
+    const allButtons = getAllByTestId('data-accordion-button')
+
+    // Attributes
+    expect(allPanels[0]).toHaveAttribute('id', 'filter-panel--0')
+    expect(allPanels[1]).toHaveAttribute('id', 'footer-panel--0')
+    expect(allButtons[0]).toHaveAttribute('id', 'filter-button--0')
+    expect(allButtons[1]).toHaveAttribute('id', 'footer-button--0')
+
+    // Equality assertions
+    expect(allPanels[0].id).not.toEqual(allPanels[1].id)
+    expect(allButtons[0].id).not.toEqual(allButtons[1].id)
+  })
+
   describe('Data attributes', () => {
     it('`Accordion` component should have `data-store-accordion` attribute', () => {
       expect(accordion).toHaveAttribute('data-store-accordion')

--- a/packages/ui/src/molecules/Accordion/AccordionButton.tsx
+++ b/packages/ui/src/molecules/Accordion/AccordionButton.tsx
@@ -19,7 +19,7 @@ const AccordionButton = forwardRef<HTMLButtonElement, AccordionButtonProps>(
     ref
   ) {
     const { indices, onChange, numberOfItems } = useAccordion()
-    const { index, panel, button } = useAccordionItem()
+    const { index, panel, button, prefixId } = useAccordionItem()
 
     const onKeyDown = (event: React.KeyboardEvent) => {
       if (!['ArrowDown', 'ArrowUp'].includes(event.key)) {
@@ -29,14 +29,18 @@ const AccordionButton = forwardRef<HTMLButtonElement, AccordionButtonProps>(
       const getNext = () => {
         const next = Number(index) + 1 === numberOfItems ? 0 : Number(index) + 1
 
-        return document.getElementById(`button--${next}`)
+        return document.getElementById(
+          `${prefixId && `${prefixId}-`}button--${next}`
+        )
       }
 
       const getPrevious = () => {
         const previous =
           Number(index) - 1 < 0 ? numberOfItems - 1 : Number(index) - 1
 
-        return document.getElementById(`button--${previous}`)
+        return document.getElementById(
+          `${prefixId && `${prefixId}-`}button--${previous}`
+        )
       }
 
       switch (event.key) {

--- a/packages/ui/src/molecules/Accordion/AccordionItem.tsx
+++ b/packages/ui/src/molecules/Accordion/AccordionItem.tsx
@@ -21,17 +21,27 @@ export interface AccordionItemProps extends HTMLAttributes<HTMLDivElement> {
    * Index of the current accordion item within the accordion.
    */
   index?: number
+  /**
+   * ID for the current Accordion item's panel and button
+   */
+  prefixId?: string
 }
 
 const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
   function AccordionItem(
-    { testId = 'store-accordion-item', children, index = 0, ...otherProps },
+    {
+      testId = 'store-accordion-item',
+      children,
+      prefixId = '',
+      index = 0,
+      ...otherProps
+    },
     ref
   ) {
     const context = {
       index,
-      panel: `panel--${index}`,
-      button: `button--${index}`,
+      panel: `${prefixId && `${prefixId}-`}panel--${index}`,
+      button: `${prefixId && `${prefixId}-`}button--${index}`,
     }
 
     return (

--- a/packages/ui/src/molecules/Accordion/AccordionItem.tsx
+++ b/packages/ui/src/molecules/Accordion/AccordionItem.tsx
@@ -22,7 +22,8 @@ export interface AccordionItemProps extends HTMLAttributes<HTMLDivElement> {
    */
   index?: number
   /**
-   * ID for the current Accordion item's panel and button
+   * Namespace ID prefix for the current Accordion item's panel and button
+   * to avoid ID duplication when multiple instances are on the same page.
    */
   prefixId?: string
 }

--- a/packages/ui/src/molecules/Accordion/AccordionItem.tsx
+++ b/packages/ui/src/molecules/Accordion/AccordionItem.tsx
@@ -5,6 +5,7 @@ interface AccordionItemContext {
   index: number
   panel: string
   button: string
+  prefixId: string
 }
 
 const AccordionItemContext = createContext<AccordionItemContext | undefined>(
@@ -41,6 +42,7 @@ const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
   ) {
     const context = {
       index,
+      prefixId,
       panel: `${prefixId && `${prefixId}-`}panel--${index}`,
       button: `${prefixId && `${prefixId}-`}button--${index}`,
     }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add the `prefixId` attribute to the `AccordionItem` component.

This will avoid the problem of having duplicate `AccordionPanel` and `AccordionButton` IDs when having two accordions on the same page.

## How it works? 

In a scenario where there is an `Accordion` being used in a filter component and another in a footer component:

<img width="572" alt="Screen Shot 2022-01-18 at 18 00 01" src="https://user-images.githubusercontent.com/15722605/150018050-5bd0352b-c96c-4fb3-a952-482ddd85a048.png">

<img width="575" alt="Screen Shot 2022-01-18 at 17 59 48" src="https://user-images.githubusercontent.com/15722605/150018075-2429fc1a-d54a-4958-9758-ec9463683d09.png">
