### PR TITLE
feat: Cart with session info

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -208,6 +208,7 @@ export type MutationSubscribeToNewsletterArgs = {
 
 export type MutationValidateCartArgs = {
   cart: IStoreCart;
+  session?: Maybe<IStoreSession>;
 };
 
 
@@ -610,6 +611,8 @@ export type StoreProduct = {
   offers: StoreAggregateOffer;
   /** Product ID, such as [ISBN](https://www.isbn-international.org/content/what-isbn) or similar global IDs. */
   productID: Scalars['String'];
+  /** The product's release date. Formatted using https://en.wikipedia.org/wiki/ISO_8601 */
+  releaseDate: Scalars['String'];
   /** Array with review information. */
   review: Array<StoreReview>;
   /** Meta tag data. */

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -85,14 +85,16 @@ export const VtexCommerce = (
           }
         )
       },
-      shippingData: ({id, body}: {id: string, body: unknown}): Promise<OrderForm> => {
+      shippingData: (
+        { id, body }: { id: string; body: unknown },
+      ): Promise<OrderForm> => {
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm/${id}/attachments/shippingData`,
           {
-            ...BASE_INIT, 
-            body: JSON.stringify(body)
-          }
-        )
+            ...BASE_INIT,
+            body: JSON.stringify(body),
+          },
+        );
       },
       orderForm: ({
         id,

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -85,6 +85,15 @@ export const VtexCommerce = (
           }
         )
       },
+      shippingData: ({id, body}: {id: string, body: unknown}): Promise<OrderForm> => {
+        return fetchAPI(
+          `${base}/api/checkout/pub/orderForm/${id}/attachments/shippingData`,
+          {
+            ...BASE_INIT, 
+            body: JSON.stringify(body)
+          }
+        )
+      },
       orderForm: ({
         id,
         refreshOutdatedData = true,

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -228,10 +228,7 @@ export const validateCart = async (
     await commerce.checkout.shippingData({ 
       id: orderForm.orderFormId, 
       body: { 
-        selectedAddresses: [{ 
-          postalCode: session.postalCode, 
-          country: 'FRA' 
-        }]
+        selectedAddresses: [session]
       }
     })
   }

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -1,17 +1,14 @@
-import deepEquals from 'fast-deep-equal'
+import deepEquals from "fast-deep-equal";
 
-import { md5 } from '../utils/md5'
-import {
-  attachmentToPropertyValue,
-  getPropertyId,
-  VALUE_REFERENCES,
-} from '../utils/propertyValue'
+import { md5 } from "../utils/md5";
+import { attachmentToPropertyValue, getPropertyId, VALUE_REFERENCES } from "../utils/propertyValue";
 
 import type {
-  IStoreCart,
+
   IStoreOffer,
   IStoreOrder,
   IStorePropertyValue,
+  MutationValidateCartArgs,
 } from '../../../__generated__/schema'
 import type {
   OrderForm,
@@ -212,7 +209,7 @@ const isOrderFormStale = (form: OrderForm) => {
  */
 export const validateCart = async (
   _: unknown,
-  { cart: { order } }: { cart: IStoreCart },
+  { cart: { order }, session }: MutationValidateCartArgs,
   ctx: Context,
 ) => {
   const { enableOrderFormSync } = ctx.storage.flags
@@ -226,6 +223,18 @@ export const validateCart = async (
   const orderForm = await commerce.checkout.orderForm({
     id: orderNumber,
   })
+
+  if (session?.postalCode) {
+    await commerce.checkout.shippingData({ 
+      id: orderForm.orderFormId, 
+      body: { 
+        selectedAddresses: [{ 
+          postalCode: session.postalCode, 
+          country: 'FRA' 
+        }]
+      }
+    })
+  }
 
   // Step1.5: Check if another system changed the orderForm with this orderNumber
   // If so, this means the user interacted with this cart elsewhere and expects

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -1,7 +1,7 @@
-import deepEquals from "fast-deep-equal";
+import deepEquals from 'fast-deep-equal'
 
-import { md5 } from "../utils/md5";
-import { attachmentToPropertyValue, getPropertyId, VALUE_REFERENCES } from "../utils/propertyValue";
+import { md5 } from '../utils/md5'
+import { attachmentToPropertyValue, getPropertyId, VALUE_REFERENCES } from '../utils/propertyValue'
 
 import type {
   IStoreSession, 
@@ -205,10 +205,10 @@ const getOrderForm = async (
     id,
   });
 
-  const shouldUpdateShippiggData =
+  const shouldUpdateShippingData =
     orderForm.shippingData?.address?.postalCode != session?.postalCode;
 
-  if (shouldUpdateShippiggData) {
+  if (shouldUpdateShippingData) {
     return commerce.checkout.shippingData({
       id: orderForm.orderFormId,
       body: {

--- a/packages/api/src/typeDefs/mutation.graphql
+++ b/packages/api/src/typeDefs/mutation.graphql
@@ -2,7 +2,7 @@ type Mutation {
   """
   Checks for changes between the cart presented in the UI and the cart stored in the ecommerce platform. If changes are detected, it returns the cart stored on the platform. Otherwise, it returns `null`.
   """
-  validateCart(cart: IStoreCart!): StoreCart
+  validateCart(cart: IStoreCart!, session: IStoreSession): StoreCart
   """
   Updates a web session with the specified values.
   """


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR replicates session info on cart, making it possible for checkout to use the same zip code the user entered during the regionalization phase.
 
## How it works?
This PR adds a new argument to validateCart mutation called `session`. This is the same argument `validateSession` uses. With this info, we can use checkout's `addShippingAddress` mutation to add the user's session info to the orderForm, making:
1. Shopping flow consistent between storefront and checkout
2. Prices are regionalized 

## How to test it?
Open your favorite starter and
1. Open store.config and switch storeframework to casinofr account, and session to:
```
session: {
    currency: {
      code: 'EUR',
      symbol: '$',
    },
    locale: 'fr-FR',
    channel: '{"salesChannel":"1","regionId":""}',
    country: 'FRA',
    postalCode: null,
    person: null,
  },
```
2. Visit `/ananas-victoria-650g-gr_28267228-4/p`
3. Set the zip code to `34000`
4. Add the product to cart
5. Make sure you see the 0.98 offer on cart.

Replicating these steps before these changes would give you the wrong (unregionalized) price on cart of 2.8

### Starters Deploy Preview
- https://github.com/vtex-sites/nextjs.store/pull/218
- https://github.com/vtex-sites/gatsby.store/pull/190
