### PR TITLE
fix: filter active brands

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -124,7 +124,9 @@ export const Query = {
     }
 
     const collections = [
-      ...brands.map((x) => ({ ...x, type: 'brand' })),
+      ...brands
+        .filter((brand) => brand.isActive)
+        .map((x) => ({ ...x, type: 'brand' })),
       ...categories,
     ]
 


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes the error below:

```
ERROR

NotFoundError: Catalog returned FullText for slug: canyon. This usually happens when there is more than one category with the same name in the same category tree level.
    at /Users/gimenes/Documents/code/vtex-sites/base.store/node_modules/@faststore/api/src/platforms/vtex/loaders/collection.ts:38:17
    at processTicksAndRejections (node:internal/process/task_queues:93:5) {
  locations: [ { line: 32, column: 3 } ],
  path: [ 'allCollections', 'edges', 9, 'node', 'breadcrumbList' ]
}
```

## How it works? 
We were receiving this error because the list of brands the api returns contains inactive brands. A simple filter solved the issue.

### `base.store` Deploy Preview
https://github.com/vtex-sites/base.store/pull/361