### PR TITLE
feat: Add CacheControl GraphQL directive

### DIFF
--- a/packages/api/src/directives/cacheControl.ts
+++ b/packages/api/src/directives/cacheControl.ts
@@ -1,0 +1,76 @@
+import { getDirective, MapperKind, mapSchema } from "@graphql-tools/utils";
+import { GraphQLSchema } from "graphql";
+
+import type { Directive } from "./index";
+
+const NAME = "cacheControl";
+
+export interface CacheControl {
+  sMaxAge?: number;
+  staleWhileRevalidate?: number;
+  scope?: string;
+}
+
+export const stringify = (
+  { scope = "private", sMaxAge = 0, staleWhileRevalidate = 0 }: CacheControl,
+) =>
+  `${scope}, s-maxage=${sMaxAge}, stale-while-revalidate=${staleWhileRevalidate}`;
+
+const min = (a: number | undefined, b: number | undefined) => {
+  if (typeof a === "number" && typeof b === "number") {
+    return a > b ? b : a;
+  }
+
+  if (typeof a === "number") {
+    return a;
+  }
+
+  return b;
+};
+
+const minScope = (
+  a: string | undefined,
+  b: string | undefined,
+) => {
+  if (typeof a === "string" && typeof b === "string") {
+    return a === "public" && b === "public" ? "public" : "private";
+  }
+
+  return a || b;
+};
+
+const directive: Directive = {
+  typeDefs:
+    `directive @cacheControl(sMaxAge: Int, staleWhileRevalidate: Int, scope: String) on FIELD_DEFINITION`,
+  transformer: (schema: GraphQLSchema) =>
+    mapSchema(schema, {
+      [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
+        const cacheControl = getDirective(schema, fieldConfig, NAME)?.[0] as
+          | CacheControl
+          | undefined;
+
+        if (cacheControl) {
+          const { sMaxAge, staleWhileRevalidate, scope } = cacheControl;
+
+          const resolver = fieldConfig.resolve
+
+          fieldConfig.resolve = (obj, args, ctx, info) => {
+            ctx.cacheControl = {
+              sMaxAge: min(ctx.cacheControl?.sMaxAge, sMaxAge),
+              staleWhileRevalidate: min(
+                ctx.cacheControl?.staleWhileRevalidate,
+                staleWhileRevalidate,
+              ),
+              scope: minScope(ctx.cacheControl?.scope, scope),
+            };
+
+            return resolver?.(obj, args, ctx, info);
+          };
+        }
+
+        return fieldConfig;
+      },
+    }),
+};
+
+export default directive;

--- a/packages/api/src/directives/index.ts
+++ b/packages/api/src/directives/index.ts
@@ -1,0 +1,6 @@
+import { GraphQLSchema } from "graphql"
+
+export type Directive = {
+  typeDefs: string
+  transformer: (schema: GraphQLSchema) => GraphQLSchema
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -5,10 +5,14 @@ import {
   getResolvers as getResolversVTEX,
 } from './platforms/vtex'
 import { typeDefs } from './typeDefs'
+import cacheControlDirective from './directives/cacheControl'
+import type { Directive } from './directives'
 import type { Options as OptionsVTEX } from './platforms/vtex'
 
 export * from './__generated__/schema'
 export * from './platforms/errors'
+export { stringify as stringifyCacheControl } from './directives/cacheControl'
+export type { CacheControl } from './directives/cacheControl'
 
 export type Options = OptionsVTEX
 
@@ -19,7 +23,11 @@ const platforms = {
   },
 }
 
-export const getTypeDefs = () => typeDefs
+const directives: Directive[] = [
+  cacheControlDirective
+]
+
+export const getTypeDefs = () => [typeDefs, ...directives.map(d => d.typeDefs)]
 
 export const getResolvers = (options: Options) =>
   platforms[options.platform].getResolvers(options)
