### PR TITLE
Send selectedFacerts product query

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -47,7 +47,7 @@ export const IntelligentSearch = (
   const getPolicyFacet = (): IStoreSelectedFacet | null => {
     const { salesChannel } = ctx.storage.channel
 
-    if (typeof salesChannel !== 'string') {
+    if (!salesChannel) {
       return null
     }
 
@@ -60,7 +60,7 @@ export const IntelligentSearch = (
   const getRegionFacet = (): IStoreSelectedFacet | null => {
     const { regionId } = ctx.storage.channel
 
-    if (typeof regionId !== 'string') {
+    if (!regionId) {
       return null
     }
 

--- a/packages/api/src/platforms/vtex/loaders/sku.ts
+++ b/packages/api/src/platforms/vtex/loaders/sku.ts
@@ -21,7 +21,10 @@ export const getSkuLoader = (_: Options, clients: Clients) => {
       return maybeFacet.value
     })
 
+    const filteredFacets = facetsList.flat(1).filter(({ key }) => key !== 'id')
+
     const { products } = await clients.search.products({
+      selectedFacets: filteredFacets,
       query: `sku:${skuIds.join(';')}`,
       page: 0,
       count: skuIds.length,

--- a/packages/api/src/platforms/vtex/loaders/sku.ts
+++ b/packages/api/src/platforms/vtex/loaders/sku.ts
@@ -21,10 +21,7 @@ export const getSkuLoader = (_: Options, clients: Clients) => {
       return maybeFacet.value
     })
 
-    const filteredFacets = facetsList.flat(1).filter(({ key }) => key !== 'id')
-
     const { products } = await clients.search.products({
-      selectedFacets: filteredFacets,
       query: `sku:${skuIds.join(';')}`,
       page: 0,
       count: skuIds.length,

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -27,7 +27,7 @@ export const Query = {
       loaders: { skuLoader },
     } = ctx
 
-    return skuLoader.load(locator.flatMap(transformSelectedFacet))
+    return skuLoader.load(locator)
   },
   collection: (_: unknown, { slug }: QueryCollectionArgs, ctx: Context) => {
     const {


### PR DESCRIPTION
## What's the purpose of this pull request?
- Send selectetFacets to product query.

## How it works? 

- When working with regionalized navigation we must filter the results and product commercial offers based on the user region. This PR aims to fix this behavior by sending the facets to search API.

## How to test it?

1. Configure the store as qavivara
2. Then make the following query with and withou regionId.

```
query {
    product(locator: [{key:"id",value:"172733622"},{key:"channel",value:"{\"salesChannel\":\"1\",\"regionId\":\"v2.F2A698AC85828A338E568B47F5566397\"}"}]) {
        offers {
            lowPrice
            offers {
            availability
            price
            listPrice
            seller {
                identifier
            }
            }
        }
    }
}
```

With the region the product must return theia vailability as InStock.

### Starters Deploy Preview
- https://github.com/vtex-sites/gatsby.store/pull/45
- https://github.com/vtex-sites/nextjs.store/pull/37

## References

@igorbrasileiro 