### PR TITLE
fix: missing additionalProperties 

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
+++ b/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
@@ -98,7 +98,7 @@ export interface Product {
   items: Item[]
   skuSpecifications?: SkuSpecification[]
   priceRange: PriceRange
-  specificationGroups: SpecificationGroup
+  specificationGroups: SpecificationGroup[]
   properties: Array<{ name: string; values: string[] }>
   selectedProperties: Array<{ key: string; value: string }>
 }
@@ -133,7 +133,10 @@ export interface Item {
   modalType: any | null
   images: Image[]
   Videos: string[]
-  variations: string[]
+  variations: Array<{
+    name: string
+    values: string[]
+  }>
   sellers: Seller[]
   attachments: Array<{
     id: number
@@ -214,5 +217,9 @@ interface PriceRange {
 interface SpecificationGroup {
   name: string
   originalName: string
-  specifications: { name: string; originalName: string; values: string[] }
+  specifications: Array<{
+    name: string
+    originalName: string
+    values: string[]
+  }>
 }

--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -73,10 +73,9 @@ export const StoreProduct: Record<string, Resolver<Root>> & {
     }
   },
   isVariantOf: (root) => root,
-  // TODO: get this value. Fix any type
-  additionalProperty: ({ attributes = [] }: any) =>
-    attributes.map((attribute: any) => ({
-      name: attribute.key,
-      value: attribute.value,
-    })),
+  additionalProperty: ({ variations = [] }) => {
+    return variations.flatMap(({ name, values }) =>
+      values.map((value) => ({ name, value }))
+    )
+  },
 }

--- a/packages/api/src/platforms/vtex/resolvers/productGroup.ts
+++ b/packages/api/src/platforms/vtex/resolvers/productGroup.ts
@@ -5,24 +5,24 @@ import type { StoreProduct } from './product'
 
 type Root = PromiseType<ReturnType<typeof StoreProduct.isVariantOf>>
 
-const BLOCKED_PROPERTIES: Record<string, boolean> = {
-  sellerId: true,
-}
+const BLOCKED_SPECIFICATIONS = new Set(['allSpecifications'])
 
 export const StoreProductGroup: Record<string, Resolver<Root>> = {
   hasVariant: (root) =>
     root.isVariantOf.items.map((item) => enhanceSku(item, root.isVariantOf)),
   productGroupID: ({ isVariantOf }) => isVariantOf.productId,
   name: ({ isVariantOf }) => isVariantOf.productName,
-  additionalProperty: ({ isVariantOf: { properties } }) =>
-    properties.flatMap((property) => {
-      if (BLOCKED_PROPERTIES[property.name]) {
-        return []
-      }
-
-      return property.values.map((propertyValue) => ({
-        name: property.name,
-        value: propertyValue,
-      }))
-    }),
+  additionalProperty: ({ isVariantOf: { specificationGroups } }) =>
+    specificationGroups
+      // filter sku specifications so we dont mess sku with product specs
+      .filter(
+        (specificationGroup) =>
+          !BLOCKED_SPECIFICATIONS.has(specificationGroup.name)
+      )
+      // Transform specs back into product specs
+      .flatMap(({ specifications }) =>
+        specifications.flatMap(({ name, values }) =>
+          values.map((value) => ({ name, value }))
+        )
+      ),
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
After changing to use the new intelligent search API, additional properties stopped being returned on Product and, and they were all moved to the ProductGroup. 

This PR fixes this regression by returning the sku specifications on `StoreProduct.additionalProperties` and product specifications on `StoreProductGroup.additionalProperties`

## How to test it?
For testing and checking, please refer to the original PR: https://github.com/vtex/faststore/pull/1107