### PR TITLE
added: full changelog section on the base release

### DIFF
--- a/docs/blog/2022-04-01-basestore.md
+++ b/docs/blog/2022-04-01-basestore.md
@@ -4,6 +4,8 @@ tags: [base store]
 hide_table_of_contents: false
 ---
 
+[Full Changelog](https://github.com/vtex-sites/base.store/blob/master/CHANGELOG.md)
+
 # Base Store - March, 2022
 
 The Base Store now has new components: `EmptyState`, `Suggestions`, and `SearchHistory`. Also to improve the page's performance, inline icons were removed from the final bundle.


### PR DESCRIPTION
## What's the purpose of this pull request?
Added a `Full changelog section` on the Base Store Release Notes to reflect its changelog, as seen in [here](https://github.com/vtex-sites/base.store/releases).
