### PR TITLE
chore: Remove slug transformation

### DIFF
--- a/packages/api/src/platforms/vtex/utils/facets.ts
+++ b/packages/api/src/platforms/vtex/utils/facets.ts
@@ -1,18 +1,6 @@
-import { BadRequestError } from './errors'
-
 export interface SelectedFacet {
   key: string
   value: string
-}
-
-const getIdFromSlug = (slug: string) => {
-  const id = slug.split('-').pop()
-
-  if (id == null) {
-    throw new BadRequestError('Error while extracting sku id from product slug')
-  }
-
-  return id
 }
 
 /**
@@ -23,9 +11,6 @@ export const transformSelectedFacet = ({ key, value }: SelectedFacet) => {
   switch (key) {
     case 'channel':
       return { key: 'trade-policy', value }
-
-    case 'slug':
-      return { key: 'id', value: getIdFromSlug(value) }
 
     default:
       return { key, value }


### PR DESCRIPTION
## What's the purpose of this pull request?
Allow users query a product by slug without any transformation.

## How it works? 
Currently, we add a `skuId` in the end of the VTEX's product slug, i.e. the final faststore product path is something like: `${vtexSlug}-${skuId}`. Because of that, I added a transformation inside faststore api to remove this skuId before sending the request to vtex. Turns out, we don't use this `fetchBySlug` strategy anymore, but `fetchBySkuId`. This PR removes this unecessary transformation to allow developers to fetch a product by the old VTEX slug standard. This will be important for store migrations. 

## How to test it?
Make sure everything is working as before on this link: https://github.com/vtex-sites/base.store/pull/394