### PR TITLE
feat: Add `Gift` component

### DIFF
--- a/packages/styles/src/molecules/gift.css
+++ b/packages/styles/src/molecules/gift.css
@@ -1,3 +1,47 @@
 [data-fs-gift] {
+  display: grid;
+  grid-template-columns: 96px repeat(4,1fr);
+  align-items: center;
+  column-gap: 12px;
+  height: 96px;
+  overflow: hidden;
+  border: 1px solid #c7ccd1;
+  border-radius: 4px;
+}
 
+[data-fs-gift-content] {
+  display: grid;
+  grid-column: 2 / span 4;
+  padding: 12px 12px 12px 0;
+}
+
+[data-fs-gift-content] h3 {
+  margin-bottom: 4px;
+  font-size: 16px;
+  color: #171a1c;
+}
+
+[data-fs-gift-content] [data-store-price] {
+  margin-right: 6px;
+  color: #5d666f;
+  text-decoration: line-through;
+}
+
+[data-fs-gift-content] [data-store-badge] {
+  padding: 4px 12px;
+  color: #171a1c;
+  text-transform: uppercase;
+  font-weight: bold;
+  border-radius: 100px;
+  background: #f1f2f3;
+}
+
+[data-fs-gift-image] {
+  height: 100%;
+}
+
+[data-fs-gift-image] img {
+  object-fit:cover;
+  width: 100%;
+  height: 100%;
 }

--- a/packages/styles/src/molecules/gift.css
+++ b/packages/styles/src/molecules/gift.css
@@ -1,12 +1,16 @@
 [data-fs-gift] {
+  position: relative;
+}
+
+[data-fs-gift-wrapper] {
   display: grid;
   grid-template-columns: 96px repeat(4,1fr);
   align-items: center;
   column-gap: 12px;
   height: 96px;
-  overflow: hidden;
   border: 1px solid #c7ccd1;
   border-radius: 4px;
+  overflow: hidden;
 }
 
 [data-fs-gift-content] {
@@ -39,6 +43,7 @@
 
 [data-fs-gift-image] {
   height: 100%;
+  overflow: hidden;
 }
 
 [data-fs-gift-image] img {
@@ -49,8 +54,8 @@
 
 [data-fs-gift-icon] {
   position: absolute;
-  top: 4px;
-  left: -4px;
+  top: -14px;
+  left: -20px;
   width: 28px;
   height: 28px;
   padding: 4px;

--- a/packages/styles/src/molecules/gift.css
+++ b/packages/styles/src/molecules/gift.css
@@ -19,6 +19,7 @@
   margin-bottom: 4px;
   font-size: 16px;
   color: #171a1c;
+  line-height: 20px;
 }
 
 [data-fs-gift-content] [data-store-price] {
@@ -44,4 +45,16 @@
   object-fit:cover;
   width: 100%;
   height: 100%;
+}
+
+[data-fs-gift-icon] {
+  position: absolute;
+  top: 4px;
+  left: -4px;
+  width: 28px;
+  height: 28px;
+  padding: 4px;
+  background-color: white;
+  border: 1px solid #c7ccd1;
+  border-radius: 100%;
 }

--- a/packages/styles/src/molecules/gift.css
+++ b/packages/styles/src/molecules/gift.css
@@ -1,0 +1,3 @@
+[data-fs-gift] {
+
+}

--- a/packages/styles/src/molecules/index.css
+++ b/packages/styles/src/molecules/index.css
@@ -8,6 +8,7 @@
 @import './carousel.css';
 @import './dropdown.css';
 @import './form.css';
+@import './gift.css';
 @import './icon-button.css';
 @import './loading-button.css';
 @import './modal.css';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -54,8 +54,12 @@ export { default as Incentive } from './atoms/Incentive'
 export type { IncentiveProps } from './atoms/Incentive'
 
 // Molecules
-export { default as Gift } from './molecules/Gift'
-export type { GiftProps } from './molecules/Gift'
+export { default as Gift, GiftContent, GiftImage } from './molecules/Gift'
+export type {
+  GiftProps,
+  GiftContentProps,
+  GiftImageProps,
+} from './molecules/Gift'
 
 export { default as ProductTitle } from './molecules/ProductTitle'
 export type { ProductTitleProps } from './molecules/ProductTitle'

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -54,6 +54,9 @@ export { default as Incentive } from './atoms/Incentive'
 export type { IncentiveProps } from './atoms/Incentive'
 
 // Molecules
+export { default as Gift } from './molecules/Gift'
+export type { GiftProps } from './molecules/Gift'
+
 export { default as ProductTitle } from './molecules/ProductTitle'
 export type { ProductTitleProps } from './molecules/ProductTitle'
 

--- a/packages/ui/src/molecules/Gift/Gift.test.tsx
+++ b/packages/ui/src/molecules/Gift/Gift.test.tsx
@@ -47,6 +47,7 @@ describe('Gift', () => {
       const { getByTestId } = render(<GiftTest />)
 
       expect(await axe(getByTestId('store-gift'))).toHaveNoViolations()
+      expect(await axe(getByTestId('store-gift'))).toHaveNoIncompletes()
     })
   })
 })

