### PR TITLE
fix: Top searches locale

### DIFF
--- a/packages/api/src/platforms/vtex/clients/sp/index.ts
+++ b/packages/api/src/platforms/vtex/clients/sp/index.ts
@@ -37,6 +37,7 @@ export type SearchEvent = {
   misspelled: boolean
   match: number
   operator: 'and' | 'or'
+  locale: string
   session?: string
   anonymous?: string
 }
@@ -50,10 +51,8 @@ export const SP = ({ account }: Options, _: Context) => {
       body: JSON.stringify({
         ...options,
         agent: '@faststore/api',
-        anonymous: user.anonymous(),
-        session: user.session(),
-        // session: 'zZlNhqz1vFJP6iPG5Oqtt',
-        // anonymous: 'Om1TNluGvgmSgU5OOTvkkd',
+        anonymous: user.anonymous(), // 'zZlNhqz1vFJP6iPG5Oqtt'
+        session: user.session(), // 'Om1TNluGvgmSgU5OOTvkkd'
       }),
       headers: {
         'content-type': 'application/json',

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -60,6 +60,7 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
         misspelled: products.correction?.misspelled ?? false,
         match: products.recordsFiltered,
         operator: products.operator,
+        locale: ctx.storage.locale,
       }).catch(console.error)
     }
 


### PR DESCRIPTION
## What's the purpose of this pull request?
To generate the top searches results correctly, we need to feed the search system with searches being performed by real users on the website. The data generation was missing the user's locale, so when fetching top searches we received an empty result.
This PR adds the locale to the data feed so we can fetch the right top searches

## How to test it?
Make sure you can see top searches results being returned after the upgrade
- https://github.com/vtex-sites/nextjs.store/pull/264

## References
https://github.com/vtex/sae-analytics/blob/master/react/index.tsx#L130-L135