### PR TITLE
feat: Add skuSelector-related properties to ProductGroup type

### DIFF
--- a/packages/api/local/server.ts
+++ b/packages/api/local/server.ts
@@ -8,7 +8,7 @@ const serverPort = '4000'
 
 const apiOptions = {
   platform: 'vtex',
-  account: 'storecomponents',
+  account: 'storeframework',
   locale: 'en-US',
   environment: 'vtexcommercestable',
   channel: '{"salesChannel":"1"}',

--- a/packages/api/local/server.ts
+++ b/packages/api/local/server.ts
@@ -8,7 +8,7 @@ const serverPort = '4000'
 
 const apiOptions = {
   platform: 'vtex',
-  account: 'storeframework',
+  account: 'storecomponents',
   locale: 'en-US',
   environment: 'vtexcommercestable',
   channel: '{"salesChannel":"1"}',

--- a/packages/api/mocks/skuVariants.ts
+++ b/packages/api/mocks/skuVariants.ts
@@ -1,0 +1,725 @@
+// These are incomplete mock for the `root` argument available to resolvers
+// for the `ProductGroup` type. Don't take this as a reference for creating
+// new resolvers.
+export const productGroupRootWithoutSkuProperties = {
+  images: [
+    {
+      imageId: '155472',
+      cacheId: '155472',
+      imageTag: '',
+      imageLabel: 'main',
+      imageText: 'main',
+      imageUrl:
+        'https://storecomponents.vtexassets.com/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000',
+    },
+    {
+      imageId: '155473',
+      cacheId: '155473',
+      imageTag: '',
+      imageLabel: 'main2',
+      imageText: 'main2',
+      imageUrl:
+        'https://storecomponents.vtexassets.com/arquivos/ids/155473/Frame.jpg?v=636793764101900000',
+    },
+    {
+      imageId: '155561',
+      cacheId: '155561',
+      imageTag: '',
+      imageLabel: 'skuvariation',
+      imageText: 'skuvariation',
+      imageUrl:
+        'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
+    },
+  ],
+  itemId: '36',
+  name: 'White Slip On 42',
+  nameComplete: 'Classic Shoes White Slip On 42',
+  variations: [],
+  isVariantOf: {
+    cacheId: 'sp-16',
+    productId: '16',
+    description: "If you go classic, you can't go wrong.",
+    productName: 'Classic Shoes',
+    linkText: 'classic-shoes',
+    brand: 'Mizuno',
+    brandId: 2000010,
+    link: '/classic-shoes/p',
+    categories: ['/Apparel & Accessories/Shoes/', '/Apparel & Accessories/'],
+    skuSpecifications: [],
+    properties: [],
+    items: [
+      {
+        images: [
+          {
+            imageId: '155474',
+            cacheId: '155474',
+            imageTag: '',
+            imageLabel: 'main',
+            imageText: 'main',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155474/Frame-1.jpg?v=636793764631500000',
+          },
+          {
+            imageId: '155475',
+            cacheId: '155475',
+            imageTag: '',
+            imageLabel: 'main2',
+            imageText: 'main2',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155475/Frame-2.jpg?v=636793764763600000',
+          },
+          {
+            imageId: '155560',
+            cacheId: '155560',
+            imageTag: '',
+            imageLabel: 'skuvariation',
+            imageText: 'skuvariation',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155560/pink-cool-sku-variation.png?v=637063239809000000',
+          },
+        ],
+        itemId: '37',
+        name: 'Cool Pink',
+        variations: [],
+      },
+      {
+        images: [
+          {
+            imageId: '155470',
+            cacheId: '155470',
+            imageTag: '',
+            imageLabel: 'main',
+            imageText: 'main',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155470/Frame-11.jpg?v=636793763155730000',
+          },
+          {
+            imageId: '155471',
+            cacheId: '155471',
+            imageTag: '',
+            imageLabel: 'hover',
+            imageText: 'hover',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155471/Frame-10.jpg?v=637018188181300000',
+          },
+          {
+            imageId: '155559',
+            cacheId: '155559',
+            imageTag: '',
+            imageLabel: 'skuvariation',
+            imageText: 'skuvariation',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155559/pink-sku-variation.png?v=637087508159070000',
+          },
+        ],
+        itemId: '35',
+        name: 'Classic Pink',
+        nameComplete: 'Classic Shoes Classic Pink',
+        variations: [],
+      },
+      {
+        images: [
+          {
+            imageId: '155472',
+            cacheId: '155472',
+            imageTag: '',
+            imageLabel: 'main',
+            imageText: 'main',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000',
+          },
+          {
+            imageId: '155473',
+            cacheId: '155473',
+            imageTag: '',
+            imageLabel: 'main2',
+            imageText: 'main2',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155473/Frame.jpg?v=636793764101900000',
+          },
+          {
+            imageId: '155561',
+            cacheId: '155561',
+            imageTag: '',
+            imageLabel: 'skuvariation',
+            imageText: 'skuvariation',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
+          },
+        ],
+        itemId: '36',
+        name: 'White Slip On 42',
+        nameComplete: 'Classic Shoes White Slip On 42',
+        variations: [],
+      },
+      {
+        images: [
+          {
+            imageId: '155472',
+            cacheId: '155472',
+            imageTag: '',
+            imageLabel: 'main',
+            imageText: 'main',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000',
+          },
+          {
+            imageId: '155473',
+            cacheId: '155473',
+            imageTag: '',
+            imageLabel: 'main2',
+            imageText: 'main2',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155473/Frame.jpg?v=636793764101900000',
+          },
+          {
+            imageId: '155561',
+            cacheId: '155561',
+            imageTag: '',
+            imageLabel: 'skuvariation',
+            imageText: 'skuvariation',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
+          },
+        ],
+        itemId: '310124175',
+        name: 'White Slip On 41',
+        nameComplete: 'Classic Shoes White Slip On 41',
+        variations: [],
+      },
+    ],
+  },
+}
+
+export const productGroup1SkuProperty = {
+  images: [
+    {
+      imageId: '155472',
+      cacheId: '155472',
+      imageTag: '',
+      imageLabel: 'main',
+      imageText: 'main',
+      imageUrl:
+        'https://storecomponents.vtexassets.com/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000',
+    },
+    {
+      imageId: '155473',
+      cacheId: '155473',
+      imageTag: '',
+      imageLabel: 'main2',
+      imageText: 'main2',
+      imageUrl:
+        'https://storecomponents.vtexassets.com/arquivos/ids/155473/Frame.jpg?v=636793764101900000',
+    },
+    {
+      imageId: '155561',
+      cacheId: '155561',
+      imageTag: '',
+      imageLabel: 'skuvariation',
+      imageText: 'skuvariation',
+      imageUrl:
+        'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
+    },
+  ],
+  itemId: '36',
+  name: 'White Slip On 42',
+  nameComplete: 'Classic Shoes White Slip On 42',
+  variations: [
+    {
+      name: 'Color',
+      values: ['White'],
+    },
+  ],
+  Color: ['White'],
+  isVariantOf: {
+    cacheId: 'sp-16',
+    productId: '16',
+    description: "If you go classic, you can't go wrong.",
+    productName: 'Classic Shoes',
+    linkText: 'classic-shoes',
+    brand: 'Mizuno',
+    brandId: 2000010,
+    link: '/classic-shoes/p',
+    categories: ['/Apparel & Accessories/Shoes/', '/Apparel & Accessories/'],
+    skuSpecifications: [
+      {
+        field: {
+          name: 'Color',
+          originalName: 'Color',
+        },
+        values: [
+          {
+            name: 'Green',
+            originalName: 'Green',
+          },
+          {
+            name: 'White',
+            originalName: 'White',
+          },
+          {
+            name: 'Red',
+            originalName: 'Red',
+          },
+        ],
+      },
+    ],
+    properties: [
+      {
+        name: 'Color',
+        originalName: 'Color',
+        values: ['Green', 'White', 'Red'],
+      },
+      {
+        name: 'Color',
+        originalName: 'Color',
+        values: ['Green', 'White', 'Red'],
+      },
+      {
+        name: 'Color',
+        originalName: 'Color',
+        values: ['Green', 'White', 'Red'],
+      },
+    ],
+    items: [
+      {
+        images: [
+          {
+            imageId: '155474',
+            cacheId: '155474',
+            imageTag: '',
+            imageLabel: 'main',
+            imageText: 'main',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155474/Frame-1.jpg?v=636793764631500000',
+          },
+          {
+            imageId: '155475',
+            cacheId: '155475',
+            imageTag: '',
+            imageLabel: 'main2',
+            imageText: 'main2',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155475/Frame-2.jpg?v=636793764763600000',
+          },
+          {
+            imageId: '155560',
+            cacheId: '155560',
+            imageTag: '',
+            imageLabel: 'skuvariation',
+            imageText: 'skuvariation',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155560/pink-cool-sku-variation.png?v=637063239809000000',
+          },
+        ],
+        itemId: '37',
+        name: 'Cool Pink',
+        variations: [
+          {
+            name: 'Color',
+            values: ['Red'],
+          },
+        ],
+        Color: ['Red'],
+      },
+      {
+        images: [
+          {
+            imageId: '155470',
+            cacheId: '155470',
+            imageTag: '',
+            imageLabel: 'main',
+            imageText: 'main',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155470/Frame-11.jpg?v=636793763155730000',
+          },
+          {
+            imageId: '155471',
+            cacheId: '155471',
+            imageTag: '',
+            imageLabel: 'hover',
+            imageText: 'hover',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155471/Frame-10.jpg?v=637018188181300000',
+          },
+          {
+            imageId: '155559',
+            cacheId: '155559',
+            imageTag: '',
+            imageLabel: 'skuvariation',
+            imageText: 'skuvariation',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155559/pink-sku-variation.png?v=637087508159070000',
+          },
+        ],
+        itemId: '35',
+        name: 'Classic Pink',
+        nameComplete: 'Classic Shoes Classic Pink',
+        variations: [
+          {
+            name: 'Color',
+            values: ['Green'],
+          },
+        ],
+        Color: ['Green'],
+      },
+      {
+        images: [
+          {
+            imageId: '155472',
+            cacheId: '155472',
+            imageTag: '',
+            imageLabel: 'main',
+            imageText: 'main',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000',
+          },
+          {
+            imageId: '155473',
+            cacheId: '155473',
+            imageTag: '',
+            imageLabel: 'main2',
+            imageText: 'main2',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155473/Frame.jpg?v=636793764101900000',
+          },
+          {
+            imageId: '155561',
+            cacheId: '155561',
+            imageTag: '',
+            imageLabel: 'skuvariation',
+            imageText: 'skuvariation',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
+          },
+        ],
+        itemId: '310124175',
+        name: 'White Slip On 41',
+        nameComplete: 'Classic Shoes White Slip On 41',
+        variations: [
+          {
+            name: 'Color',
+            values: ['White'],
+          },
+        ],
+        Color: ['White'],
+      },
+    ],
+  },
+}
+
+export const productGroup2SkuProperties = {
+  images: [
+    {
+      imageId: '155472',
+      cacheId: '155472',
+      imageTag: '',
+      imageLabel: 'main',
+      imageText: 'main',
+      imageUrl:
+        'https://storecomponents.vtexassets.com/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000',
+    },
+    {
+      imageId: '155473',
+      cacheId: '155473',
+      imageTag: '',
+      imageLabel: 'main2',
+      imageText: 'main2',
+      imageUrl:
+        'https://storecomponents.vtexassets.com/arquivos/ids/155473/Frame.jpg?v=636793764101900000',
+    },
+    {
+      imageId: '155561',
+      cacheId: '155561',
+      imageTag: '',
+      imageLabel: 'skuvariation',
+      imageText: 'skuvariation',
+      imageUrl:
+        'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
+    },
+  ],
+  itemId: '36',
+  name: 'White Slip On 42',
+  nameComplete: 'Classic Shoes White Slip On 42',
+  variations: [
+    {
+      name: 'Color',
+      values: ['White'],
+    },
+    {
+      name: 'Size',
+      values: ['42'],
+    },
+  ],
+  Color: ['White'],
+  Size: ['42'],
+  isVariantOf: {
+    cacheId: 'sp-16',
+    productId: '16',
+    description: "If you go classic, you can't go wrong.",
+    productName: 'Classic Shoes',
+    linkText: 'classic-shoes',
+    brand: 'Mizuno',
+    brandId: 2000010,
+    link: '/classic-shoes/p',
+    categories: ['/Apparel & Accessories/Shoes/', '/Apparel & Accessories/'],
+    skuSpecifications: [
+      {
+        field: {
+          name: 'Color',
+          originalName: 'Color',
+        },
+        values: [
+          {
+            name: 'Green',
+            originalName: 'Green',
+          },
+          {
+            name: 'White',
+            originalName: 'White',
+          },
+          {
+            name: 'Red',
+            originalName: 'Red',
+          },
+        ],
+      },
+      {
+        field: {
+          name: 'Size',
+          originalName: 'Size',
+        },
+        values: [
+          {
+            name: '40',
+            originalName: '40',
+          },
+          {
+            name: '42',
+            originalName: '42',
+          },
+          {
+            name: '41',
+            originalName: '41',
+          },
+        ],
+      },
+    ],
+    properties: [
+      {
+        name: 'Color',
+        originalName: 'Color',
+        values: ['Green', 'White', 'Red'],
+      },
+      {
+        name: 'Size',
+        originalName: 'Size',
+        values: ['40', '42', '41'],
+      },
+      {
+        name: 'Color',
+        originalName: 'Color',
+        values: ['Green', 'White', 'Red'],
+      },
+      {
+        name: 'Size',
+        originalName: 'Size',
+        values: ['40', '42', '41'],
+      },
+      {
+        name: 'Color',
+        originalName: 'Color',
+        values: ['Green', 'White', 'Red'],
+      },
+      {
+        name: 'Size',
+        originalName: 'Size',
+        values: ['40', '42', '41'],
+      },
+    ],
+    items: [
+      {
+        images: [
+          {
+            imageId: '155474',
+            cacheId: '155474',
+            imageTag: '',
+            imageLabel: 'main',
+            imageText: 'main',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155474/Frame-1.jpg?v=636793764631500000',
+          },
+          {
+            imageId: '155475',
+            cacheId: '155475',
+            imageTag: '',
+            imageLabel: 'main2',
+            imageText: 'main2',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155475/Frame-2.jpg?v=636793764763600000',
+          },
+          {
+            imageId: '155560',
+            cacheId: '155560',
+            imageTag: '',
+            imageLabel: 'skuvariation',
+            imageText: 'skuvariation',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155560/pink-cool-sku-variation.png?v=637063239809000000',
+          },
+        ],
+        itemId: '37',
+        name: 'Cool Pink',
+        variations: [
+          {
+            name: 'Color',
+            values: ['Red'],
+          },
+          {
+            name: 'Size',
+            values: ['42'],
+          },
+        ],
+        Color: ['Red'],
+        Size: ['42'],
+      },
+      {
+        images: [
+          {
+            imageId: '155470',
+            cacheId: '155470',
+            imageTag: '',
+            imageLabel: 'main',
+            imageText: 'main',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155470/Frame-11.jpg?v=636793763155730000',
+          },
+          {
+            imageId: '155471',
+            cacheId: '155471',
+            imageTag: '',
+            imageLabel: 'hover',
+            imageText: 'hover',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155471/Frame-10.jpg?v=637018188181300000',
+          },
+          {
+            imageId: '155559',
+            cacheId: '155559',
+            imageTag: '',
+            imageLabel: 'skuvariation',
+            imageText: 'skuvariation',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155559/pink-sku-variation.png?v=637087508159070000',
+          },
+        ],
+        itemId: '35',
+        name: 'Classic Pink',
+        nameComplete: 'Classic Shoes Classic Pink',
+        variations: [
+          {
+            name: 'Color',
+            values: ['Green'],
+          },
+          {
+            name: 'Size',
+            values: ['40'],
+          },
+        ],
+        Color: ['Green'],
+        Size: ['40'],
+      },
+      {
+        images: [
+          {
+            imageId: '155472',
+            cacheId: '155472',
+            imageTag: '',
+            imageLabel: 'main',
+            imageText: 'main',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000',
+          },
+          {
+            imageId: '155473',
+            cacheId: '155473',
+            imageTag: '',
+            imageLabel: 'main2',
+            imageText: 'main2',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155473/Frame.jpg?v=636793764101900000',
+          },
+          {
+            imageId: '155561',
+            cacheId: '155561',
+            imageTag: '',
+            imageLabel: 'skuvariation',
+            imageText: 'skuvariation',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
+          },
+        ],
+        itemId: '36',
+        name: 'White Slip On 42',
+        nameComplete: 'Classic Shoes White Slip On 42',
+        variations: [
+          {
+            name: 'Color',
+            values: ['White'],
+          },
+          {
+            name: 'Size',
+            values: ['42'],
+          },
+        ],
+        Color: ['White'],
+        Size: ['42'],
+      },
+      {
+        images: [
+          {
+            imageId: '155472',
+            cacheId: '155472',
+            imageTag: '',
+            imageLabel: 'main',
+            imageText: 'main',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000',
+          },
+          {
+            imageId: '155473',
+            cacheId: '155473',
+            imageTag: '',
+            imageLabel: 'main2',
+            imageText: 'main2',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155473/Frame.jpg?v=636793764101900000',
+          },
+          {
+            imageId: '155561',
+            cacheId: '155561',
+            imageTag: '',
+            imageLabel: 'skuvariation',
+            imageText: 'skuvariation',
+            imageUrl:
+              'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
+          },
+        ],
+        itemId: '310124175',
+        name: 'White Slip On 41',
+        nameComplete: 'Classic Shoes White Slip On 41',
+        variations: [
+          {
+            name: 'Color',
+            values: ['White'],
+          },
+          {
+            name: 'Size',
+            values: ['41'],
+          },
+        ],
+        Color: ['White'],
+        Size: ['41'],
+      },
+    ],
+  },
+}

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -20,6 +20,7 @@ import { Query } from './resolvers/query'
 import { StoreReview } from './resolvers/review'
 import { StoreSearchResult } from './resolvers/searchResult'
 import { StoreSeo } from './resolvers/seo'
+import { SkuVariants } from './resolvers/skuVariations'
 import ChannelMarshal from './utils/channel'
 import type { Loaders } from './loaders'
 import type { Clients } from './clients'
@@ -80,6 +81,7 @@ const Resolvers = {
   StoreProductGroup,
   StoreSearchResult,
   StorePropertyValue,
+  SkuVariants,
   ObjectOrString,
   Query,
   Mutation,

--- a/packages/api/src/platforms/vtex/resolvers/productGroup.ts
+++ b/packages/api/src/platforms/vtex/resolvers/productGroup.ts
@@ -3,17 +3,14 @@ import type { Resolver } from '..'
 import type { PromiseType } from '../../../typings'
 import type { StoreProduct } from './product'
 import { VALUE_REFERENCES } from '../utils/propertyValue'
-import { StoreProduct as StoreProductType } from '../../..'
-import { Item } from '../clients/search/types/ProductSearchResult'
+import {
+  createSlugsMap,
+  getActiveSkuVariations,
+  getFormattedVariations,
+  getVariantsByName,
+} from '../utils/skuVariants'
 
 type Root = PromiseType<ReturnType<typeof StoreProduct.isVariantOf>>
-
-export type SkuVariants = StoreProductType[]
-
-export type SkuVariantsByName = Record<
-  string,
-  Array<{ alt: string; src: string; label: string; value: string }>
->
 
 type SlugsMapArgs = {
   dominantVariantName: string
@@ -21,167 +18,10 @@ type SlugsMapArgs = {
 
 const BLOCKED_SPECIFICATIONS = new Set(['allSpecifications'])
 
-function createSlugsMap(
-  variants: Item[],
-  mainVariant: string,
-  baseSlug: string
-) {
-  /**
-   * Maps property value combinations to their respective SKU's slug. Enables
-   * us to retrieve the slug for the SKU that matches the currently selected
-   * variations in O(1) time.
-   *
-   * Example: `'Color-Red-Size-40': 'classic-shoes-37'`
-   */
-  const slugsMap: Record<string, string> = {}
-
-  variants.forEach((variant) => {
-    const skuSpecificationProperties = variant.variations
-
-    if (skuSpecificationProperties.length === 0) {
-      return
-    }
-
-    // Make sure that the 'name-value' pair for the `mainVariant` variation
-    // is always the first one.
-    let skuVariantKey = `${mainVariant}-${
-      skuSpecificationProperties.find(
-        (variationDetails) => variationDetails.name === mainVariant
-      )?.values[0] ?? ''
-    }`
-
-    skuSpecificationProperties.forEach((property) => {
-      skuVariantKey +=
-        property.name !== mainVariant
-          ? `-${property.name}-${property.values[0]}`
-          : ''
-    })
-
-    slugsMap[skuVariantKey] = `${baseSlug}-${variant.itemId}`
-  })
-
-  return slugsMap
-}
-
-function getActiveSkuVariations(variations: Root['variations']) {
-  const activeVariations: Record<string, string> = {}
-
-  variations.forEach((variation) => {
-    activeVariations[variation.name] = variation.values[0]
-  })
-
-  return activeVariations
-}
-
-function getVariantsByName(root: Root) {
-  const { skuSpecifications } = root.isVariantOf
-  const variants: Record<string, string[]> = {}
-
-  skuSpecifications?.forEach((specification) => {
-    variants[specification.field.originalName ?? specification.field.name] =
-      specification.values.map((value) => value.originalName ?? value.name)
-  })
-
-  return variants
-}
-
-function findSkuVariantImage(availableImages: Item['images']) {
-  return (
-    availableImages.find(
-      (imageProperties) => imageProperties.imageLabel === 'skuvariation'
-    ) ?? availableImages[0]
-  )
-}
-
-function getFormattedVariations(
-  variants: Item[],
-  dominantVariant: string,
-  dominantVariantValue: string
-) {
-  /**
-   * SKU options already formatted and indexed by their property name.
-   *
-   * Ex: {
-   *   `Size`: [
-   *     { label: '42', value: '42' },
-   *     { label: '41', value: '41' },
-   *     { label: '39', value: '39' },
-   *   ]
-   * }
-   */
-  const variantsByName: SkuVariantsByName = {}
-
-  // Prevent duplicate entries.
-  const previouslySeenPropertyValues: Record<string, number> = {}
-
-  variants.forEach((variant) => {
-    if (variant.variations.length === 0) {
-      return
-    }
-
-    const variantImageToUse = findSkuVariantImage(variant.images)
-
-    const dominantVariantEntry = variant.variations.find(
-      (variation) => variation.name === dominantVariant
-    )
-
-    const matchesDominantVariant =
-      dominantVariantEntry?.values[0] === dominantVariantValue
-
-    if (!matchesDominantVariant) {
-      if (
-        !dominantVariantEntry ||
-        dominantVariantEntry.values[0] in previouslySeenPropertyValues
-      ) {
-        return
-      }
-
-      previouslySeenPropertyValues[dominantVariantEntry.values[0]] = 1
-
-      const formattedVariant = {
-        src: variantImageToUse.imageUrl,
-        alt: variantImageToUse.imageLabel ?? '',
-        label: dominantVariantEntry.values[0],
-        value: dominantVariantEntry.values[0],
-      }
-
-      if (variantsByName[dominantVariantEntry.name]) {
-        variantsByName[dominantVariantEntry.name].push(formattedVariant)
-      } else {
-        variantsByName[dominantVariantEntry.name] = [formattedVariant]
-      }
-
-      return
-    }
-
-    variant.variations.forEach((variationProperty) => {
-      if (variationProperty.values[0] in previouslySeenPropertyValues) {
-        return
-      }
-
-      previouslySeenPropertyValues[variationProperty.values[0]] = 1
-
-      const formattedVariant = {
-        src: variantImageToUse.imageUrl,
-        alt: variantImageToUse.imageLabel ?? '',
-        label: variationProperty.values[0],
-        value: variationProperty.values[0],
-      }
-
-      if (variantsByName[variationProperty.name]) {
-        variantsByName[variationProperty.name].push(formattedVariant)
-      } else {
-        variantsByName[variationProperty.name] = [formattedVariant]
-      }
-    })
-  })
-
-  return variantsByName
-}
-
 export const StoreProductGroup: Record<string, Resolver<Root>> = {
   activeVariations: (root) => getActiveSkuVariations(root.variations),
-  allVariantsByName: (root) => getVariantsByName(root),
+  allVariantsByName: (root) =>
+    getVariantsByName(root.isVariantOf.skuSpecifications),
 
   slugsMap: (root, args) =>
     createSlugsMap(

--- a/packages/api/src/platforms/vtex/resolvers/productGroup.ts
+++ b/packages/api/src/platforms/vtex/resolvers/productGroup.ts
@@ -3,60 +3,17 @@ import type { Resolver } from '..'
 import type { PromiseType } from '../../../typings'
 import type { StoreProduct } from './product'
 import { VALUE_REFERENCES } from '../utils/propertyValue'
-import {
-  createSlugsMap,
-  getActiveSkuVariations,
-  getFormattedVariations,
-  getVariantsByName,
-} from '../utils/skuVariants'
 
 type Root = PromiseType<ReturnType<typeof StoreProduct.isVariantOf>>
-
-type SlugsMapArgs = {
-  dominantVariantName: string
-}
 
 const BLOCKED_SPECIFICATIONS = new Set(['allSpecifications'])
 
 export const StoreProductGroup: Record<string, Resolver<Root>> = {
-  activeVariations: (root) => getActiveSkuVariations(root.variations),
-  allVariantsByName: (root) =>
-    getVariantsByName(root.isVariantOf.skuSpecifications),
-
-  slugsMap: (root, args) =>
-    createSlugsMap(
-      root.isVariantOf.items,
-      // Since `dominantVariantProperty` is a required argument, we can safely
-      // access it.
-      (args as SlugsMapArgs).dominantVariantName,
-      root.isVariantOf.linkText
-    ),
-
-  availableVariations: (root, args) => {
-    // Since `dominantVariantProperty` is a required argument, we can safely
-    // access it.
-    const dominantVariantName = (args as SlugsMapArgs).dominantVariantName
-    const activeVariations = getActiveSkuVariations(root.variations)
-
-    const activeDominantVariationValue = activeVariations[dominantVariantName]
-
-    if (!activeDominantVariationValue) {
-      return null
-    }
-
-    const filteredFormattedVariations = getFormattedVariations(
-      root.isVariantOf.items,
-      dominantVariantName,
-      activeDominantVariationValue
-    )
-
-    return filteredFormattedVariations
-  },
-
   hasVariant: (root) =>
     root.isVariantOf.items.map((item) => enhanceSku(item, root.isVariantOf)),
   productGroupID: ({ isVariantOf }) => isVariantOf.productId,
   name: (root) => root.isVariantOf.productName,
+  skuVariants: (root) => root,
   additionalProperty: ({ isVariantOf: { specificationGroups } }) =>
     specificationGroups
       // Filter sku specifications so we don't mix them with product specs.

--- a/packages/api/src/platforms/vtex/resolvers/productGroup.ts
+++ b/packages/api/src/platforms/vtex/resolvers/productGroup.ts
@@ -41,9 +41,7 @@ export const StoreProductGroup: Record<string, Resolver<Root>> = {
     const activeDominantVariationValue = activeVariations[dominantVariantName]
 
     if (!activeDominantVariationValue) {
-      throw new Error(
-        'SKU does not have a value set for its dominant variation property.'
-      )
+      return null
     }
 
     const filteredFormattedVariations = getFormattedVariations(

--- a/packages/api/src/platforms/vtex/resolvers/productGroup.ts
+++ b/packages/api/src/platforms/vtex/resolvers/productGroup.ts
@@ -70,27 +70,13 @@ function createSlugsMap(
 }
 
 function getActiveSkuVariations(root: Root) {
-  return root.variations.map((variation) => ({
-    name: variation.name,
-    value: variation.values[0],
-  }))
-}
+  const activeVariations: Record<string, string> = {}
 
-function getDominantVariantValue(
-  values: Array<{ name: string; value: string }>,
-  dominantVariantName: string
-) {
-  const dominantValue = values.find(
-    (variation) => variation.name === dominantVariantName
-  )?.value
+  root.variations.forEach((variation) => {
+    activeVariations[variation.name] = variation.values[0]
+  })
 
-  if (!dominantValue) {
-    throw new Error(
-      'SKU does not have a value set for its dominant variation property.'
-    )
-  }
-
-  return dominantValue
+  return activeVariations
 }
 
 function getVariantsByName(root: Root) {
@@ -217,10 +203,13 @@ export const StoreProductGroup: Record<string, Resolver<Root>> = {
     const activeVariations = getActiveSkuVariations(root)
     const dominantVariantName = (args as SlugsMapArgs).dominantVariantProperty
 
-    const activeDominantVariationValue = getDominantVariantValue(
-      activeVariations,
-      dominantVariantName
-    )
+    const activeDominantVariationValue = activeVariations[dominantVariantName]
+
+    if (!activeDominantVariationValue) {
+      throw new Error(
+        'SKU does not have a value set for its dominant variation property.'
+      )
+    }
 
     const filteredFormattedVariations = getFormattedVariations(
       root.isVariantOf.items,

--- a/packages/api/src/platforms/vtex/resolvers/productGroup.ts
+++ b/packages/api/src/platforms/vtex/resolvers/productGroup.ts
@@ -239,7 +239,6 @@ export const StoreProductGroup: Record<string, Resolver<Root>> = {
 
   productGroupID: ({ isVariantOf }) => isVariantOf.productId,
   name: (root) => {
-    console.log(root)
     return root.isVariantOf.productName
   },
   additionalProperty: ({ isVariantOf: { specificationGroups } }) =>

--- a/packages/api/src/platforms/vtex/resolvers/productGroup.ts
+++ b/packages/api/src/platforms/vtex/resolvers/productGroup.ts
@@ -200,8 +200,10 @@ export const StoreProductGroup: Record<string, Resolver<Root>> = {
     ),
 
   filteredAvailableVariations: (root, args) => {
-    const activeVariations = getActiveSkuVariations(root)
+    // Since `dominantVariantProperty` is a required argument, we can safely
+    // access it.
     const dominantVariantName = (args as SlugsMapArgs).dominantVariantProperty
+    const activeVariations = getActiveSkuVariations(root)
 
     const activeDominantVariationValue = activeVariations[dominantVariantName]
 
@@ -232,12 +234,12 @@ export const StoreProductGroup: Record<string, Resolver<Root>> = {
   },
   additionalProperty: ({ isVariantOf: { specificationGroups } }) =>
     specificationGroups
-      // filter sku specifications so we dont mess sku with product specs
+      // Filter sku specifications so we don't mix them with product specs.
       .filter(
         (specificationGroup) =>
           !BLOCKED_SPECIFICATIONS.has(specificationGroup.name)
       )
-      // Transform specs back into product specs
+      // Transform specs back into product specs.
       .flatMap(({ specifications }) =>
         specifications.flatMap(({ name, values }) =>
           values.map((value) => ({

--- a/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
+++ b/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
@@ -36,10 +36,6 @@ export const SkuVariants: Record<string, Resolver<Root>> = {
 
     const activeDominantVariationValue = activeVariations[dominantVariantName]
 
-    if (!activeDominantVariationValue) {
-      return null
-    }
-
     const filteredFormattedVariations = getFormattedVariations(
       root.isVariantOf.items,
       dominantVariantName,

--- a/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
+++ b/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
@@ -1,0 +1,51 @@
+import type { Resolver } from '..'
+import type { PromiseType } from '../../../typings'
+import type { StoreProduct } from './product'
+import {
+  createSlugsMap,
+  getActiveSkuVariations,
+  getFormattedVariations,
+  getVariantsByName,
+} from '../utils/skuVariants'
+
+type Root = PromiseType<ReturnType<typeof StoreProduct.isVariantOf>>
+
+type SlugsMapArgs = {
+  dominantVariantName: string
+}
+
+export const SkuVariants: Record<string, Resolver<Root>> = {
+  activeVariations: (root) => getActiveSkuVariations(root.variations),
+  allVariantsByName: (root) =>
+    getVariantsByName(root.isVariantOf.skuSpecifications),
+
+  slugsMap: (root, args) =>
+    createSlugsMap(
+      root.isVariantOf.items,
+      // Since `dominantVariantProperty` is a required argument, we can safely
+      // access it.
+      (args as SlugsMapArgs).dominantVariantName,
+      root.isVariantOf.linkText
+    ),
+
+  availableVariations: (root, args) => {
+    // Since `dominantVariantProperty` is a required argument, we can safely
+    // access it.
+    const dominantVariantName = (args as SlugsMapArgs).dominantVariantName
+    const activeVariations = getActiveSkuVariations(root.variations)
+
+    const activeDominantVariationValue = activeVariations[dominantVariantName]
+
+    if (!activeDominantVariationValue) {
+      return null
+    }
+
+    const filteredFormattedVariations = getFormattedVariations(
+      root.isVariantOf.items,
+      dominantVariantName,
+      activeDominantVariationValue
+    )
+
+    return filteredFormattedVariations
+  },
+}

--- a/packages/api/src/platforms/vtex/utils/skuVariants.ts
+++ b/packages/api/src/platforms/vtex/utils/skuVariants.ts
@@ -3,10 +3,14 @@ import type { Product, Item } from '../clients/search/types/ProductSearchResult'
 
 export type SkuVariants = StoreProductType[]
 
-export type SkuVariantsByName = Record<
-  string,
-  Array<{ alt: string; src: string; label: string; value: string }>
->
+export type SkuVariantsByName = Record<string, Array<FormattedSkuVariant>>
+
+type FormattedSkuVariant = {
+  alt: string
+  src: string
+  label: string
+  value: string
+}
 
 function findSkuVariantImage(availableImages: Item['images']) {
   return (
@@ -82,6 +86,34 @@ export function getVariantsByName(
   })
 
   return variants
+}
+
+function compare(a: string, b: string) {
+  // Values are always represented as Strings, so we need to handle numbers
+  // in this special case.
+  if (!Number.isNaN(Number(a) - Number(b))) {
+    return Number(a) - Number(b)
+  }
+
+  if (a < b) {
+    return -1
+  }
+
+  if (a > b) {
+    return 1
+  }
+
+  return 0
+}
+
+function sortVariants(variantsByName: SkuVariantsByName) {
+  const sortedVariants = variantsByName
+
+  for (const variantProperty in variantsByName) {
+    variantsByName[variantProperty].sort((a, b) => compare(a.value, b.value))
+  }
+
+  return sortedVariants
 }
 
 export function getFormattedVariations(
@@ -170,5 +202,5 @@ export function getFormattedVariations(
     })
   })
 
-  return variantsByName
+  return sortVariants(variantsByName)
 }

--- a/packages/api/src/platforms/vtex/utils/skuVariants.ts
+++ b/packages/api/src/platforms/vtex/utils/skuVariants.ts
@@ -1,0 +1,168 @@
+import { StoreProduct as StoreProductType } from '../../..'
+import type { Product, Item } from '../clients/search/types/ProductSearchResult'
+
+export type SkuVariants = StoreProductType[]
+
+export type SkuVariantsByName = Record<
+  string,
+  Array<{ alt: string; src: string; label: string; value: string }>
+>
+
+function findSkuVariantImage(availableImages: Item['images']) {
+  return (
+    availableImages.find(
+      (imageProperties) => imageProperties.imageLabel === 'skuvariation'
+    ) ?? availableImages[0]
+  )
+}
+
+export function createSlugsMap(
+  variants: Item[],
+  mainVariant: string,
+  baseSlug: string
+) {
+  /**
+   * Maps property value combinations to their respective SKU's slug. Enables
+   * us to retrieve the slug for the SKU that matches the currently selected
+   * variations in O(1) time.
+   *
+   * Example: `'Color-Red-Size-40': 'classic-shoes-37'`
+   */
+  const slugsMap: Record<string, string> = {}
+
+  variants.forEach((variant) => {
+    const skuSpecificationProperties = variant.variations
+
+    if (skuSpecificationProperties.length === 0) {
+      return
+    }
+
+    // Make sure that the 'name-value' pair for the `mainVariant` variation
+    // is always the first one.
+    let skuVariantKey = `${mainVariant}-${
+      skuSpecificationProperties.find(
+        (variationDetails) => variationDetails.name === mainVariant
+      )?.values[0] ?? ''
+    }`
+
+    skuSpecificationProperties.forEach((property) => {
+      skuVariantKey +=
+        property.name !== mainVariant
+          ? `-${property.name}-${property.values[0]}`
+          : ''
+    })
+
+    slugsMap[skuVariantKey] = `${baseSlug}-${variant.itemId}`
+  })
+
+  return slugsMap
+}
+
+export function getActiveSkuVariations(variations: Item['variations']) {
+  const activeVariations: Record<string, string> = {}
+
+  variations.forEach((variation) => {
+    activeVariations[variation.name] = variation.values[0]
+  })
+
+  return activeVariations
+}
+
+export function getVariantsByName(
+  skuSpecifications: Product['skuSpecifications']
+) {
+  const variants: Record<string, string[]> = {}
+
+  skuSpecifications?.forEach((specification) => {
+    variants[specification.field.originalName ?? specification.field.name] =
+      specification.values.map((value) => value.originalName ?? value.name)
+  })
+
+  return variants
+}
+
+export function getFormattedVariations(
+  variants: Item[],
+  dominantVariant: string,
+  dominantVariantValue: string
+) {
+  /**
+   * SKU options already formatted and indexed by their property name.
+   *
+   * Ex: {
+   *   `Size`: [
+   *     { label: '42', value: '42' },
+   *     { label: '41', value: '41' },
+   *     { label: '39', value: '39' },
+   *   ]
+   * }
+   */
+  const variantsByName: SkuVariantsByName = {}
+
+  // Prevent duplicate entries.
+  const previouslySeenPropertyValues: Record<string, number> = {}
+
+  variants.forEach((variant) => {
+    if (variant.variations.length === 0) {
+      return
+    }
+
+    const variantImageToUse = findSkuVariantImage(variant.images)
+
+    const dominantVariantEntry = variant.variations.find(
+      (variation) => variation.name === dominantVariant
+    )
+
+    const matchesDominantVariant =
+      dominantVariantEntry?.values[0] === dominantVariantValue
+
+    if (!matchesDominantVariant) {
+      if (
+        !dominantVariantEntry ||
+        dominantVariantEntry.values[0] in previouslySeenPropertyValues
+      ) {
+        return
+      }
+
+      previouslySeenPropertyValues[dominantVariantEntry.values[0]] = 1
+
+      const formattedVariant = {
+        src: variantImageToUse.imageUrl,
+        alt: variantImageToUse.imageLabel ?? '',
+        label: dominantVariantEntry.values[0],
+        value: dominantVariantEntry.values[0],
+      }
+
+      if (variantsByName[dominantVariantEntry.name]) {
+        variantsByName[dominantVariantEntry.name].push(formattedVariant)
+      } else {
+        variantsByName[dominantVariantEntry.name] = [formattedVariant]
+      }
+
+      return
+    }
+
+    variant.variations.forEach((variationProperty) => {
+      if (variationProperty.values[0] in previouslySeenPropertyValues) {
+        return
+      }
+
+      previouslySeenPropertyValues[variationProperty.values[0]] = 1
+
+      const formattedVariant = {
+        src: variantImageToUse.imageUrl,
+        alt: variantImageToUse.imageLabel ?? '',
+        label: variationProperty.values[0],
+        value: variationProperty.values[0],
+      }
+
+      if (variantsByName[variationProperty.name]) {
+        variantsByName[variationProperty.name].push(formattedVariant)
+      } else {
+        variantsByName[variationProperty.name] = [formattedVariant]
+      }
+    })
+  })
+
+  return variantsByName
+}

--- a/packages/api/src/platforms/vtex/utils/skuVariants.ts
+++ b/packages/api/src/platforms/vtex/utils/skuVariants.ts
@@ -99,8 +99,7 @@ export function getFormattedVariations(
    */
   const variantsByName: SkuVariantsByName = {}
 
-  // Prevent duplicate entries.
-  const previouslySeenPropertyValues: Record<string, number> = {}
+  const previouslySeenPropertyValues = new Set<string>()
 
   variants.forEach((variant) => {
     if (variant.variations.length === 0) {
@@ -117,14 +116,16 @@ export function getFormattedVariations(
       dominantVariantEntry?.values[0] === dominantVariantValue
 
     if (!matchesDominantVariant) {
+      const nameValueIdentifier = `${dominantVariant}-${dominantVariantEntry?.values[0]}`
+
       if (
         !dominantVariantEntry ||
-        dominantVariantEntry.values[0] in previouslySeenPropertyValues
+        previouslySeenPropertyValues.has(nameValueIdentifier)
       ) {
         return
       }
 
-      previouslySeenPropertyValues[dominantVariantEntry.values[0]] = 1
+      previouslySeenPropertyValues.add(nameValueIdentifier)
 
       const formattedVariant = {
         src: variantImageToUse.imageUrl,
@@ -143,11 +144,13 @@ export function getFormattedVariations(
     }
 
     variant.variations.forEach((variationProperty) => {
-      if (variationProperty.values[0] in previouslySeenPropertyValues) {
+      const nameValueIdentifier = `${variationProperty.name}-${variationProperty.values[0]}`
+
+      if (previouslySeenPropertyValues.has(nameValueIdentifier)) {
         return
       }
 
-      previouslySeenPropertyValues[variationProperty.values[0]] = 1
+      previouslySeenPropertyValues.add(nameValueIdentifier)
 
       const formattedVariant = {
         src: variantImageToUse.imageUrl,

--- a/packages/api/src/typeDefs/index.ts
+++ b/packages/api/src/typeDefs/index.ts
@@ -25,6 +25,7 @@ import Person from './person.graphql'
 import ObjectOrString from './objectOrString.graphql'
 import Session from './session.graphql'
 import Newsletter from './newsletter.graphql'
+import SkuVariants from './skuVariants.graphql'
 
 export const typeDefs = [
   Query,
@@ -51,7 +52,8 @@ export const typeDefs = [
   Person,
   ObjectOrString,
   Session,
-  Newsletter
+  Newsletter,
+  SkuVariants,
 ]
   .map(print)
   .join('\n')

--- a/packages/api/src/typeDefs/productGroup.graphql
+++ b/packages/api/src/typeDefs/productGroup.graphql
@@ -19,17 +19,14 @@ type StoreProductGroup {
   """
   additionalProperty: [StorePropertyValue!]!
   
-  activeVariations: [SelectedVariants]
+  activeVariations: SelectedVariants
   variantsByName: VariantsByName
   slugsMap(dominantVariantProperty: String!): SlugsMap
 
   filteredAvailableVariations(dominantVariantProperty: String!): VariantsByName
 }
 
-type SelectedVariants {
-  name: String
-  value: String
-}
+scalar SelectedVariants
 
 scalar VariantsByName
 

--- a/packages/api/src/typeDefs/productGroup.graphql
+++ b/packages/api/src/typeDefs/productGroup.graphql
@@ -15,68 +15,13 @@ type StoreProductGroup {
   """
   name: String!
   """
-  SKU property values for the current SKU.
-  """
-  activeVariations: ActiveVariations
-  """
-  All available options for each SKU variant property, indexed by their name.
-  """
-  allVariantsByName: VariantsByName
-  """
   Array of additional properties.
   """
   additionalProperty: [StorePropertyValue!]!
   """
-  Maps property value combinations to their respective SKU's slug. Enables
-  us to retrieve the slug for the SKU that matches the currently selected
-  variations in O(1) time.
+  Object containing data structures to facilitate handling different SKU
+  variant properties. Specially useful for implementing SKU selection 
+  components.
   """
-  slugsMap(dominantVariantName: String!): SlugsMap
-  """
-  Available options for each varying SKU property, taking into account the
-  `dominantVariantName` property. Returns all available options for the 
-  dominant property, and only options that can be combined with its current
-  value for other properties.
-  """
-  availableVariations(dominantVariantName: String!): FormattedVariants
+  skuVariants: SkuVariants
 }
-
-"""
-Example: { `'Color-Red-Size-40': 'classic-shoes-37'` }
-"""
-scalar SlugsMap
-"""
-Example: { `Color: 'Red'`, Size: '42' }
-"""
-scalar ActiveVariations
-"""
-Example: {
-  Color: [
-    { 
-      src: "https://storecomponents.vtexassets.com/...",
-      alt: "...",
-      label: "...",
-      value: "..."
-    },
-    { 
-      src: "https://storecomponents.vtexassets.com/...",
-      alt: "...",
-      label: "...",
-      value: "..."
-    }
-  ],
-  Size: [
-    { 
-      src: "https://storecomponents.vtexassets.com/...",
-      alt: "...",
-      label: "...",
-      value: "..."
-    }
-  ]
-}
-"""
-scalar FormattedVariants
-"""
-Example: { Color: [ "Red", "Blue", "Green" ], Size: [ "40", "41" ] }
-"""
-scalar VariantsByName

--- a/packages/api/src/typeDefs/productGroup.graphql
+++ b/packages/api/src/typeDefs/productGroup.graphql
@@ -15,19 +15,68 @@ type StoreProductGroup {
   """
   name: String!
   """
+  SKU property values for the current SKU.
+  """
+  activeVariations: ActiveVariations
+  """
+  All available options for each SKU variant property, indexed by their name.
+  """
+  allVariantsByName: VariantsByName
+  """
   Array of additional properties.
   """
   additionalProperty: [StorePropertyValue!]!
-  
-  activeVariations: SelectedVariants
-  variantsByName: VariantsByName
-  slugsMap(dominantVariantProperty: String!): SlugsMap
-
-  filteredAvailableVariations(dominantVariantProperty: String!): VariantsByName
+  """
+  Maps property value combinations to their respective SKU's slug. Enables
+  us to retrieve the slug for the SKU that matches the currently selected
+  variations in O(1) time.
+  """
+  slugsMap(dominantVariantName: String!): SlugsMap
+  """
+  Available options for each varying SKU property, taking into account the
+  `dominantVariantName` property. Returns all available options for the 
+  dominant property, and only options that can be combined with its current
+  value for other properties.
+  """
+  availableVariations(dominantVariantName: String!): FormattedVariants
 }
 
-scalar SelectedVariants
-
-scalar VariantsByName
-
+"""
+Example: { `'Color-Red-Size-40': 'classic-shoes-37'` }
+"""
 scalar SlugsMap
+"""
+Example: { `Color: 'Red'`, Size: '42' }
+"""
+scalar ActiveVariations
+"""
+Example: {
+  Color: [
+    { 
+      src: "https://storecomponents.vtexassets.com/...",
+      alt: "...",
+      label: "...",
+      value: "..."
+    },
+    { 
+      src: "https://storecomponents.vtexassets.com/...",
+      alt: "...",
+      label: "...",
+      value: "..."
+    }
+  ],
+  Size: [
+    { 
+      src: "https://storecomponents.vtexassets.com/...",
+      alt: "...",
+      label: "...",
+      value: "..."
+    }
+  ]
+}
+"""
+scalar FormattedVariants
+"""
+Example: { Color: [ "Red", "Blue", "Green" ], Size: [ "40", "41" ] }
+"""
+scalar VariantsByName

--- a/packages/api/src/typeDefs/productGroup.graphql
+++ b/packages/api/src/typeDefs/productGroup.graphql
@@ -18,4 +18,19 @@ type StoreProductGroup {
   Array of additional properties.
   """
   additionalProperty: [StorePropertyValue!]!
+  
+  activeVariations: [SelectedVariants]
+  variantsByName: VariantsByName
+  slugsMap(dominantVariantProperty: String!): SlugsMap
+
+  filteredAvailableVariations(dominantVariantProperty: String!): VariantsByName
 }
+
+type SelectedVariants {
+  name: String
+  value: String
+}
+
+scalar VariantsByName
+
+scalar SlugsMap

--- a/packages/api/src/typeDefs/skuVariants.graphql
+++ b/packages/api/src/typeDefs/skuVariants.graphql
@@ -1,0 +1,87 @@
+type SkuVariants {
+  """
+  SKU property values for the current SKU.
+  """
+  activeVariations: ActiveVariations
+  """
+  All available options for each SKU variant property, indexed by their name.
+  """
+  allVariantsByName: VariantsByName
+  """
+  Maps property value combinations to their respective SKU's slug. Enables
+  us to retrieve the slug for the SKU that matches the currently selected
+  variations in O(1) time.
+  """
+  slugsMap(dominantVariantName: String!): SlugsMap
+  """
+  Available options for each varying SKU property, taking into account the
+  `dominantVariantName` property. Returns all available options for the 
+  dominant property, and only options that can be combined with its current
+  value for other properties.
+  """
+  availableVariations(dominantVariantName: String!): FormattedVariants
+}
+
+"""
+Example: 
+
+```json
+{ 
+  'Color-Red-Size-40': 'classic-shoes-37'
+}
+```
+"""
+scalar SlugsMap
+"""
+Example:
+
+```json
+{
+  Color: 'Red', Size: '42'
+}
+```
+"""
+scalar ActiveVariations
+"""
+Example:
+
+```json
+{
+  Color: [ "Red", "Blue", "Green" ],
+  Size: [ "40", "41" ]
+}
+```
+"""
+scalar VariantsByName
+"""
+Example: 
+
+```json
+{
+  Color: [
+    { 
+      src: "https://storecomponents.vtexassets.com/...",
+      alt: "...",
+      label: "...",
+      value: "..."
+    },
+    { 
+      src: "https://storecomponents.vtexassets.com/...",
+      alt: "...",
+      label: "...",
+      value: "..."
+    }
+  ],
+  Size: [
+    { 
+      src: "https://storecomponents.vtexassets.com/...",
+      alt: "...",
+      label: "...",
+      value: "..."
+    }
+  ]
+}
+```
+"""
+scalar FormattedVariants
+

--- a/packages/api/test/vtex.skuVariants.test.ts
+++ b/packages/api/test/vtex.skuVariants.test.ts
@@ -11,7 +11,7 @@ import {
   getVariantsByName,
 } from '../src/platforms/vtex/utils/skuVariants'
 
-describe('slugsMap', () => {
+describe('createSlugsMap', () => {
   it('should return an empty object for a product that has no sku specification properties.', () => {
     expect(
       createSlugsMap(
@@ -113,19 +113,19 @@ describe('getFormattedVariations', () => {
         {
           src: 'https://storecomponents.vtexassets.com/arquivos/ids/155560/pink-cool-sku-variation.png?v=637063239809000000',
           alt: 'skuvariation',
-          label: 'Red',
+          label: 'Color: Red',
           value: 'Red',
         },
         {
           src: 'https://storecomponents.vtexassets.com/arquivos/ids/155559/pink-sku-variation.png?v=637087508159070000',
           alt: 'skuvariation',
-          label: 'Green',
+          label: 'Color: Green',
           value: 'Green',
         },
         {
           src: 'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
           alt: 'skuvariation',
-          label: 'White',
+          label: 'Color: White',
           value: 'White',
         },
       ],
@@ -133,13 +133,13 @@ describe('getFormattedVariations', () => {
         {
           src: 'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
           alt: 'skuvariation',
-          label: '42',
+          label: 'Size: 42',
           value: '42',
         },
         {
           src: 'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
           alt: 'skuvariation',
-          label: '41',
+          label: 'Size: 41',
           value: '41',
         },
       ],

--- a/packages/api/test/vtex.skuVariants.test.ts
+++ b/packages/api/test/vtex.skuVariants.test.ts
@@ -1,0 +1,156 @@
+import {
+  productGroupRootWithoutSkuProperties,
+  productGroup1SkuProperty,
+  productGroup2SkuProperties,
+} from '../mocks/skuVariants'
+
+import {
+  createSlugsMap,
+  getActiveSkuVariations,
+  getFormattedVariations,
+  getVariantsByName,
+} from '../src/platforms/vtex/utils/skuVariants'
+
+describe('slugsMap', () => {
+  it('should return an empty object for a product that has no sku specification properties.', () => {
+    expect(
+      createSlugsMap(
+        productGroupRootWithoutSkuProperties.isVariantOf.items as any,
+        'Color',
+        'classic-shoes'
+      )
+    ).toEqual({})
+  })
+
+  it('should return expected result for a product that has 1 sku specification property', () => {
+    const expectedSlugsMap = {
+      'Color-Red': 'classic-shoes-37',
+      'Color-Green': 'classic-shoes-35',
+      'Color-White': 'classic-shoes-310124175',
+    }
+
+    expect(
+      createSlugsMap(
+        productGroup1SkuProperty.isVariantOf.items as any,
+        'Color',
+        'classic-shoes'
+      )
+    ).toEqual(expectedSlugsMap)
+  })
+
+  it('should return expected result for a product that has multiple sku specification properties', () => {
+    const expectedSlugsMap = {
+      'Color-Red-Size-42': 'classic-shoes-37',
+      'Color-Green-Size-40': 'classic-shoes-35',
+      'Color-White-Size-42': 'classic-shoes-36',
+      'Color-White-Size-41': 'classic-shoes-310124175',
+    }
+
+    expect(
+      createSlugsMap(
+        productGroup2SkuProperties.isVariantOf.items as any,
+        'Color',
+        'classic-shoes'
+      )
+    ).toEqual(expectedSlugsMap)
+  })
+})
+
+describe('getActiveSkuVariations', () => {
+  it('should return an empty object for a product that has no sku specification property', () => {
+    expect(
+      getActiveSkuVariations(productGroupRootWithoutSkuProperties.variations)
+    ).toEqual({})
+  })
+
+  it('should return active SKU variations for a product that has 1 sku specification property', () => {
+    const expected = {
+      Color: 'White',
+    }
+
+    expect(getActiveSkuVariations(productGroup1SkuProperty.variations)).toEqual(
+      expected
+    )
+  })
+
+  it('should return active SKU variations for a product that has multiple sku specification properties', () => {
+    const expected = {
+      Color: 'White',
+      Size: '42',
+    }
+
+    expect(
+      getActiveSkuVariations(productGroup2SkuProperties.variations)
+    ).toEqual(expected)
+  })
+})
+
+describe('getVariantsByName', () => {
+  it('should return an empty object for a product that has no sku specification property', () => {
+    expect(
+      getVariantsByName(productGroupRootWithoutSkuProperties.variations)
+    ).toEqual({})
+  })
+
+  it('should return all SKU variations indexed by name for a product that has multiple sku specification property', () => {
+    const expected = {
+      Color: ['Green', 'White', 'Red'],
+      Size: ['40', '42', '41'],
+    }
+
+    expect(
+      getVariantsByName(
+        productGroup2SkuProperties.isVariantOf.skuSpecifications
+      )
+    ).toEqual(expected)
+  })
+})
+
+describe('getFormattedVariations', () => {
+  it('should return all value options for dominantVariant and only possible combinations for others', () => {
+    const expected = {
+      Color: [
+        {
+          src: 'https://storecomponents.vtexassets.com/arquivos/ids/155560/pink-cool-sku-variation.png?v=637063239809000000',
+          alt: 'skuvariation',
+          label: 'Red',
+          value: 'Red',
+        },
+        {
+          src: 'https://storecomponents.vtexassets.com/arquivos/ids/155559/pink-sku-variation.png?v=637087508159070000',
+          alt: 'skuvariation',
+          label: 'Green',
+          value: 'Green',
+        },
+        {
+          src: 'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
+          alt: 'skuvariation',
+          label: 'White',
+          value: 'White',
+        },
+      ],
+      Size: [
+        {
+          src: 'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
+          alt: 'skuvariation',
+          label: '42',
+          value: '42',
+        },
+        {
+          src: 'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
+          alt: 'skuvariation',
+          label: '41',
+          value: '41',
+        },
+      ],
+    }
+
+    expect(
+      getFormattedVariations(
+        productGroup2SkuProperties.isVariantOf.items as any,
+        'Color',
+        'White'
+      )
+    ).toEqual(expected)
+  })
+})

--- a/packages/api/test/vtex.skuVariants.test.ts
+++ b/packages/api/test/vtex.skuVariants.test.ts
@@ -111,16 +111,16 @@ describe('getFormattedVariations', () => {
     const expected = {
       Color: [
         {
-          src: 'https://storecomponents.vtexassets.com/arquivos/ids/155560/pink-cool-sku-variation.png?v=637063239809000000',
-          alt: 'skuvariation',
-          label: 'Color: Red',
-          value: 'Red',
-        },
-        {
           src: 'https://storecomponents.vtexassets.com/arquivos/ids/155559/pink-sku-variation.png?v=637087508159070000',
           alt: 'skuvariation',
           label: 'Color: Green',
           value: 'Green',
+        },
+        {
+          src: 'https://storecomponents.vtexassets.com/arquivos/ids/155560/pink-cool-sku-variation.png?v=637063239809000000',
+          alt: 'skuvariation',
+          label: 'Color: Red',
+          value: 'Red',
         },
         {
           src: 'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
@@ -133,14 +133,14 @@ describe('getFormattedVariations', () => {
         {
           src: 'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
           alt: 'skuvariation',
-          label: 'Size: 42',
-          value: '42',
+          label: 'Size: 41',
+          value: '41',
         },
         {
           src: 'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',
           alt: 'skuvariation',
-          label: 'Size: 41',
-          value: '41',
+          label: 'Size: 42',
+          value: '42',
         },
       ],
     }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds a new attribute (`skuVariations`) to the `ProductGroup` type, that brings with it 4 new properties:

- `slugsMap`
- `availableVariations`
- `allVariantsByName`
- `activeVariations`

They should enable users to query data about SKU specification variants in a more convenient way. Specially handy for implementing SKU Selector components.

## How it works?

The new fields added to `ProductGroup` are all related to SKU variants.

**slugsMap** -> Maps property value combinations to their respective SKU's slug. Enables us to retrieve the slug for the SKU that matches the currently selected variations in `O(1)` time.

**activeVariations** -> SKU property values for the current SKU.

**availableVariations** -> Available options for each varying SKU property, taking into account the `dominantVariantName` property. Returns all available options for the dominant property, and only options that can be combined with its current value for other properties.

**allVariantsByName** -> All available options for each SKU variant property, indexed by their name.

This is an example query that only asks for the new fields:

```graphql
{
  product(locator: {key: "id", value: "36"}) {
    isVariantOf {
      skuVariants {
        activeVariations
        allVariantsByName
        slugsMap(dominantVariantName: "Color")
        availableVariations(dominantVariantName: "Color")
      }
    }
  }
}
```

And this is how a response would look like:

```json
{
  "data": {
    "product": {
      "isVariantOf": {
        "skuVariants": {
          "activeVariations": {
            "Color": "White",
            "Size": "42"
          },
          "allVariantsByName": {
            "Color": [
              "Green",
              "White",
              "Red"
            ],
            "Size": [
              "40",
              "42",
              "41"
            ]
          },
          "slugsMap": {
            "Color-Red-Size-42": "classic-shoes-37",
            "Color-Green-Size-40": "classic-shoes-35",
            "Color-White-Size-42": "classic-shoes-36",
            "Color-White-Size-41": "classic-shoes-310124175"
          },
          "availableVariations": {
            "Color": [
              {
                "src": "https://storecomponents.vtexassets.com/arquivos/ids/155560/pink-cool-sku-variation.png?v=637063239809000000",
                "alt": "skuvariation",
                "label": "Red",
                "value": "Red"
              },
              {
                "src": "https://storecomponents.vtexassets.com/arquivos/ids/155559/pink-sku-variation.png?v=637087508159070000",
                "alt": "skuvariation",
                "label": "Green",
                "value": "Green"
              },
              {
                "src": "https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000",
                "alt": "skuvariation",
                "label": "White",
                "value": "White"
              }
            ],
            "Size": [
              {
                "src": "https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000",
                "alt": "skuvariation",
                "label": "42",
                "value": "42"
              },
              {
                "src": "https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000",
                "alt": "skuvariation",
                "label": "41",
                "value": "41"
              }
            ]
          }
        }
      }
    }
  }
}
```

## How to test it?

You can either run this branch locally by running `yarn develop` inside `/packages/api` or check these fields already being used to render an SKU Selector in [this PR](https://github.com/vtex-sites/nextjs.store/pull/158).

### Starters Deploy Preview

https://sfj-5b76285--nextjs.preview.vtex.app/classic-shoes/p. -> from https://github.com/vtex-sites/nextjs.store/pull/158
