### PR TITLE
fix: StoreProduct return wrong sku

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -50,11 +50,7 @@ export const StoreProduct: Record<string, Resolver<Root>> = {
       alternateName: name ?? '',
       url: value.replace('vteximg.com.br', 'vtexassets.com'),
     })),
-  sku: ({
-    isVariantOf: {
-      skus: [sku],
-    },
-  }) => sku.id,
+  sku: ({ id }) => id,
   gtin: ({ reference }) => reference ?? '',
   review: () => [],
   aggregateRating: () => ({}),


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes incorrect sku ids being returned on the sku field of StoreProduct. 

## How it works? 
StoreProduct represents a sku on VTEX. StoreProductGroup represents a VTEX Product. As such, the `productID` and `sku` fields of StoreProduct must have the same value. This was the case on stores with one sku per product, but not on accounts where multiple skus are present on each product.
This PR uses the same logic for both `sku` and `productID` so that they always have the same value

### `base.store` Deploy Preview
Make sure that when adding a product to cart, this product shows on cart correctly.