### PR TITLE
fix: Join cart items 

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -28,6 +28,7 @@ const getId = (item: IStoreOffer) =>
   [
     item.itemOffered.sku,
     item.seller.identifier,
+    item.price < 0.01 ? 'Gift' : undefined,
     item.itemOffered.additionalProperty
       ?.filter(isAttachment)
       .map(getPropertyId)


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR improves the Cart UX by resolving edge cases related to cart item split.

## How it works?
Checkout API has a concept called orderForm. OrderForm has everything related to your current cart. It has, for instance, the items your are currently purchasing. These items are implemented using an array. For rendering the cart, you would only need to map through the array's items, rendering the products accordingly. If you follow this algorithm, however, you will end up with a poor UX because items can be split in the Checkout API, making you render the same product repeatedly.
 
Let's suppose your are buying a banana and a special promotion is applied, decreasing 50% the price of the second item purchased. By adding the second banana to cart, you would receive the following array back from Checkout API
```
[
   { name: 'banana', price: 2 },
   { name: 'banana', price: 1 },
]
```

If you follow the usual cart rendering algorithm, you would render the same item (banana) twice with 2 different prices. Talking to other VTEX employees and others, this is not the ideal behavior. The "correct" behavior would be rendering:
```
[
  { name: 'banana', price: 1.5 }
]
```

This PR implements just that. From now on, the returned array from `validateCart` mutation returns these merged prices. The only case where it does not apply is when the sku is from a different seller and have anexes. Also, gifts are split. 

Below, you can see the before after this feature on the cart:
<div style="display: flex; flex-wrap: nowrap">
<img style="width: 100%" width="400" alt="image" src="https://user-images.githubusercontent.com/1753396/183682016-ff4bdaff-6514-4837-b0de-0fcb2262e8c8.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/1753396/183684938-840188bf-301d-4a73-906a-6ddaa18058e1.png">
</div>

## How to test it?
To test these features, I created two new promotions on `storeframework` account.

1. Buy 2 get 3: Buy buying any product from `Most Wanted` collection, you get a free "Apple Magic Mouse".
2. 0.50 cents on the second product on any item of the "Just Arrived" section. 

These test promotions make sure gifts are not merged with normal items, but correctly merged when needed. The before/after on nextjs.store can be seen below:

<div style="display: flex; flex-wrap: nowrap">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/1753396/183712185-6b453314-e99b-43b3-a416-dbe8c083e0fb.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/1753396/183712094-77889b58-f299-4ec7-a751-3bc3377711be.png">
</div>


### Starters Deploy Preview
- https://github.com/vtex-sites/nextjs.store/pull/201

