### PR TITLE
Feat(api): add attachments

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -9,6 +9,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  Object: any;
 };
 
 /** Shopping cart identification input. */
@@ -55,12 +56,23 @@ export type IStoreOrganization = {
 
 /** Product input. */
 export type IStoreProduct = {
+  /** Custom Product Additional Properties. */
+  additionalProperty?: Maybe<Array<IStorePropertyValue>>;
   /** Array of product images. */
   image: Array<IStoreImage>;
   /** Product name. */
   name: Scalars['String'];
   /** Stock Keeping Unit ID. */
   sku: Scalars['String'];
+};
+
+export type IStorePropertyValue = {
+  /** Property name. */
+  name: Scalars['String'];
+  /** Property value. */
+  value: Scalars['Object'];
+  /** Property value reference. */
+  valueReference: ValueReference;
 };
 
 /** Selected facet input. */
@@ -323,6 +335,8 @@ export type StoreListItem = {
 /** Offer information. */
 export type StoreOffer = {
   __typename?: 'StoreOffer';
+  /** An additional offer that can only be obtained in combination with the first base offer (e.g. supplements and extensions that are available for a surcharge). */
+  addOn: Array<Maybe<StoreOffer>>;
   /** Offer item availability. */
   availability: Scalars['String'];
   /** Offer item condition. */
@@ -462,6 +476,8 @@ export type StorePropertyValue = {
   name: Scalars['String'];
   /** Property value. */
   value: Scalars['String'];
+  /** Property value reference. */
+  valueReference: ValueReference;
 };
 
 /** Information of a given review. */
@@ -543,4 +559,10 @@ export type StoreSuggestions = {
   products?: Maybe<Array<StoreProduct>>;
   /** Array with suggestion terms. */
   terms?: Maybe<Array<Scalars['String']>>;
+};
+
+export const enum ValueReference {
+  Attachment = 'ATTACHMENT',
+  Attribute = 'ATTRIBUTE',
+  Property = 'PROPERTY'
 };

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -9,7 +9,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  Object: any;
+  ObjectOrString: any;
 };
 
 /** Shopping cart identification input. */
@@ -69,10 +69,10 @@ export type IStoreProduct = {
 export type IStorePropertyValue = {
   /** Property name. */
   name: Scalars['String'];
-  /** Property value. */
-  value: Scalars['Object'];
-  /** Property value reference. */
-  valueReference: ValueReference;
+  /** Property value. May hold a string or the string representation of an object. */
+  value: Scalars['ObjectOrString'];
+  /** Specifies the nature of the value */
+  valueReference: Scalars['String'];
 };
 
 /** Selected facet input. */
@@ -335,8 +335,6 @@ export type StoreListItem = {
 /** Offer information. */
 export type StoreOffer = {
   __typename?: 'StoreOffer';
-  /** An additional offer that can only be obtained in combination with the first base offer (e.g. supplements and extensions that are available for a surcharge). */
-  addOn: Array<Maybe<StoreOffer>>;
   /** Offer item availability. */
   availability: Scalars['String'];
   /** Offer item condition. */
@@ -474,10 +472,10 @@ export type StorePropertyValue = {
   __typename?: 'StorePropertyValue';
   /** Property name. */
   name: Scalars['String'];
-  /** Property value. */
-  value: Scalars['String'];
-  /** Property value reference. */
-  valueReference: ValueReference;
+  /** Property value. May hold a string or the string representation of an object. */
+  value: Scalars['ObjectOrString'];
+  /** Specifies the nature of the value */
+  valueReference: Scalars['String'];
 };
 
 /** Information of a given review. */
@@ -559,10 +557,4 @@ export type StoreSuggestions = {
   products?: Maybe<Array<StoreProduct>>;
   /** Array with suggestion terms. */
   terms?: Maybe<Array<Scalars['String']>>;
-};
-
-export const enum ValueReference {
-  Attachment = 'ATTACHMENT',
-  Attribute = 'ATTRIBUTE',
-  Property = 'PROPERTY'
 };

--- a/packages/api/src/platforms/vtex/clients/commerce/types/OrderForm.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/OrderForm.ts
@@ -3,6 +3,12 @@ export interface OrderFormInputItem {
   quantity: number
   seller: string
   index?: number
+  attachments?: Attachment[]
+}
+
+export interface Attachment {
+  name: string
+  content: Record<string, string>
 }
 
 export interface OrderFormItem {

--- a/packages/api/src/platforms/vtex/clients/commerce/types/OrderForm.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/OrderForm.ts
@@ -54,6 +54,7 @@ export interface OrderFormItem {
     sellingPrices: SellingPrice[]
     total: number
   }
+  attachments: Attachment[]
 }
 
 export interface SKUSpecification {

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -13,6 +13,7 @@ import { Query } from './resolvers/query'
 import { StoreReview } from './resolvers/review'
 import { StoreSearchResult } from './resolvers/searchResult'
 import { StoreSeo } from './resolvers/seo'
+import { ObjectOrString } from './resolvers/objectOrString'
 import type { Loaders } from './loaders'
 import type { Clients } from './clients'
 import type { Channel } from './utils/channel'
@@ -67,6 +68,7 @@ const Resolvers = {
   StoreReview,
   StoreProductGroup,
   StoreSearchResult,
+  ObjectOrString,
   Query,
   Mutation,
 }

--- a/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
@@ -1,5 +1,4 @@
 import { inStock } from '../utils/productStock'
-import type { EnhancedCommercialOffer } from '../utils/enhanceCommercialOffer'
 import type { StoreProduct } from './product'
 import type { PromiseType } from '../../../typings'
 import type { Resolver } from '..'
@@ -7,7 +6,7 @@ import type { Resolver } from '..'
 type Root = PromiseType<ReturnType<typeof StoreProduct.offers>>
 
 export const StoreAggregateOffer: Record<string, Resolver<Root>> & {
-  offers: Resolver<Root, any, EnhancedCommercialOffer[]>
+  offers: Resolver<Root, any, Root>
 } = {
   highPrice: (offers) => {
     const availableOffers = offers.filter(inStock)

--- a/packages/api/src/platforms/vtex/resolvers/objectOrString.ts
+++ b/packages/api/src/platforms/vtex/resolvers/objectOrString.ts
@@ -10,11 +10,7 @@ export const ObjectOrString = new GraphQLScalarType({
   serialize: stringify,
   parseLiteral(ast) {
     if (ast.kind === Kind.STRING) {
-      try {
-        return JSON.parse(ast.value)
-      } catch (e) {
-        return ast.value
-      }
+      return getValueAsObjectOrString(ast.value)
     }
 
     return null
@@ -23,14 +19,18 @@ export const ObjectOrString = new GraphQLScalarType({
 
 function toObjectOrString(value: GraphQLScalarSerializer<any>) {
   if (typeof value === 'string') {
-    try {
-      return JSON.parse(value)
-    } catch (e) {
-      return value
-    }
+    return getValueAsObjectOrString(value)
   }
 
   return null
+}
+
+function getValueAsObjectOrString(value: string) {
+  try {
+    return JSON.parse(value)
+  } catch (e) {
+    return value
+  }
 }
 
 function stringify(value: GraphQLScalarSerializer<any>) {

--- a/packages/api/src/platforms/vtex/resolvers/objectOrString.ts
+++ b/packages/api/src/platforms/vtex/resolvers/objectOrString.ts
@@ -1,0 +1,46 @@
+import type { GraphQLScalarSerializer } from 'graphql'
+import { GraphQLScalarType } from 'graphql'
+import { Kind } from 'graphql/language'
+
+export const ObjectOrString = new GraphQLScalarType({
+  name: 'ObjectOrString',
+  description:
+    'A string or the string representation of an object (a stringified object).',
+  parseValue: toObjectOrString,
+  serialize: stringify,
+  parseLiteral(ast) {
+    if (ast.kind === Kind.STRING) {
+      try {
+        return JSON.parse(ast.value)
+      } catch (e) {
+        return ast.value
+      }
+    }
+
+    return null
+  },
+})
+
+function toObjectOrString(value: GraphQLScalarSerializer<any>) {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value)
+    } catch (e) {
+      return value
+    }
+  }
+
+  return null
+}
+
+function stringify(value: GraphQLScalarSerializer<any>) {
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  return null
+}

--- a/packages/api/src/platforms/vtex/resolvers/offer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/offer.ts
@@ -96,7 +96,17 @@ export const StoreOffer: Record<string, Resolver<Root>> = {
 
     return null
   },
-  itemOffered: ({ product }) => product,
+  itemOffered: async (root) => {
+    if (isSearchItem(root)) {
+      return root.product
+    }
+
+    if (isOrderFormItem(root)) {
+      return { ...(await root.product), attachmentsValues: root.attachments }
+    }
+
+    return null
+  },
   quantity: (root) => {
     if (isSearchItem(root)) {
       return root.AvailableQuantity ?? 0

--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -31,7 +31,12 @@ const isAttachmentDefinition = (
 ): attachment is AttachmentDefinition => 'id' in attachment
 
 export const StoreProduct: Record<string, Resolver<Root>> & {
-  offers: Resolver<Root, any, EnhancedCommercialOffer[]>
+  offers: Resolver<
+    Root,
+    any,
+    Array<EnhancedCommercialOffer<Root['sellers'][number], Root>>
+  >
+
   isVariantOf: Resolver<Root, any, Root>
 } = {
   productID: ({ itemId }) => itemId,
@@ -98,17 +103,22 @@ export const StoreProduct: Record<string, Resolver<Root>> & {
       }))
     )
 
-    const propertyValueAttachments = attachments.map((attachment) => {
-      if (isAttachmentDefinition(attachment)) {
-        return
-      }
+    // Typescript don't understand (A[] | B[]) as an array, only Array<A | B>
+    const propertyValueAttachments = (attachments as Array<
+      Root['attachments'][number]
+    >)
+      .map((attachment: Root['attachments'][number]) => {
+        if (isAttachmentDefinition(attachment)) {
+          return
+        }
 
-      return {
-        name: attachment.name,
-        value: attachment.content,
-        valueReference: VALUE_REFERENCES.attachment,
-      }
-    })
+        return {
+          name: attachment.name,
+          value: attachment.content,
+          valueReference: VALUE_REFERENCES.attachment,
+        }
+      })
+      .filter(Boolean)
 
     return [...propertyValueVariations, ...propertyValueAttachments]
   },

--- a/packages/api/src/platforms/vtex/resolvers/productGroup.ts
+++ b/packages/api/src/platforms/vtex/resolvers/productGroup.ts
@@ -2,6 +2,7 @@ import { enhanceSku } from '../utils/enhanceSku'
 import type { Resolver } from '..'
 import type { PromiseType } from '../../../typings'
 import type { StoreProduct } from './product'
+import { VALUE_REFERENCES } from '../utils/propertyValue'
 
 type Root = PromiseType<ReturnType<typeof StoreProduct.isVariantOf>>
 
@@ -22,7 +23,11 @@ export const StoreProductGroup: Record<string, Resolver<Root>> = {
       // Transform specs back into product specs
       .flatMap(({ specifications }) =>
         specifications.flatMap(({ name, values }) =>
-          values.map((value) => ({ name, value }))
+          values.map((value) => ({
+            name,
+            value,
+            valueReference: VALUE_REFERENCES.specification,
+          }))
         )
       ),
 }

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -12,11 +12,38 @@ import type {
   OrderFormItem,
 } from '../clients/commerce/types/OrderForm'
 import type { Context } from '..'
+import { VALUE_REFERENCES } from '../utils/propertyValue'
 
 type Indexed<T> = T & { index?: number }
 
+const getAttachments = (item: IStoreOffer) =>
+  item.itemOffered.additionalProperty?.filter(
+    (i) => i.valueReference === VALUE_REFERENCES.attachment
+  )
+
+const serializeAttachment = (item: IStoreOffer) => {
+  const attachments = getAttachments(item)
+
+  if (attachments?.length === 0) {
+    return null
+  }
+
+  return attachments
+    ?.map(
+      (attachment) => `${attachment.name}:${JSON.stringify(attachment.value)}`
+    )
+    .join('-')
+}
+
 const getId = (item: IStoreOffer) =>
-  [item.itemOffered.sku, item.seller.identifier, item.price].join('::')
+  [
+    item.itemOffered.sku,
+    item.seller.identifier,
+    item.price,
+    serializeAttachment(item),
+  ]
+    .filter(Boolean)
+    .join('::')
 
 const orderFormItemToOffer = (
   item: OrderFormItem,
@@ -41,6 +68,10 @@ const offerToOrderItemInput = (
   seller: offer.seller.identifier,
   id: offer.itemOffered.sku,
   index: offer.index,
+  attachments: getAttachments(offer)?.map((attachment) => ({
+    name: attachment.name,
+    content: attachment.value,
+  })),
 })
 
 const groupById = (offers: IStoreOffer[]): Map<string, IStoreOffer> =>

--- a/packages/api/src/platforms/vtex/utils/enhanceCommercialOffer.ts
+++ b/packages/api/src/platforms/vtex/utils/enhanceCommercialOffer.ts
@@ -1,23 +1,19 @@
-import type {
-  CommertialOffer,
-  Seller,
-} from '../clients/search/types/ProductSearchResult'
-import type { EnhancedSku } from './enhanceSku'
+import type { CommertialOffer } from '../clients/search/types/ProductSearchResult'
 
-export type EnhancedCommercialOffer = CommertialOffer & {
-  seller: Seller
-  product: EnhancedSku
+export type EnhancedCommercialOffer<S, P> = CommertialOffer & {
+  seller: S
+  product: P
 }
 
-export const enhanceCommercialOffer = ({
+export const enhanceCommercialOffer = <S, P>({
   offer,
   seller,
   product,
 }: {
   offer: CommertialOffer
-  seller: Seller
-  product: EnhancedSku
-}): EnhancedCommercialOffer => ({
+  seller: S
+  product: P
+}): EnhancedCommercialOffer<S, P> => ({
   ...offer,
   product,
   seller,

--- a/packages/api/src/platforms/vtex/utils/propertyValue.ts
+++ b/packages/api/src/platforms/vtex/utils/propertyValue.ts
@@ -1,0 +1,5 @@
+export const VALUE_REFERENCES = {
+  variation: 'VARIATION',
+  attachment: 'ATTACHMENT',
+  specification: 'SPECIFICATION',
+} as const

--- a/packages/api/src/typeDefs/index.ts
+++ b/packages/api/src/typeDefs/index.ts
@@ -22,6 +22,7 @@ import Cart from './cart.graphql'
 import Status from './status.graphql'
 import PropertyValue from './propertyValue.graphql'
 import Person from './person.graphql'
+import ObjectOrString from './objectOrString.graphql'
 
 export const typeDefs = [
   Query,
@@ -46,6 +47,7 @@ export const typeDefs = [
   Status,
   PropertyValue,
   Person,
+  ObjectOrString,
 ]
   .map(print)
   .join('\n')

--- a/packages/api/src/typeDefs/objectOrString.graphql
+++ b/packages/api/src/typeDefs/objectOrString.graphql
@@ -1,0 +1,1 @@
+scalar ObjectOrString

--- a/packages/api/src/typeDefs/product.graphql
+++ b/packages/api/src/typeDefs/product.graphql
@@ -80,4 +80,8 @@ input IStoreProduct {
   Array of product images.
   """
   image: [IStoreImage!]!
+  """
+  Custom Product Additional Properties.
+  """
+  additionalProperty: [IStorePropertyValue!]
 }

--- a/packages/api/src/typeDefs/propertyValue.graphql
+++ b/packages/api/src/typeDefs/propertyValue.graphql
@@ -10,6 +10,9 @@ type StorePropertyValue {
   Property name.
   """
   name: String!
+  """
+  Property value reference.
+  """
   valueReference: ValueReference!
 }
 
@@ -17,4 +20,21 @@ enum ValueReference {
   ATTRIBUTE
   ATTACHMENT
   PROPERTY
+}
+
+scalar Object
+
+input IStorePropertyValue {
+  """
+  Property value.
+  """
+  value: Object!
+  """
+  Property name.
+  """
+  name: String!
+  """
+  Property value reference.
+  """
+  valueReference: ValueReference!
 }

--- a/packages/api/src/typeDefs/propertyValue.graphql
+++ b/packages/api/src/typeDefs/propertyValue.graphql
@@ -3,38 +3,30 @@ Properties that can be associated with products and products groups.
 """
 type StorePropertyValue {
   """
-  Property value.
+  Property value. May hold a string or the string representation of an object.
   """
-  value: String!
+  value: ObjectOrString!
   """
   Property name.
   """
   name: String!
   """
-  Property value reference.
+  Specifies the nature of the value
   """
-  valueReference: ValueReference!
+  valueReference: String!
 }
-
-enum ValueReference {
-  ATTRIBUTE
-  ATTACHMENT
-  PROPERTY
-}
-
-scalar Object
 
 input IStorePropertyValue {
   """
-  Property value.
+  Property value. May hold a string or the string representation of an object.
   """
-  value: Object!
+  value: ObjectOrString!
   """
   Property name.
   """
   name: String!
   """
-  Property value reference.
+  Specifies the nature of the value
   """
-  valueReference: ValueReference!
+  valueReference: String!
 }

--- a/packages/api/src/typeDefs/propertyValue.graphql
+++ b/packages/api/src/typeDefs/propertyValue.graphql
@@ -10,4 +10,11 @@ type StorePropertyValue {
   Property name.
   """
   name: String!
+  valueReference: ValueReference!
+}
+
+enum ValueReference {
+  ATTRIBUTE
+  ATTACHMENT
+  PROPERTY
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds support for attachments on FastStore API. Attachments are a way to customize a product. If a product is added to the cart with a different attachment, a new offer should be created for it. An offer should be considered the same as another one if and only if the attachments (and its value) are also equal.

## How it works?
The attachments are included under the `additionalProperty` field, where they can be filtered through `valueReference` comparison. They are received in the same format they're sent.

## How to test it?

JSON variables of the graphql query to the validateCart mutation:

```json
{
  "cart": {
    "order": {
      "orderNumber": "911b0ceef77e4b98b9ca250a5d2fab2b",
      "acceptedOffer": [
        {
          "price": 602.78,
          "listPrice": 834.97,
          "seller": {
            "identifier": "1"
          },
          "quantity": 1,
          "itemOffered": {
            "sku": "2000586",
            "image": [
              {
                "url": "http://storeframework.vtexassets.com/arquivos/ids/177382/assumenda.jpg?v=637753139967300000",
                "alternateName": "hic"
              }
            ],
            "name": "Bells add-ons",
            "additionalProperty": [
              {
                "name": "1-3-lines",
                "value": "{\"Line 1\":\"1\",\"Line 2\":\"2\",\"Line 3\":\"3\"}",
                "valueReference": "ATTACHMENT"
              }
            ]
          }
        }
      ]
    }
  }
}
```

### Starters Deploy Preview
https://github.com/vtex-sites/nextjs.store/pull/47
https://github.com/vtex-sites/gatsby.store/pull/53

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->