### PR TITLE
fix: Wrong typings on search API

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
+++ b/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
@@ -12,7 +12,7 @@ export interface ProductSearchResult {
   query: string
   operator: 'and' | 'or'
   fuzzy: string
-  correction: Correction
+  correction?: Correction
 }
 
 interface Correction {

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -57,7 +57,7 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
       sp.sendEvent({
         type: 'search.query',
         text: searchArgs.query,
-        misspelled: products.correction.misspelled,
+        misspelled: products.correction?.misspelled ?? false,
         match: products.recordsFiltered,
         operator: products.operator,
       }).catch(console.error)


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes wrong typings on the Search API. A nice side effect is fixing the following error:
```
error TypeError: Cannot read properties of undefined (reading 'misspelled')
    at Object.products (//.cache/functions/graphql.js:29161:41)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
    at async Promise.all (index 0)
    at //.cache/functions/graphql.js:31422:23
    at handler (//.cache/functions/graphql.js:32146:20)
    at //node_modules/gatsby/src/commands/serve.ts:228:13 {
  locations: [ { line: 9, column: 5 } ],
  path: [ 'search', 'products' ]
}
```

