### PR TITLE
chore(gatsby-cms-plugin): fetch content by ID using REST API from CMS for preview

### DIFF
--- a/packages/gatsby-plugin-cms/src/node-api/cms/types.ts
+++ b/packages/gatsby-plugin-cms/src/node-api/cms/types.ts
@@ -41,3 +41,19 @@ export type PageContent = {
   name: string
   sections: Block[]
 } & Record<string, Record<string, Block['props']>>
+
+export type RemoteRESTPageContent = {
+  id: string
+  name: string
+  status: string
+  type: string
+  versionId: string
+  sections: Section[]
+  children?: string[]
+  parent?: string
+} & Record<string, unknown>
+
+export interface Section {
+  name: string
+  data: unknown
+}

--- a/packages/gatsby-plugin-cms/src/utils/fetch.ts
+++ b/packages/gatsby-plugin-cms/src/utils/fetch.ts
@@ -1,10 +1,20 @@
 import unfetch from 'isomorphic-unfetch'
 import retry from 'fetch-retry'
 
-const fetch = (input: RequestInfo, init?: RequestInit) =>
+export const fetch = (input: RequestInfo, init?: RequestInit) =>
   retry(unfetch, {
     retries: 3,
     retryDelay: 500,
   })(input, init)
 
-export default fetch
+export const fetchAPI = async <T>(input: RequestInfo, init?: RequestInit) => {
+  const response = await fetch(input, init)
+
+  if (response.ok) {
+    return response.json() as Promise<T>
+  }
+
+  console.error(await response.text())
+
+  throw new Error(`Error while fetching ${input}`)
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR enables gatsby-plugin-cms to receive `webhookBody` params, fetch the values on the CMS API and return it to preview on webOps.

## How does it work? 

REST API example: https://storecomponents.myvtex.com/_v/cms/api/faststore/home/72de3769-347e-4734-855a-e5a4f072f66b?versionId=e2f4f2c0-9001-4f6b-b318-35f50ae2e3fb

## How to test it?

1. clone this repo and branch
2. link it on your favorite account (you can try with storecomponents.store) using [wml](https://github.com/wix/wml)
3. run `yarn develop` on this folder to build the files and start the server on your store using `ENABLE_GATSBY_REFRESH_ENDPOINT=true`, you should see the home page from production.
4. to reproduce the preview, call your refresh endpoint using this values:
```bash
curl -X POST -H "Content-Type: application/json" http://127.0.0.1:8000/__refresh -d '{"id": "847b580d-83cb-4129-ae5f-1ea69123ff66", "contentType": "home", "versionId": "61e0bd61-fc46-44d0-bebd-0897a35c6214"}'
```

## References

_This PR was totally inspired by https://github.com/vtex/cms/pull/8 from @tlgimenes_ 