### PR TITLE
chore: Remove @store-framework from CODEOWNERS (keep @faststore)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @vtex/store-framework @vtex/faststore
+* @vtex/faststore


### PR DESCRIPTION
## What's the purpose of this pull request?

A [@vtex/faststore][1] team (13 members) has been recently created so we can remove [@vtex/store-framework][2] (23 members) to keep things organized and avoid notifying unrelated people.

[1]: https://github.com/orgs/vtex/teams/faststore
[2]: https://github.com/orgs/vtex/teams/store-framework