--- a/packages/ui/src/molecules/Gift/Gift.test.tsx
+++ b/packages/ui/src/molecules/Gift/Gift.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import React from 'react'
+
+import Gift from './Gift'
+
+describe('Gift', () => {
+  it('should have `data-fs-gift` attribute', () => {
+    const { getByTestId } = render(<Gift>Testing</Gift>)
+
+    expect(getByTestId('store-gift')).toHaveAttribute('data-fs-gift')
+  })
+
+  describe('Accessibility', () => {
+    it('should have no violations', async () => {
+      const { getByTestId } = render(<Gift>Testing</Gift>)
+
+      expect(await axe(getByTestId('store-gift'))).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/molecules/Gift/Gift.test.tsx
+++ b/packages/ui/src/molecules/Gift/Gift.test.tsx
@@ -3,17 +3,48 @@ import { axe } from 'jest-axe'
 import React from 'react'
 
 import Gift from './Gift'
+import GiftImage from './GiftImage'
+import GiftContent from './GiftContent'
+
+const GiftTest = () => {
+  return (
+    <Gift>
+      <GiftImage>
+        <div>An image</div>
+      </GiftImage>
+      <GiftContent>
+        <h3>Product Name</h3>
+        <p>89.90</p>
+        <span>Free</span>
+      </GiftContent>
+    </Gift>
+  )
+}
 
 describe('Gift', () => {
-  it('should have `data-fs-gift` attribute', () => {
-    const { getByTestId } = render(<Gift>Testing</Gift>)
+  describe('Data attributes', () => {
+    const { getByTestId } = render(<GiftTest />)
 
-    expect(getByTestId('store-gift')).toHaveAttribute('data-fs-gift')
+    const gift = getByTestId('store-gift')
+    const giftImage = getByTestId('store-gift-image')
+    const giftContent = getByTestId('store-gift-content')
+
+    it('`Gift` component should have `data-fs-gift` attribute', () => {
+      expect(gift).toHaveAttribute('data-fs-gift')
+    })
+
+    it('`GiftImage` component should have `data-fs-gift-image` attribute', () => {
+      expect(giftImage).toHaveAttribute('data-fs-gift-image')
+    })
+
+    it('`GiftContent` component should have `data-fs-gift-content` attribute', () => {
+      expect(giftContent).toHaveAttribute('data-fs-gift-content')
+    })
   })
 
   describe('Accessibility', () => {
     it('should have no violations', async () => {
-      const { getByTestId } = render(<Gift>Testing</Gift>)
+      const { getByTestId } = render(<GiftTest />)
 
       expect(await axe(getByTestId('store-gift'))).toHaveNoViolations()
     })

--- a/packages/ui/src/molecules/Gift/Gift.tsx
+++ b/packages/ui/src/molecules/Gift/Gift.tsx
@@ -15,7 +15,7 @@ export interface GiftProps extends HTMLAttributes<HTMLDivElement> {
    */
   icon?: ReactNode
   /**
-   * Label to be required for accessibility.
+   * Label to be required for accessibility for the Icon.
    */
   'aria-label'?: string
 }

--- a/packages/ui/src/molecules/Gift/Gift.tsx
+++ b/packages/ui/src/molecules/Gift/Gift.tsx
@@ -26,7 +26,7 @@ const Gift = forwardRef<HTMLDivElement, GiftProps>(function Gift(
   return (
     <div ref={ref} data-fs-gift data-testid={testId} {...otherProps}>
       {icon && <Icon component={icon} data-fs-gift-icon />}
-      {children}
+      <div data-fs-gift-wrapper>{children}</div>
     </div>
   )
 })

--- a/packages/ui/src/molecules/Gift/Gift.tsx
+++ b/packages/ui/src/molecules/Gift/Gift.tsx
@@ -3,6 +3,7 @@ import type { HTMLAttributes } from 'react'
 import type { ReactNode } from 'react'
 
 import Icon from '../../atoms/Icon'
+
 export interface GiftProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress,

--- a/packages/ui/src/molecules/Gift/Gift.tsx
+++ b/packages/ui/src/molecules/Gift/Gift.tsx
@@ -1,20 +1,31 @@
 import React, { forwardRef } from 'react'
 import type { HTMLAttributes } from 'react'
+import type { ReactNode } from 'react'
 
+import Icon from '../../atoms/Icon'
 export interface GiftProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress,
    * testing-library, and jest).
    */
   testId?: string
+  /**
+   * A React component that will be rendered as an icon.
+   */
+  icon?: ReactNode
+  /**
+   * Label to be required for accessibility.
+   */
+  'aria-label'?: string
 }
 
 const Gift = forwardRef<HTMLDivElement, GiftProps>(function Gift(
-  { testId = 'store-gift', children, ...otherProps },
+  { icon, testId = 'store-gift', children, ...otherProps },
   ref
 ) {
   return (
     <div ref={ref} data-fs-gift data-testid={testId} {...otherProps}>
+      {icon && <Icon component={icon} data-fs-gift-icon />}
       {children}
     </div>
   )

--- a/packages/ui/src/molecules/Gift/Gift.tsx
+++ b/packages/ui/src/molecules/Gift/Gift.tsx
@@ -14,10 +14,6 @@ export interface GiftProps extends HTMLAttributes<HTMLDivElement> {
    * A React component that will be rendered as an icon.
    */
   icon?: ReactNode
-  /**
-   * Label to be required for accessibility for the Icon.
-   */
-  'aria-label'?: string
 }
 
 const Gift = forwardRef<HTMLDivElement, GiftProps>(function Gift(

--- a/packages/ui/src/molecules/Gift/Gift.tsx
+++ b/packages/ui/src/molecules/Gift/Gift.tsx
@@ -1,0 +1,23 @@
+import React, { forwardRef } from 'react'
+import type { HTMLAttributes } from 'react'
+
+export interface GiftProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * ID to find this component in testing tools (e.g.: cypress,
+   * testing-library, and jest).
+   */
+  testId?: string
+}
+
+const Gift = forwardRef<HTMLDivElement, GiftProps>(function Gift(
+  { testId = 'store-gift', children, ...otherProps },
+  ref
+) {
+  return (
+    <div ref={ref} data-fs-gift data-testid={testId} {...otherProps}>
+      {children}
+    </div>
+  )
+})
+
+export default Gift

--- a/packages/ui/src/molecules/Gift/GiftContent.tsx
+++ b/packages/ui/src/molecules/Gift/GiftContent.tsx
@@ -10,7 +10,7 @@ export interface GiftContentProps extends HTMLAttributes<HTMLElement> {
 
 const GiftContent = forwardRef<HTMLElement, GiftContentProps>(
   function GiftContent(
-    { testId = 'store-card-content', children, ...otherProps },
+    { testId = 'store-gift-content', children, ...otherProps },
     ref
   ) {
     return (

--- a/packages/ui/src/molecules/Gift/GiftContent.tsx
+++ b/packages/ui/src/molecules/Gift/GiftContent.tsx
@@ -1,0 +1,29 @@
+import type { HTMLAttributes } from 'react'
+import React, { forwardRef } from 'react'
+
+export interface GiftContentProps extends HTMLAttributes<HTMLElement> {
+  /**
+   * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
+   */
+  testId?: string
+}
+
+const GiftContent = forwardRef<HTMLElement, GiftContentProps>(
+  function GiftContent(
+    { testId = 'store-card-content', children, ...otherProps },
+    ref
+  ) {
+    return (
+      <section
+        ref={ref}
+        data-fs-gift-content
+        data-testid={testId}
+        {...otherProps}
+      >
+        {children}
+      </section>
+    )
+  }
+)
+
+export default GiftContent

--- a/packages/ui/src/molecules/Gift/GiftImage.tsx
+++ b/packages/ui/src/molecules/Gift/GiftImage.tsx
@@ -9,7 +9,7 @@ export interface GiftImageProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 const GiftImage = forwardRef<HTMLDivElement, GiftImageProps>(function GiftImage(
-  { testId = 'store-card-image', children, ...otherProps },
+  { testId = 'store-gift-image', children, ...otherProps },
   ref
 ) {
   return (

--- a/packages/ui/src/molecules/Gift/GiftImage.tsx
+++ b/packages/ui/src/molecules/Gift/GiftImage.tsx
@@ -1,0 +1,22 @@
+import type { HTMLAttributes } from 'react'
+import React, { forwardRef } from 'react'
+
+export interface GiftImageProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
+   */
+  testId?: string
+}
+
+const GiftImage = forwardRef<HTMLDivElement, GiftImageProps>(function GiftImage(
+  { testId = 'store-card-image', children, ...otherProps },
+  ref
+) {
+  return (
+    <div ref={ref} data-fs-gift-image data-testid={testId} {...otherProps}>
+      {children}
+    </div>
+  )
+})
+
+export default GiftImage

--- a/packages/ui/src/molecules/Gift/index.tsx
+++ b/packages/ui/src/molecules/Gift/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './Gift'
+export type { GiftProps } from './Gift'

--- a/packages/ui/src/molecules/Gift/index.tsx
+++ b/packages/ui/src/molecules/Gift/index.tsx
@@ -1,2 +1,8 @@
 export { default } from './Gift'
 export type { GiftProps } from './Gift'
+
+export { default as GiftContent } from './GiftContent'
+export type { GiftContentProps } from './GiftContent'
+
+export { default as GiftImage } from './GiftImage'
+export type { GiftImageProps } from './GiftImage'

--- a/packages/ui/src/molecules/Gift/stories/Gift.mdx
+++ b/packages/ui/src/molecules/Gift/stories/Gift.mdx
@@ -18,6 +18,9 @@ import Gift from '../Gift'
 [data-fs-gift] {
 }
 
+[data-fs-gift-icon] {
+}
+
 [data-fs-gift-content] {
 }
 

--- a/packages/ui/src/molecules/Gift/stories/Gift.mdx
+++ b/packages/ui/src/molecules/Gift/stories/Gift.mdx
@@ -17,4 +17,10 @@ import Gift from '../Gift'
 ```css
 [data-fs-gift] {
 }
+
+[data-fs-gift-content] {
+}
+
+[data-fs-gift-image] {
+}
 ```

--- a/packages/ui/src/molecules/Gift/stories/Gift.mdx
+++ b/packages/ui/src/molecules/Gift/stories/Gift.mdx
@@ -8,6 +8,14 @@ import Gift from '../Gift'
   <Story id="molecules-gift--gift" />
 </Canvas>
 
+## Components
+
+The `Gift` uses the [Compound Component](https://kentcdodds.com/blog/compound-components-with-react-hooks) pattern, its components are:
+
+- `Gift`: the wrapper component, it can receive a `Icon` prop and `aria-label` for the Icon.
+- `GiftImage`: the component's that display the product image.
+- `GiftContent`: the component that can display the product's title, price, and a badge.
+
 ## Props
 
 <ArgsTable of={Gift} />
@@ -16,6 +24,9 @@ import Gift from '../Gift'
 
 ```css
 [data-fs-gift] {
+}
+
+[data-fs-gift-wrapper] {
 }
 
 [data-fs-gift-icon] {

--- a/packages/ui/src/molecules/Gift/stories/Gift.mdx
+++ b/packages/ui/src/molecules/Gift/stories/Gift.mdx
@@ -12,7 +12,7 @@ import Gift from '../Gift'
 
 The `Gift` uses the [Compound Component](https://kentcdodds.com/blog/compound-components-with-react-hooks) pattern, its components are:
 
-- `Gift`: the wrapper component, it can receive a `Icon` prop and `aria-label` for the Icon.
+- `Gift`: the wrapper component, it can receive a `Icon` prop.
 - `GiftImage`: the component's that display the product image.
 - `GiftContent`: the component that can display the product's title, price, and a badge.
 

--- a/packages/ui/src/molecules/Gift/stories/Gift.mdx
+++ b/packages/ui/src/molecules/Gift/stories/Gift.mdx
@@ -1,0 +1,20 @@
+import { Canvas, Props, Story, ArgsTable } from '@storybook/addon-docs'
+
+import Gift from '../Gift'
+
+# Gift
+
+<Canvas>
+  <Story id="molecules-gift--gift" />
+</Canvas>
+
+## Props
+
+<ArgsTable of={Gift} />
+
+## CSS Selectors
+
+```css
+[data-fs-gift] {
+}
+```

--- a/packages/ui/src/molecules/Gift/stories/Gift.stories.tsx
+++ b/packages/ui/src/molecules/Gift/stories/Gift.stories.tsx
@@ -10,6 +10,21 @@ import GiftImage from '../GiftImage'
 import type { GiftProps } from '../Gift'
 import mdx from './Gift.mdx'
 
+const Tag = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+    <path fill="none" d="M0 0h256v256H0z" />
+    <path
+      d="M122.7 25.9 42 42l-16.1 80.7a8 8 0 0 0 2.2 7.2l104.4 104.4a7.9 7.9 0 0 0 11.3 0l90.5-90.5a7.9 7.9 0 0 0 0-11.3L129.9 28.1a8 8 0 0 0-7.2-2.2Z"
+      fill="none"
+      stroke="#000"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="16"
+    />
+    <circle cx="84" cy="84" r="12" />
+  </svg>
+)
+
 function useIntlFormatter(price: number) {
   return useMemo(() => {
     const formattedPrice = new Intl.NumberFormat('en-GB', {
@@ -22,7 +37,7 @@ function useIntlFormatter(price: number) {
 }
 
 const GiftTemplate: Story<GiftProps> = ({ testId }) => (
-  <GiftComponent testId={testId}>
+  <GiftComponent testId={testId} icon={<Tag />}>
     <GiftImage>
       <img
         alt="Aedle VK-1 L Headphone"

--- a/packages/ui/src/molecules/Gift/stories/Gift.stories.tsx
+++ b/packages/ui/src/molecules/Gift/stories/Gift.stories.tsx
@@ -1,0 +1,22 @@
+import type { Story, Meta } from '@storybook/react'
+import React from 'react'
+
+import type { GiftProps } from '../Gift'
+import Component from '../Gift'
+import mdx from './Gift.mdx'
+
+const GiftTemplate: Story<GiftProps> = ({ testId }) => (
+  <Component testId={testId}>Gift</Component>
+)
+
+export const Gift = GiftTemplate.bind({})
+Gift.storyName = 'Gift'
+
+export default {
+  title: 'Molecules/Gift',
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+} as Meta

--- a/packages/ui/src/molecules/Gift/stories/Gift.stories.tsx
+++ b/packages/ui/src/molecules/Gift/stories/Gift.stories.tsx
@@ -1,12 +1,42 @@
 import type { Story, Meta } from '@storybook/react'
-import React from 'react'
+import React, { useMemo } from 'react'
 
+import Badge from '../../../atoms/Badge/Badge'
+import Price from '../../../atoms/Price/Price'
+// Gift components
+import GiftComponent from '../Gift'
+import GiftContent from '../GiftContent'
+import GiftImage from '../GiftImage'
 import type { GiftProps } from '../Gift'
-import Component from '../Gift'
 import mdx from './Gift.mdx'
 
+function useIntlFormatter(price: number) {
+  return useMemo(() => {
+    const formattedPrice = new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(price)
+
+    return formattedPrice
+  }, [price])
+}
+
 const GiftTemplate: Story<GiftProps> = ({ testId }) => (
-  <Component testId={testId}>Gift</Component>
+  <GiftComponent testId={testId}>
+    <GiftImage>
+      <img
+        alt="Aedle VK-1 L Headphone"
+        src="https://assets.vtex.app/unsafe/1608x1206/center/middle/https%3A%2F%2Fstoreframework.vtexassets.com%2Farquivos%2Fids%2F190901%2Funsplash-headphone.jpg%3Fv%3D637800115948430000"
+      />
+    </GiftImage>
+    <GiftContent>
+      <h3>Get a pair of Aedle VK-1 L Headphone</h3>
+      <div>
+        <Price value={145} formatter={useIntlFormatter} />
+        <Badge>Free</Badge>
+      </div>
+    </GiftContent>
+  </GiftComponent>
 )
 
 export const Gift = GiftTemplate.bind({})


### PR DESCRIPTION
## What's the purpose of this pull request?

- Adds `Gift` component.

## How it works?

<!--- Tell us the role of the new feature, or component, in its context. --->

<img width="323" alt="image" src="https://user-images.githubusercontent.com/3356699/186891763-ce3382e0-b4e9-4957-a5d3-4db7cb05254a.png">

## How to test it?

Run `yarn storybook` locally and check the [Gift component page](http://localhost:6006/?path=/docs/molecules-gift--gift).

<img width="519" alt="image" src="https://user-images.githubusercontent.com/3356699/186904653-9bb132ce-b3b8-4f21-8e5a-efccdd8d6320.png">

### Starters Deploy Preview

[Gift - NextJS Storybook](https://nextjs-store-storybook-git-feat-fs-552-gift-component-faststore.vercel.app/?path=/docs/molecules-gift--default-story)

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

[FS - 552 Create Gift component](https://vtex-dev.atlassian.net/browse/FS-552?atlOrigin=eyJpIjoiYzc4ZThjZGQyMGYzNDRhNmJiOGRjODBmYmY4N2ZjYzgiLCJwIjoiaiJ9)
