### PR TITLE
docs: Favor the Admin app over the CLI to setup FastStore

### DIFF
--- a/apps/docs/docs/how-to-guides/platform-integration/vtex/setting-up-an-account.md
+++ b/apps/docs/docs/how-to-guides/platform-integration/vtex/setting-up-an-account.md
@@ -33,4 +33,4 @@ In this step by step, you'll install the FastStore Admin app in your account via
 
 2. Open the Admin app at `https://{workspace}--{account}.myvtex.com/admin/faststore` and follow the setup steps.
 
-Once the setup completes, all dependencies needed for developing a FastStore website will have been created: `Happy coding on FastStore 🎉`.
+Once the setup completes, all dependencies needed for developing a FastStore website will have been installed: `Happy coding on FastStore 🎉`.

--- a/apps/docs/docs/how-to-guides/platform-integration/vtex/setting-up-an-account.md
+++ b/apps/docs/docs/how-to-guides/platform-integration/vtex/setting-up-an-account.md
@@ -23,26 +23,14 @@ Before proceeding any further, make sure you have:
 
 ## Step by step
 
-In this step by step, you'll use the FastStore plugin for the VTEX IO CLI to install, with a single command, all dependencies needed for developing a FastStore website.
+In this step by step, you'll install the FastStore Admin app in your account via the VTEX IO CLI.
 
-1. Install the FastStore plugin for the VTEX IO CLI:
-
-   ```
-   vtex plugins install faststore
-   ```
-
-2. Log in to your VTEX account:
-
-   - _Remember to replace the values between curly brackets according to your scenario._
+1. Install the FastStore Admin app in your account:
 
    ```
-   vtex login {account}
+   vtex install vtex.admin-faststore
    ```
 
-3. Set up your VTEX account for FastStore by running the following command:
+2. Open the Admin app at `https://{workspace}--{account}.myvtex.com/admin/faststore` and follow the setup steps.
 
-   ```
-   vtex faststore setup
-   ```
-
-Once the command completes, you should see the following message: `Happy coding on FastStore 🎉`.
+Once the setup completes, all dependencies needed for developing a FastStore website will have been created: `Happy coding on FastStore 🎉`.


### PR DESCRIPTION
## What's the purpose of this pull request?

Recently we've developed an Admin app for FastStore called `vtex.admin-faststore` that helps set up the store and all its dependencies. We decided to favor installing this app and going through the setup via Admin over using the CLI plugin. This is an initial attempt to update the documentation with this information.

## References

- [Internal] https://vtex-dev.atlassian.net/browse/EDU-7605