### PR TITLE
docs: Fix NextJS and Gatsby sections on using a GraphQL IDE

### DIFF
--- a/apps/docs/blog/2022-08-05-faststore.md
+++ b/apps/docs/blog/2022-08-05-faststore.md
@@ -33,7 +33,7 @@ The `search` query has been enhanced to allow cross-selling and upselling of pro
 
   The `PriceRange` component now displays the min/max values centered above the `Slider`'s thumbs and allows for more customizations.
 
-- 🐛  **`PriceRange` track position fixed** - [#1404](https://github.com/vtex/faststore/pull/1404)
+- 🐛 **`PriceRange` track position fixed** - [#1404](https://github.com/vtex/faststore/pull/1404)
 
   The track position of the `PriceRange` component has been adjusted for maximum absolute values greater than a hundred.
 
@@ -47,54 +47,56 @@ The `search` query has been enhanced to allow cross-selling and upselling of pro
 
   The `Slider` component now includes the `step` prop that allows specifying the interval between the input values.
 
-- 🐛  **`Slider` values are now rounded** - [#1417](https://github.com/vtex/faststore/pull/1417)
+- 🐛 **`Slider` values are now rounded** - [#1417](https://github.com/vtex/faststore/pull/1417)
   The `Slider` component now displays only rounded values.
 
-- 🐛  **`Slider` thumb elements repositioned** - [#1423](https://github.com/vtex/faststore/pull/1423)
+- 🐛 **`Slider` thumb elements repositioned** - [#1423](https://github.com/vtex/faststore/pull/1423)
 
   The `Slider` thumb elements' have been repositioned in the DOM so they can have customized behavior states.
 
 ## FastStore API
 
 - 🧹 **Generated schema types updated** - [#1413](https://github.com/vtex/faststore/pull/1413)/[#1431](https://github.com/vtex/faststore/pull/1431)
-  
+
   The generated TS types from the GraphQL schema have been updated.
 
 ### VTEX Platform
 
 - 🎉 **Support for Cross Selling now available** - [#1396](https://github.com/vtex/faststore/pull/1396)
-  
+
   The following facets have been added to the existing `Search` query in order to allow cross-selling and upselling products:
+
   - `buy`
   - `view`
   - `similars`
   - `viewAndBought`
   - `accessories`
-  - `suggestions` 
+  - `suggestions`
 
 - 🎉 **New `subscribeToNewsletter` mutation available** - [#1385](https://github.com/vtex/faststore/pull/1385)
-  
-  The new `subscribeToNewsletter` mutation allows stores to save data to their MasterData newsletter list.   
+
+  The new `subscribeToNewsletter` mutation allows stores to save data to their MasterData newsletter list.
 
 - 🎉 **New `skuSelector`-related properties added to `ProductGroup`** - [#1407](https://github.com/vtex/faststore/pull/1407)
 
-  The `ProductGroup` type now includes the `skuVariations` attribute, which brings with it four new properties: 
+  The `ProductGroup` type now includes the `skuVariations` attribute, which brings with it four new properties:
+
   - `allVariantsByName` - Returns all available options for each SKU variant property, indexed by their name.
   - `slugsMap` - Returns the slug for the SKU that matches the currently selected product variations.
-  - `activeVariations` - Returns the property values for the current SKU. 
+  - `activeVariations` - Returns the property values for the current SKU.
   - `availableVariations` - Returns the available options for each varying SKU property, considering the `dominantVariantName` property.
-  
+
   These new properties allow users to query data about SKU specification variants more quickly and are especially handy for implementing SKU Selector components.
-  
-- 🐛  **`StoreOffer` resolver fixed** - [#1399](https://github.com/vtex/faststore/pull/1399)
+
+- 🐛 **`StoreOffer` resolver fixed** - [#1399](https://github.com/vtex/faststore/pull/1399)
 
   The `priceCurrency` field from `StoreOffer` now grabs the same info from the current context's sales channel and fetches the correct price currency value.
 
 - 🐛 **Missing Catalog page types now available** - [#1411](https://github.com/vtex/faststore/pull/1411)
 
-  The FastStore API now supports the following page types: `SubCategory`, `Collection`, `Cluster`. This should enable stores to render pages that match those types without issues. 
+  The FastStore API now supports the following page types: `SubCategory`, `Collection`, `Cluster`. This should enable stores to render pages that match those types without issues.
 
-- 🐛  **Issues related to Collection pages fixed** - [#1429](https://github.com/vtex/faststore/pull/1429)
+- 🐛 **Issues related to Collection pages fixed** - [#1429](https://github.com/vtex/faststore/pull/1429)
 
   Issues when trying to fetch the `StoreCollection.breadcrumbList` field for Collection pages have been fixed. Before detecting the page type of a certain route, the `slufigyRoot` function now checks if the page is a Collection one.
 
@@ -119,13 +121,13 @@ The `search` query has been enhanced to allow cross-selling and upselling of pro
 - [Analytics on FastStore](/conceptual-guides/analytics-on-faststore) - [#1405](https://github.com/vtex/faststore/pull/1405)
 - [Analytics on official starters](/conceptual-guides/analytics-on-official-starters) - [#1405](https://github.com/vtex/faststore/pull/1405)
 
-**UI** 
+**UI**
 
 - [`AggregateRating`](/reference/ui/molecules/AggregateRating) - [#1395](https://github.com/vtex/faststore/pull/1395)
 
-**API** 
+**API**
 
-- [Using GraphiQL to explore the FastStore API](/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api) - [#1390](https://github.com/vtex/faststore/pull/1390)
+- [Using GraphiQL to explore the FastStore API](/how-to-guides/faststore-api/explore-the-faststore-api) - [#1390](https://github.com/vtex/faststore/pull/1390)
 - [Fetching API data on the storefront](/how-to-guides/faststore-api/fetching-api-data) - [#1403](https://github.com/vtex/faststore/pull/1403)
 
 **VTEX Headless CMS**
@@ -137,7 +139,7 @@ The `search` query has been enhanced to allow cross-selling and upselling of pro
 - [Configuring external DNS for a custom domain](how-to-guides/platform-integration/vtex/hosting-a-faststore-vtex-website) - [#1406](https://github.com/vtex/faststore/pull/1406)/[#1422](https://github.com/vtex/faststore/pull/1422)
 - [FasStore API overview](/reference/api/faststore-api) - [#1366](https://github.com/vtex/faststore/pull/1366)
 - [Extending the GraphQL schema](/how-to-guides/faststore-api/extending-the-faststore-api) - [#1416](https://github.com/vtex/faststore/pull/1416)
-- [Using GraphiQL to explore the FastStore API](/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api) - [#1428](https://github.com/vtex/faststore/pull/1428) / [#1432](https://github.com/vtex/faststore/pull/1432)
+- [Using GraphiQL to explore the FastStore API](/how-to-guides/faststore-api/explore-the-faststore-api) - [#1428](https://github.com/vtex/faststore/pull/1428) / [#1432](https://github.com/vtex/faststore/pull/1432)
 
 ## Internal
 

--- a/apps/docs/docs/how-to-guides/faststore-api/explore-the-faststore-api.mdx
+++ b/apps/docs/docs/how-to-guides/faststore-api/explore-the-faststore-api.mdx
@@ -2,10 +2,10 @@
 sidebar_position: 1
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
 
-# Using GraphiQL to explore the FastStore API
+# Using a GraphQL IDE to explore the FastStore API
 
 [GraphiQL](https://github.com/graphql/graphiql) is an Integrated Development Environment (IDE) for [GraphQL](https://graphql.org/). You can run GraphiQL on your browser to try out queries and mutations in a GraphQL API.
 
@@ -14,16 +14,19 @@ You can explore your store's GraphQL data layer by running a local server of you
 ## Getting started
 
 The first steps to getting GraphiQL up and running are different depending on the framework you are using on your project:
+
 - [Next.js](#nextjs)
 - [Gatsby](#gatsby)
 
 ### Gatsby
 
 Follow these steps to run a local server and access GraphiQL:
+
 1. Open the terminal and change to your FastStore project directory.
 2. Install dependencies by running the command `yarn`.
-1. Run the command `yarn develop`.
-2. Once the local server is up and running, access this address on your browser:
+3. Run the command `yarn develop`.
+4. Once the local server is up and running, access this address on your browser:
+
 ```
 http://localhost:8000/__graphql
 ```
@@ -37,18 +40,19 @@ If these steps do not work for you, you may not have the latest version of the `
 ### Next.js
 
 Follow these steps to run a local server and access GraphQL Playground:
+
 1. Clone the [graphql-playground repository](https://github.com/graphql/graphql-playground).
 2. Open the terminal and change to the `graphql-playground` root directory.
 3. Install dependencies by running the command `yarn`.
 4. Change the directory to the `packages/graphql-playground-react` folder.
 5. Run the command `yarn` to install dependencies.
-6. Run the command `yarn start` to start running `graphql-playground`. Once it is running, it will open a new browser tab with the `graphql-playground` interface on `http://localhost:3000/v2/new`. 
-![graphql playground interface with endpoint prompt](https://vtexhelp.vtexassets.com/assets/docs/src/7%20graphiql%20gatsby%20workaround___dc8d4ebfc6cd476bdea1c9d4c746b2d2.png)
+6. Run the command `yarn start` to start running `graphql-playground`. Once it is running, it will open a new browser tab with the `graphql-playground` interface on `http://localhost:3000/v2/new`.
+   ![graphql playground interface with endpoint prompt](https://vtexhelp.vtexassets.com/assets/docs/src/7%20graphiql%20gatsby%20workaround___dc8d4ebfc6cd476bdea1c9d4c746b2d2.png)
 7. Change the directory to the root of your FastStore project.
 8. Run the command `yarn develop`.
 9. Enter `http://localhost:3000/api/graphql` in the endpoint URL field.
 10. Click `USE ENDPOINT`.
-![graphql playground interface](https://vtexhelp.vtexassets.com/assets/docs/src/8%20graphiql%20gatsby%20workaround___7ce1dd5fcfcd3a3f844e4fad09288512.png)
+    ![graphql playground interface](https://vtexhelp.vtexassets.com/assets/docs/src/8%20graphiql%20gatsby%20workaround___7ce1dd5fcfcd3a3f844e4fad09288512.png)
 
 ## Building queries
 
@@ -76,7 +80,7 @@ Check your framework documentation and learn more about [how Gatsby deals with G
 
 You can click `QUERY VARIABLES` at the bottom of the screen to open another text box where you can organize the query variables in JSON format.
 
-Setting the **Query Variables** section is recommended when a query has multiple arguments. Inside the query/mutation parentheses, define the names and types of the variables. Note that the variable names must be preceded by a dollar sign (`$`). 
+Setting the **Query Variables** section is recommended when a query has multiple arguments. Inside the query/mutation parentheses, define the names and types of the variables. Note that the variable names must be preceded by a dollar sign (`$`).
 
 In the following example, `MyFirstQuery` accepts two variables: `$first` of type `Int` and `$after` of type `String`. The exclamation mark after the type indicates that the corresponding variable is required.
 
@@ -91,8 +95,8 @@ See an example of how to code this:
 <TabItem value="query" label="Query" default>
 
 ```graphql
-query ExampleWithVariables ($first: Int!, $after: String) {
-  allProducts (first: $first, after: $after) {
+query ExampleWithVariables($first: Int!, $after: String) {
+  allProducts(first: $first, after: $after) {
     edges {
       node {
         name
@@ -129,6 +133,6 @@ VTEX is continuously working to ensure that the FastStore API types and fields a
 
 ## Checking your query history
 
- The **History** panel provides a list of all previously executed queries. Click the query summary presented on the **History** panel to view it in the editor.
+The **History** panel provides a list of all previously executed queries. Click the query summary presented on the **History** panel to view it in the editor.
 
 ![graphiql history](https://vtexhelp.vtexassets.com/assets/docs/src/te6%20graphiql%20jun2022___c6de0eb13aa2c21637def56f3be650b4.png)

--- a/apps/docs/docs/how-to-guides/faststore-api/explore-the-faststore-api.mdx
+++ b/apps/docs/docs/how-to-guides/faststore-api/explore-the-faststore-api.mdx
@@ -13,7 +13,7 @@ There are different GraphQL IDEs you can use. In this tutorial, you will learn h
 
 ## Getting started
 
-To use a GraphQL playground, you must run your project in a local server and use the local GraphQL path in your GraphQL IDE of choice. Follow the steps below to do this with [graphql-playground](https://github.com/graphql/graphql-playground):
+To use a GraphQL playground, you must run your project in a local server and use the local GraphQL path in your GraphQL IDE of choice. Follow the steps below:
 
 1. Clone the [graphql-playground repository](https://github.com/graphql/graphql-playground).
 2. Open the terminal and change to the `graphql-playground` root directory.
@@ -49,7 +49,7 @@ In the following example, `MyFirstQuery` accepts two variables: `$first` of type
 
 Create a JSON object on the Query Variables pane with your variable names and values as key-value pairs.
 
-See an example of how to code this:
+See this code example:
 
 <Tabs>
 

--- a/apps/docs/docs/how-to-guides/faststore-api/explore-the-faststore-api.mdx
+++ b/apps/docs/docs/how-to-guides/faststore-api/explore-the-faststore-api.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem'
 
 You can use [GraphQL](https://graphql.org/) Integrated Development Environments (IDEs) to try out queries and mutations. This means you can explore your store's GraphQL data layer by running a local server of your project.
 
-There are different GraphQL IDEs you can use. In this tutorial, you will learn how to use [graphql-playground](https://github.com/graphql/graphql-playground), but feel free to use another one.
+There are different GraphQL IDEs you can use. In this tutorial, you will learn how to use [graphql-playground](https://github.com/graphql/graphql-playground), but feel free to use another one. It is likely that other IDEs also contain most features described below.
 
 ## Getting started
 

--- a/apps/docs/docs/how-to-guides/faststore-api/explore-the-faststore-api.mdx
+++ b/apps/docs/docs/how-to-guides/faststore-api/explore-the-faststore-api.mdx
@@ -7,39 +7,13 @@ import TabItem from '@theme/TabItem'
 
 # Using a GraphQL IDE to explore the FastStore API
 
-[GraphiQL](https://github.com/graphql/graphiql) is an Integrated Development Environment (IDE) for [GraphQL](https://graphql.org/). You can run GraphiQL on your browser to try out queries and mutations in a GraphQL API.
+You can use [GraphQL](https://graphql.org/) Integrated Development Environments (IDEs) to try out queries and mutations. This means you can explore your store's GraphQL data layer by running a local server of your project.
 
-You can explore your store's GraphQL data layer by running a local server of your project.
+There are different GraphQL IDEs you can use. In this tutorial, you will learn how to use [graphql-playground](https://github.com/graphql/graphql-playground), but feel free to use another one.
 
 ## Getting started
 
-The first steps to getting GraphiQL up and running are different depending on the framework you are using on your project:
-
-- [Next.js](#nextjs)
-- [Gatsby](#gatsby)
-
-### Gatsby
-
-Follow these steps to run a local server and access GraphiQL:
-
-1. Open the terminal and change to your FastStore project directory.
-2. Install dependencies by running the command `yarn`.
-3. Run the command `yarn develop`.
-4. Once the local server is up and running, access this address on your browser:
-
-```
-http://localhost:8000/__graphql
-```
-
-![graphiql home](https://vtexhelp.vtexassets.com/assets/docs/src/_te1%20graphiql%20jun2022___94e3a61397f80a3dae952941d2bb32cc.png)
-
-:::caution
-If these steps do not work for you, you may not have the latest version of the `@faststore/api` dependency installed. You can reinstall it by running the command `yarn` in your project.
-:::
-
-### Next.js
-
-Follow these steps to run a local server and access GraphQL Playground:
+To use a GraphQL playground, you must run your project in a local server and use the local GraphQL path in your GraphQL IDE of choice. Follow the steps below to do this with [graphql-playground](https://github.com/graphql/graphql-playground):
 
 1. Clone the [graphql-playground repository](https://github.com/graphql/graphql-playground).
 2. Open the terminal and change to the `graphql-playground` root directory.
@@ -50,7 +24,10 @@ Follow these steps to run a local server and access GraphQL Playground:
    ![graphql playground interface with endpoint prompt](https://vtexhelp.vtexassets.com/assets/docs/src/7%20graphiql%20gatsby%20workaround___dc8d4ebfc6cd476bdea1c9d4c746b2d2.png)
 7. Change the directory to the root of your FastStore project.
 8. Run the command `yarn develop`.
-9. Enter `http://localhost:3000/api/graphql` in the endpoint URL field.
+9. Enter your local GraphQL path in the endpoint URL field.
+
+It is probably `http://localhost:3000/api/graphql` if you are running a [nextjs.store](https://github.com/vtex-sites/nextjs.store) based project and `http://localhost:8000/api/graphql` if your store is based on the [gatsby.store](https://github.com/vtex-sites/gatsby.store).
+
 10. Click `USE ENDPOINT`.
     ![graphql playground interface](https://vtexhelp.vtexassets.com/assets/docs/src/8%20graphiql%20gatsby%20workaround___7ce1dd5fcfcd3a3f844e4fad09288512.png)
 
@@ -58,22 +35,8 @@ Follow these steps to run a local server and access GraphQL Playground:
 
 You can use the text box on the left side to type queries and mutations. When you are done, click the <img alt="Execute query" className="inline w-6" src="https://vtexhelp.vtexassets.com/assets/docs/src/executeQuery___7272503777684ec305975f94ff9f3698.png"/> **Execute Query** button or press `Ctrl + Enter` to submit your request.
 
-![graphiql query](https://vtexhelp.vtexassets.com/assets/docs/src/t2%20graphiql%20jun2022___6d2398d64e34bdacd154f807df1ddf97.png)
-
 :::info
-If you are not sure what arguments or fields are allowed or required by some query, press `Ctrl + space` to use autocomplete. It will show you all the available options. You can also use the `Explorer` tab. Learn more about it in [Exploring queries interactively](#exploring-queries-interactively).
-:::
-
-## Exploring queries interactively
-
-Click the `Explorer` button to open the GraphiQL Explorer and tick the desired fields and inputs to build queries interactively. By doing so, you may avoid the repetitive process of manually inputting these values.
-
-![graphiql explorer](https://vtexhelp.vtexassets.com/assets/docs/src/_te3%20graphiql%20jun2022___1ecd4aa2fb20395eb6262e704ef48268.png)
-
-:::caution
-Note that the FastStore API extends the data layer provided by the framework you use (e.g., Gatsby, Next.js). This data layer may contain many other types and fields that are displayed in GraphiQL. To know what elements are actually part of the FastStore API, check the reference docs for [queries](https://www.faststore.dev/reference/api/queries) or [mutations](https://www.faststore.dev/reference/api/mutations).
-
-Check your framework documentation and learn more about [how Gatsby deals with GraphQL query options](https://www.gatsbyjs.com/docs/graphql-reference/) or [Data fetching in Next.js](https://nextjs.org/docs/basic-features/data-fetching/overview).
+If you are not sure what arguments or fields are allowed or required by some query, press `Ctrl + space` to use autocomplete. It will show you all the available options.
 :::
 
 ## Passing arguments
@@ -86,8 +49,6 @@ In the following example, `MyFirstQuery` accepts two variables: `$first` of type
 
 Create a JSON object on the Query Variables pane with your variable names and values as key-value pairs.
 
-![graphiql variables](https://vtexhelp.vtexassets.com/assets/docs/src/_te4%20graphiql%20jun2022___9134ece78377ac52bf839486d0de9aa9.png)
-
 See an example of how to code this:
 
 <Tabs>
@@ -95,7 +56,7 @@ See an example of how to code this:
 <TabItem value="query" label="Query" default>
 
 ```graphql
-query ExampleWithVariables($first: Int!, $after: String) {
+query `MyFirstQuery`($first: Int!, $after: String) {
   allProducts(first: $first, after: $after) {
     edges {
       node {
@@ -125,14 +86,10 @@ query ExampleWithVariables($first: Int!, $after: String) {
 
 You can also learn more about the types and fields available by opening up the `DOCS` tab in the upper right corner. There you can search or browse through FastStore API queries, mutations and types in order to read the corresponding descriptions.
 
-![graphiql docs](https://vtexhelp.vtexassets.com/assets/docs/src/_te5%20graphiql%20jun2022___1040a138b8450b6be3d6e3765ac46289.png)
-
 :::caution
-VTEX is continuously working to ensure that the FastStore API types and fields are documented and available via GraphiQL. However, other APIs and frameworks (e.g., Gatsby, Next.js) may not necessarily be documented this way.
+VTEX is continuously working to ensure that the FastStore API types and fields are documented and available via GraphQL IDEs. However, other APIs and frameworks (e.g., Gatsby, Next.js) may not necessarily be documented this way.
 :::
 
 ## Checking your query history
 
 The **History** panel provides a list of all previously executed queries. Click the query summary presented on the **History** panel to view it in the editor.
-
-![graphiql history](https://vtexhelp.vtexassets.com/assets/docs/src/te6%20graphiql%20jun2022___c6de0eb13aa2c21637def56f3be650b4.png)

--- a/apps/docs/docs/how-to-guides/faststore-api/extending-the-faststore-api.md
+++ b/apps/docs/docs/how-to-guides/faststore-api/extending-the-faststore-api.md
@@ -7,7 +7,7 @@ For those cases, it is possible to extend the FastStore API schema, adding new d
 In this guide you will learn how to implement this in your project. You can also view a [summary](#summary) of the expected behavior and a [complete code example](#complete-code-example).
 
 :::info
-Once you have implemented the schema extension in your code, you can run a local [test with GraphiQL](/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api).
+Once you have implemented the schema extension in your code, you can run a local [test with a GraphQL IDE](/how-to-guides/faststore-api/explore-the-faststore-api).
 :::
 
 ## Step by step
@@ -249,4 +249,4 @@ const getEnvelop = async () =>
 
 ## Summary
 
-After completing the steps above, the FastStore GraphQL API schema of your project will be extended and you will be able to use your custom API fields in your store. See these other guides to learn how to [test your schema using GraphiQL](/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api) and [fetch API information in your storefront](/how-to-guides/faststore-api/fetching-api-data).
+After completing the steps above, the FastStore GraphQL API schema of your project will be extended and you will be able to use your custom API fields in your store. See these other guides to learn how to [test your schema using a GraphQL IDE](/how-to-guides/faststore-api/explore-the-faststore-api) and [fetch API information in your storefront](/how-to-guides/faststore-api/fetching-api-data).

--- a/apps/docs/docs/how-to-guides/faststore-api/fetching-api-data.mdx
+++ b/apps/docs/docs/how-to-guides/faststore-api/fetching-api-data.mdx
@@ -1,5 +1,5 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
 
 # Fetching API data on the storefront
 
@@ -14,6 +14,7 @@ The FastStore API extends the data layer of your preferred static site generatio
 This means that updating a given product's information on your ecommerce platform does not automatically update the information displayed on a previously built product page. Whenever you wish to update the information displayed on your website according to your ecommerce platform data, you should redeploy your website, which will trigger page re-generation.
 
 We also recommend that you take the time to learn more about data fetching in the context of the framework you are using, by checking the corresponding article:
+
 - [Next.js Data fetching overview](https://nextjs.org/docs/basic-features/data-fetching/overview)
 - [Querying data in pages with Gatsby](https://www.gatsbyjs.com/docs/how-to/querying-data/page-query/)
 
@@ -29,7 +30,7 @@ Below you can see more details about each step along with code examples.
 
 ### 1. Building a query
 
-First, you need to know what API data you want to use on your page and how to structure a GraphQL query to get it. It is a good idea to check the [FastStore API reference on queries](https://www.faststore.dev/reference/api/queries). You can also [use GraphiQL to build and test queries](https://www.faststore.dev/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api) to make sure it works as expected.
+First, you need to know what API data you want to use on your page and how to structure a GraphQL query to get it. It is a good idea to check the [FastStore API reference on queries](https://www.faststore.dev/reference/api/queries). You can also [use a GraphQL IDE to build and test queries](https://www.faststore.dev/how-to-guides/faststore-api/explore-the-faststore-api) to make sure it works as expected.
 
 Once you have your query structure, you can pass that as a variable on your code by using the `gql` tag, like in the example below.
 
@@ -61,6 +62,7 @@ const query = gql`
 Queries must be declared in this way on each page on which you wish to use their data. To reuse query snippets across multiple files, you may use [GraphQL fragments](https://graphql.org/learn/queries/#fragments). In the example below you can see an SEO fragment being used to build the same query as the example above.
 
 Declaring the fragment:
+
 ```javascript
 import { gql } from '@faststore/graphql-utils'
 ...
@@ -76,6 +78,7 @@ export const fragment = gql`
 ```
 
 Using the fragment, on the same file or a different one:
+
 ```javascript
 import { gql } from '@faststore/graphql-utils'
 ...
@@ -258,6 +261,7 @@ export const querySSR = gql`
 ### 2. Importing the generated query
 
 Once you have declared your query on the page code, you can trigger the generation of your query types by running this command:
+
 ```
 yarn generate
 ```
@@ -267,6 +271,7 @@ Whenever you make changes to your declared queries you must regenerate the types
 :::
 
 Then you must import the types generated, like in this example:
+
 ```javascript
 import { gql } from '@faststore/graphql-utils'
 import type { ProductPageQueryQuery } from '@generated/graphql'
@@ -307,9 +312,10 @@ After completing the steps described above, your code should look like the examp
 
 :::info
 It is also a good idea to see how data fetching is implemented in pages from [FastStore starters](https://www.faststore.dev/starters), such as:
+
 - [Next.js store product page](https://github.com/vtex-sites/nextjs.store/blob/main/src/pages/%5Bslug%5D/p.tsx)
 - [Gatsby store product page](https://github.com/vtex-sites/gatsby.store/blob/main/src/pages/%5Bslug%5D/p.tsx)
-:::
+  :::
 
 ```javascript
 import { gql } from '@faststore/graphql-utils'
@@ -347,5 +353,3 @@ const query = gql`
   }
 `
 ```
-
-

--- a/apps/docs/docs/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api.mdx
+++ b/apps/docs/docs/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api.mdx
@@ -46,7 +46,7 @@ Follow these steps to run a local server and access GraphQL Playground:
 ![graphql playground interface with endpoint prompt](https://vtexhelp.vtexassets.com/assets/docs/src/7%20graphiql%20gatsby%20workaround___dc8d4ebfc6cd476bdea1c9d4c746b2d2.png)
 7. Change the directory to the root of your FastStore project.
 8. Run the command `yarn develop`.
-9. Enter `http://localhost:8000/api/graphql` in the endpoint URL field.
+9. Enter `http://localhost:3000/api/graphql` in the endpoint URL field.
 10. Click `USE ENDPOINT`.
 ![graphql playground interface](https://vtexhelp.vtexassets.com/assets/docs/src/8%20graphiql%20gatsby%20workaround___7ce1dd5fcfcd3a3f844e4fad09288512.png)
 

--- a/apps/docs/docs/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api.mdx
+++ b/apps/docs/docs/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api.mdx
@@ -17,7 +17,7 @@ The first steps to getting GraphiQL up and running are different depending on th
 - [Next.js](#nextjs)
 - [Gatsby](#gatsby)
 
-### Next.js
+### Gatsby
 
 Follow these steps to run a local server and access GraphiQL:
 1. Open the terminal and change to your FastStore project directory.
@@ -34,7 +34,7 @@ http://localhost:8000/__graphql
 If these steps do not work for you, you may not have the latest version of the `@faststore/api` dependency installed. You can reinstall it by running the command `yarn` in your project.
 :::
 
-### Gatsby
+### Next.js
 
 Follow these steps to run a local server and access GraphiQL:
 1. Clone the [graphql-playground repository](https://github.com/graphql/graphql-playground).

--- a/apps/docs/docs/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api.mdx
+++ b/apps/docs/docs/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api.mdx
@@ -5,15 +5,15 @@ sidebar_position: 1
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Using a GraphQL IDE to explore the FastStore API
+# Using GraphiQL to explore the FastStore API
 
-[GraphiQL](https://github.com/graphql/graphiql) and [GraphQL Playground](https://github.com/graphql/graphql-playground) are an Integrated Development Environment (IDE) for [GraphQL](https://graphql.org/). You can run them on your browser to try out queries and mutations in a GraphQL API.
+[GraphiQL](https://github.com/graphql/graphiql) is an Integrated Development Environment (IDE) for [GraphQL](https://graphql.org/). You can run GraphiQL on your browser to try out queries and mutations in a GraphQL API.
 
 You can explore your store's GraphQL data layer by running a local server of your project.
 
 ## Getting started
 
-The first steps to getting them up and running are different depending on the framework you are using on your project:
+The first steps to getting GraphiQL up and running are different depending on the framework you are using on your project:
 - [Next.js](#nextjs)
 - [Gatsby](#gatsby)
 

--- a/apps/docs/docs/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api.mdx
+++ b/apps/docs/docs/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api.mdx
@@ -36,7 +36,7 @@ If these steps do not work for you, you may not have the latest version of the `
 
 ### Next.js
 
-Follow these steps to run a local server and access GraphiQL:
+Follow these steps to run a local server and access GraphQL Playground:
 1. Clone the [graphql-playground repository](https://github.com/graphql/graphql-playground).
 2. Open the terminal and change to the `graphql-playground` root directory.
 3. Install dependencies by running the command `yarn`.

--- a/apps/docs/docs/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api.mdx
+++ b/apps/docs/docs/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api.mdx
@@ -5,15 +5,15 @@ sidebar_position: 1
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Using GraphiQL to explore the FastStore API
+# Using a GraphQL IDE to explore the FastStore API
 
-[GraphiQL](https://github.com/graphql/graphiql) is an Integrated Development Environment (IDE) for [GraphQL](https://graphql.org/). You can run GraphiQL on your browser to try out queries and mutations in a GraphQL API.
+[GraphiQL](https://github.com/graphql/graphiql) and [GraphQL Playground](https://github.com/graphql/graphql-playground) are an Integrated Development Environment (IDE) for [GraphQL](https://graphql.org/). You can run them on your browser to try out queries and mutations in a GraphQL API.
 
 You can explore your store's GraphQL data layer by running a local server of your project.
 
 ## Getting started
 
-The first steps to getting GraphiQL up and running are different depending on the framework you are using on your project:
+The first steps to getting them up and running are different depending on the framework you are using on your project:
 - [Next.js](#nextjs)
 - [Gatsby](#gatsby)
 


### PR DESCRIPTION
## What's the purpose of this pull request?

The section names were inverted. Only Gatsby provides **GraphiQL** to explore the API via http://localhost:8000/__graphql. Our NextJS starter doesn't provide something similar, so the section about using **GraphQL Playground** is more suitable for it. 

I also suggested renaming the title to "GraphQL IDEs" instead of just "GraphiQL" because the latter is only used in Gatsby. 

@vtex/tech-writers feel free to revert/undo/add changes!

Before|After
-|-
[Link](https://faststore-git-docs-improvementextending-schema-ad066c-faststore.vercel.app/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api)|[Link](https://faststore-git-docs-graphql-ide-faststore.vercel.app/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api)

## References

- https://www.faststore.dev/how-to-guides/faststore-api/using-graphiql-to-explore-the-faststore-api
- https://github.com/vtex/faststore/pull/1428/