### PR TITLE
fix(ui): fixes tsconfig.json to exclude storybook types inside .d.ts file

### DIFF
--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -8,6 +8,7 @@
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/**/*.stories.ts",
-    "src/**/*.stories.tsx"
+    "src/**/*.stories.tsx",
+    "src/typings/utils.d.ts",
   ]
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes a bug introduced to the `TableProps` type in https://github.com/vtex/faststore/pull/1470 but that was possibly present before in other components. In the other PR, `TableProps` were changed so that they could extend all of `<table>` native HTML properties.

When I went to use these new props, I was faced with a new, unexpected required prop: `css`. That was weird because none of the native types introduced this variable.

![Screen Shot 2022-09-22 at 11 03 49](https://user-images.githubusercontent.com/8127610/191768337-0ecf525b-262c-48f4-9d3a-c5b9a96d48ff.png)

Searching the internet, I found [this article](https://stackoverflow.com/a/71737324/6352590) explaining it was caused by Storybook types being considered by TS during the build process. So I should just exclude `.stories.tsx` in `tsconfig.json` and everything would work, except it was already being excluded 🤡 . 

So I went searching for any imports from storybook, and found an `utils.d.ts` file that did just that. After excluding this file in `tsconfig.json` and checking the `dist` files in the local build, the `css` property was gone 🎉 

## How it works?

Excludes `src/typings/utils.d.ts` in `tsconfig.json` to prevent TS from considering storybook types during the build.

## How to test it?

You can build this version locally and search for the `css` property on the `TableProps` type in the `dist` folder. It's no longer there.

## References

https://stackoverflow.com/a/71737324/6352590