### PR TITLE
feat(ui): improve extensibility of table and accordion molecules

### DIFF
--- a/packages/ui/src/molecules/Accordion/AccordionItem.tsx
+++ b/packages/ui/src/molecules/Accordion/AccordionItem.tsx
@@ -13,7 +13,7 @@ const AccordionItemContext = createContext<AccordionItemContext | undefined>(
   undefined
 )
 
-export interface Props extends HTMLAttributes<HTMLDivElement> {
+interface Props extends HTMLAttributes<HTMLDivElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress,
    * testing-library, and jest).
@@ -38,7 +38,6 @@ export type AccordionItemProps<C extends ElementType> = PolymorphicComponentProp
 type AccordionItemComponent = <C extends ElementType = 'div'>(
   props: AccordionItemProps<C>
 ) => ReactElement | null
-
 
 const AccordionItem: AccordionItemComponent = forwardRef(
   function AccordionItem<C extends ElementType = 'div'>(
@@ -88,6 +87,6 @@ export function useAccordionItem() {
  * **DON'T** import this directly to use this component, use the default export
  * instead.
  */
- export const StorybookAccordionItem = AccordionItem as FC<Props>
+export const StorybookAccordionItem = AccordionItem as FC<Props>
 
 export default AccordionItem

--- a/packages/ui/src/molecules/Accordion/AccordionItem.tsx
+++ b/packages/ui/src/molecules/Accordion/AccordionItem.tsx
@@ -1,5 +1,6 @@
-import type { HTMLAttributes } from 'react'
 import React, { useContext, forwardRef, createContext } from 'react'
+import type { ElementType, FC, HTMLAttributes, ReactElement } from 'react'
+import type { PolymorphicComponentPropsWithRef, PolymorphicRef } from '../../typings'
 
 interface AccordionItemContext {
   index: number
@@ -12,7 +13,7 @@ const AccordionItemContext = createContext<AccordionItemContext | undefined>(
   undefined
 )
 
-export interface AccordionItemProps extends HTMLAttributes<HTMLDivElement> {
+export interface Props extends HTMLAttributes<HTMLDivElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress,
    * testing-library, and jest).
@@ -29,17 +30,30 @@ export interface AccordionItemProps extends HTMLAttributes<HTMLDivElement> {
   prefixId?: string
 }
 
-const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
-  function AccordionItem(
+export type AccordionItemProps<C extends ElementType> = PolymorphicComponentPropsWithRef<
+  C,
+  Props
+>
+
+type AccordionItemComponent = <C extends ElementType = 'div'>(
+  props: AccordionItemProps<C>
+) => ReactElement | null
+
+
+const AccordionItem: AccordionItemComponent = forwardRef(
+  function AccordionItem<C extends ElementType = 'div'>(
     {
       testId = 'store-accordion-item',
       children,
       prefixId = '',
       index = 0,
+      as: MaybeComponent,
       ...otherProps
-    },
-    ref
+    }: AccordionItemProps<C>,
+    ref: PolymorphicRef<C>
   ) {
+    const Component = MaybeComponent ?? 'div'
+
     const context = {
       index,
       prefixId,
@@ -49,9 +63,9 @@ const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
 
     return (
       <AccordionItemContext.Provider value={context}>
-        <div ref={ref} data-accordion-item data-testid={testId} {...otherProps}>
+        <Component ref={ref} data-accordion-item data-testid={testId} {...otherProps}>
           {children}
-        </div>
+        </Component>
       </AccordionItemContext.Provider>
     )
   }
@@ -68,5 +82,12 @@ export function useAccordionItem() {
 
   return context
 }
+
+/**
+ * This is only being exported to make it easier to use in Storybook.
+ * **DON'T** import this directly to use this component, use the default export
+ * instead.
+ */
+ export const StorybookAccordionItem = AccordionItem as FC<Props>
 
 export default AccordionItem

--- a/packages/ui/src/molecules/Accordion/stories/Accordion.mdx
+++ b/packages/ui/src/molecules/Accordion/stories/Accordion.mdx
@@ -1,7 +1,7 @@
 import { Canvas, Props, Story, ArgsTable } from '@storybook/addon-docs'
 
 import Accordion from '../Accordion'
-import AccordionItem from '../AccordionItem'
+import { StorybookAccordionItem } from '../AccordionItem'
 import AccordionButton from '../AccordionButton'
 import AccordionPanel from '../AccordionPanel'
 
@@ -40,7 +40,7 @@ Besides those attributes, the following props are also supported:
 
 ### `AccordionItem`
 
-<ArgsTable of={AccordionItem} />
+<ArgsTable of={StorybookAccordionItem} />
 
 ### `AccordionButton`
 

--- a/packages/ui/src/molecules/Table/Table.tsx
+++ b/packages/ui/src/molecules/Table/Table.tsx
@@ -1,7 +1,7 @@
-import type { HTMLAttributes } from 'react'
+import type { DetailedHTMLProps, TableHTMLAttributes } from 'react'
 import React, { forwardRef } from 'react'
 
-export interface TableProps extends HTMLAttributes<HTMLTableElement> {
+export interface TableProps extends DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR improves extensibility of both table and accordion molecules.

## How it works?

It makes accordions items polymorphic, which means any HTML element (such as `article`) can be used to render the item.

## How to test it?

I'll open a PR referencing this PR on the nextjs.store starter.

### Starters Deploy Preview

TBD
