### PR TITLE
feat: search suggestions

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -108,7 +108,6 @@ export type QuerySearchArgs = {
   first?: Maybe<Scalars['Int']>;
   selectedFacets?: Maybe<Array<IStoreSelectedFacet>>;
   sort?: Maybe<StoreSort>;
-  suggestions?: Maybe<Scalars['Boolean']>;
   term?: Maybe<Scalars['String']>;
 };
 
@@ -332,7 +331,7 @@ export type StoreSearchResult = {
   __typename?: 'StoreSearchResult';
   facets?: Maybe<Array<StoreFacet>>;
   products?: Maybe<StoreProductConnection>;
-  suggestions?: Maybe<Array<StoreSuggestion>>;
+  suggestions?: Maybe<StoreSuggestions>;
 };
 
 export type StoreSeo = {
@@ -367,7 +366,8 @@ export const enum StoreStatus {
   Warning = 'WARNING'
 };
 
-export type StoreSuggestion = {
-  __typename?: 'StoreSuggestion';
-  term: Scalars['String'];
+export type StoreSuggestions = {
+  __typename?: 'StoreSuggestions';
+  products?: Maybe<Array<StoreProduct>>;
+  terms?: Maybe<Array<Scalars['String']>>;
 };

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -105,9 +105,10 @@ export type QueryProductArgs = {
 
 export type QuerySearchArgs = {
   after?: Maybe<Scalars['String']>;
-  first: Scalars['Int'];
+  first?: Maybe<Scalars['Int']>;
   selectedFacets?: Maybe<Array<IStoreSelectedFacet>>;
   sort?: Maybe<StoreSort>;
+  suggestions?: Maybe<Scalars['Boolean']>;
   term?: Maybe<Scalars['String']>;
 };
 
@@ -329,8 +330,9 @@ export type StoreReviewRating = {
 
 export type StoreSearchResult = {
   __typename?: 'StoreSearchResult';
-  facets: Array<StoreFacet>;
-  products: StoreProductConnection;
+  facets?: Maybe<Array<StoreFacet>>;
+  products?: Maybe<StoreProductConnection>;
+  suggestions?: Maybe<Array<StoreSuggestion>>;
 };
 
 export type StoreSeo = {
@@ -363,4 +365,9 @@ export const enum StoreStatus {
   Error = 'ERROR',
   Info = 'INFO',
   Warning = 'WARNING'
+};
+
+export type StoreSuggestion = {
+  __typename?: 'StoreSuggestion';
+  term: Scalars['String'];
 };

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -24,6 +24,7 @@ export interface SearchArgs {
   selectedFacets?: SelectedFacet[]
   fuzzy?: '0' | '1'
   hideUnavailableItems?: boolean
+  suggestions?: boolean
 }
 
 export interface ProductLocator {
@@ -84,11 +85,21 @@ export const IntelligentSearch = (
   const products = (args: Omit<SearchArgs, 'type'>) =>
     search<ProductSearchResult>({ ...args, type: 'product_search' })
 
+  const suggestedProducts = (
+    args: Omit<SearchArgs, 'type'>
+  ): Promise<ProductSearchResult> =>
+    fetchAPI(`${base}/api/suggestion_products/?term=${args.query}`)
+
+  const suggestedTerms = (args: Omit<SearchArgs, 'type'>) =>
+    fetchAPI(`${base}/api/split/suggestion_search/?q=${args.query}`)
+
   const facets = (args: Omit<SearchArgs, 'type'>) =>
     search<FacetSearchResult>({ ...args, type: 'facets' })
 
   return {
     facets,
     products,
+    suggestedTerms,
+    suggestedProducts,
   }
 }

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -1,9 +1,12 @@
-import type { Context, Options } from '../../index'
-import { fetchAPI } from '../fetch'
-import type { SelectedFacet } from '../../utils/facets'
-import type { ProductSearchResult } from './types/ProductSearchResult'
-import type { FacetSearchResult } from './types/FacetSearchResult'
 import type { IStoreSelectedFacet } from '../../../../__generated__/schema'
+import type { Context, Options } from '../../index'
+import type { SelectedFacet } from '../../utils/facets'
+import { fetchAPI } from '../fetch'
+import type { FacetSearchResult } from './types/FacetSearchResult'
+import type {
+  ProductSearchResult,
+  SuggestedTerms,
+} from './types/ProductSearchResult'
 
 export type Sort =
   | 'price:desc'
@@ -24,7 +27,6 @@ export interface SearchArgs {
   selectedFacets?: SelectedFacet[]
   fuzzy?: '0' | '1'
   hideUnavailableItems?: boolean
-  suggestions?: boolean
 }
 
 export interface ProductLocator {
@@ -90,7 +92,9 @@ export const IntelligentSearch = (
   ): Promise<ProductSearchResult> =>
     fetchAPI(`${base}/api/suggestion_products/?term=${args.query}`)
 
-  const suggestedTerms = (args: Omit<SearchArgs, 'type'>) =>
+  const suggestedTerms = (
+    args: Omit<SearchArgs, 'type'>
+  ): Promise<SuggestedTerms> =>
     fetchAPI(`${base}/api/split/suggestion_search/?q=${args.query}`)
 
   const facets = (args: Omit<SearchArgs, 'type'>) =>

--- a/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
+++ b/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
@@ -53,6 +53,30 @@ interface Page {
   proxyURL: string
 }
 
+export interface First {
+  index: number
+}
+
+export interface SuggestedTerms {
+  total: number
+  sampling: boolean
+  translated: boolean
+  locale: string
+  query: string
+  operator: string
+  suggestion: Suggestion
+  correction: Correction
+}
+
+export interface Suggestion {
+  searches: Search[]
+}
+
+export interface Search {
+  term: string
+  count: number
+}
+
 export interface Product {
   productId: string
   productName: string

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -38,7 +38,14 @@ export const Query = {
   },
   search: async (
     _: unknown,
-    { first, after: maybeAfter, sort, term, selectedFacets }: QuerySearchArgs,
+    {
+      first,
+      after: maybeAfter,
+      sort,
+      term,
+      selectedFacets,
+      suggestions,
+    }: QuerySearchArgs,
     ctx: Context
   ) => {
     // Insert channel in context for later usage
@@ -52,11 +59,12 @@ export const Query = {
 
     const after = maybeAfter ? Number(maybeAfter) : 0
     const searchArgs = {
-      page: Math.ceil(after / first),
+      page: Math.ceil(after / first!),
       count: first,
       query: term,
       sort: SORT_MAP[sort ?? 'score_desc'],
-      selectedFacets: selectedFacets?.flatMap(transformSelectedFacet) ?? [],
+      selectedFacets: selectedFacets?.map(transformSelectedFacet) ?? [],
+      suggestions,
     }
 
     return searchArgs

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -38,14 +38,7 @@ export const Query = {
   },
   search: async (
     _: unknown,
-    {
-      first,
-      after: maybeAfter,
-      sort,
-      term,
-      selectedFacets,
-      suggestions,
-    }: QuerySearchArgs,
+    { first, after: maybeAfter, sort, term, selectedFacets }: QuerySearchArgs,
     ctx: Context
   ) => {
     // Insert channel in context for later usage
@@ -63,8 +56,7 @@ export const Query = {
       count: first,
       query: term,
       sort: SORT_MAP[sort ?? 'score_desc'],
-      selectedFacets: selectedFacets?.map(transformSelectedFacet) ?? [],
-      suggestions,
+      selectedFacets: selectedFacets?.flatMap(transformSelectedFacet) ?? [],
     }
 
     return searchArgs

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -1,7 +1,7 @@
-import { enhanceSku } from '../utils/enhanceSku'
 import type { Resolver } from '..'
 import type { SearchArgs } from '../clients/search'
 import type { Facet } from '../clients/search/types/FacetSearchResult'
+import { enhanceSku } from '../utils/enhanceSku'
 
 type Root = Omit<SearchArgs, 'type'>
 

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -8,6 +8,31 @@ type Root = Omit<SearchArgs, 'type'>
 const REMOVED_FACETS_FROM_COLLECTION_PAGE = ['departamento', 'Departamento']
 
 export const StoreSearchResult: Record<string, Resolver<Root>> = {
+  suggestions: async (searchArgs, _, ctx) => {
+    const {
+      clients: { search },
+    } = ctx
+
+    const terms = await search.suggestedTerms(searchArgs)
+    const products = await search.suggestedProducts(searchArgs)
+
+    const skus = products.products
+      .map((product) => {
+        const [maybeSku] = product.items
+
+        return maybeSku && enhanceSku(maybeSku, product)
+      })
+      .filter((sku) => !!sku)
+
+    const {
+      suggestion: { searches },
+    } = terms
+
+    return {
+      terms: searches.map((item) => item.term),
+      products: skus,
+    }
+  },
   products: async (searchArgs, _, ctx) => {
     const {
       clients: { search, sp },

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -39,9 +39,14 @@ enum StoreFacetType {
   RANGE
 }
 
+type StoreSuggestion {
+  term: String!
+}
+
 type StoreSearchResult {
-  products: StoreProductConnection!
-  facets: [StoreFacet!]!
+  products: StoreProductConnection
+  facets: [StoreFacet!]
+  suggestions: [StoreSuggestion!]
 }
 
 type Query {

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -55,11 +55,12 @@ type Query {
   collection(slug: String!): StoreCollection!
 
   search(
-    first: Int!
+    first: Int
     after: String
     sort: StoreSort = score_desc
     term: String = ""
     selectedFacets: [IStoreSelectedFacet!]
+    suggestions: Boolean = false
   ): StoreSearchResult!
 
   allProducts(first: Int!, after: String): StoreProductConnection!

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -39,14 +39,15 @@ enum StoreFacetType {
   RANGE
 }
 
-type StoreSuggestion {
-  term: String!
+type StoreSuggestions {
+  terms: [String!]
+  products: [StoreProduct!]
 }
 
 type StoreSearchResult {
   products: StoreProductConnection
   facets: [StoreFacet!]
-  suggestions: [StoreSuggestion!]
+  suggestions: StoreSuggestions
 }
 
 type Query {
@@ -60,7 +61,6 @@ type Query {
     sort: StoreSort = score_desc
     term: String = ""
     selectedFacets: [IStoreSelectedFacet!]
-    suggestions: Boolean = false
   ): StoreSearchResult!
 
   allProducts(first: Int!, after: String): StoreProductConnection!


### PR DESCRIPTION
## What's the purpose of this pull request?

The standardization of Search Suggestions (terms - autocomplete - and products).

## How it works? 
```gql
{
  search(term: "iphone") {
    suggestions {
      terms
      products {
        name
        slug
      }
    }
  }
}
```

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### `base.store` Deploy Preview
https://github.com/vtex-sites/base.store/pull/437

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
