### PR TITLE
chore: Best offer first

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
@@ -3,17 +3,36 @@ import type { Simulation } from '../clients/commerce/types/Simulation'
 
 type Resolvers = (root: Simulation & { product: EnhancedSku }) => unknown
 
+const inStock = (item: Simulation['items'][0]) =>
+  item.availability === 'https://schema.org/InStock'
+
+// Smallest Available Selling Price First
+export const sortOfferByPrice = (
+  items: Simulation['items']
+): Simulation['items'] =>
+  items.sort((a, b) => {
+    if (inStock(a) && !inStock(b)) {
+      return -1
+    }
+
+    if (!inStock(a) && inStock(b)) {
+      return 1
+    }
+
+    return a.sellingPrice - b.sellingPrice
+  })
+
 export const StoreAggregateOffer: Record<string, Resolvers> = {
-  highPrice: ({ items }) =>
-    items.reduce(
-      (acc, curr) => (acc > curr.sellingPrice ? acc : curr.sellingPrice),
-      items[0]?.sellingPrice ?? 0
-    ) / 1e2,
-  lowPrice: ({ items }) =>
-    items.reduce(
-      (acc, curr) => (acc < curr.sellingPrice ? acc : curr.sellingPrice),
-      items[0]?.sellingPrice ?? 0
-    ) / 1e2,
+  highPrice: ({ items }) => {
+    const highPrice = items[items.length - 1]?.sellingPrice
+
+    return (highPrice ?? 0) / 1e2
+  },
+  lowPrice: ({ items }) => {
+    const lowPrice = items[0]?.sellingPrice
+
+    return (lowPrice ?? 0) / 1e2
+  },
   offerCount: ({ items }) => items.length,
   priceCurrency: () => '',
   offers: ({ items, product }) => items.map((item) => ({ ...item, product })),

--- a/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
@@ -24,12 +24,14 @@ export const sortOfferByPrice = (
 
 export const StoreAggregateOffer: Record<string, Resolvers> = {
   highPrice: ({ items }) => {
-    const highPrice = items[items.length - 1]?.sellingPrice
+    const availableItems = items.filter(inStock)
+    const highPrice = availableItems.pop()?.sellingPrice
 
     return (highPrice ?? 0) / 1e2
   },
   lowPrice: ({ items }) => {
-    const lowPrice = items[0]?.sellingPrice
+    const availableItems = items.filter(inStock)
+    const lowPrice = availableItems[0]?.sellingPrice
 
     return (lowPrice ?? 0) / 1e2
   },

--- a/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
@@ -4,7 +4,7 @@ import type { Simulation } from '../clients/commerce/types/Simulation'
 type Resolvers = (root: Simulation & { product: EnhancedSku }) => unknown
 
 const inStock = (item: Simulation['items'][0]) =>
-  item.availability === 'https://schema.org/InStock'
+  item.availability === 'available'
 
 // Smallest Available Selling Price First
 export const sortOfferByPrice = (

--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -1,6 +1,7 @@
+import { slugify } from '../utils/slugify'
 import type { Resolver } from '..'
 import type { EnhancedSku } from '../utils/enhanceSku'
-import { slugify } from '../utils/slugify'
+import { sortOfferByPrice } from './aggregateOffer'
 
 type Root = EnhancedSku
 
@@ -81,7 +82,11 @@ export const StoreProduct: Record<string, Resolver<Root>> = {
 
     const simulation = await simulationLoader.load(items)
 
-    return { ...simulation, product }
+    return {
+      ...simulation,
+      items: sortOfferByPrice(simulation.items),
+      product,
+    }
   },
   isVariantOf: ({ isVariantOf }) => isVariantOf,
   additionalProperty: ({ attributes = [] }) =>

--- a/packages/api/test/vtex.aggregateOffer.test.ts
+++ b/packages/api/test/vtex.aggregateOffer.test.ts
@@ -5,46 +5,46 @@ describe('AggregateOffer', () => {
     const sorted = sortOfferByPrice([
       {
         sellingPrice: 10,
-        availability: 'https://schema.org/InStock',
+        availability: 'available',
       },
       {
         sellingPrice: 20,
-        availability: 'https://schema.org/OutOfStock',
+        availability: 'unavailable',
       },
       {
         sellingPrice: 30,
-        availability: 'https://schema.org/InStock',
+        availability: 'available',
       },
       {
         sellingPrice: 10,
-        availability: 'https://schema.org/OutOfStock',
+        availability: 'unavailable',
       },
       {
         sellingPrice: 1,
-        availability: 'https://schema.org/InStock',
+        availability: 'available',
       },
     ] as any)
 
     expect(sorted).toEqual([
       {
         sellingPrice: 1,
-        availability: 'https://schema.org/InStock',
+        availability: 'available',
       },
       {
         sellingPrice: 10,
-        availability: 'https://schema.org/InStock',
+        availability: 'available',
       },
       {
         sellingPrice: 30,
-        availability: 'https://schema.org/InStock',
+        availability: 'available',
       },
       {
         sellingPrice: 10,
-        availability: 'https://schema.org/OutOfStock',
+        availability: 'unavailable',
       },
       {
         sellingPrice: 20,
-        availability: 'https://schema.org/OutOfStock',
+        availability: 'unavailable',
       },
     ])
   })

--- a/packages/api/test/vtex.aggregateOffer.test.ts
+++ b/packages/api/test/vtex.aggregateOffer.test.ts
@@ -1,0 +1,51 @@
+import { sortOfferByPrice } from '../src/platforms/vtex/resolvers/aggregateOffer'
+
+describe('AggregateOffer', () => {
+  it('Should return best offers first', () => {
+    const sorted = sortOfferByPrice([
+      {
+        sellingPrice: 10,
+        availability: 'https://schema.org/InStock',
+      },
+      {
+        sellingPrice: 20,
+        availability: 'https://schema.org/OutOfStock',
+      },
+      {
+        sellingPrice: 30,
+        availability: 'https://schema.org/InStock',
+      },
+      {
+        sellingPrice: 10,
+        availability: 'https://schema.org/OutOfStock',
+      },
+      {
+        sellingPrice: 1,
+        availability: 'https://schema.org/InStock',
+      },
+    ] as any)
+
+    expect(sorted).toEqual([
+      {
+        sellingPrice: 1,
+        availability: 'https://schema.org/InStock',
+      },
+      {
+        sellingPrice: 10,
+        availability: 'https://schema.org/InStock',
+      },
+      {
+        sellingPrice: 30,
+        availability: 'https://schema.org/InStock',
+      },
+      {
+        sellingPrice: 10,
+        availability: 'https://schema.org/OutOfStock',
+      },
+      {
+        sellingPrice: 20,
+        availability: 'https://schema.org/OutOfStock',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## What's the purpose of this pull request?
Moves computation from the frontend to the backend

## How it works? 
As stated on [this comment](https://github.com/vtex-sites/base.store/blob/f0190f3cded3506f92b9061b8de96aaca62d8725/src/components/product/ProductCard/ProductCard.tsx#L56), this PR sorts offers by placing the best offers on the first bit of the offers array, allowing us to stop doing this computation on the frontend. This should reduce TBT

## How to test it?
Tests included, but also, check the `base.store` preview: https://github.com/vtex-sites/base.store/pull/411