### PR TITLE
Docs/api guides release note

### DIFF
--- a/apps/docs/blog/2022-09-01-faststore.md
+++ b/apps/docs/blog/2022-09-01-faststore.md
@@ -15,6 +15,6 @@ There are new and improved FastStore API guides available on our [documentation 
 
 Previously, the [GraphQL IDE guide](/how-to-guides/faststore-api/explore-the-faststore-api) focused on GraphiQL. However, GraphiQL is not natively supported by the [Base Store starters](/starters/base) anymore.
 
-Now, you can still run your FastStore project locally and, although the new guide contains specific instructions for using [graphql-playground](https://github.com/graphql/graphql-playground), you may use your prefered GraphQL IDE.
+Now, you can still run your FastStore project locally and, although the new guide contains specific instructions for using [graphql-playground](https://github.com/graphql/graphql-playground), you may use your preferred GraphQL IDE.
 
 Also, now you can find more precise instructions and code examples of how to use the FastStore API in your storefront with the guides [Fetching API data on the storefront](/how-to-guides/faststore-api/fetching-api-data) and [Extending the GraphQL schema](/how-to-guides/faststore-api/extending-the-faststore-api).

--- a/apps/docs/blog/2022-09-01-faststore.md
+++ b/apps/docs/blog/2022-09-01-faststore.md
@@ -1,0 +1,20 @@
+---
+description: New and improved FastStore API guides available
+tags: [faststore]
+---
+
+# New and improved FastStore API guides
+
+There are new and improved FastStore API guides available on our [documentation portal](/docs):
+
+- [Using a GraphQL IDE to explore the FastStore API](/how-to-guides/faststore-api/explore-the-faststore-api)
+- [Fetching API data on the storefront](/how-to-guides/faststore-api/fetching-api-data)
+- [Extending the GraphQL schema](/how-to-guides/faststore-api/extending-the-faststore-api)
+
+## What has changed?
+
+Previously, the [GraphQL IDE guide](/how-to-guides/faststore-api/explore-the-faststore-api) focused on GraphiQL. However, GraphiQL is not natively supported by the [Base Store starters](/starters/base) anymore.
+
+Now, you can still run your FastStore project locally and, although the new guide contains specific instructions for using [graphql-playground](https://github.com/graphql/graphql-playground), you may use your prefered GraphQL IDE.
+
+Also, now you can find more precise instructions and code examples of how to use the FastStore API in your storefront with the guides [Fetching API data on the storefront](/how-to-guides/faststore-api/fetching-api-data) and [Extending the GraphQL schema](/how-to-guides/faststore-api/extending-the-faststore-api).

--- a/apps/docs/blog/2022-09-01-faststore.md
+++ b/apps/docs/blog/2022-09-01-faststore.md
@@ -17,4 +17,4 @@ Previously, the [GraphQL IDE guide](/how-to-guides/faststore-api/explore-the-fas
 
 Now, you can still run your FastStore project locally and, although the new guide contains specific instructions for using [graphql-playground](https://github.com/graphql/graphql-playground), you may use your preferred GraphQL IDE.
 
-Also, now you can find more precise instructions and code examples of how to use the FastStore API in your storefront with the guides [Fetching API data on the storefront](/how-to-guides/faststore-api/fetching-api-data) and [Extending the GraphQL schema](/how-to-guides/faststore-api/extending-the-faststore-api).
+In addition, now you can find more precise instructions and code examples of how to use the FastStore API in your storefront with the guides [Fetching API data on the storefront](/how-to-guides/faststore-api/fetching-api-data) and [Extending the GraphQL schema](/how-to-guides/faststore-api/extending-the-faststore-api).

--- a/apps/docs/static/data/releases.json
+++ b/apps/docs/static/data/releases.json
@@ -1,5 +1,11 @@
 [
   {
+    "title": "New and improved FastStore API guides",
+    "product": "FastStore",
+    "fileName": "2022-09-01-faststore",
+    "description": "There are new and improved guides available on our documentation portal."
+  },
+  {
     "title": "FastStore - July, 2022",
     "product": "FastStore",
     "fileName": "2022-08-05-faststore",
@@ -10,11 +16,5 @@
     "product": "WebOps",
     "fileName": "2022-07-19-webops",
     "description": "To go live, FastStore projects developed with Gatsby 4 and Next.js require a new environment variable."
-  },
-  {
-    "title": "Base Store - June, 2022",
-    "product": "Base Store",
-    "fileName": "2022-07-01-basestore",
-    "description": "PLPs now support price range filtering, and nonexistent PDPs can now handle 404 errors. Also, more components have been updated to conform to the new Base Store Theming architecture."
   }
 ]

--- a/apps/docs/static/data/releases.json
+++ b/apps/docs/static/data/releases.json
@@ -3,7 +3,7 @@
     "title": "New and improved FastStore API guides",
     "product": "FastStore",
     "fileName": "2022-09-01-faststore",
-    "description": "There are new and improved guides available on our documentation portal."
+    "description": "There are new and improved FastStore API guides available on our documentation portal."
   },
   {
     "title": "FastStore - July, 2022",


### PR DESCRIPTION
## What's the purpose of this pull request?
Creating a release note for the new and improved FastStore API guides:
- [Using a GraphQL IDE to explore the FastStore API](/how-to-guides/faststore-api/explore-the-faststore-api)
- [Fetching API data on the storefront](/how-to-guides/faststore-api/fetching-api-data)

## [Preview](https://faststore-8ueiihn82-faststore.vercel.app/releases)
- [Extending the GraphQL schema](/how-to-guides/faststore-api/extending-the-faststore-api)

