### PR TITLE
fix: Take collection pages into account on `slugifyRoot` function

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/collection.ts
+++ b/packages/api/src/platforms/vtex/resolvers/collection.ts
@@ -11,8 +11,11 @@ const isBrand = (x: any): x is Brand | CollectionPageType =>
   x.type === 'brand' ||
   (isCollectionPageType(x) && x.pageType.toLowerCase() === 'brand')
 
+const isCollection = (x: Root): x is CollectionPageType =>
+  isCollectionPageType(x) && x.pageType.toLowerCase() === 'collection'
+
 const slugifyRoot = (root: Root) => {
-  if (isBrand(root)) {
+  if (isBrand(root) || isCollection(root)) {
     return slugify(root.name)
   }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to solve issues users were facing trying to fetch the field `StoreCollection.breadcrumbList` for collection pages.

## How it works?

Adds a new check for collection pages in the step that precedes the requests we make to figure out the pagetype for a certain route, inside the `breadcrumbList` field resolver. 

## How to test it?

Using the same test case from https://community.vtex.com/t/problemas-nas-rotas-de-collection-clusters/33353/4.

- Clone this branch locally;
- Update the account found at `src/packages/api/local/index.ts` to `homologappoffpremium`;
- Run `yarn develop` inside `src/packages/api`;
- Run the following query:

```graphql
{
  collection(slug: "novidades-feminino") {
    slug
    seo {
      title
      description
    }
    meta {
      selectedFacets {
        key
        value
      }
    }
    breadcrumbList {
      itemListElement {
        name
        item
        position
      }
      numberOfItems
    }
    id
    type
  }
}
```

and you should get no errors :).

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
