### PR TITLE
chore: `PriceRange` improvements

### DIFF
--- a/packages/ui/src/atoms/Slider/Slider.tsx
+++ b/packages/ui/src/atoms/Slider/Slider.tsx
@@ -108,8 +108,12 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
       <div data-store-slider data-testid={testId} className={className}>
         <div
           style={{
-            left: `${minPercent}%`,
-            width: `${maxPercent - minPercent}%`,
+            left: `${minPercent < min.absolute ? min.absolute : minPercent}%`,
+            width: `${
+              maxPercent - minPercent > 100
+                ? 100 - minPercent
+                : maxPercent - minPercent
+            }%`,
           }}
           data-slider-range
         />

--- a/packages/ui/src/atoms/Slider/Slider.tsx
+++ b/packages/ui/src/atoms/Slider/Slider.tsx
@@ -7,6 +7,7 @@ import React, {
   useImperativeHandle,
   forwardRef,
 } from 'react'
+import type { ReactNode } from 'react'
 
 interface Range {
   absolute: number
@@ -44,6 +45,14 @@ export type SliderProps = {
    * Returns the value of element's class content attribute.
    */
   className?: string
+  /**
+   * Component that renders min value label above the left thumb.
+   */
+  minValueLabelComponent?: (minValue: number) => ReactNode
+  /**
+   * Component that renders max value label above the right thumb.
+   */
+  maxValueLabelComponent?: (maxValue: number) => ReactNode
 }
 
 type SliderRefType = {
@@ -63,6 +72,8 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
       testId = 'store-slider',
       getAriaValueText,
       className,
+      minValueLabelComponent,
+      maxValueLabelComponent,
     },
     ref
   ) {
@@ -102,6 +113,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
           }}
           data-slider-range
         />
+        {minValueLabelComponent && minValueLabelComponent(minVal)}
         <input
           type="range"
           min={min.absolute}
@@ -122,6 +134,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
           aria-label={String(minVal)}
           aria-labelledby={getAriaValueText?.(minVal, 'min')}
         />
+        {maxValueLabelComponent && maxValueLabelComponent(maxVal)}
         <input
           type="range"
           min={min.absolute}

--- a/packages/ui/src/molecules/PriceRange/PriceRange.tsx
+++ b/packages/ui/src/molecules/PriceRange/PriceRange.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useImperativeHandle, forwardRef } from 'react'
+import React, { useRef, useImperativeHandle, forwardRef } from 'react'
 import type { AriaAttributes } from 'react'
 
 import Price from '../../atoms/Price'
@@ -47,11 +47,9 @@ const PriceRange = forwardRef<PriceRangeRefType | undefined, PriceRangeProps>(
     const sliderRef = useRef<{
       setSliderValues: (values: { min: number; max: number }) => void
     }>()
-    const [edges, setEdges] = useState({ min: min.selected, max: max.selected })
 
     useImperativeHandle(ref, () => ({
       setPriceRangeValues: (values: { min: number; max: number }) => {
-        setEdges(values)
         onChange?.(values)
         sliderRef.current?.setSliderValues(values)
       },
@@ -64,26 +62,33 @@ const PriceRange = forwardRef<PriceRangeRefType | undefined, PriceRangeProps>(
           min={min}
           max={max}
           onEnd={onEnd}
-          onChange={(value) => {
-            setEdges(value)
-            onChange?.(value)
-          }}
           aria-label={ariaLabel}
+          onChange={(value) => onChange?.(value)}
+          minValueLabelComponent={(minValue) => (
+            <Price
+              value={minValue}
+              variant={variant}
+              formatter={formatter}
+              style={{
+                position: 'absolute',
+                left: `calc(${minValue}% + (${8 - minValue * 0.2}px))`,
+              }}
+              data-price-range-value-label="min"
+            />
+          )}
+          maxValueLabelComponent={(maxValue) => (
+            <Price
+              formatter={formatter}
+              variant={variant}
+              value={maxValue}
+              style={{
+                position: 'absolute',
+                left: `calc(${maxValue}% + (${8 - maxValue * 0.2}px))`,
+              }}
+              data-price-range-value-label="max"
+            />
+          )}
         />
-        <div data-price-range-values>
-          <Price
-            formatter={formatter}
-            data-price-range-value="min"
-            value={edges.min}
-            variant={variant}
-          />
-          <Price
-            formatter={formatter}
-            data-price-range-value="max"
-            value={edges.max}
-            variant={variant}
-          />
-        </div>
       </div>
     )
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to improve the `PriceRange` component by changing the appearance according to the starters' prototype. ([`PriceRange` Figma prototype](https://www.figma.com/file/v2OvaPeIPyB1tZ0iX8ILqE/Handoff-v5-(Price-Range)?node-id=847%3A58234))

Some changes had to be made to the `Slider` component to make room for customizations.

## How it works?

Now, the component displays the min/max values centered above the `Slider`'s thumbs.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

- [Value Bubbles for Range Inputs](https://css-tricks.com/value-bubbles-for-range-inputs/)
