### PR TITLE
docs: Re-add wml instructions for linking @faststore/api

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -34,6 +34,29 @@ Example:
 }
 ```
 
+#### Linking local changes from `@faststore/api`
+
+`graphql-js` package is cumbersome when using `yarn link` because it requires only one instance of the package and there are two.
+
+For this reason, to see our changes at FastStore running on a local store, we need to use [wml](https://github.com/wix/wml).
+
+So, suppose you want to make changes into the API package and test it at your local base.store, wml is used to copy all files from `packages/api` to `<path-to-base.store>/node_modules/@faststore/api`. It also watches for changes to copy/paste on the go.
+
+To do this:
+
+```bash
+## At FastStore `/api` package folder (faststore/packages/api)
+$ yarn develop
+
+## These can be executed anywhere
+$ npm install -g wml
+$ wml add <faststore>/packages/api <path-to>.store/node_modules/@faststore/api
+$ wml start
+
+## Finally, at the base.store folder (base.store)
+$ yarn clean && yarn develop
+```
+
 ### Creating Components on the `faststore/ui`
 
 You can generate the boilerplate files for your new component using the following command:

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -36,7 +36,7 @@ Example:
 
 #### Linking local changes from `@faststore/api`
 
-`graphql-js` package is cumbersome when using `yarn link` because it requires only one instance of the package and there are two.
+Sometimes symbolic links aren't enough (e.g., dealing with the local `graphql-js` package is cumbersome when using `yarn link` because it requires only one instance of the package, and there are two).
 
 For this reason, to see our changes at FastStore running on a local store, we need to use [wml](https://github.com/wix/wml).
 
@@ -49,7 +49,7 @@ To do this:
 $ yarn develop
 
 ## These can be executed anywhere
-$ npm install -g wml
+$ yarn global add wml
 $ wml add <faststore>/packages/api <path-to>.store/node_modules/@faststore/api
 $ wml start
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ These are the clients running in production with FastStore:
 - [Carrefour](https://mercado.carrefour.com.br/)
 
 ## Contributing
-This is still a work in progress, however, if you are also an adventurous person, you can read the code and have some fun!
+
+This is still a work in progress, however, if you are also an adventurous person, you can read the code and have some fun! See [CONTRIBUTING.MD](https://github.com/vtex/faststore/blob/master/CONTRIBUTING.MD) for more information.
 
 ## Getting help
 


### PR DESCRIPTION
## What's the purpose of this pull request?

In #1055 we added instructions on properly linking, due to duplicate instances of the `graphql-js` package, a local `@faststore/api` package to a store. However, that section got removed by mistake in [#1060](https://github.com/vtex/faststore/commit/3aa669c2c766e49b14bd7abea6fde48937a1eba2#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L93-L114) while we were migrating the documentation.

This PR adds the instructions back into the `CONTRIBUTING.MD` file: https://github.com/vtex/faststore/blob/docs/wml/CONTRIBUTING.MD#linking-local-changes-from-faststoreapi.

## References

- #1055 
- #1060's https://github.com/vtex/faststore/commit/3aa669c2c766e49b14bd7abea6fde48937a1eba2#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L93-L114