### PR TITLE
docs: remove Tailwind installation from docs

### DIFF
--- a/docs/docs/reference/ui/get-started-faststore-ui.md
+++ b/docs/docs/reference/ui/get-started-faststore-ui.md
@@ -8,12 +8,6 @@ Install `@faststore/ui` as a dependency of your FastStore project via the comman
 npm install @faststore/ui
 ```
 
-For styling, you can **optionally** install our default style theme developed with [Tailwind CSS](https://tailwindcss.com/):
-
-```bash npm2yarn
-npm install @vtex/theme-b2c-tailwind
-```
-
 ---
 
 ## Usage
@@ -22,7 +16,6 @@ Check our references and import the desired components to your page.
 
 ```tsx
 import { Button } from '@faststore/ui'
-import '@vtex/theme-b2c-tailwind/dist/index.css'
 ```
 
 ```tsx


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR removes the Tailwind installation section from the _Get Started_ guide, preventing users from changing the styles in the starter's components.

P.S.: This is a step to introduce the global tokens documentation.
## How it works? 
<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview
<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References
<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
