### PR TITLE
[feat] Add support to workspace

### DIFF
--- a/packages/api/mocks/AllProductsQuery.ts
+++ b/packages/api/mocks/AllProductsQuery.ts
@@ -73,7 +73,7 @@ export const AllProductsQueryFirst5 = `query AllProducts {
 
 export const productSearchPage1Count5Fetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&hideUnavailableItems=false',
+    'https://master--storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&hideUnavailableItems=false',
   init: undefined,
   result: {
     products: [

--- a/packages/api/mocks/ProductQuery.ts
+++ b/packages/api/mocks/ProductQuery.ts
@@ -62,7 +62,7 @@ export const ProductByIdQuery = `query ProductQuery {
 
 export const productSearchFetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A64953394&sort=&fuzzy=0&hideUnavailableItems=false',
+    'https://master--storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A64953394&sort=&fuzzy=0&hideUnavailableItems=false',
   init: undefined,
   result: {
     products: [

--- a/packages/api/mocks/SearchQuery.ts
+++ b/packages/api/mocks/SearchQuery.ts
@@ -100,7 +100,7 @@ export const SearchQueryFirst5Products = `query SearchQuery {
 
 export const productSearchCategory1Fetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&hideUnavailableItems=false',
+    'https://master--storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&hideUnavailableItems=false',
   init: undefined,
   result: {
     products: [
@@ -1383,7 +1383,7 @@ export const productSearchCategory1Fetch = {
 
 export const attributeSearchCategory1Fetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/facets/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&hideUnavailableItems=false',
+    'https://master--storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/facets/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&hideUnavailableItems=false',
   init: undefined,
   result: {
     facets: [
@@ -1412,7 +1412,7 @@ export const attributeSearchCategory1Fetch = {
           },
         ],
         type: 'PRICERANGE',
-        name: 'Pre¿o',
+        name: 'Preï¿½o',
         hidden: false,
         key: 'price',
         quantity: 3,

--- a/packages/api/mocks/ValidateCartMutation.ts
+++ b/packages/api/mocks/ValidateCartMutation.ts
@@ -334,7 +334,7 @@ export const checkoutOrderFormItemsInvalidFetch = {
 
 export const productSearchPage1Count1Fetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A2737806&sort=&fuzzy=0&hideUnavailableItems=false',
+    'https://master--storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A2737806&sort=&fuzzy=0&hideUnavailableItems=false',
   init: undefined,
   result: {
     products: [

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -32,10 +32,11 @@ export interface ProductLocator {
 }
 
 export const IntelligentSearch = (
-  { account, environment, hideUnavailableItems }: Options,
+  { account, environment, hideUnavailableItems, workspace }: Options,
   ctx: Context
 ) => {
-  const base = `https://${account}.${environment}.com.br/api/io`
+  const accountBase = [workspace ?? 'master', account].join('--')
+  const base = `https://${accountBase}.${environment}.com.br/api/io`
   const policyFacet: IStoreSelectedFacet = {
     key: 'trade-policy',
     value: ctx.storage.channel.salesChannel,

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -22,6 +22,7 @@ export interface Options {
   platform: 'vtex'
   account: string
   environment: 'vtexcommercestable' | 'vtexcommercebeta'
+  workspace?: string
   // Default sales channel to use for fetching products
   channel: string
   hideUnavailableItems: boolean


### PR DESCRIPTION
## What's the purpose of this pull request?
After the last change, which changed the Intelligent Search route, when using accounts that are in the VTEX CMS, and are developing the FastStore version in a different workspace, the search for products always returns as "Not found"! This commit resolves the issue, adding the workspace option to the FastStore settings, and keeping the "master" as the default.

## How it works? 
<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview
<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->
[VTEX Community - Problema no desenvolvimento com VTEX CMS em produção](https://community.vtex.com/t/problema-no-desenvolvimento-com-vtex-cms-em-producao/28157)

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
