### PR TITLE
fix: Top searches

### DIFF
--- a/packages/api/mocks/AllProductsQuery.ts
+++ b/packages/api/mocks/AllProductsQuery.ts
@@ -73,7 +73,7 @@ export const AllProductsQueryFirst5 = `query AllProducts {
 
 export const productSearchPage1Count5Fetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&hideUnavailableItems=false',
+    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&locale=en-US&hideUnavailableItems=false',
   init: undefined,
   result: {
     products: [

--- a/packages/api/mocks/ProductQuery.ts
+++ b/packages/api/mocks/ProductQuery.ts
@@ -62,7 +62,7 @@ export const ProductByIdQuery = `query ProductQuery {
 
 export const productSearchFetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A64953394&sort=&fuzzy=0&hideUnavailableItems=false',
+    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A64953394&sort=&fuzzy=0&locale=en-US&hideUnavailableItems=false',
   init: undefined,
   result: {
     products: [

--- a/packages/api/mocks/SearchQuery.ts
+++ b/packages/api/mocks/SearchQuery.ts
@@ -100,7 +100,7 @@ export const SearchQueryFirst5Products = `query SearchQuery {
 
 export const productSearchCategory1Fetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&hideUnavailableItems=false',
+    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&locale=en-US&hideUnavailableItems=false',
   init: undefined,
   result: {
     products: [
@@ -1383,7 +1383,7 @@ export const productSearchCategory1Fetch = {
 
 export const attributeSearchCategory1Fetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/facets/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&hideUnavailableItems=false',
+    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/facets/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=0&locale=en-US&hideUnavailableItems=false',
   init: undefined,
   result: {
     facets: [
@@ -1412,7 +1412,7 @@ export const attributeSearchCategory1Fetch = {
           },
         ],
         type: 'PRICERANGE',
-        name: 'Pre¿o',
+        name: 'Preï¿½o',
         hidden: false,
         key: 'price',
         quantity: 3,

--- a/packages/api/mocks/ValidateCartMutation.ts
+++ b/packages/api/mocks/ValidateCartMutation.ts
@@ -362,7 +362,7 @@ export const checkoutOrderFormCustomDataInvalidFetch = {
 
 export const productSearchPage1Count1Fetch = {
   info:
-    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A2737806&sort=&fuzzy=0&hideUnavailableItems=false',
+    'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A2737806&sort=&fuzzy=0&locale=en-US&hideUnavailableItems=false',
   init: undefined,
   result: {
     products: [

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -105,6 +105,7 @@ export const IntelligentSearch = (
       query,
       sort,
       fuzzy,
+      locale: ctx.storage.locale,
     })
 
     if (hideUnavailableItems !== undefined) {
@@ -125,20 +126,39 @@ export const IntelligentSearch = (
 
   const suggestedProducts = (
     args: Omit<SearchArgs, 'type'>
-  ): Promise<ProductSearchResult> =>
-    fetchAPI(
-      `${base}/_v/api/intelligent-search/product_search?query=${args.query}`
+  ): Promise<ProductSearchResult> => {
+    const params = new URLSearchParams({
+      query: args.query?.toString() ?? '',
+      locale: ctx.storage.locale,
+    })
+
+    return fetchAPI(
+      `${base}/_v/api/intelligent-search/product_search?${params.toString()}`
     )
+  }
 
   const suggestedTerms = (
     args: Omit<SearchArgs, 'type'>
-  ): Promise<Suggestion> =>
-    fetchAPI(
-      `${base}/_v/api/intelligent-search/search_suggestions?query=${args.query}`
-    )
+  ): Promise<Suggestion> => {
+    const params = new URLSearchParams({
+      query: args.query?.toString() ?? '',
+      locale: ctx.storage.locale,
+    })
 
-  const topSearches = (): Promise<Suggestion> =>
-    fetchAPI(`${base}/_v/api/intelligent-search/top_searches`)
+    return fetchAPI(
+      `${base}/_v/api/intelligent-search/search_suggestions?${params.toString()}`
+    )
+  }
+
+  const topSearches = (): Promise<Suggestion> => {
+    const params = new URLSearchParams({
+      locale: ctx.storage.locale,
+    })
+
+    return fetchAPI(
+      `${base}/_v/api/intelligent-search/top_searches?${params.toString()}`
+    )
+  }
 
   const facets = (args: Omit<SearchArgs, 'type'>) =>
     search<FacetSearchResult>({ ...args, type: 'facets' })

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -26,6 +26,7 @@ export interface Options {
   environment: 'vtexcommercestable' | 'vtexcommercebeta'
   // Default sales channel to use for fetching products
   channel: string
+  locale: string
   hideUnavailableItems: boolean
   flags?: FeatureFlags
 }
@@ -45,6 +46,7 @@ export interface Context {
    * */
   storage: {
     channel: Required<Channel>
+    locale: string
     flags: FeatureFlags
   }
   headers: Record<string, string>
@@ -79,6 +81,7 @@ export const getContextFactory = (options: Options) => (ctx: any): Context => {
   ctx.storage = {
     channel: ChannelMarshal.parse(options.channel),
     flags: options.flags ?? {},
+    locale: options.locale,
   }
   ctx.clients = getClients(options, ctx)
   ctx.loaders = getLoaders(options, ctx)

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -1,5 +1,10 @@
+import { mutateChannelContext, mutateLocaleContext } from '../utils/contex'
 import { enhanceSku } from '../utils/enhanceSku'
-import { transformSelectedFacet } from '../utils/facets'
+import {
+  findChannel,
+  findLocale,
+  transformSelectedFacet,
+} from '../utils/facets'
 import { SORT_MAP } from '../utils/sort'
 import { StoreCollection } from './collection'
 import type {
@@ -11,16 +16,19 @@ import type {
 } from '../../../__generated__/schema'
 import type { CategoryTree } from '../clients/commerce/types/CategoryTree'
 import type { Context } from '../index'
-import { mutateChannelContext } from '../utils/channel'
 
 export const Query = {
   product: async (_: unknown, { locator }: QueryProductArgs, ctx: Context) => {
     // Insert channel in context for later usage
-    const channelString = locator.find((facet) => facet.key === 'channel')
-      ?.value
+    const channel = findChannel(locator)
+    const locale = findLocale(locator)
 
-    if (channelString) {
-      mutateChannelContext(ctx, channelString)
+    if (channel) {
+      mutateChannelContext(ctx, channel)
+    }
+
+    if (locale) {
+      mutateLocaleContext(ctx, locale)
     }
 
     const {
@@ -42,12 +50,15 @@ export const Query = {
     ctx: Context
   ) => {
     // Insert channel in context for later usage
-    const channelString = selectedFacets?.find(
-      (facet) => facet.key === 'channel'
-    )?.value
+    const channel = findChannel(selectedFacets)
+    const locale = findLocale(selectedFacets)
 
-    if (channelString) {
-      mutateChannelContext(ctx, channelString)
+    if (channel) {
+      mutateChannelContext(ctx, channel)
+    }
+
+    if (locale) {
+      mutateLocaleContext(ctx, locale)
     }
 
     const after = maybeAfter ? Number(maybeAfter) : 0

--- a/packages/api/src/platforms/vtex/utils/channel.ts
+++ b/packages/api/src/platforms/vtex/utils/channel.ts
@@ -1,5 +1,3 @@
-import type { Context } from '..'
-
 export interface Channel {
   regionId?: string
   salesChannel?: string
@@ -24,8 +22,4 @@ export default class ChannelMarshal {
   public static stringify(channel: Channel): string {
     return JSON.stringify(channel)
   }
-}
-
-export const mutateChannelContext = (ctx: Context, channelString: string) => {
-  ctx.storage.channel = ChannelMarshal.parse(channelString)
 }

--- a/packages/api/src/platforms/vtex/utils/contex.ts
+++ b/packages/api/src/platforms/vtex/utils/contex.ts
@@ -1,0 +1,10 @@
+import ChannelMarshal from './channel'
+import type { Context } from '..'
+
+export const mutateChannelContext = (ctx: Context, channelString: string) => {
+  ctx.storage.channel = ChannelMarshal.parse(channelString)
+}
+
+export const mutateLocaleContext = (ctx: Context, locale: string) => {
+  ctx.storage.locale = locale
+}

--- a/packages/api/src/platforms/vtex/utils/facets.ts
+++ b/packages/api/src/platforms/vtex/utils/facets.ts
@@ -1,4 +1,5 @@
 import ChannelMarshal from './channel'
+import type { Maybe } from '../../../__generated__/schema'
 
 export interface SelectedFacet {
   key: string
@@ -24,7 +25,17 @@ export const transformSelectedFacet = ({ key, value }: SelectedFacet) => {
       return channelFacets
     }
 
+    case 'locale': {
+      return [] // remove this facet from search
+    }
+
     default:
       return { key, value }
   }
 }
+
+export const findLocale = (facets?: Maybe<SelectedFacet[]>) =>
+  facets?.find((x) => x.key === 'locale')?.value ?? null
+
+export const findChannel = (facets?: Maybe<SelectedFacet[]>) =>
+  facets?.find((facet) => facet.key === 'channel')?.value ?? null

--- a/packages/api/test/mutations.test.ts
+++ b/packages/api/test/mutations.test.ts
@@ -26,6 +26,7 @@ const apiOptions = {
   account: 'storeframework',
   environment: 'vtexcommercestable',
   channel: '{"salesChannel":"1"}',
+  locale: 'en-US',
   hideUnavailableItems: false,
   flags: {
     enableOrderFormSync: true,

--- a/packages/api/test/queries.test.ts
+++ b/packages/api/test/queries.test.ts
@@ -38,7 +38,11 @@ const apiOptions = {
   account: 'storeframework',
   environment: 'vtexcommercestable',
   channel: '{"salesChannel":"1"}',
+  locale: 'en-US',
   hideUnavailableItems: false,
+  flags: {
+    enableOrderFormSync: true,
+  },
 } as Options
 
 const mockedFetch = jest.fn()

--- a/packages/api/test/schema.test.ts
+++ b/packages/api/test/schema.test.ts
@@ -65,7 +65,11 @@ beforeAll(async () => {
     account: 'storeframework',
     environment: 'vtexcommercestable',
     channel: '{"salesChannel":"1"}',
+    locale: 'en-US',
     hideUnavailableItems: false,
+    flags: {
+      enableOrderFormSync: true,
+    },
   })
 })
 


### PR DESCRIPTION
## What's the purpose of this pull request?
Fixes top search results

## How it works? 
Some accounts require the `?locale` being passed to the search API for it to return anything as suggestions. This PR requires the locale to be passed to the api so we forward this data to the search API.

## How to test it?
Change account to `casinofr` and make the following query:
```
query Suggestions($selectedFacets: [IStoreSelectedFacet!]!) {
  search(first: 10, term:"", selectedFacets: $selectedFacets) {
    suggestions {
      terms
      products {
        name
      }
    }
  }
}
```

Make sure that when 
```
{
"selectedFacets": [
    {
      "key": "locale",
      "value": "fr-FR"
    }
  ],
}
```

you receive results. With 
```
{
"selectedFacets": [],
}
```

you receive nothing

### Starters Deploy Preview
- https://github.com/vtex-sites/nextjs.store/pull/71
- https://github.com/vtex-sites/gatsby.store/pull/69