### PR TITLE
feat: Adds OrderSummary component to FastStore UI

### DIFF
--- a/packages/styles/src/molecules/index.css
+++ b/packages/styles/src/molecules/index.css
@@ -20,3 +20,4 @@
 @import './search-input.css';
 @import './table.css';
 @import './product-title.css';
+@import './order-summary.css';

--- a/packages/styles/src/molecules/index.css
+++ b/packages/styles/src/molecules/index.css
@@ -12,12 +12,12 @@
 @import './icon-button.css';
 @import './loading-button.css';
 @import './modal.css';
+@import './order-summary.css';
 @import './payment-methods.css';
 @import './price-range.css';
 @import './product-card.css';
+@import './product-title.css';
 @import './quantity-selector.css';
 @import './radio-group.css';
 @import './search-input.css';
 @import './table.css';
-@import './product-title.css';
-@import './order-summary.css';

--- a/packages/styles/src/molecules/order-summary.css
+++ b/packages/styles/src/molecules/order-summary.css
@@ -1,0 +1,18 @@
+[data-fs-order-summary] {
+  padding: 1rem;
+}
+
+[data-fs-order-summary] > li {
+  display: flex;
+  justify-content: space-between;
+  line-height: 1.5;
+}
+
+[data-fs-order-summary] > li[data-fs-order-summary-discount] {
+  color: #1e493b;
+}
+
+[data-fs-order-summary-total] {
+  font-size: 20px;
+  font-weight: 700;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -64,6 +64,9 @@ export type {
 export { default as ProductTitle } from './molecules/ProductTitle'
 export type { ProductTitleProps } from './molecules/ProductTitle'
 
+export { default as OrderSummary } from './molecules/OrderSummary'
+export type { OrderSummaryProps } from './molecules/OrderSummary'
+
 export { default as AggregateRating } from './molecules/AggregateRating'
 export type { AggregateRatingProps } from './molecules/AggregateRating'
 

--- a/packages/ui/src/molecules/OrderSummary/OrderSummary.test.tsx
+++ b/packages/ui/src/molecules/OrderSummary/OrderSummary.test.tsx
@@ -7,7 +7,7 @@ import OrderSummary from './OrderSummary'
 const ELEMENT_NOT_FOUND_MESSAGE = 'Unable to find an element by:'
 
 describe('OrderSummary', () => {
-  it('should have `data-store-order-summary` attribute', () => {
+  it('should have `data-fs-order-summary` attribute', () => {
     const { getByTestId } = render(<OrderSummary />)
 
     expect(getByTestId('store-order-summary')).toHaveAttribute(

--- a/packages/ui/src/molecules/OrderSummary/OrderSummary.test.tsx
+++ b/packages/ui/src/molecules/OrderSummary/OrderSummary.test.tsx
@@ -1,0 +1,103 @@
+import { render } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import React from 'react'
+
+import OrderSummary from './OrderSummary'
+
+const ELEMENT_NOT_FOUND_MESSAGE = 'Unable to find an element by:'
+
+describe('OrderSummary', () => {
+  it('should have `data-store-order-summary` attribute', () => {
+    const { getByTestId } = render(<OrderSummary />)
+
+    expect(getByTestId('store-order-summary')).toHaveAttribute(
+      'data-fs-order-summary'
+    )
+  })
+
+  it('should always render total labels and values elements', async () => {
+    const { getByTestId } = render(<OrderSummary />)
+
+    expect(getByTestId('store-order-summary-total-label')).toBeInTheDocument()
+    expect(getByTestId('store-order-summary-total-value')).toBeInTheDocument()
+  })
+
+  it('should not render subtotal or discount labels and values if subtotalValue or discountValue are not provided', async () => {
+    const { getByTestId } = render(
+      <OrderSummary totalLabel="Total" totalValue="250$" />
+    )
+
+    expect(() =>
+      getByTestId('store-order-summary-subtotal-label')
+    ).toThrowError(ELEMENT_NOT_FOUND_MESSAGE)
+    expect(() => getByTestId('store-order-summary-subtotal-value')).toThrow(
+      ELEMENT_NOT_FOUND_MESSAGE
+    )
+
+    expect(() => getByTestId('store-order-summary-discount-label')).toThrow(
+      ELEMENT_NOT_FOUND_MESSAGE
+    )
+    expect(() => getByTestId('store-order-summary-discount-value')).toThrow(
+      ELEMENT_NOT_FOUND_MESSAGE
+    )
+  })
+
+  it('should render subtotal label and value if subtotalValue is provided', async () => {
+    const { getByTestId } = render(
+      <OrderSummary
+        subtotalLabel="Subtotal"
+        totalLabel="Total"
+        subtotalValue="300$"
+        totalValue="250$"
+      />
+    )
+
+    expect(
+      getByTestId('store-order-summary-subtotal-label')
+    ).toBeInTheDocument()
+    expect(getByTestId('store-order-summary-subtotal-label')).toHaveTextContent(
+      'Subtotal'
+    )
+
+    expect(
+      getByTestId('store-order-summary-subtotal-value')
+    ).toBeInTheDocument()
+    expect(getByTestId('store-order-summary-subtotal-value')).toHaveTextContent(
+      '300$'
+    )
+  })
+
+  it('should render discount label and value if discountValue is provided', async () => {
+    const { getByTestId } = render(
+      <OrderSummary
+        subtotalLabel="Subtotal"
+        totalLabel="Total"
+        subtotalValue="300$"
+        totalValue="250$"
+        discountLabel="Discount"
+        discountValue="-50$"
+      />
+    )
+
+    expect(
+      getByTestId('store-order-summary-discount-label')
+    ).toBeInTheDocument()
+    expect(getByTestId('store-order-summary-discount-label')).toHaveTextContent(
+      'Discount'
+    )
+    expect(
+      getByTestId('store-order-summary-discount-value')
+    ).toBeInTheDocument()
+    expect(getByTestId('store-order-summary-discount-value')).toHaveTextContent(
+      '-50$'
+    )
+  })
+
+  describe('Accessibility', () => {
+    it('should have no violations', async () => {
+      const { getByTestId } = render(<OrderSummary />)
+
+      expect(await axe(getByTestId('store-order-summary'))).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/molecules/OrderSummary/OrderSummary.tsx
+++ b/packages/ui/src/molecules/OrderSummary/OrderSummary.tsx
@@ -1,0 +1,109 @@
+import React, { forwardRef } from 'react'
+import List, { ListProps } from '../../atoms/List'
+
+export interface OrderSummaryProps<T = HTMLElement> extends Omit<ListProps<T>, 'variant'> {
+  /**
+   * ID to find this component in testing tools (e.g.: cypress,
+   * testing-library, and jest).
+   */
+  testId?: string
+  /**
+   * Label for the subtotal value of the order. Will only show if subtotalValue is provided.
+   */
+  subtotalLabel?: string
+  /**
+   * Subtotal value of the order.  If provided, subtotal label and value will be shown.
+   */
+  subtotalValue?: string
+  /**
+   * Label for the discount value for the order. Will only show if discountValue is provided.
+   */
+  discountLabel?: string
+  /**
+   * Discount value for the order. If provided, discount label and value will be shown.
+   */
+  discountValue?: string
+  /**
+   * Label for the total value of the order.
+   */
+  totalLabel?: string
+  /**
+   * Total value of the order.
+   */
+  totalValue?: string
+}
+
+const OrderSummary = forwardRef<HTMLUListElement, OrderSummaryProps>(
+  function OrderSummary(
+    {
+      testId = 'store-order-summary',
+      children,
+      subtotalLabel,
+      subtotalValue,
+      discountLabel,
+      discountValue,
+      totalLabel,
+      totalValue,
+      ...otherProps
+    },
+    ref
+  ) {
+    return (
+      <List
+        ref={ref}
+        data-fs-order-summary
+        data-testid={testId}
+        {...otherProps}
+      >
+        {subtotalValue ? (
+          <li data-fs-order-summary-subtotal>
+            <span
+              data-fs-order-summary-subtotal-label
+              data-testid={`${testId}-subtotal-label`}
+            >
+              {subtotalLabel}
+            </span>
+            <span
+              data-fs-order-summary-subtotal-value
+              data-testid={`${testId}-subtotal-value`}
+            >
+              {subtotalValue}
+            </span>
+          </li>
+        ) : null}
+        {discountValue ? (
+          <li data-fs-order-summary-discount>
+            <span
+              data-fs-order-summary-discount-label
+              data-testid={`${testId}-discount-label`}
+            >
+              {discountLabel}
+            </span>
+            <span
+              data-fs-order-summary-discount-value
+              data-testid={`${testId}-discount-value`}
+            >
+              {discountValue}
+            </span>
+          </li>
+        ) : null}
+        <li data-fs-order-summary-total>
+          <span
+            data-fs-order-summary-total-label
+            data-testid={`${testId}-total-label`}
+          >
+            {totalLabel}
+          </span>
+          <span
+            data-fs-order-summary-total-value
+            data-testid={`${testId}-total-value`}
+          >
+            {totalValue}
+          </span>
+        </li>
+      </List>
+    )
+  }
+)
+
+export default OrderSummary

--- a/packages/ui/src/molecules/OrderSummary/index.tsx
+++ b/packages/ui/src/molecules/OrderSummary/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './OrderSummary'
+export type { OrderSummaryProps } from './OrderSummary'

--- a/packages/ui/src/molecules/OrderSummary/stories/OrderSummary.mdx
+++ b/packages/ui/src/molecules/OrderSummary/stories/OrderSummary.mdx
@@ -1,0 +1,29 @@
+import { Canvas, Props, Story, ArgsTable } from '@storybook/addon-docs'
+
+import OrderSummary from '../OrderSummary'
+
+# OrderSummary
+
+<Canvas>
+  <Story id="molecules-ordersummary--order-summary" />
+</Canvas>
+
+## Props
+
+<ArgsTable of={ OrderSummary } />
+
+## CSS Selectors
+
+```css
+[data-fs-order-summary] {}
+[data-fs-order-summary-subtotal] {}
+[data-fs-order-summary-subtotal-label] {}
+[data-fs-order-summary-subtotal-value] {}
+[data-fs-order-summary-discount] {}
+[data-fs-order-summary-discount-label] {}
+[data-fs-order-summary-discount-value] {}
+[data-fs-order-summary-total] {}
+[data-fs-order-summary-total-label] {}
+[data-fs-order-summary-total-value] {}
+
+```

--- a/packages/ui/src/molecules/OrderSummary/stories/OrderSummary.stories.tsx
+++ b/packages/ui/src/molecules/OrderSummary/stories/OrderSummary.stories.tsx
@@ -1,0 +1,29 @@
+import type { Story, Meta } from '@storybook/react'
+import React from 'react'
+
+import type { OrderSummaryProps } from '../OrderSummary'
+import Component from '../OrderSummary'
+import mdx from './OrderSummary.mdx'
+
+const OrderSummaryTemplate: Story<OrderSummaryProps> = () => (
+  <Component 
+    subtotalLabel='Subtotal (3 products)'
+    subtotalValue='$300'
+    discountLabel='Discount'
+    discountValue='-$50'
+    totalLabel='Total'
+    totalValue='250$'
+  />
+)
+
+export const OrderSummary = OrderSummaryTemplate.bind({})
+OrderSummary.storyName = 'OrderSummary'
+
+export default {
+  title: 'Molecules/OrderSummary',
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+} as Meta


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds OrderSummary component to FastStore UI

## How it works?

This component was migrated from nextjs.store. 

## How to test it?

[See the starter PR](https://github.com/vtex-sites/nextjs.store/pull/238)

### Starters Deploy Preview

https://github.com/vtex-sites/nextjs.store/pull/238