### PR TITLE
fix(api): PDP and PLP breadcrumb list item's URL paths

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/collection.ts
+++ b/packages/api/src/platforms/vtex/resolvers/collection.ts
@@ -84,7 +84,7 @@ export const StoreCollection: Record<string, Resolver<Root>> = {
 
     return {
       itemListElement: pageTypes.map((pageType, index) => ({
-        item: new URL(`https://${pageType.url}`).pathname,
+        item: new URL(`https://${pageType.url}`).pathname.toLowerCase(),
         name: pageType.name,
         position: index + 1,
       })),

--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -1,5 +1,6 @@
 import type { Resolver } from '..'
 import type { EnhancedSku } from '../utils/enhanceSku'
+import { slugify } from '../utils/slugify'
 
 type Root = EnhancedSku
 
@@ -28,7 +29,9 @@ export const StoreProduct: Record<string, Resolver<Root>> = {
     itemListElement: [
       ...categoryTrees.reverse().map(({ categoryNames }, index) => ({
         name: categoryNames[categoryNames.length - 1],
-        item: `/${categoryNames.join('/').toLowerCase()}`,
+        item: `/${categoryNames
+          .map((categoryName) => slugify(categoryName))
+          .join('/')}`,
         position: index + 1,
       })),
       {


### PR DESCRIPTION
## What's the purpose of this pull request?

- [x] Fix upper case in the PLP/collection's breadcrumb.

Before|After
-|-
`/Kitchen-and-Home-Appliances` ([not working](https://base.vtex.app/Kitchen-and-Home-Appliances))|`/kitchen-and-home-appliances` ([working](https://base.vtex.app/kitchen-and-home-appliances))
![Screen Shot 2022-02-10 at 23 03 45](https://user-images.githubusercontent.com/381395/153527340-726f9379-8c1c-498a-a179-75ee8e7c1dc1.png)|![Screen Shot 2022-02-10 at 23 07 23](https://user-images.githubusercontent.com/381395/153527365-e4214e7a-04db-4ae3-90ac-c9b520d1be16.png)

- [x] Fix spaces in the PDP/product's breadcrumb.

 Before|After
-|-
`/kitchen and home appliances` ([not working](https://base.vtex.app/kitchen%20and%20home%20appliances))|`/kitchen-and-home-appliances` ([working](https://base.vtex.app/kitchen-and-home-appliances))
![Screen Shot 2022-02-10 at 23 03 00](https://user-images.githubusercontent.com/381395/153527775-4f3e4f6a-071e-4dee-a24e-cbaec89eb891.png)|![Screen Shot 2022-02-10 at 23 14 01](https://user-images.githubusercontent.com/381395/153527810-c3122e0e-7d49-4fa2-ad25-fc71180a1ce2.png)

### `base.store` Deploy Preview

[8d954a56253469514b1ffe7d2d8de29399db9db0](https://github.com/vtex-sites/base.store/commit/8d954a56253469514b1ffe7d2d8de29399db9db0)

- https://sfj-8d954a5--base.preview.vtex.app/kitchen-and-home-appliances/fridges breadcrumb displays a link to `/kitchen-and-home-appliances` (no `/Kitchen-and-Home-Appliances`).
- https://sfj-8d954a5--base.preview.vtex.app/ergonomic-wooden-bacon-3169709/p breadcrumb displays links to `/kitchen-and-home-appliances` (no `/kitchen and home appliances`) and `kitchen-and-home-appliances/fridges` (no `/fridges`).