### PR TITLE
fix: Uses catalog slugify

### DIFF
--- a/packages/api/mocks/CollectionQuery.ts
+++ b/packages/api/mocks/CollectionQuery.ts
@@ -38,7 +38,7 @@ export const pageTypeDesksFetch = {
 
 export const pageTypeOfficeFetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/catalog_system/pub/portal/pagetype/Office',
+    'https://storeframework.vtexcommercestable.com.br/api/catalog_system/pub/portal/pagetype/office',
   init: undefined,
   result: JSON.parse(
     '{"id":"9282","name":"Office","url":"storeframework.vtexcommercestable.com.br/Office","title":"Office","metaTagDescription":"For the office and home office","pageType":"Department"}'
@@ -47,7 +47,7 @@ export const pageTypeOfficeFetch = {
 
 export const pageTypeOfficeDesksFetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/catalog_system/pub/portal/pagetype/Office/Desks',
+    'https://storeframework.vtexcommercestable.com.br/api/catalog_system/pub/portal/pagetype/office/desks',
   init: undefined,
   result: JSON.parse(
     '{"id":"9295","name":"Desks","url":"storeframework.vtexcommercestable.com.br/Office/Desks","title":"Desks","metaTagDescription":"Desks for better productivity","pageType":"Category"}'

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@graphql-tools/schema": "^8.2.0",
     "@rollup/plugin-graphql": "^1.0.0",
-    "@sindresorhus/slugify": "^1.1.2",
     "dataloader": "^2.0.0",
     "fast-deep-equal": "^3.1.3",
     "isomorphic-unfetch": "^3.1.0",

--- a/packages/api/src/platforms/vtex/utils/slugify.ts
+++ b/packages/api/src/platforms/vtex/utils/slugify.ts
@@ -1,4 +1,43 @@
-import rawSlugify from '@sindresorhus/slugify'
+/* eslint-disable no-useless-escape */
+/**
+ * VTEX catalog slugify function
+ *
+ * Sometimes, we need to slugify strings for creating urls. An example is the
+ * brand urls, where we create them from the brand's name.
+ * This slugify function should match exactly what VTEX catalog generates. Any mismatch
+ * will lead to broken links.
+ * Hopefully, we had this function implemented on VTEX IO and we've been using it for
+ * years now. However, looking at the code, I think we can save lots of computing. I'm
+ * in a hurry for doing these tests now, so I'll leave a small TODO.
+ *
+ * TODO: Research for better ways of computing this slugify function. Things I'd try are:
+ * - Join those 3 regexs for special characters into a sigle one.
+ * - Replace the regexp of `removeDiacritics` function with a Map. We can make the complexity
+ * of this function be O(n) with n=string.length
+ */
+const from =
+  'ÁÄÂÀÃÅČÇĆĎÉĚËÈÊẼĔȆÍÌÎÏŇÑÓÖÒÔÕØŘŔŠŤÚŮÜÙÛÝŸŽáäâàãåčçćďéěëèêẽĕȇíìîïňñóöòôõøðřŕšťúůüùûýÿžþÞĐđßÆa'
 
-export const slugify = (path: string) =>
-  rawSlugify(path, { separator: '-', lowercase: true })
+const to =
+  'AAAAAACCCDEEEEEEEEIIIINNOOOOOORRSTUUUUUYYZaaaaaacccdeeeeeeeeiiiinnooooooorrstuuuuuyyzbBDdBAa'
+
+const removeDiacritics = (str: string) => {
+  let newStr = str.slice(0)
+
+  for (let i = 0; i < from.length; i++) {
+    newStr = newStr.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i))
+  }
+
+  return newStr
+}
+
+const slugifySpecialCharacters = (str: string) => {
+  return str.replace(/[·/_,:]/, '-')
+}
+
+export function slugify(str: string) {
+  const noCommas = str.replace(/,/g, '')
+  const replaced = noCommas.replace(/[*+~.()'"!:@&\[\]`/ %$#?{}|><=_^]/g, '-')
+
+  return slugifySpecialCharacters(removeDiacritics(replaced)).toLowerCase()
+}

--- a/packages/api/src/platforms/vtex/utils/slugify.ts
+++ b/packages/api/src/platforms/vtex/utils/slugify.ts
@@ -38,6 +38,7 @@ const slugifySpecialCharacters = (str: string) => {
 export function slugify(str: string) {
   const noCommas = str.replace(/,/g, '')
   const replaced = noCommas.replace(/[*+~.()'"!:@&\[\]`/ %$#?{}|><=_^]/g, '-')
+  const slugified = slugifySpecialCharacters(removeDiacritics(replaced))
 
-  return slugifySpecialCharacters(removeDiacritics(replaced)).toLowerCase()
+  return slugified.toLowerCase()
 }

--- a/packages/api/src/platforms/vtex/utils/slugify.ts
+++ b/packages/api/src/platforms/vtex/utils/slugify.ts
@@ -2,6 +2,9 @@
 /**
  * VTEX catalog slugify function
  *
+ * Copied from:
+ * https://github.com/vtex/rewriter/blob/1ce2010783e0586cab42534ce2fb7a983d8a3a84/node/clients/catalog.ts#L72
+ *
  * Sometimes, we need to slugify strings for creating urls. An example is the
  * brand urls, where we create them from the brand's name.
  * This slugify function should match exactly what VTEX catalog generates. Any mismatch
@@ -14,6 +17,7 @@
  * - Join those 3 regexs for special characters into a single one.
  * - Replace the regexp of `removeDiacritics` function with a Map. We can make the complexity
  * of this function be O(n) with n=string.length
+ *
  */
 const from =
   'ÁÄÂÀÃÅČÇĆĎÉĚËÈÊẼĔȆÍÌÎÏŇÑÓÖÒÔÕØŘŔŠŤÚŮÜÙÛÝŸŽáäâàãåčçćďéěëèêẽĕȇíìîïňñóöòôõøðřŕšťúůüùûýÿžþÞĐđßÆa'

--- a/packages/api/src/platforms/vtex/utils/slugify.ts
+++ b/packages/api/src/platforms/vtex/utils/slugify.ts
@@ -11,7 +11,7 @@
  * in a hurry for doing these tests now, so I'll leave a small TODO.
  *
  * TODO: Research for better ways of computing this slugify function. Things I'd try are:
- * - Join those 3 regexs for special characters into a sigle one.
+ * - Join those 3 regexs for special characters into a single one.
  * - Replace the regexp of `removeDiacritics` function with a Map. We can make the complexity
  * of this function be O(n) with n=string.length
  */

--- a/packages/api/test/__snapshots__/queries.test.ts.snap
+++ b/packages/api/test/__snapshots__/queries.test.ts.snap
@@ -119,7 +119,7 @@ Object {
               "selectedFacets": Array [
                 Object {
                   "key": "brand",
-                  "value": "i-robot",
+                  "value": "irobot",
                 },
               ],
             },

--- a/packages/api/test/__snapshots__/queries.test.ts.snap
+++ b/packages/api/test/__snapshots__/queries.test.ts.snap
@@ -724,7 +724,7 @@ Object {
         "title": "Desks",
         "titleTemplate": "",
       },
-      "slug": "Office/Desks",
+      "slug": "office/desks",
       "type": "Category",
     },
   },


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes slug mismatches, thus broken links, between `@faststore/api` and VTEX catalog.

## How it works? 
It uses same, the battle tested, slugify function VTEX IO uses for slugifying links. This is now possbile thanks to Gatsby v4. 

> Note: If you are not using gatsby v4, please upgrade before updating this library.

## How to test it?
Make sure all links on `base.store` are working as intended. Also, I have changed the category name from `Computer and Software` to `Computer & Software`. This change used to break other versions of `base.store`, however, now, it should be working.

BaseStore link: 
https://github.com/vtex-sites/base.store/pull/468

## References
- Slugify implementation on VTEX IO: https://github.com/vtex/rewriter/blob/1ce2010783e0586cab42534ce2fb7a983d8a3a84/node/clients/catalog.ts#L72