### PR TITLE
fix(sdk): Revert "feat: Add url to events (#1174)"

### DIFF
--- a/packages/sdk/src/analytics/events/add_payment_info.ts
+++ b/packages/sdk/src/analytics/events/add_payment_info.ts
@@ -1,4 +1,4 @@
-import type { CurrencyCode, Item, LocatorParam } from './common'
+import type { CurrencyCode, Item } from './common'
 
 export interface AddPaymentInfoParams<T extends Item = Item> {
   currency?: CurrencyCode
@@ -10,5 +10,5 @@ export interface AddPaymentInfoParams<T extends Item = Item> {
 
 export interface AddPaymentInfoEvent<T extends Item = Item> {
   name: 'add_payment_info'
-  params: AddPaymentInfoParams<T> & LocatorParam
+  params: AddPaymentInfoParams<T>
 }

--- a/packages/sdk/src/analytics/events/add_shipping_info.ts
+++ b/packages/sdk/src/analytics/events/add_shipping_info.ts
@@ -1,4 +1,4 @@
-import type { CurrencyCode, Item, LocatorParam } from './common'
+import type { CurrencyCode, Item } from './common'
 
 export interface AddShippingInfoParams<T extends Item = Item> {
   currency?: CurrencyCode
@@ -10,5 +10,5 @@ export interface AddShippingInfoParams<T extends Item = Item> {
 
 export interface AddShippingInfoEvent<T extends Item = Item> {
   name: 'add_shipping_info'
-  params: AddShippingInfoParams<T> & LocatorParam
+  params: AddShippingInfoParams<T>
 }

--- a/packages/sdk/src/analytics/events/add_to_cart.ts
+++ b/packages/sdk/src/analytics/events/add_to_cart.ts
@@ -1,4 +1,4 @@
-import type { CurrencyCode, Item, LocatorParam } from './common'
+import type { CurrencyCode, Item } from './common'
 
 export interface AddToCartParams<T extends Item = Item> {
   currency?: CurrencyCode
@@ -8,5 +8,5 @@ export interface AddToCartParams<T extends Item = Item> {
 
 export interface AddToCartEvent<T extends Item = Item> {
   name: 'add_to_cart'
-  params: AddToCartParams<T> & LocatorParam
+  params: AddToCartParams<T>
 }

--- a/packages/sdk/src/analytics/events/add_to_wishlist.ts
+++ b/packages/sdk/src/analytics/events/add_to_wishlist.ts
@@ -1,4 +1,4 @@
-import type { CurrencyCode, Item, LocatorParam } from './common'
+import type { CurrencyCode, Item } from './common'
 
 export interface AddToWishlistParams<T extends Item = Item> {
   currency?: CurrencyCode
@@ -8,5 +8,5 @@ export interface AddToWishlistParams<T extends Item = Item> {
 
 export interface AddToWishlistEvent<T extends Item = Item> {
   name: 'add_to_wishlist'
-  params: AddToWishlistParams<T> & LocatorParam
+  params: AddToWishlistParams<T>
 }

--- a/packages/sdk/src/analytics/events/begin_checkout.ts
+++ b/packages/sdk/src/analytics/events/begin_checkout.ts
@@ -1,4 +1,4 @@
-import type { CurrencyCode, Item, LocatorParam } from './common'
+import type { CurrencyCode, Item } from './common'
 
 export interface BeginCheckoutParams<T extends Item = Item> {
   currency?: CurrencyCode
@@ -9,5 +9,5 @@ export interface BeginCheckoutParams<T extends Item = Item> {
 
 export interface BeginCheckoutEvent<T extends Item = Item> {
   name: 'begin_checkout'
-  params: BeginCheckoutParams<T> & LocatorParam
+  params: BeginCheckoutParams<T>
 }

--- a/packages/sdk/src/analytics/events/common.ts
+++ b/packages/sdk/src/analytics/events/common.ts
@@ -1,8 +1,3 @@
-export interface LocatorParam {
-  /** @description url where this event was emitted. Helps tracking event origin */
-  url: string
-}
-
 export interface ItemId {
   item_id: string
 }
@@ -11,7 +6,7 @@ export interface ItemName {
   item_name: string
 }
 
-export type ItemUniqueIdentifier = ItemId & ItemName
+export type ItemUniqueIdentifier = ItemId | ItemName
 
 export interface ItemWithoutIdentifier {
   /**

--- a/packages/sdk/src/analytics/events/login.ts
+++ b/packages/sdk/src/analytics/events/login.ts
@@ -1,12 +1,10 @@
 // This isn't an ecommerce exclusive event, but it makes sense to include it in stores
 
-import type { LocatorParam } from './common'
-
 export interface LoginParams {
   method?: string
 }
 
 export interface LoginEvent {
   name: 'login'
-  params: LoginParams & LocatorParam
+  params: LoginParams
 }

--- a/packages/sdk/src/analytics/events/purchase.ts
+++ b/packages/sdk/src/analytics/events/purchase.ts
@@ -1,4 +1,4 @@
-import type { CurrencyCode, Item, LocatorParam } from './common'
+import type { CurrencyCode, Item } from './common'
 
 export interface PurchaseParams<T extends Item = Item> {
   currency?: CurrencyCode
@@ -13,5 +13,5 @@ export interface PurchaseParams<T extends Item = Item> {
 
 export interface PurchaseEvent<T extends Item = Item> {
   name: 'purchase'
-  params: PurchaseParams<T> & LocatorParam
+  params: PurchaseParams<T>
 }

--- a/packages/sdk/src/analytics/events/refund.ts
+++ b/packages/sdk/src/analytics/events/refund.ts
@@ -1,4 +1,4 @@
-import type { CurrencyCode, Item, LocatorParam } from './common'
+import type { CurrencyCode, Item } from './common'
 
 export interface RefundParams<T extends Item = Item> {
   currency?: CurrencyCode
@@ -13,5 +13,5 @@ export interface RefundParams<T extends Item = Item> {
 
 export interface RefundEvent<T extends Item = Item> {
   name: 'refund'
-  params: RefundParams<T> & LocatorParam
+  params: RefundParams<T>
 }

--- a/packages/sdk/src/analytics/events/remove_from_cart.ts
+++ b/packages/sdk/src/analytics/events/remove_from_cart.ts
@@ -1,4 +1,4 @@
-import type { CurrencyCode, Item, LocatorParam } from './common'
+import type { CurrencyCode, Item } from './common'
 
 export interface RemoveFromCartParams<T extends Item = Item> {
   currency?: CurrencyCode
@@ -8,5 +8,5 @@ export interface RemoveFromCartParams<T extends Item = Item> {
 
 export interface RemoveFromCartEvent<T extends Item = Item> {
   name: 'remove_from_cart'
-  params: RemoveFromCartParams<T> & LocatorParam
+  params: RemoveFromCartParams<T>
 }

--- a/packages/sdk/src/analytics/events/search.ts
+++ b/packages/sdk/src/analytics/events/search.ts
@@ -1,15 +1,10 @@
 // This isn't an ecommerce exclusive event, but it makes sense to include it in stores
 
-import type { LocatorParam } from './common'
-
 export interface SearchParams {
-  /** @description search term used on the search result */
   search_term: string
-  /** @description number of products filtered on the search result */
-  records_filtered: number
 }
 
 export interface SearchEvent {
   name: 'search'
-  params: SearchParams & LocatorParam
+  params: SearchParams
 }

--- a/packages/sdk/src/analytics/events/select_item.ts
+++ b/packages/sdk/src/analytics/events/select_item.ts
@@ -1,4 +1,4 @@
-import type { Item, LocatorParam } from './common'
+import type { Item } from './common'
 
 export interface SelectItemParams<T extends Item = Item> {
   item_list_id?: string
@@ -8,5 +8,5 @@ export interface SelectItemParams<T extends Item = Item> {
 
 export interface SelectItemEvent<T extends Item = Item> {
   name: 'select_item'
-  params: SelectItemParams<T> & LocatorParam
+  params: SelectItemParams<T>
 }

--- a/packages/sdk/src/analytics/events/select_promotion.ts
+++ b/packages/sdk/src/analytics/events/select_promotion.ts
@@ -1,4 +1,4 @@
-import type { LocatorParam, PromotionItem, PromotionParams } from './common'
+import type { PromotionItem, PromotionParams } from './common'
 
 export interface SelectPromotionItems<T extends PromotionItem = PromotionItem> {
   items?: T[]
@@ -10,5 +10,5 @@ export type SelectPromotionParams<
 
 export interface SelectPromotionEvent<T extends PromotionItem = PromotionItem> {
   name: 'select_promotion'
-  params: SelectPromotionParams<T> & LocatorParam
+  params: SelectPromotionParams<T>
 }

--- a/packages/sdk/src/analytics/events/share.ts
+++ b/packages/sdk/src/analytics/events/share.ts
@@ -1,7 +1,5 @@
 // This isn't an ecommerce exclusive event, but it makes sense to include it in stores
 
-import type { LocatorParam } from './common'
-
 export interface ShareParams {
   method?: string
   content_type?: string
@@ -10,5 +8,5 @@ export interface ShareParams {
 
 export interface ShareEvent {
   name: 'share'
-  params: ShareParams & LocatorParam
+  params: ShareParams
 }

--- a/packages/sdk/src/analytics/events/signup.ts
+++ b/packages/sdk/src/analytics/events/signup.ts
@@ -1,12 +1,10 @@
 // This isn't an ecommerce exclusive event, but it makes sense to include it in stores
 
-import type { LocatorParam } from './common'
-
 export interface SignupParams {
   method?: string
 }
 
 export interface SignupEvent {
   name: 'signup'
-  params: SignupParams & LocatorParam
+  params: SignupParams
 }

--- a/packages/sdk/src/analytics/events/view_cart.ts
+++ b/packages/sdk/src/analytics/events/view_cart.ts
@@ -1,4 +1,4 @@
-import type { CurrencyCode, Item, LocatorParam } from './common'
+import type { CurrencyCode, Item } from './common'
 
 export interface ViewCartParams<T extends Item = Item> {
   currency?: CurrencyCode
@@ -8,5 +8,5 @@ export interface ViewCartParams<T extends Item = Item> {
 
 export interface ViewCartEvent<T extends Item = Item> {
   name: 'view_cart'
-  params: ViewCartParams<T> & LocatorParam
+  params: ViewCartParams<T>
 }

--- a/packages/sdk/src/analytics/events/view_item.ts
+++ b/packages/sdk/src/analytics/events/view_item.ts
@@ -1,4 +1,4 @@
-import type { CurrencyCode, Item, LocatorParam } from './common'
+import type { CurrencyCode, Item } from './common'
 
 export interface ViewItemParams<T extends Item = Item> {
   currency?: CurrencyCode
@@ -8,5 +8,5 @@ export interface ViewItemParams<T extends Item = Item> {
 
 export interface ViewItemEvent<T extends Item = Item> {
   name: 'view_item'
-  params: ViewItemParams<T> & LocatorParam
+  params: ViewItemParams<T>
 }

--- a/packages/sdk/src/analytics/events/view_item_list.ts
+++ b/packages/sdk/src/analytics/events/view_item_list.ts
@@ -1,4 +1,4 @@
-import type { Item, LocatorParam } from './common'
+import type { Item } from './common'
 
 export interface ViewItemListParams<T extends Item = Item> {
   item_list_id?: string
@@ -8,5 +8,5 @@ export interface ViewItemListParams<T extends Item = Item> {
 
 export interface ViewItemListEvent<T extends Item = Item> {
   name: 'view_item_list'
-  params: ViewItemListParams<T> & LocatorParam
+  params: ViewItemListParams<T>
 }

--- a/packages/sdk/src/analytics/events/view_promotion.ts
+++ b/packages/sdk/src/analytics/events/view_promotion.ts
@@ -1,4 +1,4 @@
-import type { LocatorParam, PromotionItem, PromotionParams } from './common'
+import type { PromotionItem, PromotionParams } from './common'
 
 export interface ViewPromotionItems<T extends PromotionItem = PromotionItem> {
   items?: T[]
@@ -10,5 +10,5 @@ export type ViewPromotionParams<
 
 export interface ViewPromotionEvent<T extends PromotionItem = PromotionItem> {
   name: 'view_promotion'
-  params: ViewPromotionParams<T> & LocatorParam
+  params: ViewPromotionParams<T>
 }

--- a/packages/sdk/test/analytics/__fixtures__/EventSamples.ts
+++ b/packages/sdk/test/analytics/__fixtures__/EventSamples.ts
@@ -31,8 +31,7 @@ export const WRAPPED_CUSTOM_EVENT_SAMPLE: WrappedAnalyticsEvent<CustomEvent> = {
 export const ADD_TO_CART_SAMPLE: AddToCartEvent = {
   name: 'add_to_cart',
   params: {
-    url: 'http://localhost/',
-    items: [{ item_id: 'PRODUCT_ID', item_name: 'Amazing Product' }],
+    items: [{ item_id: 'PRODUCT_ID' }],
   },
 }
 
@@ -41,8 +40,7 @@ export const WRAPPED_ADD_TO_CART_SAMPLE: WrappedAnalyticsEvent<AddToCartEvent> =
   params: {
     name: 'store:add_to_cart',
     params: {
-      url: 'http://localhost/',
-      items: [{ item_id: 'PRODUCT_ID', item_name: 'Amazing Product' }],
+      items: [{ item_id: 'PRODUCT_ID' }],
     },
   },
 }


### PR DESCRIPTION
This reverts commit 0e2befe3cb5dc99521a470c4096e31237b93a9c0.

## What's the purpose of this pull request?
The Analytics SDK types should be 100% compliant with Google Analytics 4, which means we can't add custom properties to events directly on the SDK. It's possible to do so in stores by extending the provided types. Also, collecting the URL on all events is redundant, since GA4 already collects this data automatically.
