### PR TITLE
fix: Round `Slider` absolute values

### DIFF
--- a/packages/ui/src/atoms/Slider/Slider.tsx
+++ b/packages/ui/src/atoms/Slider/Slider.tsx
@@ -131,8 +131,8 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
         {minValueLabelComponent && minValueLabelComponent(minVal)}
         <input
           type="range"
-          min={min.absolute}
-          max={max.absolute}
+          min={Math.round(min.absolute)}
+          max={Math.round(max.absolute)}
           value={minVal}
           step={step}
           onMouseUp={() => onEnd?.({ min: minVal, max: maxVal })}
@@ -154,8 +154,8 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
         {maxValueLabelComponent && maxValueLabelComponent(maxVal)}
         <input
           type="range"
-          min={min.absolute}
-          max={max.absolute}
+          min={Math.round(min.absolute)}
+          max={Math.round(max.absolute)}
           value={maxVal}
           step={step}
           onMouseUp={() => onEnd?.({ min: minVal, max: maxVal })}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix a `PriceRange` case that absolute values are decimals, breaking input integer values.