### PR TITLE
docs: fix extending graphql example

### DIFF
--- a/apps/docs/docs/how-to-guides/faststore-api/extending-the-faststore-api.md
+++ b/apps/docs/docs/how-to-guides/faststore-api/extending-the-faststore-api.md
@@ -52,7 +52,8 @@ const typeDefs = `
 `
 ```
 
-### Step 3 - Create resolvers
+### Step 3 - Create 
+
 
 Resolvers are the functions that give meaning to the data you have structured in the type definitions. This means a resolver will be executed when the corresponding piece of information is queried.
 
@@ -128,7 +129,6 @@ const getMergedSchemas = async () =>
         typeDefs: mergedTypeDefs,
       }),
     ],
-    resolvers,
   })
 
 // Merging schemas into a final schema
@@ -222,7 +222,6 @@ const getMergedSchemas = async () =>
         typeDefs: mergedTypeDefs,
       }),
     ],
-    resolvers,
   })
 
 // Merging schemas into a final schema

--- a/apps/docs/docs/how-to-guides/faststore-api/extending-the-faststore-api.md
+++ b/apps/docs/docs/how-to-guides/faststore-api/extending-the-faststore-api.md
@@ -52,7 +52,7 @@ const typeDefs = `
 `
 ```
 
-### Step 3 - Create 
+### Step 3 - Create resolvers
 
 
 Resolvers are the functions that give meaning to the data you have structured in the type definitions. This means a resolver will be executed when the corresponding piece of information is queried.

--- a/apps/docs/docs/how-to-guides/faststore-api/extending-the-faststore-api.md
+++ b/apps/docs/docs/how-to-guides/faststore-api/extending-the-faststore-api.md
@@ -54,7 +54,6 @@ const typeDefs = `
 
 ### Step 3 - Create resolvers
 
-
 Resolvers are the functions that give meaning to the data you have structured in the type definitions. This means a resolver will be executed when the corresponding piece of information is queried.
 
 A resolver can perform an operation on an existing field or fetch data from a proprietary API, for example.


### PR DESCRIPTION
## What's the purpose of this pull request?

Correctly use resolvers in the schema extension.

## How it works?

Resolvers are being misused when merging schemas.

## How to test it?

When you do this extension:

```ts
// src/server/index.ts file

const typeDefs = `
  type Query {
    numberSix: Int! # Should always return the number 6 when queried
    numberSeven: Int! # Should always return 7
  }
`

const resolvers = {
  Query: {
    numberSix() {
      return 6
    },
    numberSeven() {
      return 7
    },
  },
}

const nativeApiSchema = getSchema(apiOptions)

const mergedTypeDefs = mergeTypeDefs([getTypeDefs(), typeDefs])

const getMergedSchemas = async () =>
  mergeSchemas({
    schemas: [
      await nativeApiSchema,
      makeExecutableSchema({
        resolvers,
        typeDefs: mergedTypeDefs,
      }),
    ],
    resolvers,
  })

export const apiSchema = getMergedSchemas()
```
so when you extend the schema and try to run your new query, you will get this error

```cmd
GraphQLError [Object]: Cannot return null for non-nullable field Query.numberSeven.
    at numberSevenQuerynumberSevenResolverHandler (eval at compileQuery (/Users/emersonlaurentino/develop/vtex/faststore/sites/nextjs.store/node_modules/graphql-jit/dist/execution.js:75:13), <anonymous>:179:86)
    at __value.then.__context.nullErrors.push.__context.GraphQLError.line (eval at compileQuery (/Users/emersonlaurentino/develop/vtex/faststore/sites/nextjs.store/node_modules/graphql-jit/dist/execution.js:75:13), <anonymous>:68:9)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  locations: [ { line: 2, column: 5 } ],
  path: [ 'numberSeven' ]
}
```

just removing `resolvers` from the mergeSchemas root and keeping it inside `makeExecutableSchema` solves the problem.

### Starters Deploy Preview

https://github.com/vtex-sites/nextjs.store/compare/examples/extending-graphql
https://github.com/vtex-sites/gatsby.store/compare/examples/extending-graphql

## References

https://www.faststore.dev/how-to-guides/faststore-api/extending-the-faststore-api
