### PR TITLE
chore: Attempt to fix the publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
+    "conventional-changelog-conventionalcommits": "^5.0.0",
     "eslint": "^8.17.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11490,6 +11490,15 @@ conventional-changelog-angular@^5.0.3:
     compare-func "^2.0.0"
     q "^1.5.1"
 
+conventional-changelog-conventionalcommits@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz#41bdce54eb65a848a4a3ffdca93e92fa22b64a86"
+  integrity sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==
+  dependencies:
+    compare-func "^2.0.0"
+    lodash "^4.17.15"
+    q "^1.5.1"
+
 conventional-changelog-core@^3.1.6:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-3.2.3.tgz#b31410856f431c847086a7dcb4d2ca184a7d88fb"
@@ -24333,6 +24342,8 @@ ssri@^6.0.0, ssri@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
   integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
+  dependencies:
+    figgy-pudding "^3.5.1"
 
 ssri@^8.0.1:
   version "8.0.1"
@@ -26520,10 +26531,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
## What's the purpose of this pull request?

See [the last merge commit](https://github.com/vtex/faststore/commit/2ee105ca2c335e1a7dad60efa55f29cfdc587c22) in https://github.com/vtex/faststore/commits/main. Its **CD / FastStore (push)** check failed with an error [`lerna ERR! EPRESET Unable to load conventional-changelog preset 'conventionalcommits' (conventional-changelog-conventionalcommits)`](https://github.com/vtex/faststore/runs/7619824436?check_suite_focus=true#step:10:41).

We had recently changed the changelog preset from `angular` to `conventionalcommits` in https://github.com/vtex/faststore/pull/1425, but didn't get to test if it worked till now. _I think_ it may be because we didn't install this [`conventional-changelog-conventionalcommits`](https://github.com/conventional-changelog/conventional-changelog/tree/bfe3bf1c49d4a125474b398b2d304749fd3b56c7/packages/conventional-changelog-conventionalcommits), but I'm not sure.

Note that when I tried to `yarn add --dev conventional-changelog-conventionalcommits` it first errored with:
```
▶ yarn add --dev conventional-changelog-conventionalcommits
yarn add v1.22.19
error Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if y
ou really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```
So I used `yarn add --dev conventional-changelog-conventionalcommits -W`, but I'm not sure this is the correct way.

## How to test it?

Not sure if this is going to work until this is merged and the action runs.

## References

- https://github.com/vtex/faststore/pull/1425
- https://github.com/vtex/faststore/runs/7619824436?check_suite_focus=true#step:10:41
- https://github.com/conventional-changelog/conventional-changelog/tree/bfe3bf1c49d4a125474b398b2d304749fd3b56c7/packages/conventional-changelog-conventionalcommits
- https://github.com/lerna/lerna/blob/5cfcd3a3209be547c3f259220453e5fd620fa10b/commands/version/README.md?rgh-link-date=2022-07-29T18%3A43%3A02Z#--changelog-preset