@@ -27,8 +35,11 @@ export const getResolvers = (options: Options) =>
 export const getContextFactory = (options: Options) =>
   platforms[options.platform].getContextFactory(options)
 
-export const getSchema = async (options: Options) =>
-  makeExecutableSchema({
+export const getSchema = async (options: Options) => {
+  const schema = makeExecutableSchema({
     resolvers: getResolvers(options),
-    typeDefs,
+    typeDefs: getTypeDefs(),
   })
+
+  return directives.reduce((s, d) => d.transformer(s), schema)
+}

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -24,7 +24,6 @@ import ChannelMarshal from './utils/channel'
 import type { Loaders } from './loaders'
 import type { Clients } from './clients'
 import type { Channel } from './utils/channel'
-import type { CacheControl } from '../../directives/cacheControl'
 import type { SearchArgs } from './clients/search'
 
 export interface Options {

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -1,5 +1,4 @@
 import { getClients } from './clients'
-import type { SearchArgs } from './clients/search'
 import { getLoaders } from './loaders'
 import { StoreAggregateOffer } from './resolvers/aggregateOffer'
 import { StoreAggregateRating } from './resolvers/aggregateRating'
@@ -25,6 +24,8 @@ import ChannelMarshal from './utils/channel'
 import type { Loaders } from './loaders'
 import type { Clients } from './clients'
 import type { Channel } from './utils/channel'
+import type { CacheControl } from '../../directives/cacheControl'
+import type { SearchArgs } from './clients/search'
 
 export interface Options {
   platform: 'vtex'

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -176,6 +176,7 @@ type Query {
     """
     locator: [IStoreSelectedFacet!]!
   ): StoreProduct!
+    @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
 
   """
   Returns the details of a collection based on the collection slug.
@@ -186,6 +187,7 @@ type Query {
     """
     slug: String!
   ): StoreCollection!
+    @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
 
   """
   Returns the result of a product, facet, or suggestion search.
@@ -212,6 +214,7 @@ type Query {
     """
     selectedFacets: [IStoreSelectedFacet!]
   ): StoreSearchResult!
+    @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
 
   """
   Returns information about all products.
@@ -220,12 +223,13 @@ type Query {
     """
     Product pagination argument, indicating how many items should be returned from the complete result list.
     """
-    first: Int!,
+    first: Int!
     """
     Product pagination argument, indicating the cursor corresponding with the item after which the items should be fetched.
     """
     after: String
   ): StoreProductConnection!
+    @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
 
   """
   Returns information about all collections.
@@ -234,10 +238,11 @@ type Query {
     """
     Collection pagination argument, indicating how many items should be returned from the complete result list.
     """
-    first: Int!,
+    first: Int!
     """
     Collection pagination argument, indicating the cursor corresponding with the item after which the items should be fetched.
     """
     after: String
   ): StoreCollectionConnection!
+    @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds the `@cacheControl` directive to the graphql schema of `@faststore/api`

## How it works?
`@cacheControl` directive is implemented using graphql-tools package and allows three main arguments, `scope`, `sMaxAge` and `staleWhileRevalidate`

When the directive is found multiple times in the query execution, a no-cache strategy is used. This strategy uses the minimal number and scope. For instance, if two directives are found during the query execution, one with `sMaxAge=10` and another with `sMaxAge=100`, the final computed `sMaxAge` will be 10s. The same is valid for the scope, where `private` is preffered over `public`.

When no cacheControl is provided or when an error occurs, a `no-cache, no-store` should be returned

## How to test it?
Open one of the starters below and make sure the responses for product queries are returned with the correct cache-control cache headers. Also, make sure the `x-faststore-cache` is received with a hit. Note that mutations are returned with no-cache. Also, forcing an error should return you a `no-cache. no-store`

https://github.com/vtex-sites/nextjs.store/pull/259
https://github.com/vtex-sites/gatsby.store/pull/209

## References
https://www.apollographql.com/docs/apollo-server/performance/caching/#in-your-schema-static