### PR TITLE
fix: Spot pricing sort for lowPrice/highPrice

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
@@ -10,13 +10,14 @@ export const StoreAggregateOffer: Record<string, Resolver<Root>> & {
 } = {
   highPrice: (offers) => {
     const availableOffers = offers.filter(inStock)
+    const highOffer = availableOffers[availableOffers.length - 1]
 
-    return price(availableOffers[availableOffers.length - 1]) ?? 0
+    return highOffer != null ? price(highOffer) : 0
   },
   lowPrice: (offers) => {
-    const availableOffers = offers.filter(inStock)
+    const [lowOffer] = offers.filter(inStock)
 
-    return price(availableOffers[0]) ?? 0
+    return lowOffer ? price(lowOffer) : 0
   },
   offerCount: (offers) => offers.length,
   priceCurrency: () => '',

--- a/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
@@ -1,4 +1,4 @@
-import { inStock } from '../utils/productStock'
+import { inStock, price } from '../utils/productStock'
 import type { StoreProduct } from './product'
 import type { PromiseType } from '../../../typings'
 import type { Resolver } from '..'
@@ -11,12 +11,12 @@ export const StoreAggregateOffer: Record<string, Resolver<Root>> & {
   highPrice: (offers) => {
     const availableOffers = offers.filter(inStock)
 
-    return availableOffers[availableOffers.length - 1]?.Price ?? 0
+    return price(availableOffers[availableOffers.length - 1]) ?? 0
   },
   lowPrice: (offers) => {
     const availableOffers = offers.filter(inStock)
 
-    return availableOffers[0]?.Price ?? 0
+    return price(availableOffers[0]) ?? 0
   },
   offerCount: (offers) => offers.length,
   priceCurrency: () => '',

--- a/packages/api/src/platforms/vtex/utils/productStock.ts
+++ b/packages/api/src/platforms/vtex/utils/productStock.ts
@@ -10,7 +10,7 @@ export const sellingPrice = (offer: CommertialOffer) => offer.Price ?? 0
 export const availability = (available: boolean) =>
   available ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock'
 
-// Smallest Available Selling Price First
+// Smallest Available Spot Price First
 export const bestOfferFirst = (
   a: Pick<CommertialOffer, 'AvailableQuantity' | 'spotPrice'>,
   b: Pick<CommertialOffer, 'AvailableQuantity' | 'spotPrice'>


### PR DESCRIPTION
## What's the purpose of this pull request?
SKUs can have multiple sellers. We have an heuristic for choosing the best seller. This is written on [bestOfferFirst](https://github.com/vtex/faststore/blob/779174d8a957e2f339af68b7f65e26c330f1533d/packages/api/src/platforms/vtex/utils/productStock.ts#L14) function.This function sorts the smallest available spotPrice first. 

The issue we had is that AggregateOffers's low/hight price was returning the `sellingPrice` instead of the `spotPrice`, making the values inconsistent. 

This PR addresses this issue by making low/high price return the same properties used on `bestOfferFirst`

### Starters Deploy Preview
- https://github.com/vtex-sites/nextjs.store/pull/111
- https://github.com/vtex-sites/gatsby.store/pull/102