### PR TITLE
Update dataloader to 2.1.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@graphql-tools/schema": "^8.2.0",
     "@rollup/plugin-graphql": "^1.0.0",
-    "dataloader": "^2.0.0",
+    "dataloader": "^2.1.0",
     "fast-deep-equal": "^3.1.3",
     "isomorphic-unfetch": "^3.1.0",
     "p-limit": "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12343,10 +12343,15 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-dataloader@2.0.0, dataloader@^2.0.0:
+dataloader@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
   integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
+
+dataloader@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.1.0.tgz#c69c538235e85e7ac6c6c444bae8ecabf5de9df7"
+  integrity sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==
 
 date-fns@^1.27.2:
   version "1.30.1"


### PR DESCRIPTION
## What's the purpose of this pull request?
DataLoader used to rely on `setImmediate` existing on the browser which caused a lot of errors as reported on https://github.com/graphql/dataloader/issues/249. This caused us to have an [unwanted dependency on base.store
](https://github.com/vtex-sites/base.store/blob/master/src/server/index.ts#L2-L6). They issue has since been fixed in [version 2.1.0](https://github.com/graphql/dataloader/blob/main/CHANGELOG.md#210
). And we can get rid of it.

## How to test it?
Test if the preview works as it should.

### `base.store` Deploy Preview
https://preview-493--base.preview.vtex.app/

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->