### PR TITLE
feat: Product releaseDate

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
+++ b/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
@@ -90,6 +90,7 @@ export interface Product {
   specificationGroups: SpecificationGroup[]
   properties: Array<{ name: string; values: string[] }>
   selectedProperties: Array<{ key: string; value: string }>
+  releaseDate: string
 }
 
 interface Image {

--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -116,4 +116,5 @@ export const StoreProduct: Record<string, Resolver<Root>> & {
 
     return [...propertyValueSpecifications, ...propertyValueAttachments]
   },
+  releaseDate: ({ isVariantOf: { releaseDate } }) => releaseDate ?? ''
 }

--- a/packages/api/src/typeDefs/product.graphql
+++ b/packages/api/src/typeDefs/product.graphql
@@ -62,6 +62,10 @@ type StoreProduct {
   Array of additional properties.
   """
   additionalProperty: [StorePropertyValue!]!
+  """
+  The product's release date. Formatted using https://en.wikipedia.org/wiki/ISO_8601
+  """
+  releaseDate: String!
 }
 
 """


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR is a one liner that returns the product's release date using [schema.org's field](https://schema.org/Product) on Product entity. This should fix this [issue](https://vtex.slack.com/archives/C0164SHMAV9/p1659473353883529)

### Starters Deploy Preview
- nextjs.store https://github.com/vtex-sites/nextjs.store/pull/207

I tried adding this to gatsby too, however, gatsby library does not accept releaseDate as input

## References
- [schema.org releaseDate field](https://schema.org/releaseDate)