### PR TITLE
chore(ui): Clean up some minor linter warnings from previous PR

### DIFF
--- a/packages/ui/src/molecules/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/ui/src/molecules/Breadcrumb/Breadcrumb.test.tsx
@@ -73,6 +73,7 @@ describe('Breadcrumb', () => {
     for (const item of Array.from(listItems)) {
       expect(item.nodeName).toEqual('LI')
     }
+
     expect(listItems).toHaveLength(2)
   })
 
@@ -90,6 +91,7 @@ describe('Breadcrumb', () => {
     for (const divider of Array.from(dividers)) {
       expect(divider).toHaveAttribute('aria-hidden', 'true')
     }
+
     expect(dividers).toHaveLength(2)
   })
 


### PR DESCRIPTION
## What's the purpose of this pull request?

I totally missed the **GH Actions / Lint** warnings in https://github.com/vtex/faststore/pull/1143 and @eduardoformiga reminded me of that.

![CleanShot 2022-02-23 at 20 32 16](https://user-images.githubusercontent.com/381395/155427345-70014b21-2ffd-4c13-884f-b23a2f813a05.png)

## How to test it?

Go to https://github.com/vtex/faststore/pull/1159/files and there should be no warning on `packages/ui/src/molecules/Breadcrumb/Breadcrumb.test.tsx`.

## References

- https://github.com/vtex/faststore/pull/1143/files#r813406187
- https://github.com/vtex/faststore/pull/1143/files#r813406441