### PR TITLE
docs: Update docs on how to extend `@faststore/api`'s schema

### DIFF
--- a/apps/docs/docs/how-to-guides/faststore-api/extending-the-faststore-api.md
+++ b/apps/docs/docs/how-to-guides/faststore-api/extending-the-faststore-api.md
@@ -11,6 +11,7 @@ To extend the schema, one can:
 ```ts
 import { getSchema, getTypeDefs } from '@faststore/api'
 import { makeExecutableSchema, mergeSchemas } from '@graphql-tools/schema'
+import { mergeTypeDefs } from '@graphql-tools/merge'
 import { ApolloServer } from 'apollo-server'
 
 // Setup type extensions
@@ -45,6 +46,7 @@ const getMergedSchemas = async () =>
         typeDefs: mergedTypeDefs,
       }),
     ],
+    resolvers,
   })
 
 // Merge schemas into a final schema


### PR DESCRIPTION
## What's the purpose of this pull request?

Our instructions on how to extend the base GraphQL schema from `@faststore/api` don't fully work on the current setup we have on `gatsby.store`. This PR updates them 😄 .
