### PR TITLE
Chore: Housekeeping module name references

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -57,7 +57,7 @@ ComponentName
 ```
 ✔  ++ faststore/packages/ui/src/atoms/ComponentName/ComponentName.tsx
 ✔  ++ faststore/packages/ui/src/atoms/ComponentName/index.tsx
-✔  ++ faststore/themes/theme-b2c-tailwind/src/atoms/component-name.css
+✔  ++ faststore/packages/styles/src/atoms/component-name.css
 ✔  ++ faststore/packages/ui/src/atoms/ComponentName/ComponentName.test.tsx
 ✔  ++ faststore/packages/ui/src/atoms/ComponentName/stories/ComponentName.stories.tsx
 ✔  ++ faststore/packages/ui/src/atoms/ComponentName/stories/ComponentName.mdx

--- a/apps/docs/docs/reference.md
+++ b/apps/docs/docs/reference.md
@@ -36,7 +36,7 @@ FastStore encapsulates the following three main packages:
 Besides these three main libraries, FastStore also counts with the following packages:
 
 - **`graphql-utils`** - Extracts and processes GraphQL queries.
-- **`lighthouse-config`** - An ecommerce focused [Lighthouse](https://developers.google.com/web/tools/lighthouse/) CI configuration.
+- **`lighthouse`** - An ecommerce focused [Lighthouse](https://developers.google.com/web/tools/lighthouse/) CI configuration.
 - **`renovate-config`** - Configuration of [Renovate](https://github.com/renovatebot/renovate), a bot responsible for updating dependencies automatically.
 
 :::caution

--- a/apps/docs/docs/reference.md
+++ b/apps/docs/docs/reference.md
@@ -37,7 +37,6 @@ Besides these three main libraries, FastStore also counts with the following pac
 
 - **`graphql-utils`** - Extracts and processes GraphQL queries.
 - **`lighthouse`** - An ecommerce focused [Lighthouse](https://developers.google.com/web/tools/lighthouse/) CI configuration.
-- **`renovate-config`** - Configuration of [Renovate](https://github.com/renovatebot/renovate), a bot responsible for updating dependencies automatically.
 
 :::caution
 If you check FastStore repository on GitHub, you'll also find some Gatsby-specific plugins (`@vtex/gatsby-plugin-cms`, `@vtex/gatsby-plugin-nginx`, `@vtex/gatsby-source-store`, `@vtex/gatsby-source-vtex`. We aim to provide Gatsby-agnostic solutions for these plugins soon.

--- a/apps/docs/docs/reference.md
+++ b/apps/docs/docs/reference.md
@@ -38,10 +38,6 @@ Besides these three main libraries, FastStore also counts with the following pac
 - **`graphql-utils`** - Extracts and processes GraphQL queries.
 - **`lighthouse`** - An ecommerce focused [Lighthouse](https://developers.google.com/web/tools/lighthouse/) CI configuration.
 
-:::caution
-If you check FastStore repository on GitHub, you'll also find some Gatsby-specific plugins (`@vtex/gatsby-plugin-cms`, `@vtex/gatsby-plugin-nginx`, `@vtex/gatsby-source-store`, `@vtex/gatsby-source-vtex`. We aim to provide Gatsby-agnostic solutions for these plugins soon.
-:::
-
 ## Get involved
 
 <IconGrid>

--- a/generators/plopfile.ts
+++ b/generators/plopfile.ts
@@ -30,7 +30,7 @@ export default (plop: NodePlopAPI) => {
         },
         {
           type: 'add',
-          path: '../themes/theme-b2c-tailwind/src/{{atomicGroup}}/{{kebabCase name}}.css',
+          path: '../packages/styles/src/{{atomicGroup}}/{{kebabCase name}}.css',
           templateFile: 'templates/style.css.hbs',
         },
         {

--- a/packages/graphql-utils/README.md
+++ b/packages/graphql-utils/README.md
@@ -1,4 +1,4 @@
-# @vtex/graphql-utils
+# @faststore/graphql-utils
 
 GraphQL utilities to use GraphQL over HTTP with ZERO bundle sizes
 
@@ -31,7 +31,7 @@ Installing this plugin may vary depending on your setup. The instructions below 
 To install, just
 
 ```sh
-$ yarn add @vtex/graphql-utils
+$ yarn add @faststore/graphql-utils
 ```
 
 > Note. Also make sure to install [graphql codegen cli](https://www.graphql-code-generator.com/docs/getting-started/installation)
@@ -44,7 +44,7 @@ To generate the persisted query file, add this plugin to your codegen config. If
 generates:
 path/to/persisted.json:
  plugins:
-   - @vtex/graphql-utils/codegen
+   - @faststore/graphql-utils/codegen
 ```
 
 Now, open your terminal and run:
@@ -63,7 +63,7 @@ To use it on Gatsby, we need to setup the babel plugin. To do this, we can use G
 // ...
 exports.onCreateBabelConfig = ({ actions }) => {
   actions.setBabelPlugin({
-    name: `@vtex/graphql-utils/babel`,
+    name: `@faststore/graphql-utils/babel`,
     options: {},
   })
 }
@@ -76,7 +76,7 @@ Now you should be good to go and create your queries.
 Now that you have successfully installed and configured both babel and codegen plugins, you can start writing your queries. Let's start by declaring the following code:
 
 ```tsx
-import { gql, request } from '@vtex/graphql-utils'
+import { gql, request } from '@faststore/graphql-utils'
 
 const MyQuery = gql`
   query MyQuery { ... }
