### PR TITLE
refactor: Import the `Tiles` & `Tile` components from the starter

### DIFF
--- a/packages/styles/src/organisms/index.css
+++ b/packages/styles/src/organisms/index.css
@@ -1,2 +1,3 @@
 @import './hero.css';
 @import './out-of-stock.css';
+@import './tiles.css';

--- a/packages/styles/src/organisms/tiles.css
+++ b/packages/styles/src/organisms/tiles.css
@@ -1,0 +1,75 @@
+[data-fs-tiles] {
+  --aspect-ratio-portrait: 3 / 4;
+  --aspect-ratio-landscape: 4 / 3;
+  --gap: 16px;
+
+  display: grid;
+  grid-template-rows: repeat(2, auto);
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--gap);
+  color: white;
+}
+
+[data-fs-tiles] + [data-fs-tiles] {
+  margin-top: var(--gap);
+}
+
+[data-fs-tile] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: var(--aspect-ratio-portrait);
+  background-color: red;
+}
+
+[data-fs-tile]:nth-child(n + 1) {
+  background-color: #001082;
+}
+
+[data-fs-tile]:nth-child(n + 2) {
+  background-color: #0017b9;
+}
+
+[data-fs-tile]:nth-child(n + 3) {
+  background-color: #1930d3;
+}
+
+[data-fs-tile]:nth-child(n + 4) {
+  background-color: #4d62ff;
+}
+
+[data-fs-tiles-variant="expanded-first-two"] {
+  grid-template-columns: none;
+}
+
+[data-fs-tiles-variant="expanded-first-two"] [data-fs-tile] {
+  aspect-ratio: var(--aspect-ratio-landscape);
+}
+
+[data-fs-tiles-variant="expanded-first"] [data-fs-tile]:first-child {
+  grid-column: 1 / 3;
+  aspect-ratio: var(--aspect-ratio-landscape);
+}
+
+@media only screen and (min-width: 769px) {
+  [data-fs-tiles] {
+    grid-template-rows: none;
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  [data-fs-tiles-variant="expanded-first-two"] {
+    grid-template: none / repeat(2, 1fr);
+  }
+
+  [data-fs-tiles-variant="expanded-first"] {
+    display: flex;
+  }
+
+  [data-fs-tiles-variant="expanded-first"] [data-fs-tile] {
+    flex-grow: calc(var(--aspect-ratio-portrait));
+  }
+
+  [data-fs-tiles-variant="expanded-first"] [data-fs-tile]:first-child {
+    flex-grow: calc(var(--aspect-ratio-landscape));
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -190,6 +190,9 @@ export type {
   OutOfStockTitleProps,
 } from './organisms/OutOfStock'
 
+export { Tiles, Tile } from './organisms/Tiles'
+export type { TilesProps, TileProps } from './organisms/Tiles'
+
 export { default as Hero, HeroHeading, HeroImage } from './organisms/Hero'
 export type {
   HeroProps,

--- a/packages/ui/src/organisms/Tiles/Tile.tsx
+++ b/packages/ui/src/organisms/Tiles/Tile.tsx
@@ -1,0 +1,23 @@
+import React, { forwardRef } from 'react'
+import type { HTMLAttributes } from 'react'
+
+export interface TileProps extends HTMLAttributes<HTMLLIElement> {
+  /**
+   * ID to find this component in testing tools (e.g.: Cypress,
+   * Testing Library, and Jest).
+   */
+  testId?: string
+}
+
+const Tile = forwardRef<HTMLLIElement, TileProps>(function Tile(
+  { testId = 'store-tile', children, ...otherProps },
+  ref
+) {
+  return (
+    <li ref={ref} data-fs-tile data-testid={testId} {...otherProps}>
+      {children}
+    </li>
+  )
+})
+
+export default Tile

--- a/packages/ui/src/organisms/Tiles/Tiles.tsx
+++ b/packages/ui/src/organisms/Tiles/Tiles.tsx
@@ -1,0 +1,64 @@
+import React, { Children, forwardRef } from 'react'
+import type { HTMLAttributes, ReactElement } from 'react'
+
+import { Tile } from '.'
+
+export interface TilesProps extends HTMLAttributes<HTMLUListElement> {
+  /**
+   * ID to find this component in testing tools (e.g.: Cypress,
+   * Testing Library, and Jest).
+   */
+  testId?: string
+}
+
+const MIN_CHILDREN = 2
+const MAX_CHILDREN = 4
+const NUMBER_ITEMS_TO_EXPAND_FIRST_TWO = 2
+const NUMBER_ITEMS_TO_EXPAND_FIRST = 3
+
+const Tiles = forwardRef<HTMLUListElement, TilesProps>(function Tiles(
+  { testId = 'store-tiles', children, ...otherProps },
+  ref
+) {
+  const childrenCount = Children.count(children)
+
+  if (process.env.NODE_ENV === 'development') {
+    const isOutOfBounds =
+      childrenCount < MIN_CHILDREN || childrenCount > MAX_CHILDREN
+
+    if (isOutOfBounds) {
+      throw new Error(
+        `Tiles cannot receive less than ${MIN_CHILDREN} or more than ${MAX_CHILDREN} children.`
+      )
+    }
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    Children.forEach(children as ReactElement, (child) => {
+      if (child.type !== Tile) {
+        throw new Error('Only Tile components allowed as children.')
+      }
+    })
+  }
+
+  const expandedClass =
+    childrenCount === NUMBER_ITEMS_TO_EXPAND_FIRST
+      ? 'expanded-first'
+      : childrenCount === NUMBER_ITEMS_TO_EXPAND_FIRST_TWO
+      ? 'expanded-first-two'
+      : ''
+
+  return (
+    <ul
+      ref={ref}
+      data-fs-tiles
+      data-fs-tiles-variant={expandedClass}
+      data-testid={testId}
+      {...otherProps}
+    >
+      {children}
+    </ul>
+  )
+})
+
+export default Tiles

--- a/packages/ui/src/organisms/Tiles/index.ts
+++ b/packages/ui/src/organisms/Tiles/index.ts
@@ -1,0 +1,5 @@
+export { default as Tiles } from './Tiles'
+export type { TilesProps } from './Tiles'
+
+export { default as Tile } from './Tile'
+export type { TileProps } from './Tile'

--- a/packages/ui/src/organisms/Tiles/stories/Tiles.mdx
+++ b/packages/ui/src/organisms/Tiles/stories/Tiles.mdx
@@ -1,0 +1,39 @@
+import { ArgsTable, Canvas, Story } from '@storybook/addon-docs'
+
+import { Tile, Tiles } from '../'
+
+# Tiles
+
+<Canvas>
+  <Story id="organisms-tiles--tiles" />
+</Canvas>
+
+## Components
+
+- `Tiles`: the parent component that wraps one or many `Tile`s.
+- `Tile`: the child component.
+
+## Props
+
+Besides those attributes, the following props are also supported:
+
+### `Tiles`
+
+<ArgsTable of={Tiles} />
+
+### `Tile`
+
+<ArgsTable of={Tile} />
+
+## CSS Selectors
+
+```css
+[data-fs-tiles] {
+}
+
+[data-fs-tiles-variant='expanded-first'|'expanded-first-two'] {
+}
+
+[data-fs-tile] {
+}
+```

--- a/packages/ui/src/organisms/Tiles/stories/Tiles.stories.tsx
+++ b/packages/ui/src/organisms/Tiles/stories/Tiles.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import { Tile, Tiles as UITiles } from '../'
+import mdx from './Tiles.mdx'
+
+import type { Story, Meta } from '@storybook/react'
+import type { TilesProps } from '../'
+
+const TilesTemplate: Story<TilesProps> = () => (
+  <>
+    <UITiles>
+      <Tile>Tile #1</Tile>
+      <Tile>Tile #2</Tile>
+    </UITiles>
+    <UITiles>
+      <Tile>Tile #1</Tile>
+      <Tile>Tile #2</Tile>
+      <Tile>Tile #3</Tile>
+      <Tile>Tile #4</Tile>
+    </UITiles>
+    <UITiles>
+      <Tile>Tile #1</Tile>
+      <Tile>Tile #2</Tile>
+      <Tile>Tile #3</Tile>
+    </UITiles>
+  </>
+)
+
+export const Tiles = TilesTemplate.bind({})
+
+export default {
+  title: 'Organisms/Tiles',
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+} as Meta


### PR DESCRIPTION
## What's the purpose of this pull request?

Extract the `Tiles` and `Tile` component from the [starters](https://github.com/vtex-sites/nextjs.store/tree/81b2cbcae8157703130ab18356178cb15c8bcf12/src/components/ui/Tiles) and move it to the `@faststore/ui` package.

## How to test it?

Run `yarn storybook` locally and check the [`Tiles` component page](http://localhost:6006/?path=/docs/organisms-tiles--tiles).

Its Storybook page:
![CleanShot 2022-07-29 at 15 26 25](https://user-images.githubusercontent.com/381395/181822535-577ec95e-0076-4191-ab20-d4a64386e9d4.png)

The same component being used on the starter:
![CleanShot 2022-07-29 at 15 41 38](https://user-images.githubusercontent.com/381395/181824154-5f0a8e64-7520-470a-b26a-452c0f837149.png)

### Starters Deploy Preview

- https://github.com/vtex-sites/nextjs.store/pull/185 and the [deploy preview](https://preview-185--nextjs.preview.vtex.app/)