### PR TITLE
feat: useStorage update onFocus

### DIFF
--- a/packages/sdk/src/storage/useStorage.ts
+++ b/packages/sdk/src/storage/useStorage.ts
@@ -6,7 +6,7 @@
  * between server/browser. When state is 'hydrated', the value in the heap
  * is the same as the value in IDB
  */
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { get, set } from 'idb-keyval'
 
 const getItem = async <T>(key: string) => {
@@ -49,10 +49,18 @@ export const useStorage = <T>(key: string, initialValue: T | (() => T)) => {
       }
     }
 
+    const focusHandler = () => {
+      if (document.visibilityState === 'visible') {
+        effect()
+      }
+    }
+
     setTimeout(effect, 0)
+    document.addEventListener('visibilitychange', focusHandler)
 
     return () => {
       cancel = true
+      document.removeEventListener('visibilitychange', focusHandler)
     }
   }, [key])
 

--- a/packages/sdk/src/storage/useStorage.ts
+++ b/packages/sdk/src/storage/useStorage.ts
@@ -57,10 +57,12 @@ export const useStorage = <T>(key: string, initialValue: T | (() => T)) => {
 
     setTimeout(effect, 0)
     document.addEventListener('visibilitychange', focusHandler)
+    window.addEventListener('focus', focusHandler)
 
     return () => {
       cancel = true
       document.removeEventListener('visibilitychange', focusHandler)
+      window.removeEventListener('focus', focusHandler)
     }
   }, [key])
 


### PR DESCRIPTION
## What's the purpose of this pull request?
Update useStorage hook on focus.

## How it works? 
IndexedDB is consistent across multiple windows. Sadly, we don't have a way of hooking into indexedDB to know when it has changed or not with our current dependencies, `idb-keyval`. 
To make the app consistent across multiple tabs, I propose the `onFocus` trick.  The idea is to update the stored value on `useStorage` hook each time the tab is focused. This way, we ensure when the user sees a tab, it's in a consistent state.

## How to test it?
Open two tabs and add items to cart. Make sure the two carts display the same products.
More info at: https://vtex.slack.com/archives/C01AKAJDUEQ/p1653391800179519

### Starters Deploy Preview
- https://github.com/vtex-sites/nextjs.store/pull/58
- https://github.com/vtex-sites/gatsby.store/pull/58