### PR TITLE
chore: `Slider` improvements

### DIFF
--- a/packages/ui/src/atoms/Slider/Slider.tsx
+++ b/packages/ui/src/atoms/Slider/Slider.tsx
@@ -112,15 +112,11 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
     return (
       <div data-store-slider data-testid={testId} className={className}>
         <div
-          style={{
-            left: `${minPercent < min.absolute ? min.absolute : minPercent}%`,
-            width: `${
-              maxPercent - minPercent > 100
-                ? 100 - minPercent
-                : maxPercent - minPercent
-            }%`,
-          }}
           data-slider-range
+          style={{
+            left: `${minPercent}%`,
+            width: `${maxPercent - minPercent}%`,
+          }}
         />
         {minValueLabelComponent && minValueLabelComponent(minVal)}
         <input

--- a/packages/ui/src/atoms/Slider/Slider.tsx
+++ b/packages/ui/src/atoms/Slider/Slider.tsx
@@ -82,6 +82,10 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
     },
     ref
   ) {
+    const widthPercent = useMemo(
+      () => (max.absolute - min.absolute) / 100,
+      [max.absolute, min.absolute]
+    )
     const [minPercent, setMinPercent] = useState(() =>
       percent(min.selected, min.absolute, max.absolute)
     )
@@ -90,21 +94,27 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
       percent(max.selected, min.absolute, max.absolute)
     )
 
-    const { minVal, maxVal } = useMemo(() => {
-      const widthPercent = (max.absolute - min.absolute) / 100
-
-      return {
-        minVal: Math.round(min.absolute + minPercent * widthPercent),
-        maxVal: Math.round(min.absolute + maxPercent * widthPercent),
-      }
-    }, [min, max, maxPercent, minPercent])
+    const [minVal, setMinVal] = useState(() =>
+      Math.round(min.absolute + minPercent * widthPercent)
+    )
+    const [maxVal, setMaxVal] = useState(() =>
+      Math.round(min.absolute + maxPercent * widthPercent)
+    )
 
     useImperativeHandle(ref, () => ({
       setSliderValues: (values: { min: number; max: number }) => {
         const sliderMinValue = Math.min(Number(values.min), maxVal)
-        const sliderMaxValue = Math.max(Number(values.max), minVal)
-
+        setMinVal(sliderMinValue)
         setMinPercent(percent(sliderMinValue, min.absolute, max.absolute))
+
+        if (values.max > max.absolute) {
+          setMaxVal(max.absolute)
+          setMaxPercent(percent(max.absolute, min.absolute, max.absolute))
+          return
+        }
+
+        const sliderMaxValue = Math.max(Number(values.max), minVal)
+        setMaxVal(sliderMaxValue)
         setMaxPercent(percent(sliderMaxValue, min.absolute, max.absolute))
       },
     }))
@@ -130,6 +140,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
           onChange={(event) => {
             const minValue = Math.min(Number(event.target.value), maxVal)
 
+            setMinVal(minValue)
             setMinPercent(percent(minValue, min.absolute, max.absolute))
             onChange?.({ min: minValue, max: maxVal })
           }}
@@ -152,6 +163,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
           onChange={(event) => {
             const maxValue = Math.max(Number(event.target.value), minVal)
 
+            setMaxVal(maxValue)
             setMaxPercent(percent(maxValue, min.absolute, max.absolute))
             onChange?.({ min: minVal, max: maxValue })
           }}

--- a/packages/ui/src/atoms/Slider/Slider.tsx
+++ b/packages/ui/src/atoms/Slider/Slider.tsx
@@ -94,8 +94,8 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
       const widthPercent = (max.absolute - min.absolute) / 100
 
       return {
-        minVal: min.absolute + minPercent * widthPercent,
-        maxVal: min.absolute + maxPercent * widthPercent,
+        minVal: Math.round(min.absolute + minPercent * widthPercent),
+        maxVal: Math.round(min.absolute + maxPercent * widthPercent),
       }
     }, [min, max, maxPercent, minPercent])
 

--- a/packages/ui/src/atoms/Slider/Slider.tsx
+++ b/packages/ui/src/atoms/Slider/Slider.tsx
@@ -24,6 +24,10 @@ export type SliderProps = {
    */
   max: Range
   /**
+   * Specifies the number interval to be used in the inputs.
+   */
+  step?: number
+  /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    *
    * @default 'store-slider'
@@ -72,6 +76,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
       testId = 'store-slider',
       getAriaValueText,
       className,
+      step,
       minValueLabelComponent,
       maxValueLabelComponent,
     },
@@ -123,6 +128,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
           min={min.absolute}
           max={max.absolute}
           value={minVal}
+          step={step}
           onMouseUp={() => onEnd?.({ min: minVal, max: maxVal })}
           onTouchEnd={() => onEnd?.({ min: minVal, max: maxVal })}
           onChange={(event) => {
@@ -144,6 +150,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
           min={min.absolute}
           max={max.absolute}
           value={maxVal}
+          step={step}
           onMouseUp={() => onEnd?.({ min: minVal, max: maxVal })}
           onTouchEnd={() => onEnd?.({ min: minVal, max: maxVal })}
           onChange={(event) => {

--- a/packages/ui/src/molecules/PriceRange/PriceRange.tsx
+++ b/packages/ui/src/molecules/PriceRange/PriceRange.tsx
@@ -36,6 +36,7 @@ const PriceRange = forwardRef<PriceRangeRefType | undefined, PriceRangeProps>(
       formatter,
       max,
       min,
+      step,
       onChange,
       onEnd,
       testId = 'store-price-range',
@@ -61,6 +62,7 @@ const PriceRange = forwardRef<PriceRangeRefType | undefined, PriceRangeProps>(
           ref={sliderRef}
           min={min}
           max={max}
+          step={step}
           onEnd={onEnd}
           aria-label={ariaLabel}
           onChange={(value) => onChange?.(value)}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add the `step` prop to the `Slider` component and be adjustable on starters. Also, it fixes `Slider`'s input range values to display only integer/precise number values.

### Starters Deploy Preview

Related to [`nextjs.store`'s PR #146](https://github.com/vtex-sites/nextjs.store/pull/146)