### PR TITLE
Fix: Adds Banner's missing other props

### DIFF
--- a/packages/ui/src/molecules/Banner/Banner.test.tsx
+++ b/packages/ui/src/molecules/Banner/Banner.test.tsx
@@ -9,7 +9,7 @@ import BannerLink from './BannerLink'
 
 const BannerTest = () => {
   return (
-    <Banner>
+    <Banner data-custom-attribute>
       <BannerImage>
         <img
           alt="A person with hands on the pocket, carrying a round straw bag"
@@ -38,6 +38,10 @@ describe('Banner', () => {
 
     it('`Banner` component should have `data-store-banner` attribute', () => {
       expect(banner).toHaveAttribute('data-store-banner')
+    })
+
+    it('`Banner` component should have custom data attribute `data-custom-attribute`', () => {
+      expect(banner).toHaveAttribute('data-custom-attribute')
     })
 
     it('`BannerImage` component should have `data-banner-image` attribute', () => {

--- a/packages/ui/src/molecules/Banner/Banner.tsx
+++ b/packages/ui/src/molecules/Banner/Banner.tsx
@@ -15,9 +15,10 @@ const Banner = ({
   testId = 'store-banner',
   children,
   variant = 'vertical',
+  ...otherProps
 }: BannerProps) => {
   return (
-    <article data-store-banner={variant} data-testid={testId}>
+    <article data-store-banner={variant} data-testid={testId} {...otherProps}>
       {children}
     </article>
   )

--- a/packages/ui/src/molecules/Banner/Banner.tsx
+++ b/packages/ui/src/molecules/Banner/Banner.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
+import type { HTMLAttributes } from 'react'
 
 type BannerDirectionVariant = 'vertical' | 'horizontal'
-export interface BannerProps {
+export interface BannerProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress,
    * testing-library, and jest).
@@ -11,17 +12,20 @@ export interface BannerProps {
   variant?: BannerDirectionVariant
 }
 
-const Banner = ({
-  testId = 'store-banner',
-  children,
-  variant = 'vertical',
-  ...otherProps
-}: BannerProps) => {
+const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
+  { testId = 'store-banner', children, variant = 'vertical', ...otherProps },
+  ref
+) {
   return (
-    <article data-store-banner={variant} data-testid={testId} {...otherProps}>
+    <article
+      ref={ref}
+      data-store-banner={variant}
+      data-testid={testId}
+      {...otherProps}
+    >
       {children}
     </article>
   )
-}
+})
 
 export default Banner


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add the missing `otherProps` param to the `Banner` component.