### PR TITLE
feat: setFacets

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -49,7 +49,7 @@
     "size-limit": "^4.10.2",
     "tsdx": "^0.14.1",
     "tslib": "^2.3.1",
-    "typescript": "^4.2.4"
+    "typescript": "^4.6.2"
   },
   "dependencies": {
     "idb-keyval": "^5.1.3"

--- a/packages/sdk/src/search/useSearchState.ts
+++ b/packages/sdk/src/search/useSearchState.ts
@@ -82,6 +82,10 @@ type Action =
       payload: { facet: Facet; unique: boolean }
     }
   | {
+      type: 'setFacets'
+      payload: Facet[]
+    }
+  | {
       type: 'removeFacet'
       payload: Facet
     }
@@ -190,6 +194,11 @@ export const reducer = (state: State, action: Action) => {
     case 'setFacet':
       return setFacet(state, action.payload.facet, action.payload.unique)
 
+    case 'setFacets':
+      return state.selectedFacets !== action.payload
+        ? { ...state, selectedFacets: action.payload }
+        : state
+
     case 'removeFacet':
       return removeFacet(state, action.payload)
 
@@ -232,6 +241,8 @@ export const useSearchState = (
       setPage: (page: number) => dispatch({ type: 'setPage', payload: page }),
       setFacet: (facet: Facet, unique = false) =>
         dispatch({ type: 'setFacet', payload: { facet, unique } }),
+      setFacets: (facets: Facet[]) =>
+        dispatch({ type: 'setFacets', payload: facets }),
       removeFacet: (facet: Facet) =>
         dispatch({ type: 'removeFacet', payload: facet }),
       toggleFacet: (facet: Facet) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -30862,6 +30862,11 @@ typescript@^4.4.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
   integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
+typescript@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.39"
   resolved "https://registry.yarnpkg.com/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz#9e0f5aabd5eebfcffd65a796487541196f4b1211"


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds `setFacets` function to the search context. This function sets all selected facets without any processing, allowing full control of selected facets by the developer.

## How it works? 
When creating a filter interface for mobile devices, we need to allow the final user to select multiple facets before applying them, all at once. This is usually accomplished by the developer managing which facets are selected in a state outside this module. Without `setFacets`, the developer had to do some magic by using `toggleFacets` function, which was not well suited for this task. `setFacets` allows the developer to use our module in a controlled way, setting all facets externally.

### `base.store` Deploy Preview
https://github.com/vtex-sites/base.store/pull/422
