### PR TITLE
fix(api): Add missing `totalCount` field to `pageInfo` in `allCollections` query

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -142,6 +142,7 @@ export const Query = {
         endCursor: (
           Math.min(first, validCollections.length - after) - 1
         ).toString(),
+        totalCount: validCollections.length,
       },
       edges: validCollections
         .slice(after, after + first)


### PR DESCRIPTION
## What's the purpose of this pull request?

The `allCollections` query always fails if the user asks for the `pageInfo.totalCount` field, that is because the resolver for that query would never return that field.

## How it works? 

Now the resolver will return the number of valid collections in the store when a user asks for `pageInfo.totalCount`.

## How to test it?

I used the local server to test it (spoilers 🤫 ).

### `base.store` Deploy Preview
<!--- Add a link to a deploy preview from `base.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
