### PR TITLE
feat: Add search event API

### DIFF
--- a/packages/api/src/platforms/vtex/clients/fetch.ts
+++ b/packages/api/src/platforms/vtex/clients/fetch.ts
@@ -4,7 +4,7 @@ export const fetchAPI = async (info: RequestInfo, init?: RequestInit) => {
   const response = await fetch(info, init)
 
   if (response.ok) {
-    return response.json()
+    return response.status !== 204 ? response.json() : undefined
   }
 
   console.error(info, init, response)

--- a/packages/api/src/platforms/vtex/clients/index.ts
+++ b/packages/api/src/platforms/vtex/clients/index.ts
@@ -1,5 +1,6 @@
 import { VtexCommerce } from './commerce'
 import { IntelligentSearch } from './search'
+import { SP } from './sp'
 import type { Context, Options } from '..'
 
 export type Clients = ReturnType<typeof getClients>
@@ -7,9 +8,11 @@ export type Clients = ReturnType<typeof getClients>
 export const getClients = (options: Options, ctx: Context) => {
   const search = IntelligentSearch(options, ctx)
   const commerce = VtexCommerce(options, ctx)
+  const sp = SP(options, ctx)
 
   return {
     search,
     commerce,
+    sp,
   }
 }

--- a/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
+++ b/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
@@ -7,7 +7,7 @@ export interface ProductSearchResult {
   translated: boolean
   locale: string
   query: string
-  operator: string
+  operator: 'and' | 'or'
   fuzzy: string
   correction: Correction
 }

--- a/packages/api/src/platforms/vtex/clients/sp/index.ts
+++ b/packages/api/src/platforms/vtex/clients/sp/index.ts
@@ -1,0 +1,67 @@
+/**
+ * Client for SP, Intelligent search's analytics event API
+ * More info at: https://www.notion.so/vtexhandbook/Event-API-Documentation-48eee26730cf4d7f80f8fd7262231f84
+ */
+import { fetchAPI } from '../fetch'
+import type { Options, Context } from '../../index'
+
+const THIRTY_MINUTES_S = 30 * 60
+const ONE_YEAR_S = 365 * 24 * 3600
+
+const randomUUID = () => (Math.random() * 1e6).toFixed(0)
+
+const timelapsed = (past: number) => (Date.now() - past) / 1e3
+
+const createId = (expiresSecond: number) => {
+  let payload = randomUUID()
+  let createdAt = Date.now()
+
+  return () => {
+    if (timelapsed(createdAt) > expiresSecond) {
+      payload = randomUUID()
+      createdAt = Date.now()
+    }
+
+    return payload
+  }
+}
+
+const user = {
+  anonymous: createId(ONE_YEAR_S),
+  session: createId(THIRTY_MINUTES_S),
+}
+
+export type SearchEvent = {
+  type: 'search.query'
+  text: string // 'zapatilha'
+  misspelled: boolean
+  match: number
+  operator: 'and' | 'or'
+  session?: string
+  anonymous?: string
+}
+
+export const SP = ({ account }: Options, _: Context) => {
+  const base = `https://sp.vtex.com/event-api/v1/${account}/event`
+
+  const sendEvent = (options: SearchEvent) => {
+    return fetchAPI(base, {
+      method: 'POST',
+      body: JSON.stringify({
+        ...options,
+        agent: '@faststore/api',
+        anonymous: user.anonymous(),
+        session: user.session(),
+        // session: 'zZlNhqz1vFJP6iPG5Oqtt',
+        // anonymous: 'Om1TNluGvgmSgU5OOTvkkd',
+      }),
+      headers: {
+        'content-type': 'application/json',
+      },
+    })
+  }
+
+  return {
+    sendEvent,
+  }
+}

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -10,10 +10,22 @@ const REMOVED_FACETS_FROM_COLLECTION_PAGE = ['departamento']
 export const StoreSearchResult: Record<string, Resolver<Root>> = {
   products: async (searchArgs, _, ctx) => {
     const {
-      clients: { search },
+      clients: { search, sp },
     } = ctx
 
     const products = await search.products(searchArgs)
+
+    // Raise event on search's analytics API when performing
+    // a full text search.
+    if (searchArgs.query) {
+      sp.sendEvent({
+        type: 'search.query',
+        text: searchArgs.query,
+        misspelled: products.correction.misspelled,
+        match: products.total,
+        operator: products.operator,
+      }).catch(console.error)
+    }
 
     const skus = products.products
       .map((product) => {


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR integrates the VTEX Intelligent Search Analytics API with `@faststore/api`. More specifically, it integrates product queries with search.query event.

## How it works? 
For intelligent search to work properly, some events must be send to their tracking endpoints `https://sp.vtex.com/event-api/v1`. A few of these events (`session.ping` and `search.click`) were already implemented on our starters. However, a missing event was `search.query`. This event is important for populating indices, like `Top Searches` and `Suggestions`. This event was hard to implement because some info was missing on the frontend. To address this issue, an integration on `@faststore/api` was proposed.

`@faststore/api` is a BFF GraphQL layer between the React frontend and the VTEX Intelligent Search API. Every time a search is performed on the frontend, resolvers on `@faststore/api` are run and perform a search on Intelligent Search API.

This PR integrates IS tracking API with `@faststore/api` right after a search is performed. On the resolvers, we have all necessary info IS tracking API requires. 
A drawback of this solution is that user ID's are faked, so no session tracking is possible with this approach.

## How to test it?
Use one of the deploy previews below and make sure the request to SP returns a 204. 
https://github.com/vtex-sites/nextjs.store/pull/2
https://github.com/vtex-sites/gatsby.store/pull/2

## References
More info about Search Tracking API
https://www.notion.so/vtexhandbook/Event-API-Documentation-48eee26730cf4d7f80f8fd7262231f84
