### PR TITLE
fix: Cart item availability

### DIFF
--- a/packages/api/src/platforms/vtex/clients/fetch.ts
+++ b/packages/api/src/platforms/vtex/clients/fetch.ts
@@ -7,6 +7,7 @@ export const fetchAPI = async (info: RequestInfo, init?: RequestInit) => {
     return response.json()
   }
 
+  console.error(info, init, response)
   const text = await response.text()
 
   throw new Error(text)

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -63,14 +63,10 @@ const equals = (storeOrder: IStoreOrder, orderForm: OrderForm) => {
   const orderFormItems = orderForm.items.map(orderFormItemToOffer).map(pick)
   const storeOrderItems = storeOrder.acceptedOffer.map(pick)
 
-  if (
-    storeOrder.orderNumber !== orderForm.orderFormId ||
-    !deepEquals(orderFormItems, storeOrderItems)
-  ) {
-    return false
-  }
+  const isSameOrder = storeOrder.orderNumber === orderForm.orderFormId
+  const orderItensAreSync = deepEquals(orderFormItems, storeOrderItems)
 
-  return true
+  return isSameOrder && orderItensAreSync
 }
 
 /**


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR makes the cart module to respect the inventory limits of a certain product.

Currently, when adding an unavailable product to card, the UI let's the counter to increase indefinitely without warning the user the product has limited inventory. This PR addresses this issue by limiting the amount of products the user can add to cart. Also, if the user adds more itens, a toast message is raised warning the user

## How it works? 
Optimistic UI is a design pattern that improves greatly the UI responsiveness by not blocking the user/UI interaction while the server process requests. Our SDK's cart module is optimistic. This means that the user does not need to wait for the ecommerce platform to process anything before adding/removing items from cart.
To achieve an optimistic cart, the cart state is copied from the server into the client. Any change to cart state is performed locally and the UI reacts to these changes. At some point, the local cart state needs to be synced with the server one. This sync between client/server state is done by `validateCart` mutation. This mutation's return is the server's state of the cart and is, thus, the source of truth for the cart's state. If `validateCart` returns null, this means that both client and server state matches perfectly, and thus no change needs to be performed on the client.

There was a bug in `validateCart` mutation when the a product had a limited inventory. When the user tried to add more items than possible, the mutation returned null, indicating to the UI the operation was valid. When the user got to the checkout phase, he saw that the number of items on `/checkout` differs from the one present on the minicart, thus creating a mistrust with the store. 
To solve this bug, when the user tries to add more itens than possible,  the quantity is lowered to the available products and a message is returned saying the operation was impossible. More specifically, the bug happened because the `equals` function was not applied between server and client states, but between sever and server states. The fix was change `equals` to compare server and client states

Below, you can see the before/after comparison of the fix. The `/tasty-cotton-chicken-30559418/p` product has 5 items on stock as of the make of this PR and it should be impossible to add more than the quantity available.
<div style="display:flex">
<img alt="before" src="https://user-images.githubusercontent.com/1753396/155583964-a45e2000-442e-4cd0-ac60-d2ffd4425c7a.gif" />
<img alt="after" src="https://user-images.githubusercontent.com/1753396/155583976-584b2b34-0480-4c8b-944b-bb0fe4bc1393.gif" />
</div>

## How to test it?
Test using the product:  `/tasty-cotton-chicken-30559418/p`

### `base.store` Deploy Preview
https://github.com/vtex-sites/base.store/pull/366

## References
