### PR TITLE
fix: Promotions

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/offer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/offer.ts
@@ -69,7 +69,7 @@ export const StoreOffer: Record<string, Resolver<Root>> = {
     }
 
     if (isOrderFormItem(root)) {
-      return root.price / 1e2
+      return root.sellingPrice / 1e2
     }
 
     return null


### PR DESCRIPTION
## What's the purpose of this pull request?
When dealing with "Buy 2 Get 3" kind of promotions our code got crazy. This was because of a miss interpretation between of selling prices and prices. 

This PR fixes this issue.

## How to test it?
You can use carrefourbrfood for testing this. Open `store.config.js`, change account to carrefourbrfood and use sales channel 2. After that, visit the following url: `/cafe-pilao-senseo-intenso-18-saches-8756201-2618/p`. Add 6 items on cart and make sure the promotion was applied correctly. 

### Starters Deploy Preview
- https://github.com/vtex-sites/nextjs.store/pull/32
- https://github.com/vtex-sites/gatsby.store/pull/42