### PR TITLE
Adding information about authentication app

### DIFF
--- a/docs/blog/2022-05-02-cms.md
+++ b/docs/blog/2022-05-02-cms.md
@@ -19,7 +19,7 @@ CMS previews may contain sales promotions and product launches that are not yet 
 
 ## What needs to be done?
 
-This improvement is already available by default for all VTEX Headless CMS users. However, in order to be able to access the private previews, you must install the `vtex.faststore-auth` app in your account. To do this, run:
+Every CMS preview is now private by default. However, to be able to log in and view the private previews, you must install the `vtex.faststore-auth` app in your account. To do this, run the following command:
 ```
 vtex install vtex.faststore-auth
 ```

--- a/docs/blog/2022-05-02-cms.md
+++ b/docs/blog/2022-05-02-cms.md
@@ -24,6 +24,6 @@ Every CMS preview is now private by default. However, to be able to log in and v
 vtex install vtex.faststore-auth
 ```
 
-::: info
+:::info
 If, for any reason, you need your CMS previews to be accessed by the public or third-party solutions, you may disable authentication by adding `USE_CMS_PREVIEW_AUTH=false` to your repository's `vtex.env` file.
 :::

--- a/docs/blog/2022-05-02-cms.md
+++ b/docs/blog/2022-05-02-cms.md
@@ -24,4 +24,6 @@ Every CMS preview is now private by default. However, to be able to log in and v
 vtex install vtex.faststore-auth
 ```
 
+::: info
 If, for any reason, you need your CMS previews to be accessed by the public or third-party solutions, you may disable authentication by adding `USE_CMS_PREVIEW_AUTH=false` to your repository's `vtex.env` file.
+:::

--- a/docs/blog/2022-05-02-cms.md
+++ b/docs/blog/2022-05-02-cms.md
@@ -19,4 +19,9 @@ CMS previews may contain sales promotions and product launches that are not yet 
 
 ## What needs to be done?
 
-Nothing. This improvement is already available by default for all VTEX Headless CMS users. However, if, for any reason, you need your CMS previews to be accessed by the public or third-party solutions, you may disable authentication by adding `USE_CMS_PREVIEW_AUTH=false` to your repository's `vtex.env` file.
+This improvement is already available by default for all VTEX Headless CMS users. However, in order to be able to access the private previews, you must install the `vtex.faststore-auth` app in your account. To do this, run:
+```
+vtex install vtex.faststore-auth
+```
+
+If, for any reason, you need your CMS previews to be accessed by the public or third-party solutions, you may disable authentication by adding `USE_CMS_PREVIEW_AUTH=false` to your repository's `vtex.env` file.


### PR DESCRIPTION
# Update release note: [VTEX Headless CMS previews are now private by default](https://www.faststore.dev/releases/2022/05/02/cms)

The team requested a small update to the `what should be done` section, instructing the install of the app that allows for authentication required for accessing the previews.