### PR TITLE
chore: Improve github CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
         with:
           node-version: '14.x'
           cache: 'yarn'
-        run: yarn install --lock-frozen
+
+      - run: yarn install --lock-frozen
 
       - name: Lint
         run: yarn lint
@@ -47,7 +48,8 @@ jobs:
         with:
           node-version: '14.x'
           cache: 'yarn'
-        run: yarn install --lock-frozen
+
+      - run: yarn install --lock-frozen
 
 
       - name: Test
@@ -66,7 +68,8 @@ jobs:
         with:
           node-version: '14.x'
           cache: 'yarn'
-        run: yarn install --lock-frozen
+
+      - run: yarn install --lock-frozen
 
       - name: Build
         run: yarn build --scope "@vtex/gatsby-plugin-thumbor" --scope "@faststore/ui" --scope "@faststore/sdk" --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,14 @@
 name: CI
 
 on:
+  # Allow run CI for forked repos
+  pull_request_target:
+    branches:
+      - main
+
   workflow_dispatch:
+
+  # Allow run CI for any branch different from main, master
   push:
     branches-ignore:
       - main
@@ -15,15 +22,14 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node 14.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14.x'
-
-      - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@v1
+          cache: 'yarn'
+        run: yarn install --lock-frozen
 
       - name: Lint
         run: yarn lint
@@ -34,15 +40,15 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node 14.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14.x'
+          cache: 'yarn'
+        run: yarn install --lock-frozen
 
-      - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@v1
 
       - name: Test
         run: yarn test --ci --maxWorkers=2
@@ -53,15 +59,14 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node 14.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14.x'
-
-      - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@v1
+          cache: 'yarn'
+        run: yarn install --lock-frozen
 
       - name: Build
         run: yarn build --scope "@vtex/gatsby-plugin-thumbor" --scope "@faststore/ui" --scope "@faststore/sdk" --ci


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR use the [default github actions for node](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md) and adds a trigger for `pull_request_target: branch: main`.

This PR will allow run the github actions at this PR https://github.com/vtex/faststore/pull/1238

## How it works? 

## How to test it?
Needs to be tested manually

## References
https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md
