### PR TITLE
feat: Moves some Filter logic to api

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -4,6 +4,7 @@ import type { SearchArgs } from '../clients/search'
 import type { Attribute } from '../clients/search/types/AttributeSearchResult'
 
 type Root = Omit<SearchArgs, 'type'>
+
 const REMOVED_FACETS_FROM_COLLECTION_PAGE = ['departamento']
 
 export const StoreSearchResult: Record<string, Resolver<Root>> = {

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -1,8 +1,10 @@
 import { enhanceSku } from '../utils/enhanceSku'
 import type { Resolver } from '..'
 import type { SearchArgs } from '../clients/search'
+import type { Attribute } from '../clients/search/types/AttributeSearchResult'
 
 type Root = Omit<SearchArgs, 'type'>
+const FILTERED_FACETS_FROM_COLLECTION_PAGE = ['departamento']
 
 export const StoreSearchResult: Record<string, Resolver<Root>> = {
   products: async (searchArgs, _, ctx) => {
@@ -41,6 +43,33 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const facets = await is.facets(searchArgs)
 
-    return facets.attributes ?? []
+    const isCollectionPage = !searchArgs.query
+    const filteredFacets = facets?.attributes?.reduce((acc, currentFacet) => {
+      const shouldFilterFacet = FILTERED_FACETS_FROM_COLLECTION_PAGE.includes(
+        currentFacet.key
+      )
+
+      const shouldFilterFromCollectionPage =
+        isCollectionPage && shouldFilterFacet
+
+      const isText = currentFacet.type === 'text'
+
+      if (shouldFilterFromCollectionPage || !isText) {
+        return acc
+      }
+
+      currentFacet.values.sort((a, b) => {
+        const firstItemLabel = a.label ?? ''
+        const secondItemLabel = b.label ?? ''
+
+        return firstItemLabel.localeCompare(secondItemLabel)
+      })
+
+      acc.push(currentFacet)
+
+      return acc
+    }, [] as Attribute[])
+
+    return filteredFacets ?? []
   },
 }

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -50,12 +50,10 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
         currentFacet.key
       )
 
-      const shouldFilterFromCollectionPage =
+      const shouldRemoveFacetFromCollectionPage =
         isCollectionPage && shouldFilterFacet
 
-      const isText = currentFacet.type === 'text'
-
-      if (shouldFilterFromCollectionPage || !isText) {
+      if (shouldRemoveFacetFromCollectionPage) {
         return acc
       }
 

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -4,7 +4,7 @@ import type { SearchArgs } from '../clients/search'
 import type { Attribute } from '../clients/search/types/AttributeSearchResult'
 
 type Root = Omit<SearchArgs, 'type'>
-const FILTERED_FACETS_FROM_COLLECTION_PAGE = ['departamento']
+const REMOVED_FACETS_FROM_COLLECTION_PAGE = ['departamento']
 
 export const StoreSearchResult: Record<string, Resolver<Root>> = {
   products: async (searchArgs, _, ctx) => {
@@ -45,7 +45,7 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const isCollectionPage = !searchArgs.query
     const filteredFacets = facets?.attributes?.reduce((acc, currentFacet) => {
-      const shouldFilterFacet = FILTERED_FACETS_FROM_COLLECTION_PAGE.includes(
+      const shouldFilterFacet = REMOVED_FACETS_FROM_COLLECTION_PAGE.includes(
         currentFacet.key
       )
 


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR is based on [this comment](https://github.com/vtex-sites/base.store/pull/321#pullrequestreview-877461915) and aims to move some logic from the `Filter` component from the frontend to the backend (API):
- Sorts the facets values alphabetically
- Removes the `departamento` facet from the Collection (PLP) page.
