### PR TITLE
feat: Adds support to pass input refs to `Slider`

### DIFF
--- a/packages/ui/src/atoms/Slider/Slider.tsx
+++ b/packages/ui/src/atoms/Slider/Slider.tsx
@@ -2,6 +2,7 @@
  * This code is inspired by the work of [sandra-lewis](https://codesandbox.io/u/sandra-lewis)
  */
 import React, { useState, useMemo } from 'react'
+import type { MutableRefObject } from 'react'
 
 interface Range {
   absolute: number
@@ -39,6 +40,14 @@ export type SliderProps = {
    * Returns the value of element's class content attribute.
    */
   className?: string
+  /**
+   * Specifies a ref object for the min value
+   */
+  minValueRef?: MutableRefObject<HTMLInputElement | null>
+  /**
+   * Specifies a ref object for the max value
+   */
+  maxValueRef?: MutableRefObject<HTMLInputElement | null>
 }
 
 const percent = (value: number, min: number, max: number) =>
@@ -52,6 +61,8 @@ const Slider = ({
   testId = 'store-slider',
   getAriaValueText,
   className,
+  minValueRef,
+  maxValueRef,
 }: SliderProps) => {
   const [minPercent, setMinPercent] = useState(() =>
     percent(min.selected, min.absolute, max.absolute)
@@ -77,6 +88,7 @@ const Slider = ({
         data-slider-range
       />
       <input
+        ref={minValueRef}
         type="range"
         min={min.absolute}
         max={max.absolute}
@@ -97,6 +109,7 @@ const Slider = ({
         aria-labelledby={getAriaValueText?.(minVal, 'min')}
       />
       <input
+        ref={maxValueRef}
         type="range"
         min={min.absolute}
         max={max.absolute}

--- a/packages/ui/src/molecules/PriceRange/PriceRange.tsx
+++ b/packages/ui/src/molecules/PriceRange/PriceRange.tsx
@@ -35,6 +35,7 @@ const PriceRange = ({
   testId = 'store-price-range',
   variant,
   'aria-label': ariaLabel,
+  ...otherProps
 }: PriceRangeProps) => {
   const [edges, setEdges] = useState({ min: min.selected, max: max.selected })
 
@@ -49,6 +50,7 @@ const PriceRange = ({
           onChange?.(value)
         }}
         aria-label={ariaLabel}
+        {...otherProps}
       />
       <div data-price-range-values>
         <Price


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add support for the `Slider` component to receive refs for both inputs (min and max values).

## How it works?

The purpose of these changes is to control/change the min and max `Slider` inputs when necessary, by triggering input's functions from other components that are using the `Slider`.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->