### PR TITLE
fix: Cart item with additionalProperty

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -69,6 +69,8 @@ export type IStoreProduct = {
 export type IStorePropertyValue = {
   /** Property name. */
   name: Scalars['String'];
+  /** Property id. This propert changes according to the content of the object. */
+  propertyID?: Maybe<Scalars['String']>;
   /** Property value. May hold a string or the string representation of an object. */
   value: Scalars['ObjectOrString'];
   /** Specifies the nature of the value */

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -5,6 +5,7 @@ import type {
   IStoreCart,
   IStoreOffer,
   IStoreOrder,
+  IStorePropertyValue,
 } from '../../../__generated__/schema'
 import type {
   OrderForm,
@@ -20,17 +21,18 @@ import {
 
 type Indexed<T> = T & { index?: number }
 
-const getAttachments = (item: IStoreOffer) =>
-  item.itemOffered.additionalProperty?.filter(
-    (i) => i.valueReference === VALUE_REFERENCES.attachment
-  )
+const isAttachment = (value: IStorePropertyValue) =>
+  value.valueReference === VALUE_REFERENCES.attachment
 
 const getId = (item: IStoreOffer) =>
   [
     item.itemOffered.sku,
     item.seller.identifier,
     item.price,
-    item.itemOffered.additionalProperty?.map(getPropertyId).join('-'),
+    item.itemOffered.additionalProperty
+      ?.filter(isAttachment)
+      .map(getPropertyId)
+      .join('-'),
   ]
     .filter(Boolean)
     .join('::')
@@ -59,7 +61,9 @@ const offerToOrderItemInput = (
   seller: offer.seller.identifier,
   id: offer.itemOffered.sku,
   index: offer.index,
-  attachments: (getAttachments(offer) ?? []).map((attachment) => ({
+  attachments: (
+    offer.itemOffered.additionalProperty?.filter(isAttachment) ?? []
+  ).map((attachment) => ({
     name: attachment.name,
     content: attachment.value,
   })),

--- a/packages/api/src/typeDefs/propertyValue.graphql
+++ b/packages/api/src/typeDefs/propertyValue.graphql
@@ -22,6 +22,10 @@ type StorePropertyValue {
 
 input IStorePropertyValue {
   """
+  Property id. This propert changes according to the content of the object.
+  """
+  propertyID: String
+  """
   Property value. May hold a string or the string representation of an object.
   """
   value: ObjectOrString!


### PR DESCRIPTION
## What's the purpose of this pull request?
When adding a product to cart with additionalProperties we were receiving the following error:
```
GraphQLError [Object]: Variable "$additionalProperty" got invalid value { propertyID: "4ba0a4d37b7f733da5ddb281ea50d883", name: "activeSubscriptions", value: "abonnements", valueReference: "SPECIFICATION" }; Field "propertyID" is not defined by type IStorePropertyValue.
```

This PR addresses this issue

## Starters
- https://github.com/vtex-sites/nextjs.store/pull/75
- https://github.com/vtex-sites/gatsby.store/pull/74