### PR TITLE
chore(sdk): Fix setSession function type to receive partial session

### DIFF
--- a/packages/sdk/src/session/Provider.tsx
+++ b/packages/sdk/src/session/Provider.tsx
@@ -22,7 +22,7 @@ export interface Session {
 }
 
 export interface ContextValue extends Session {
-  setSession: (session: Session) => void
+  setSession: (session: Partial<Session>) => void
 }
 
 export const Context = createContext<ContextValue | undefined>(undefined)
@@ -58,10 +58,10 @@ export const Provider: FC<Props> = ({
     })
   )
 
-  const value = useMemo(
+  const value = useMemo<ContextValue>(
     () => ({
       ...session,
-      setSession: (data: Session) => setSession({ ...session, ...data }),
+      setSession: (data) => setSession({ ...session, ...data }),
     }),
     [session, setSession]
   )


### PR DESCRIPTION
## What's the purpose of this pull request?
Fix ContextValue setSession function type.

## How it works? 
setSession function allows receiving partial session as parameter input, but the type says that need to pass session.
before:
```ts
export interface ContextValue extends Session {
  setSession: (session: Session) => void
}
// ...
const value = useMemo(
    () => ({
      ...session,
      setSession: (data: Session) => setSession({ ...session, ...data }),
    }),
    [session, setSession]
  )
```

after:
```ts
export interface ContextValue extends Session {
  setSession: (session: Partial<Session>) => void
}
// ...
const value = useMemo<ContextValue>(
    () => ({
      ...session,
      setSession: (data) => setSession({ ...session, ...data }),
    }),
    [session, setSession]
  )
```

After the fix, is possible to pass partial session:
```ts
const { setSession } = useSession()
setSession({ postalCode: 'foo' })
```
## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### `base.store` Deploy Preview
https://github.com/vtex-sites/base.store/pull/388

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
