### PR TITLE
feat(sdk): Improve useStorage and Optimistic revalidate effect

### DIFF
--- a/packages/sdk/src/cart/Optimistic.tsx
+++ b/packages/sdk/src/cart/Optimistic.tsx
@@ -44,12 +44,16 @@ export const OptimisticProvider = <T extends Item = Item>({
 
       setIsValidating(false)
       if (newCart != null) {
-        setCart(newCart)
+        setTimeout(() => {
+          setCart(newCart)
+        }, 0)
       }
     }
 
     // Enqueue validation
-    queue = queue.then(revalidate)
+    setTimeout(() => {
+      queue = queue.then(revalidate)
+    }, 0)
 
     return () => {
       cancel = true

--- a/packages/sdk/src/cart/Optimistic.tsx
+++ b/packages/sdk/src/cart/Optimistic.tsx
@@ -44,9 +44,7 @@ export const OptimisticProvider = <T extends Item = Item>({
 
       setIsValidating(false)
       if (newCart != null) {
-        setTimeout(() => {
-          setCart(newCart)
-        }, 0)
+        setCart(newCart)
       }
     }
 

--- a/packages/sdk/src/storage/useStorage.ts
+++ b/packages/sdk/src/storage/useStorage.ts
@@ -45,11 +45,13 @@ export const useStorage = <T>(key: string, initialValue: T | (() => T)) => {
       const item = await getItem<T>(key)
 
       if (!cancel && item !== null) {
-        setData(item)
+        setTimeout(() => {
+          setData(item)
+        }, 0)
       }
     }
 
-    effect()
+    setTimeout(effect, 0)
 
     return () => {
       cancel = true

--- a/packages/sdk/src/storage/useStorage.ts
+++ b/packages/sdk/src/storage/useStorage.ts
@@ -45,9 +45,7 @@ export const useStorage = <T>(key: string, initialValue: T | (() => T)) => {
       const item = await getItem<T>(key)
 
       if (!cancel && item !== null) {
-        setTimeout(() => {
-          setData(item)
-        }, 0)
+        setData(item)
       }
     }
 


### PR DESCRIPTION
## What's the purpose of this pull request?
Improve the performance of useStorage hook.

## How it works? 
The useStorage hook has an effect that fetches an item from the indexedDB, then update an internal state with this item. So, exists two tasks, one is a micro-task because is a promise and the other one belongs to the same task. The problem is these two tasks sometimes can create tasks that took more than 50ms and are considered Long Tasks.  Know this, this PR wraps the async promise and the set state inside a setTimeout. Why setTimeout, because it creates a new task. For more information about tasks and microtasks you can read this [article](https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/)

Take a look at the quantity of long tasks after the hydration
**Before**:
![image](https://user-images.githubusercontent.com/15680320/159784365-a7acb44b-b6e1-4041-ae54-fcad5effa2bb.png)
**After**:
![image](https://user-images.githubusercontent.com/15680320/159784275-ce877e5c-88d6-445f-974f-db8bf6cb3266.png)

Run PSI API for mobile 15 times and the result is this

**Before**: using production https://623b35ed844ee300083a6a4a--basestore.netlify.app/
| Metric | Mean | Standard deviation |
|--------|--------|--------|
| Cumulative Layout shift (CLS) | 0 | 0 |
| First Contentful Paint (FCP) | 1374.77 | 41989.24 |
| First Contentful Paint 3g (FCP) | 2950.40 | 301420.73 |
| Largest Contentful Paint (LCP) | 2038.73 | 6.44 |
| Time to Interactive (TTI) | 3556.91 | 2587.85 |
| Total Blocking Time (TBT) | 381.35 | 1197.05 |
| Performance score | 0.889 | 0.000189 |
| JavaScript Execution Time | 1524.33 | 16593.14 |
| Speed Index | 2577.09 | 14417.72 |

Using https://sfj-86eb203--base.preview.vtex.app/
| Metric | Mean | Standard deviation |
|--------|--------|--------|
| Cumulative Layout shift (CLS) | 0 | 0 |
| First Contentful Paint (FCP) | 1241.4360950543794 | 48858.223245183246 |
| First Contentful Paint 3g (FCP) | 2591.795666633926 | 346806.5173277669 |
| Largest Contentful Paint (LCP) | 2085.24143603237 | 620.4396250922497 |
| Time to Interactive (TTI) | 3448.2983300299215 | 17528.68604983101 |
| Total Blocking Time (TBT) | 395.70000000000005 | 40.56000000000141 |
| Performance score | 0.882 | 0.00009600000000000014 |
| JavaScript Execution Time | 1452.6079999999997 | 6068.96649600012 |
| Speed Index | 2755.665328848717 | 292407.41411333304 |

**After**: using https://deploy-preview-416--basestore.netlify.app/
| Metric | Mean | Standard deviation |
|--------|--------|--------|
| Cumulative Layout shift (CLS) | 0 | 0 |
| First Contentful Paint (FCP) | 1192.30 | 22365.39 |
| First Contentful Paint 3g (FCP) | 2377.30 | 89280.68 |
| Largest Contentful Paint (LCP) | 1912.85 | 12547.15 |
| Time to Interactive (TTI) | 3244.72 | 4820.48 |
| Total Blocking Time (TBT) | 354.77 | 1982.53 |
| Performance score | 0.891 | 0.000099 |
| JavaScript Execution Time | 1397.53 | 13404.71 |
| Speed Index | 3481.75 | 687891.91 |

Using https://sfj-b706982--base.preview.vtex.app/
| Metric | Mean | Standard deviation |
|--------|--------|--------|
| Cumulative Layout shift (CLS) | 0 | 0 |
| First Contentful Paint (FCP) | 1146.591710387593 | 46688.01969331607 |
| First Contentful Paint 3g (FCP) | 2286.5917103875936 | 185172.6858950842 |
| Largest Contentful Paint (LCP) | 1799.2311087744408 | 696.6499034977962 |
| Time to Interactive (TTI) | 3416.154703867696 | 1247.8465910818973 |
| Total Blocking Time (TBT) | 322.825 | 30.631875000000015 |
| Performance score | 0.9185000000000002 | 0.000012750000000000017 |
| JavaScript Execution Time | 1334.0718000000002 | 414.42193835999586 |
| Speed Index | 1586.9125547973374 | 1212.1435711435802 |

## How to test it?
Run PSI or run performance test using DevTools

### `base.store` Deploy Preview
https://github.com/vtex-sites/base.store/pull/416

## References
https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/
