### PR TITLE
refactor: Extract `SkuSelector` component from the starter

### DIFF
--- a/packages/styles/src/molecules/index.css
+++ b/packages/styles/src/molecules/index.css
@@ -18,5 +18,6 @@
 @import './quantity-selector.css';
 @import './radio-group.css';
 @import './search-input.css';
+@import './sku-selector.css';
 @import './table.css';
 @import './product-title.css';

--- a/packages/styles/src/molecules/sku-selector.css
+++ b/packages/styles/src/molecules/sku-selector.css
@@ -1,3 +1,3 @@
-[data-store-sku-selector] {
+[data-fs-sku-selector] {
 
 }

--- a/packages/styles/src/molecules/sku-selector.css
+++ b/packages/styles/src/molecules/sku-selector.css
@@ -1,3 +1,84 @@
 [data-fs-sku-selector] {
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: 0.5rem;
+  column-gap: 0.5rem;
+  font-size: 14px;
+}
 
+[data-fs-sku-selector-title] {
+  width: 100%;
+  margin-bottom: 0.25rem;
+}
+
+[data-store-radio-option] {
+  position: relative;
+  width: 3rem;
+  height: 3rem;
+}
+
+[data-store-radio-option] span {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border: 1px solid #171a1c;
+  border-radius: 2px;
+  box-shadow: 0;
+  transition: box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+[data-store-radio-option] [data-fs-sku-selector-option] {
+  position: absolute;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+}
+
+[data-store-radio-option]
+  [data-fs-sku-selector-option]:hover:not(:disabled):not(:checked)
+  + span {
+  border-color: #00419e;
+  border-width: 2px;
+}
+
+[data-store-radio-option] [data-fs-sku-selector-option]:checked + span {
+  border-color: #00419e;
+  border-width: 2px;
+  box-shadow: 0 0 0 3px #8db6fa80;
+}
+
+[data-store-radio-option] [data-fs-sku-selector-option]:disabled {
+  cursor: not-allowed;
+}
+
+[data-store-radio-option] [data-fs-sku-selector-option]:disabled + span {
+  overflow: hidden;
+  color: #5d666f;
+  border-color: #5d666f;
+}
+
+[data-store-radio-option] [data-fs-sku-selector-option]:disabled + span::after {
+  position: absolute;
+  width: 1px;
+  height: 160%;
+  content: '';
+  background-color: #5d666f;
+  transform: rotate(45deg);
+  transform-origin: center;
+}
+
+[data-fs-sku-selector-variant='label']
+  [data-fs-sku-selector-option]:hover:not(:disabled)
+  + span {
+  background-color: #f1f2f3;
+}
+
+[data-fs-sku-selector-variant='label']
+  [data-fs-sku-selector-option]:checked
+  + span {
+  background-color: #f1f2f3;
 }

--- a/packages/styles/src/molecules/sku-selector.css
+++ b/packages/styles/src/molecules/sku-selector.css
@@ -1,0 +1,3 @@
+[data-store-sku-selector] {
+
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -54,6 +54,9 @@ export { default as Incentive } from './atoms/Incentive'
 export type { IncentiveProps } from './atoms/Incentive'
 
 // Molecules
+export { default as SkuSelector } from './molecules/SkuSelector'
+export type { SkuSelectorProps } from './molecules/SkuSelector'
+
 export { default as Gift, GiftContent, GiftImage } from './molecules/Gift'
 export type {
   GiftProps,

--- a/packages/ui/src/molecules/SkuSelector/SkuSelector.test.tsx
+++ b/packages/ui/src/molecules/SkuSelector/SkuSelector.test.tsx
@@ -4,16 +4,37 @@ import React from 'react'
 
 import SkuSelector from './SkuSelector'
 
-describe('SkuSelector', () => {
-  it('should have `data-fs-sku-selector` attribute', () => {
-    const { getByTestId } = render(<SkuSelector variant={'label'} options={[]} activeValue={''}>Testing</SkuSelector>)
+const SkuSelectorTest = () => {
+  const options = [
+    { label: 'Option round', value: 'Round' },
+    { label: 'Option square', value: 'Square' },
+  ]
 
-    expect(getByTestId('store-sku-selector')).toHaveAttribute('data-fs-sku-selector')
+  return <SkuSelector variant="label" options={options} activeValue="Square" />
+}
+
+describe('SkuSelector', () => {
+  describe('Data attributes', () => {
+    it('should have `data-fs-sku-selector` attribute', () => {
+      const { getByTestId } = render(<SkuSelectorTest />)
+
+      expect(getByTestId('store-sku-selector')).toHaveAttribute(
+        'data-fs-sku-selector'
+      )
+    })
+
+    it('should have `data-fs-sku-selector-variant` attribute', () => {
+      const { getByTestId } = render(<SkuSelectorTest />)
+
+      expect(getByTestId('store-sku-selector')).toHaveAttribute(
+        'data-fs-sku-selector-variant'
+      )
+    })
   })
 
   describe('Accessibility', () => {
     it('should have no violations', async () => {
-      const { getByTestId } = render(<SkuSelector variant={'label'} options={[]} activeValue={''}>Testing</SkuSelector>)
+      const { getByTestId } = render(<SkuSelectorTest />)
 
       expect(await axe(getByTestId('store-sku-selector'))).toHaveNoViolations()
     })

--- a/packages/ui/src/molecules/SkuSelector/SkuSelector.test.tsx
+++ b/packages/ui/src/molecules/SkuSelector/SkuSelector.test.tsx
@@ -5,10 +5,10 @@ import React from 'react'
 import SkuSelector from './SkuSelector'
 
 describe('SkuSelector', () => {
-  it('should have `data-store-sku-selector` attribute', () => {
+  it('should have `data-fs-sku-selector` attribute', () => {
     const { getByTestId } = render(<SkuSelector variant={'label'} options={[]} activeValue={''}>Testing</SkuSelector>)
 
-    expect(getByTestId('store-sku-selector')).toHaveAttribute('data-store-sku-selector')
+    expect(getByTestId('store-sku-selector')).toHaveAttribute('data-fs-sku-selector')
   })
 
   describe('Accessibility', () => {

--- a/packages/ui/src/molecules/SkuSelector/SkuSelector.test.tsx
+++ b/packages/ui/src/molecules/SkuSelector/SkuSelector.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import React from 'react'
+
+import SkuSelector from './SkuSelector'
+
+describe('SkuSelector', () => {
+  it('should have `data-store-sku-selector` attribute', () => {
+    const { getByTestId } = render(<SkuSelector variant={'label'} options={[]} activeValue={''}>Testing</SkuSelector>)
+
+    expect(getByTestId('store-sku-selector')).toHaveAttribute('data-store-sku-selector')
+  })
+
+  describe('Accessibility', () => {
+    it('should have no violations', async () => {
+      const { getByTestId } = render(<SkuSelector variant={'label'} options={[]} activeValue={''}>Testing</SkuSelector>)
+
+      expect(await axe(getByTestId('store-sku-selector'))).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/molecules/SkuSelector/SkuSelector.tsx
+++ b/packages/ui/src/molecules/SkuSelector/SkuSelector.tsx
@@ -6,17 +6,17 @@ interface SkuProps {
   /**
    * Alternative text description of the image.
    */
-  alt: string
+  alt?: string
   /**
    * Image URL.
    */
-  src: string
+  src?: string
   /**
-   * Label to describe the image when selected.
+   * Label to describe the option when selected.
    */
   label: string
   /**
-   * Current value for this SKU.
+   * Current value for this option.
    */
   value: string
   /**
@@ -90,7 +90,6 @@ const SkuSelector = forwardRef<HTMLDivElement, SkuSelectorProps>(
           </Label>
         )}
         <RadioGroup
-          // data-fs-sku-selector-options
           selectedValue={activeValue}
           name={`sku-selector-${variant}${radioGroupId}`}
           onChange={(e) => {

--- a/packages/ui/src/molecules/SkuSelector/SkuSelector.tsx
+++ b/packages/ui/src/molecules/SkuSelector/SkuSelector.tsx
@@ -1,0 +1,107 @@
+import React, { forwardRef } from 'react'
+import type { HTMLAttributes, ChangeEventHandler } from 'react'
+import { Label, RadioGroup } from '../..'
+
+interface SkuProps {
+  /**
+   * Alternative text description of the image.
+   */
+  alt: string
+  /**
+   * Image URL.
+   */
+  src: string
+  /**
+   * Label to describe the image when selected.
+   */
+  label: string
+  /**
+   * Current value for this SKU.
+   */
+  value: string
+  /**
+   * Specifies that this option should be disabled.
+   */
+  disabled?: boolean
+}
+
+// TODO: Add the 'color' variant back once the store supports naturally handling color SKUs.
+type Variant = 'label' | 'image'
+
+export interface SkuSelectorProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * ID to find this component in testing tools (e.g.: cypress,
+   * testing-library, and jest).
+   */
+  testId?: string
+  /**
+   * ID of the current instance of the component.
+   */
+  id?: string
+  /**
+   * Specify which variant the component should handle.
+   */
+  variant: Variant
+  /**
+   * SKU options that should be rendered.
+   */
+  options: SkuProps[]
+  /**
+   * Section label for the SKU selector.
+   */
+  label?: string
+  /**
+   * Currently active variation's value.
+   */
+  activeValue: string
+  /**
+   * Function to be triggered when SKU option change.
+   */
+  onChange?: ChangeEventHandler<HTMLInputElement>
+}
+
+const SkuSelector = forwardRef<HTMLDivElement, SkuSelectorProps>(
+  function SkuSelector(
+    {
+      id,
+      label,
+      variant,
+      onChange,
+      testId = 'store-sku-selector',
+      activeValue,
+      children,
+      ...otherProps
+    },
+    ref
+  ) {
+    const radioGroupId = id ? `-${id}` : ''
+
+    return (
+      <div
+        ref={ref}
+        data-fs-sku-selector
+        data-testid={testId}
+        data-fs-sku-selector-variant={variant}
+        {...otherProps}
+      >
+        {label && (
+          <Label data-fs-sku-selector-title>
+            {label}: <strong>{activeValue}</strong>
+          </Label>
+        )}
+        <RadioGroup
+          // data-fs-sku-selector-options
+          selectedValue={activeValue}
+          name={`sku-selector-${variant}${radioGroupId}`}
+          onChange={(e) => {
+            onChange?.(e)
+          }}
+        >
+          {children}
+        </RadioGroup>
+      </div>
+    )
+  }
+)
+
+export default SkuSelector

--- a/packages/ui/src/molecules/SkuSelector/index.tsx
+++ b/packages/ui/src/molecules/SkuSelector/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './SkuSelector'
+export type { SkuSelectorProps } from './SkuSelector'

--- a/packages/ui/src/molecules/SkuSelector/stories/SkuSelector.mdx
+++ b/packages/ui/src/molecules/SkuSelector/stories/SkuSelector.mdx
@@ -1,0 +1,20 @@
+import { Canvas, Props, Story, ArgsTable } from '@storybook/addon-docs'
+
+import SkuSelector from '../SkuSelector'
+
+# SkuSelector
+
+<Canvas>
+  <Story id="molecules-skuselector--sku-selector" />
+</Canvas>
+
+## Props
+
+<ArgsTable of={ SkuSelector } />
+
+## CSS Selectors
+
+```css
+[data-store-sku-selector] {
+}
+```

--- a/packages/ui/src/molecules/SkuSelector/stories/SkuSelector.mdx
+++ b/packages/ui/src/molecules/SkuSelector/stories/SkuSelector.mdx
@@ -15,6 +15,10 @@ import SkuSelector from '../SkuSelector'
 ## CSS Selectors
 
 ```css
-[data-store-sku-selector] {
+[data-fs-sku-selector] {
+}
+[data-fs-sku-selector-variant='(label|image)'] {
+}
+[data-fs-sku-selector-title] {
 }
 ```

--- a/packages/ui/src/molecules/SkuSelector/stories/SkuSelector.stories.tsx
+++ b/packages/ui/src/molecules/SkuSelector/stories/SkuSelector.stories.tsx
@@ -1,13 +1,43 @@
 import type { Story, Meta } from '@storybook/react'
 import React from 'react'
+import { RadioOption } from '../../..'
 
 import type { SkuSelectorProps } from '../SkuSelector'
 import Component from '../SkuSelector'
 import mdx from './SkuSelector.mdx'
 
-const SkuSelectorTemplate: Story<SkuSelectorProps> = ({ testId }) => (
-  <Component testId={testId} variant={'label'} options={[]} activeValue={''}>SkuSelector</Component>
-)
+const SkuSelectorTemplate: Story<SkuSelectorProps> = ({ testId }) => {
+  const activeValue = 'Square'
+  const options = [
+    { label: 'Option round', value: 'Round' },
+    { label: 'Option square', value: 'Square' },
+  ]
+  const variant = 'label'
+
+  return (
+    <Component
+      testId={testId}
+      variant={variant}
+      options={options}
+      activeValue={activeValue}
+      label='Option'
+    >
+      {options.map((option, index) => {
+        return (
+          <RadioOption
+            data-fs-sku-selector-option
+            key={String(index)}
+            label={option.label}
+            value={option.value}
+            checked={option.value === activeValue}
+          >
+            <span>{option.value}</span>
+          </RadioOption>
+        )
+      })}
+    </Component>
+  )
+}
 
 export const SkuSelector = SkuSelectorTemplate.bind({})
 SkuSelector.storyName = 'SkuSelector'

--- a/packages/ui/src/molecules/SkuSelector/stories/SkuSelector.stories.tsx
+++ b/packages/ui/src/molecules/SkuSelector/stories/SkuSelector.stories.tsx
@@ -7,10 +7,10 @@ import Component from '../SkuSelector'
 import mdx from './SkuSelector.mdx'
 
 const SkuSelectorTemplate: Story<SkuSelectorProps> = ({ testId }) => {
-  const activeValue = 'Square'
+  const activeValue = 'Pink'
   const options = [
-    { label: 'Option round', value: 'Round' },
-    { label: 'Option square', value: 'Square' },
+    { label: 'Color Pink', value: 'Pink' },
+    { label: 'Color White', value: 'White' },
   ]
   const variant = 'label'
 
@@ -20,7 +20,7 @@ const SkuSelectorTemplate: Story<SkuSelectorProps> = ({ testId }) => {
       variant={variant}
       options={options}
       activeValue={activeValue}
-      label='Option'
+      label='Color'
     >
       {options.map((option, index) => {
         return (

--- a/packages/ui/src/molecules/SkuSelector/stories/SkuSelector.stories.tsx
+++ b/packages/ui/src/molecules/SkuSelector/stories/SkuSelector.stories.tsx
@@ -1,0 +1,22 @@
+import type { Story, Meta } from '@storybook/react'
+import React from 'react'
+
+import type { SkuSelectorProps } from '../SkuSelector'
+import Component from '../SkuSelector'
+import mdx from './SkuSelector.mdx'
+
+const SkuSelectorTemplate: Story<SkuSelectorProps> = ({ testId }) => (
+  <Component testId={testId} variant={'label'} options={[]} activeValue={''}>SkuSelector</Component>
+)
+
+export const SkuSelector = SkuSelectorTemplate.bind({})
+SkuSelector.storyName = 'SkuSelector'
+
+export default {
+  title: 'Molecules/SkuSelector',
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+} as Meta


### PR DESCRIPTION
## What's the purpose of this pull request?

Extract the `SkuSelector` component from our starter to `@faststore/ui`.

## How to test it?

Run `yarn storybook` and check the new `SkuSelector` entry at http://localhost:6006/?path=/story/molecules-skuselector--sku-selector

![Screen Shot 2022-09-12 at 12 29 47](https://user-images.githubusercontent.com/19983991/189694597-11958db0-9c5e-4784-bacf-28364c188914.png)

### Starters Deploy Preview
- https://preview-240--nextjs.preview.vtex.app/apple-magic-mouse-99988212/p

## References

- https://vtex-dev.atlassian.net/browse/FS-248 (internal)
- https://github.com/vtex-sites/nextjs.store/pull/240
