### PR TITLE
fix: Offer availability

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
+++ b/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
@@ -154,7 +154,7 @@ export interface CommertialOffer {
   ItemMetadataAttachment: any[]
   Price: number
   ListPrice: number
-  spotPrice?: number
+  spotPrice: number
   PriceWithoutDiscount: number
   RewardValue: number
   PriceValidUntil: string

--- a/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
@@ -1,23 +1,25 @@
-import type { Item } from '../clients/search/types/ProductSearchResult'
+import { inStock } from '../utils/productStock'
+import type { EnhancedCommercialOffer } from '../utils/enhanceCommercialOffer'
 import type { StoreProduct } from './product'
 import type { PromiseType } from '../../../typings'
 import type { Resolver } from '..'
-import type { EnhancedSku } from '../utils/enhanceSku'
 
 type Root = PromiseType<ReturnType<typeof StoreProduct.offers>>
 
 export const StoreAggregateOffer: Record<string, Resolver<Root>> & {
-  offers: Resolver<Root, any, Array<Item & { product: EnhancedSku }>>
+  offers: Resolver<Root, any, EnhancedCommercialOffer[]>
 } = {
-  highPrice: ({ product }) =>
-    product.isVariantOf.priceRange.sellingPrice.highPrice ?? 0,
-  lowPrice: (root) =>
-    root.product.isVariantOf.priceRange.sellingPrice.lowPrice ?? 0,
-  offerCount: ({ items }) => items.length,
+  highPrice: (offers) => {
+    const availableOffers = offers.filter(inStock)
+
+    return availableOffers[availableOffers.length - 1]?.Price ?? 0
+  },
+  lowPrice: (offers) => {
+    const availableOffers = offers.filter(inStock)
+
+    return availableOffers[0]?.Price ?? 0
+  },
+  offerCount: (offers) => offers.length,
   priceCurrency: () => '',
-  offers: ({ items, product }) =>
-    items.map((item) => ({
-      ...item,
-      product,
-    })),
+  offers: (offers) => offers,
 }

--- a/packages/api/src/platforms/vtex/resolvers/offer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/offer.ts
@@ -18,7 +18,7 @@ type SearchProduct = ArrayElementType<
 type Root = SearchProduct | OrderFormProduct
 
 const isSearchItem = (item: Root): item is SearchProduct =>
-  'seller' in item && 'product' in item
+  'Price' in item && 'seller' in item && 'product' in item
 
 const isOrderFormItem = (item: Root): item is OrderFormProduct =>
   'skuName' in item

--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -69,7 +69,11 @@ export const StoreProduct: Record<string, Resolver<Root>> & {
   offers: (root) =>
     root.sellers
       .flatMap((seller) =>
-        enhanceCommercialOffer(seller.commertialOffer, seller, root)
+        enhanceCommercialOffer({
+          offer: seller.commertialOffer,
+          seller,
+          product: root,
+        })
       )
       .sort(bestOfferFirst),
   isVariantOf: (root) => root,

--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -1,9 +1,9 @@
+import { enhanceCommercialOffer } from '../utils/enhanceCommercialOffer'
+import { bestOfferFirst } from '../utils/productStock'
+import type { EnhancedCommercialOffer } from '../utils/enhanceCommercialOffer'
 import type { Resolver } from '..'
-import { sortOfferByPrice } from '../utils/productStock'
 import type { PromiseType } from '../../../typings'
 import type { Query } from './query'
-import type { Item } from '../clients/search/types/ProductSearchResult'
-import type { EnhancedSku } from '../utils/enhanceSku'
 
 type Root = PromiseType<ReturnType<typeof Query.product>>
 
@@ -19,7 +19,7 @@ const nonEmptyArray = <T>(array: T[] | null | undefined) =>
   Array.isArray(array) && array.length > 0 ? array : null
 
 export const StoreProduct: Record<string, Resolver<Root>> & {
-  offers: Resolver<Root, any, { items: Item[]; product: EnhancedSku }>
+  offers: Resolver<Root, any, EnhancedCommercialOffer[]>
   isVariantOf: Resolver<Root, any, Root>
 } = {
   productID: ({ itemId }) => itemId,
@@ -66,12 +66,12 @@ export const StoreProduct: Record<string, Resolver<Root>> & {
   gtin: ({ referenceId }) => referenceId[0]?.Value ?? '',
   review: () => [],
   aggregateRating: () => ({}),
-  offers: (product): { items: Item[]; product: Root } => {
-    return {
-      items: sortOfferByPrice(product.isVariantOf.items),
-      product,
-    }
-  },
+  offers: (root) =>
+    root.sellers
+      .flatMap((seller) =>
+        enhanceCommercialOffer(seller.commertialOffer, seller, root)
+      )
+      .sort(bestOfferFirst),
   isVariantOf: (root) => root,
   additionalProperty: ({ variations = [] }) => {
     return variations.flatMap(({ name, values }) =>

--- a/packages/api/src/platforms/vtex/utils/enhanceCommercialOffer.ts
+++ b/packages/api/src/platforms/vtex/utils/enhanceCommercialOffer.ts
@@ -9,11 +9,15 @@ export type EnhancedCommercialOffer = CommertialOffer & {
   product: EnhancedSku
 }
 
-export const enhanceCommercialOffer = (
-  offer: CommertialOffer,
-  seller: Seller,
+export const enhanceCommercialOffer = ({
+  offer,
+  seller,
+  product,
+}: {
+  offer: CommertialOffer
+  seller: Seller
   product: EnhancedSku
-): EnhancedCommercialOffer => ({
+}): EnhancedCommercialOffer => ({
   ...offer,
   product,
   seller,

--- a/packages/api/src/platforms/vtex/utils/enhanceCommercialOffer.ts
+++ b/packages/api/src/platforms/vtex/utils/enhanceCommercialOffer.ts
@@ -1,0 +1,20 @@
+import type {
+  CommertialOffer,
+  Seller,
+} from '../clients/search/types/ProductSearchResult'
+import type { EnhancedSku } from './enhanceSku'
+
+export type EnhancedCommercialOffer = CommertialOffer & {
+  seller: Seller
+  product: EnhancedSku
+}
+
+export const enhanceCommercialOffer = (
+  offer: CommertialOffer,
+  seller: Seller,
+  product: EnhancedSku
+): EnhancedCommercialOffer => ({
+  ...offer,
+  product,
+  seller,
+})

--- a/packages/api/src/platforms/vtex/utils/productStock.ts
+++ b/packages/api/src/platforms/vtex/utils/productStock.ts
@@ -1,33 +1,24 @@
-import type {
-  Item,
-  Seller,
-  CommertialOffer,
-} from '../clients/search/types/ProductSearchResult'
+import type { CommertialOffer } from '../clients/search/types/ProductSearchResult'
 
-export const inStock = (item: Item) =>
-  item.sellers.find((seller) => seller.commertialOffer.AvailableQuantity > 0)
+export const inStock = (offer: CommertialOffer) => offer.AvailableQuantity > 0
 
-export const getFirstSeller = (sellers: Seller[]): Seller | undefined =>
-  sellers[0]
+export const price = (offer: CommertialOffer) => offer.spotPrice ?? 0
+export const sellingPrice = (offer: CommertialOffer) => offer.Price ?? 0
 
-export const getItemPriceByKey = (
-  item: Item,
-  key: keyof CommertialOffer
-): number => getFirstSeller(item.sellers)?.commertialOffer[key] ?? 0
+export const availability = (available: boolean) =>
+  available ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock'
 
 // Smallest Available Selling Price First
-export const sortOfferByPrice = (items: Item[]): Item[] =>
-  items.sort((a, b) => {
-    if (inStock(a) && !inStock(b)) {
-      return -1
-    }
+export const bestOfferFirst = (a: CommertialOffer, b: CommertialOffer) => {
+  if (inStock(a) && !inStock(b)) {
+    return -1
+  }
 
-    if (!inStock(a) && inStock(b)) {
-      return 1
-    }
+  if (!inStock(a) && inStock(b)) {
+    return 1
+  }
 
-    return getItemPriceByKey(a, 'Price') - getItemPriceByKey(b, 'Price')
-  })
+  return price(a) - price(b)
+}
 
-export const inStockOrderFormItem = (availability: string) =>
-  availability === 'available'
+export const inStockOrderFormItem = (item: string) => item === 'available'

--- a/packages/api/src/platforms/vtex/utils/productStock.ts
+++ b/packages/api/src/platforms/vtex/utils/productStock.ts
@@ -1,15 +1,20 @@
 import type { CommertialOffer } from '../clients/search/types/ProductSearchResult'
 
-export const inStock = (offer: CommertialOffer) => offer.AvailableQuantity > 0
+export const inStock = (offer: Pick<CommertialOffer, 'AvailableQuantity'>) =>
+  offer.AvailableQuantity > 0
 
-export const price = (offer: CommertialOffer) => offer.spotPrice ?? 0
+export const price = (offer: Pick<CommertialOffer, 'spotPrice'>) =>
+  offer.spotPrice ?? 0
 export const sellingPrice = (offer: CommertialOffer) => offer.Price ?? 0
 
 export const availability = (available: boolean) =>
   available ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock'
 
 // Smallest Available Selling Price First
-export const bestOfferFirst = (a: CommertialOffer, b: CommertialOffer) => {
+export const bestOfferFirst = (
+  a: Pick<CommertialOffer, 'AvailableQuantity' | 'spotPrice'>,
+  b: Pick<CommertialOffer, 'AvailableQuantity' | 'spotPrice'>
+) => {
   if (inStock(a) && !inStock(b)) {
     return -1
   }

--- a/packages/api/src/platforms/vtex/utils/productStock.ts
+++ b/packages/api/src/platforms/vtex/utils/productStock.ts
@@ -26,4 +26,5 @@ export const bestOfferFirst = (
   return price(a) - price(b)
 }
 
-export const inStockOrderFormItem = (item: string) => item === 'available'
+export const inStockOrderFormItem = (itemAvailability: string) =>
+  itemAvailability === 'available'

--- a/packages/api/test/__snapshots__/queries.test.ts.snap
+++ b/packages/api/test/__snapshots__/queries.test.ts.snap
@@ -762,9 +762,9 @@ Object {
               },
               "name": "green",
               "offers": Object {
-                "highPrice": 264.63,
+                "highPrice": 129.09,
                 "lowPrice": 129.09,
-                "offerCount": 2,
+                "offerCount": 1,
                 "offers": Array [
                   Object {
                     "availability": "https://schema.org/InStock",
@@ -784,25 +784,6 @@ Object {
                       "identifier": "1",
                     },
                     "sellingPrice": 129.09,
-                  },
-                  Object {
-                    "availability": "https://schema.org/InStock",
-                    "itemCondition": "https://schema.org/NewCondition",
-                    "itemOffered": Object {
-                      "seo": Object {
-                        "canonical": "",
-                        "description": "Consequatur placeat optio adipisci aut voluptate excepturi.",
-                        "title": "Licensed Cotton Hat Licensed",
-                        "titleTemplate": "",
-                      },
-                    },
-                    "listPrice": 325.77,
-                    "price": 264.63,
-                    "quantity": 10000,
-                    "seller": Object {
-                      "identifier": "1",
-                    },
-                    "sellingPrice": 264.63,
                   },
                 ],
                 "priceCurrency": "",
@@ -853,9 +834,9 @@ Object {
               },
               "name": "red",
               "offers": Object {
-                "highPrice": 770,
+                "highPrice": 362.36,
                 "lowPrice": 362.36,
-                "offerCount": 2,
+                "offerCount": 1,
                 "offers": Array [
                   Object {
                     "availability": "https://schema.org/InStock",
@@ -875,25 +856,6 @@ Object {
                       "identifier": "1",
                     },
                     "sellingPrice": 362.36,
-                  },
-                  Object {
-                    "availability": "https://schema.org/InStock",
-                    "itemCondition": "https://schema.org/NewCondition",
-                    "itemOffered": Object {
-                      "seo": Object {
-                        "canonical": "",
-                        "description": "Ipsa in sequi incidunt dolores.",
-                        "title": "Handmade Granite Computer Unbranded",
-                        "titleTemplate": "",
-                      },
-                    },
-                    "listPrice": 881.98,
-                    "price": 770,
-                    "quantity": 10000,
-                    "seller": Object {
-                      "identifier": "1",
-                    },
-                    "sellingPrice": 770,
                   },
                 ],
                 "priceCurrency": "",
@@ -958,9 +920,9 @@ Object {
               },
               "name": "olive",
               "offers": Object {
-                "highPrice": 642.91,
+                "highPrice": 247.01,
                 "lowPrice": 247.01,
-                "offerCount": 3,
+                "offerCount": 1,
                 "offers": Array [
                   Object {
                     "availability": "https://schema.org/InStock",
@@ -980,44 +942,6 @@ Object {
                       "identifier": "1",
                     },
                     "sellingPrice": 247.01,
-                  },
-                  Object {
-                    "availability": "https://schema.org/InStock",
-                    "itemCondition": "https://schema.org/NewCondition",
-                    "itemOffered": Object {
-                      "seo": Object {
-                        "canonical": "",
-                        "description": "Dolor harum perferendis voluptatem tempora voluptatum ut et sapiente iure.",
-                        "title": "Small Cotton Cheese",
-                        "titleTemplate": "",
-                      },
-                    },
-                    "listPrice": 504.39,
-                    "price": 333.67,
-                    "quantity": 10000,
-                    "seller": Object {
-                      "identifier": "1",
-                    },
-                    "sellingPrice": 333.67,
-                  },
-                  Object {
-                    "availability": "https://schema.org/InStock",
-                    "itemCondition": "https://schema.org/NewCondition",
-                    "itemOffered": Object {
-                      "seo": Object {
-                        "canonical": "",
-                        "description": "Dolor harum perferendis voluptatem tempora voluptatum ut et sapiente iure.",
-                        "title": "Small Cotton Cheese",
-                        "titleTemplate": "",
-                      },
-                    },
-                    "listPrice": 955.48,
-                    "price": 642.91,
-                    "quantity": 10000,
-                    "seller": Object {
-                      "identifier": "1",
-                    },
-                    "sellingPrice": 642.91,
                   },
                 ],
                 "priceCurrency": "",
@@ -1068,9 +992,9 @@ Object {
               },
               "name": "fuchsia",
               "offers": Object {
-                "highPrice": 582.1,
+                "highPrice": 1.37,
                 "lowPrice": 1.37,
-                "offerCount": 2,
+                "offerCount": 1,
                 "offers": Array [
                   Object {
                     "availability": "https://schema.org/InStock",
@@ -1090,25 +1014,6 @@ Object {
                       "identifier": "1",
                     },
                     "sellingPrice": 1.37,
-                  },
-                  Object {
-                    "availability": "https://schema.org/InStock",
-                    "itemCondition": "https://schema.org/NewCondition",
-                    "itemOffered": Object {
-                      "seo": Object {
-                        "canonical": "",
-                        "description": "Recusandae dolores alias.",
-                        "title": "Tasty Frozen Tuna Handmade",
-                        "titleTemplate": "",
-                      },
-                    },
-                    "listPrice": 638.97,
-                    "price": 582.1,
-                    "quantity": 10000,
-                    "seller": Object {
-                      "identifier": "1",
-                    },
-                    "sellingPrice": 582.1,
                   },
                 ],
                 "priceCurrency": "",
@@ -1163,9 +1068,9 @@ Object {
               },
               "name": "olive",
               "offers": Object {
-                "highPrice": 517.54,
+                "highPrice": 175.38,
                 "lowPrice": 175.38,
-                "offerCount": 2,
+                "offerCount": 1,
                 "offers": Array [
                   Object {
                     "availability": "https://schema.org/InStock",
@@ -1185,25 +1090,6 @@ Object {
                       "identifier": "1",
                     },
                     "sellingPrice": 175.38,
-                  },
-                  Object {
-                    "availability": "https://schema.org/InStock",
-                    "itemCondition": "https://schema.org/NewCondition",
-                    "itemOffered": Object {
-                      "seo": Object {
-                        "canonical": "",
-                        "description": "Aliquam a cumque ratione voluptatem in.",
-                        "title": "Sleek Metal Pizza",
-                        "titleTemplate": "",
-                      },
-                    },
-                    "listPrice": 666.42,
-                    "price": 517.54,
-                    "quantity": 10000,
-                    "seller": Object {
-                      "identifier": "1",
-                    },
-                    "sellingPrice": 517.54,
                   },
                 ],
                 "priceCurrency": "",

--- a/packages/api/test/vtex.aggregateOffer.test.ts
+++ b/packages/api/test/vtex.aggregateOffer.test.ts
@@ -1,53 +1,26 @@
-import type {
-  CommertialOffer,
-  Item,
-} from '../src/platforms/vtex/clients/search/types/ProductSearchResult'
-import { sortOfferByPrice } from '../src/platforms/vtex/utils/productStock'
+import { bestOfferFirst } from '../src/platforms/vtex/utils/productStock'
+import type { CommertialOffer } from '../src/platforms/vtex/clients/search/types/ProductSearchResult'
 
-type TestItem = {
-  sellers: Array<{
-    commertialOffer: Pick<CommertialOffer, 'AvailableQuantity' | 'Price'>
-  }>
-}
+type TestItem = Pick<CommertialOffer, 'AvailableQuantity' | 'spotPrice'>
 
 describe('AggregateOffer', () => {
   it('Should return best offers first', () => {
     const testItems: TestItem[] = [
-      {
-        sellers: [{ commertialOffer: { AvailableQuantity: 1, Price: 10 } }],
-      },
-      {
-        sellers: [{ commertialOffer: { AvailableQuantity: 0, Price: 20 } }],
-      },
-      {
-        sellers: [{ commertialOffer: { AvailableQuantity: 1, Price: 30 } }],
-      },
-      {
-        sellers: [{ commertialOffer: { AvailableQuantity: 0, Price: 10 } }],
-      },
-      {
-        sellers: [{ commertialOffer: { AvailableQuantity: 1, Price: 1 } }],
-      },
+      { AvailableQuantity: 1, spotPrice: 10 },
+      { AvailableQuantity: 0, spotPrice: 20 },
+      { AvailableQuantity: 1, spotPrice: 30 },
+      { AvailableQuantity: 0, spotPrice: 10 },
+      { AvailableQuantity: 1, spotPrice: 1 },
     ]
 
-    const sorted = sortOfferByPrice(testItems as Item[])
+    const sorted = testItems.sort(bestOfferFirst)
 
     expect(sorted).toEqual([
-      {
-        sellers: [{ commertialOffer: { AvailableQuantity: 1, Price: 1 } }],
-      },
-      {
-        sellers: [{ commertialOffer: { AvailableQuantity: 1, Price: 10 } }],
-      },
-      {
-        sellers: [{ commertialOffer: { AvailableQuantity: 1, Price: 30 } }],
-      },
-      {
-        sellers: [{ commertialOffer: { AvailableQuantity: 0, Price: 10 } }],
-      },
-      {
-        sellers: [{ commertialOffer: { AvailableQuantity: 0, Price: 20 } }],
-      },
+      { AvailableQuantity: 1, spotPrice: 1 },
+      { AvailableQuantity: 1, spotPrice: 10 },
+      { AvailableQuantity: 1, spotPrice: 30 },
+      { AvailableQuantity: 0, spotPrice: 10 },
+      { AvailableQuantity: 0, spotPrice: 20 },
     ])
   })
 })


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes offer availability bug introduced on #1216

## How it works? 
In `@faststore/api`'s schema, a Product has an AggregateOffer. This means that, for each VTEX SKU, we have an aggregate of all offers from all sellers for that specific SKU. 

It turns out, that after #1216, an SKU got all offers from all skus for that product. This lead to unavailable SKUS being marked as available. This PR fixes that by returning offers for that specific sku only/

### Starters Deploy Preview
- [gatsby.store](https://github.com/vtex-sites/gatsby.store/pull/31) 
- [nextjs.store](https://github.com/vtex-sites/nextjs.store/pull/22)