### PR TITLE
fix: fix breadcrumb component bug

### DIFF
--- a/packages/ui/src/molecules/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/ui/src/molecules/Breadcrumb/Breadcrumb.test.tsx
@@ -95,6 +95,20 @@ describe('Breadcrumb', () => {
     expect(dividers).toHaveLength(2)
   })
 
+  it('Should not render null values', () => {
+    const { getAllByTestId } = render(
+      <Breadcrumb>
+        <a href="/office">Office</a>
+        <a href="/office/chairs">Chairs</a>
+        <a href="/office/chairs/tulip">Tulip</a>
+        {false && <a href="/office/chairs/tulip/red">Tulip Red</a>}
+        {null}
+      </Breadcrumb>
+    )
+
+    expect(getAllByTestId('store-breadcrumb-item')).toHaveLength(3)
+  })
+
   it('AXE Test', async () => {
     render(
       <Breadcrumb aria-label="test modal" divider="/">

--- a/packages/ui/src/molecules/Breadcrumb/Breadcrumb.tsx
+++ b/packages/ui/src/molecules/Breadcrumb/Breadcrumb.tsx
@@ -76,8 +76,6 @@ const Breadcrumb = forwardRef<HTMLDivElement, BreadcrumbProps>(
     },
     ref
   ) {
-    const lastIndex = React.Children.count(children)
-
     return (
       <nav
         aria-label="Breadcrumb"
@@ -88,20 +86,22 @@ const Breadcrumb = forwardRef<HTMLDivElement, BreadcrumbProps>(
         {...otherProps}
       >
         <List data-breadcrumb-list variant="ordered">
-          {React.Children.map(children, (child, index) => {
-            const isLastItem = index === lastIndex - 1
+          {React.Children.toArray(children).map(
+            (child, index, childrenArray) => {
+              const isLastItem = index === childrenArray.length - 1
 
-            return (
-              <ListItem
-                isLastItem={isLastItem}
-                divider={rawDivider}
-                key={`breadcrumb-${index}`}
-                testId={testId}
-              >
-                {child}
-              </ListItem>
-            )
-          })}
+              return (
+                <ListItem
+                  isLastItem={isLastItem}
+                  divider={rawDivider}
+                  key={`breadcrumb-${index}`}
+                  testId={testId}
+                >
+                  {child}
+                </ListItem>
+              )
+            }
+          )}
         </List>
       </nav>
     )


### PR DESCRIPTION
Signed-off-by: Arthur Andrade <arthurfelandrade@gmail.com>

## What's the purpose of this pull request?
This PR fix a Breadcrumb bug. This bug occurs when a conditional rendering is called inside the Breadcrumb, even if the rendering is false the component renders the divider, like in the picture.

![Screen Shot 2022-03-24 at 15 45 09](https://user-images.githubusercontent.com/51174217/159993946-1ba6d924-b66a-4c26-97ff-2a4d9c7493bc.png)

![Screen Shot 2022-03-24 at 15 45 55](https://user-images.githubusercontent.com/51174217/159993907-8027cbf2-6b8e-4a00-87f6-fee16712f246.png)

To fix this bug, the function` React.Children.toArray` was added, it converts from `ReactChildren` to `Array` and filters the `null` childrens