@@ -95,7 +95,7 @@ That's it! you can use this in most GraphQL Clients, like Apollo Client, SWR, an
 For instance, to use it with SWR, you can declare a useQuery hook:
 
 ```tsx
-import { request } from '@vtex/graphql-utils'
+import { request } from '@faststore/graphql-utils'
 
 const useQuery = ({ operationName, variables }) =>
   useSWR(`/graphql/${operationName}::${JSON.stringify(variables)}`, {
@@ -106,7 +106,7 @@ const useQuery = ({ operationName, variables }) =>
 and use it on your code like:
 
 ```tsx
-import { gql } from '@vtex/graphql-utils'
+import { gql } from '@faststore/graphql-utils'
 
 const MyQuery = qql`
   query MyQuery { ... }

--- a/packages/ui/.storybook/main.js
+++ b/packages/ui/.storybook/main.js
@@ -9,5 +9,5 @@ module.exports = {
     '@storybook/addon-a11y',
     'storybook-addon-themes',
   ],
-  staticDirs: ['../../../themes'],
+  staticDirs: ['../../styles'],
 }

--- a/packages/ui/.storybook/preview-head.html
+++ b/packages/ui/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" type="text/css" href="./theme-b2c-tailwind/dist/index.css" />
+<link rel="stylesheet" type="text/css" href="./dist/index.css" />

--- a/packages/ui/.storybook/preview.js
+++ b/packages/ui/.storybook/preview.js
@@ -17,12 +17,12 @@ export const parameters = {
   },
   themes: {
     clearable: false,
-    default: 'theme-b2c-tailwind',
+    default: 'styles',
     list: [
       { name: 'none', class: 'no-theme', color: '#FFFFFF' },
       {
-        name: 'theme-b2c-tailwind',
-        class: 'theme-b2c-tailwind',
+        name: 'styles',
+        class: 'styles',
         color: '#999999',
       },
     ],
@@ -39,7 +39,7 @@ export const parameters = {
         var theme = document.createElement('link')
         theme.rel = 'stylesheet'
         theme.type = 'text/css'
-        theme.href = `./${themeName}/dist/index.css`
+        theme.href = `./dist/index.css`
 
         document
           .getElementById('storybook-preview-iframe')

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -72,7 +72,7 @@
     "@types/jest-axe": "^3.5.3",
     "@types/tabbable": "^3.1.1",
     "@types/testing-library__jest-dom": "^5.9.5",
-    "@vtex/theme-b2c-tailwind": "^1.8.42",
+    "@faststore/styles": "^1.10.18",
     "@vtex/tsconfig": "^0.5.0",
     "chalk": "^5.0.0",
     "jest-axe": "^5.0.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -73,7 +73,6 @@
     "@types/tabbable": "^3.1.1",
     "@types/testing-library__jest-dom": "^5.9.5",
     "@faststore/styles": "^1.10.18",
-    "@vtex/tsconfig": "^0.5.0",
     "chalk": "^5.0.0",
     "jest-axe": "^5.0.1",
     "jest-matcher-utils": "^27.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8454,13 +8454,6 @@
     "@typescript-eslint/types" "5.28.0"
     eslint-visitor-keys "^3.3.0"
 
-"@vtex/theme-b2c-tailwind@^1.8.42":
-  version "1.8.42"
-  resolved "https://registry.yarnpkg.com/@vtex/theme-b2c-tailwind/-/theme-b2c-tailwind-1.8.42.tgz#593a1eb9d7d03d1553203e4c10deb0f7ceb08a2c"
-  integrity sha512-JbgYXWvJM+tQ92rEnHbrGdH3gqQFnBBQXzKz2RjWtntvSiWR7K93xbeAQ4rVPrwUP3cp82aOlVFGtNz8QYF9lg==
-  dependencies:
-    postcss-cli "^8.3.1"
-
 "@vtex/tsconfig@^0.5.0":
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/@vtex/tsconfig/-/tsconfig-0.5.6.tgz#c0eb4222a75d1b8a4fefb1d85bbd9349880ddbe5"
@@ -24345,8 +24338,6 @@ ssri@^6.0.0, ssri@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
   integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
-  dependencies:
-    figgy-pudding "^3.5.1"
 
 ssri@^8.0.1:
   version "8.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8454,11 +8454,6 @@
     "@typescript-eslint/types" "5.28.0"
     eslint-visitor-keys "^3.3.0"
 
-"@vtex/tsconfig@^0.5.0":
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/@vtex/tsconfig/-/tsconfig-0.5.6.tgz#c0eb4222a75d1b8a4fefb1d85bbd9349880ddbe5"
-  integrity sha512-3pdtp0QiUjW3YqyA+2YPV3AsAJ68wHWELrg7JMlr7ULHNb4mUfmTBx31zbWG94K3OWp0KJFfF3ytQ+I68foqKA==
-
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"


### PR DESCRIPTION
## What's the purpose of this pull request?

Housekeeping PR.

- [x] Updates from `theme-b2c-tailwind` to `styles` package.
- [x] Makes `@faststore/ui` storybook use the `styles` package.
- [x] Fixes plop style generator.
- [x] Updates some `README.md` and docs. 
- [x] Removes unused `@vtex/tsconfig` from `@faststore/ui`.


## References
https://github.com/vtex/faststore/pull/1326
https://github.com/vtex/faststore/pull/1379
https://github.com/vtex/faststore/pull/1296