### PR TITLE
fix: @faststore/graphql-utils

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -341,8 +341,9 @@ export type StoreFacetRange = {
   key: Scalars['String'];
   /** Facet label. */
   label: Scalars['String'];
+  /** Maximum facet range value. */
   max: StoreFacetValueRange;
-  /** Array with information on each facet value. */
+  /** Minimum facet range value. */
   min: StoreFacetValueRange;
 };
 
@@ -367,9 +368,12 @@ export type StoreFacetValueBoolean = {
   value: Scalars['String'];
 };
 
+/** Search facet range value information. Used for minimum and maximum range values. */
 export type StoreFacetValueRange = {
   __typename?: 'StoreFacetValueRange';
+  /** Search facet range absolute value. */
   absolute: Scalars['Float'];
+  /** Search facet range selected value. */
   selected: Scalars['Float'];
 };
 

--- a/packages/graphql-utils/tsconfig.json
+++ b/packages/graphql-utils/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "shared/tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "module": "commonjs"
   },
   "include": ["src"]
 }

--- a/packages/lighthouse/tsconfig.json
+++ b/packages/lighthouse/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "shared/tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "module": "commonjs"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
After changing TypeScript target, @faststore/graphql-utils started being built with `es modules`. This caused the following issue on the stores:
```
[BABEL]: Cannot use import statement outside a module (While processing: ~/vtex-sites/gatsby.store/node_modules/@faststore/graphql-utils/babel.js)
``` 

changing it to `commonjs` should fix the issue