### PR TITLE
chore: Add 32k header limit to nginx-generator

### DIFF
--- a/packages/gatsby-plugin-nginx/src/nginx-generator.ts
+++ b/packages/gatsby-plugin-nginx/src/nginx-generator.ts
@@ -175,6 +175,7 @@ function generateNginxConfiguration({
               children: [
                 ...serverOptions.map((cmd) => ({ cmd })),
                 { cmd: ['listen', '0.0.0.0:$PORT', 'default_server'] },
+                { cmd: ['large_client_header_buffers', '4', '32k'] },
                 // https://www.gatsbyjs.com/docs/how-to/adding-common-features/add-404-page/
                 { cmd: ['error_page', '404', '/404.html'] },
 

--- a/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
+++ b/packages/gatsby-plugin-nginx/test/nginx-generator.test.ts
@@ -314,6 +314,7 @@ describe('generateNginxConfiguration', () => {
         gzip_types text/plain text/css text/xml application/javascript application/x-javascript application/xml application/xml+rss application/emacscript application/json image/svg+xml;
         server {
           listen 0.0.0.0:$PORT default_server;
+          large_client_header_buffers 4 32k;
           error_page 404 /404.html;
           location /nginx.conf {
             deny all;


### PR DESCRIPTION
Copied from https://github.com/vtex/faststore/pull/1439.