### PR TITLE
fix: using data-fs instead data-store

### DIFF
--- a/apps/docs/docs/how-to-guides/contributing/design-principles.md
+++ b/apps/docs/docs/how-to-guides/contributing/design-principles.md
@@ -6,7 +6,7 @@ This documentation is currently under development.
 
 ## Data Attributes for styling
 
-We decided to use data attributes for styling with this pattern: `data-store-component-kebab-case-name`.
+We decided to use data attributes for styling with this pattern: `data-fs-component-kebab-case-name`.
 
 Creating a new molecule component called CheckboxGroup:
 
@@ -15,7 +15,7 @@ interface CheckboxGroupProps {}
 
 const CheckboxGroup = ({ onChange, testId, ...props }: CheckboxGroupProps) => {
   return (
-    <div data-store-checkbox-group data-testid={testId}>
+    <div data-fs-checkbox-group data-testid={testId}>
       {' '}
       {/* Pay attention to the data-attribute */}
       <Checkbox data-checkbox-group onChange={onChange} {...props} />{' '}
@@ -68,11 +68,11 @@ Styling the disabled state:
 Another example for a carousel component:
 
 ```css
-[data-store-carousel] {
+[data-fs-carousel] {
 }
-[data-store-carousel-arrows='left'] {
+[data-fs-carousel-arrows='left'] {
 }
-[data-store-carousel-arrows='right'] {
+[data-fs-carousel-arrows='right'] {
 }
 ```
 

--- a/apps/docs/docs/reference/ui/atoms/Badge.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Badge.mdx
@@ -33,7 +33,7 @@ import { Badge } from '@faststore/ui'
   <TabItem value="css" label="CSS">
 
 ```css
-[data-store-badge] {
+[data-fs-badge] {
   background-color: #be185d;
   color: #fff;
   display: inline-block;
@@ -75,7 +75,7 @@ Use the Badge component to highlight:
 
 ## Customization
 
-`data-store-badge`
+`data-fs-badge`
 
 ## Best practices
 

--- a/apps/docs/docs/reference/ui/atoms/Button.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Button.mdx
@@ -54,7 +54,7 @@ Use the `Button` component to communicate user actions on the following componen
 
 ## Customization
 
-`data-store-button`
+`data-fs-button`
 
 ## Best practices
 

--- a/apps/docs/docs/reference/ui/atoms/Checkbox.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Checkbox.mdx
@@ -31,4 +31,4 @@ import { Checkbox } from '@faststore/ui'
 
 ## Customization
 
-`data-store-checkbox`
+`data-fs-checkbox`

--- a/apps/docs/docs/reference/ui/atoms/Icon.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Icon.mdx
@@ -30,4 +30,4 @@ import { Icon } from '@faststore/ui'
 
 ## Customization
 
-`data-store-icon`
+`data-fs-icon`

--- a/apps/docs/docs/reference/ui/atoms/Incentive.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Incentive.mdx
@@ -35,4 +35,4 @@ The `Incentive` component supports all attributes supported by the `<div>` tag. 
 
 ## Customization
 
-`data-store-incentive`
+`data-fs-incentive`

--- a/apps/docs/docs/reference/ui/atoms/Input.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Input.mdx
@@ -44,7 +44,7 @@ import { Input } from '@faststore/ui'
 
 ## Customization
 
-`data-store-input`
+`data-fs-input`
 
 `data-success`
 

--- a/apps/docs/docs/reference/ui/atoms/Label.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Label.mdx
@@ -28,4 +28,4 @@ import { Label } from '@faststore/ui'
 
 ## Customization
 
-`data-store-label`
+`data-fs-label`

--- a/apps/docs/docs/reference/ui/atoms/Link.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Link.mdx
@@ -44,4 +44,4 @@ Besides those attributes, the following props are also supported:
 
 ## Customization
 
-`data-store-link`
+`data-fs-link`

--- a/apps/docs/docs/reference/ui/atoms/List.mdx
+++ b/apps/docs/docs/reference/ui/atoms/List.mdx
@@ -81,7 +81,7 @@ import { List } from '@faststore/ui'
 
 ## Customization
 
-`data-store-list`
+`data-fs-list`
 
 `data-unordered`
 

--- a/apps/docs/docs/reference/ui/atoms/Overlay.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Overlay.mdx
@@ -46,4 +46,4 @@ function Component () {
 
 ## Customization
 
-`data-store-overlay`
+`data-fs-overlay`

--- a/apps/docs/docs/reference/ui/atoms/Popover.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Popover.mdx
@@ -46,4 +46,4 @@ function() {
 
 ## Customization
 
-`data-store-popover`
+`data-fs-popover`

--- a/apps/docs/docs/reference/ui/atoms/Price.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Price.mdx
@@ -86,7 +86,7 @@ import { Price } from '@faststore/ui'
         .formatToParts(price)
         .map((part) => {
           const props = {
-            [`data-store-price-${part.type}`]: true,
+            [`data-fs-price-${part.type}`]: true,
           }
 
           if (part.type === 'integer') {
@@ -146,7 +146,7 @@ import { Price } from '@faststore/ui'
 
 ## Customization
 
-`data-store-price`
+`data-fs-price`
 
 `data-variant`
 

--- a/apps/docs/docs/reference/ui/atoms/Radio.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Radio.mdx
@@ -28,4 +28,4 @@ import { Radio } from '@faststore/ui'
 
 ## Customization
 
-`data-store-radio`
+`data-fs-radio`

--- a/apps/docs/docs/reference/ui/atoms/Select.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Select.mdx
@@ -88,7 +88,7 @@ import { Select } from '@faststore/ui'
 
 ## Customization
 
-`data-store-select`
+`data-fs-select`
 
 ## Best practices
 

--- a/apps/docs/docs/reference/ui/atoms/Skeleton.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Skeleton.mdx
@@ -28,4 +28,4 @@ import { Skeleton } from '@faststore/ui'
 
 ## Customization
 
-`data-store-skeleton`
+`data-fs-skeleton`

--- a/apps/docs/docs/reference/ui/atoms/Slider.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Slider.mdx
@@ -31,7 +31,7 @@ import { Slider } from '@faststore/ui'
 
 ## Customization
 
-`data-store-slider`
+`data-fs-slider`
 
 `data-slider-range`
 

--- a/apps/docs/docs/reference/ui/atoms/Spinner.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Spinner.mdx
@@ -28,4 +28,4 @@ import { Spinner } from '@faststore/ui'
 
 ## Customization
 
-`data-store-spinner`
+`data-fs-spinner`

--- a/apps/docs/docs/reference/ui/atoms/TextArea.mdx
+++ b/apps/docs/docs/reference/ui/atoms/TextArea.mdx
@@ -50,7 +50,7 @@ import { TextArea } from '@faststore/ui'
 
 ## Customization
 
-`data-store-textarea`
+`data-fs-textarea`
 
 `data-success`
 

--- a/apps/docs/docs/reference/ui/molecules/Accordion.mdx
+++ b/apps/docs/docs/reference/ui/molecules/Accordion.mdx
@@ -199,7 +199,7 @@ Besides those attributes, the following props are also supported:
 
 ## Customization
 
-`data-store-accordion`
+`data-fs-accordion`
 
 `data-accordion-item`
 

--- a/apps/docs/docs/reference/ui/molecules/AggregateRating.mdx
+++ b/apps/docs/docs/reference/ui/molecules/AggregateRating.mdx
@@ -37,16 +37,16 @@ import { AggregateRating } from '@faststore/ui'
 <TabItem value="css" label="CSS">
 
 ```css
-[data-store-aggregate-rating] {
+[data-fs-aggregate-rating] {
   display: flex;
 }
 
-[data-store-aggregate-rating] svg[data-store-aggregate-rating-item] {
+[data-fs-aggregate-rating] svg[data-fs-aggregate-rating-item] {
   width: 1.5rem;
   margin-right: 0.5rem;
 }
 
-li[data-store-aggregate-rating-item] {
+li[data-fs-aggregate-rating-item] {
   color: #ffb100;
 }
 ```
@@ -95,32 +95,32 @@ li[data-store-aggregate-rating-item] {
 <TabItem value="css" label="CSS">
 
 ```css
-[data-store-aggregate-rating] {
+[data-fs-aggregate-rating] {
   display: flex;
 }
 
-[data-store-aggregate-rating] svg[data-store-aggregate-rating-item] {
+[data-fs-aggregate-rating] svg[data-fs-aggregate-rating-item] {
   width: 1.5rem;
   margin-right: 0.5rem;
 }
 
 /* Unicode symbols */
-li[data-store-aggregate-rating-item] {
+li[data-fs-aggregate-rating-item] {
   color: #ff6d75;
 }
 
 /* Unicode symbols with CSS */
-span[data-store-aggregate-rating-item] {
+span[data-fs-aggregate-rating-item] {
   color: #ffb100;
 }
 
-[data-store-aggregate-rating] span[data-store-aggregate-rating-item="full"]:after,
-[data-store-aggregate-rating] span[data-store-aggregate-rating-item="partial"]:after {
+[data-fs-aggregate-rating] span[data-fs-aggregate-rating-item="full"]:after,
+[data-fs-aggregate-rating] span[data-fs-aggregate-rating-item="partial"]:after {
   content: "★";
   display: block;
 }
 
-[data-store-aggregate-rating] span[data-store-aggregate-rating-item="empty"]:after {
+[data-fs-aggregate-rating] span[data-fs-aggregate-rating-item="empty"]:after {
   content: "☆";
   display: block;
 }
@@ -149,6 +149,6 @@ span[data-store-aggregate-rating-item] {
 
 ## Customization
 
-`data-store-aggregate-rating`
+`data-fs-aggregate-rating`
 
 `data-aggregate-rating-item=(full|partial|empty)`

--- a/apps/docs/docs/reference/ui/molecules/Alert.mdx
+++ b/apps/docs/docs/reference/ui/molecules/Alert.mdx
@@ -56,4 +56,4 @@ function Component() {
 
 ## Customization
 
-`data-store-alert`
+`data-fs-alert`

--- a/apps/docs/docs/reference/ui/molecules/Banner.mdx
+++ b/apps/docs/docs/reference/ui/molecules/Banner.mdx
@@ -116,9 +116,9 @@ Besides those attributes, the following props are also supported:
 
 ## Customization
 
-`data-store-banner`
+`data-fs-banner`
 
-`data-store-banner=('vertical'|'horizontal')`
+`data-fs-banner=('vertical'|'horizontal')`
 
 `data-banner-image`
 

--- a/apps/docs/docs/reference/ui/molecules/Breadcrumb.mdx
+++ b/apps/docs/docs/reference/ui/molecules/Breadcrumb.mdx
@@ -41,7 +41,7 @@ import { Breadcrumb } from '@faststore/ui'
 
 ## Customization
 
-`data-store-breadcrumb`
+`data-fs-breadcrumb`
 
 `data-breadcrumb-item`
 

--- a/apps/docs/docs/reference/ui/molecules/Bullets.mdx
+++ b/apps/docs/docs/reference/ui/molecules/Bullets.mdx
@@ -32,7 +32,7 @@ import { Bullets } from '@faststore/ui'
 
 ## Customization
 
-`data-store-bullets`
+`data-fs-bullets`
 
 `data-bullet-item`
 

--- a/apps/docs/docs/reference/ui/molecules/Card.mdx
+++ b/apps/docs/docs/reference/ui/molecules/Card.mdx
@@ -72,13 +72,13 @@ All Card-related components support all attributes also supported by the `<div>`
 
 ## Customization
 
-`data-store-card`
+`data-fs-card`
 
-`data-store-card-image`
+`data-fs-card-image`
 
-`data-store-card-content`
+`data-fs-card-content`
 
-`data-store-card-actions`
+`data-fs-card-actions`
 
 ## Best practices
 

--- a/apps/docs/docs/reference/ui/molecules/Carousel.mdx
+++ b/apps/docs/docs/reference/ui/molecules/Carousel.mdx
@@ -47,7 +47,7 @@ import { Carousel } from '@faststore/ui'
 
 ## Customization
 
-`data-store-carousel`
+`data-fs-carousel`
 
 `data-carousel-track-container`
 
@@ -61,4 +61,4 @@ import { Carousel } from '@faststore/ui'
 
 `data-carousel-bullets`
 
-`[data-carousel-bullets] [data-store-bullets]`
+`[data-carousel-bullets] [data-fs-bullets]`

--- a/apps/docs/docs/reference/ui/molecules/Dropdown.mdx
+++ b/apps/docs/docs/reference/ui/molecules/Dropdown.mdx
@@ -53,21 +53,21 @@ import { Dropdown, DropdownButton, DropdownMenu, DropdownItem } from '@faststore
   <TabItem value="css" label="CSS">
 
 ```css
-[data-store-dropdown-button] {
+[data-fs-dropdown-button] {
   @apply bg-pink-500 text-white text-base w-36 rounded-md p-1;
   @apply focus:bg-pink-700;
 }
 
-[data-store-dropdown-item] {
+[data-fs-dropdown-item] {
   @apply bg-gray-300 p-2 text-base border-2;
   @apply focus:bg-pink-700 focus:text-white focus:border-pink-300  focus:outline-none;
 }
 
-[data-store-dropdown-overlay] {
+[data-fs-dropdown-overlay] {
   @apply bg-transparent;
 }
 
-[data-store-dropdown-menu] {
+[data-fs-dropdown-menu] {
   @apply flex flex-col m-0;
   @apply border border-gray-700;
   padding: 0;
@@ -103,13 +103,13 @@ Use the `Dropdown` component to create:
 
 ## Customization
 
-`data-store-dropdown-button`
+`data-fs-dropdown-button`
 
-`data-store-dropdown-item`
+`data-fs-dropdown-item`
 
-`data-store-dropdown-overlay`
+`data-fs-dropdown-overlay`
 
-`data-store-dropdown-menu`
+`data-fs-dropdown-menu`
 
 ## Best practices
 

--- a/apps/docs/docs/reference/ui/molecules/Form.mdx
+++ b/apps/docs/docs/reference/ui/molecules/Form.mdx
@@ -72,4 +72,4 @@ The Form component supports all attributes also supported by the `<form>` HTML t
 
 ## Customization
 
-`data-store-form`
+`data-fs-form`

--- a/apps/docs/docs/reference/ui/molecules/IconButton.mdx
+++ b/apps/docs/docs/reference/ui/molecules/IconButton.mdx
@@ -39,6 +39,6 @@ import { IconButton } from '@faststore/ui'
 
 ## Customization
 
-`data-store-icon-button`
+`data-fs-icon-button`
 
 This component inherits [Button](/reference/ui/atoms/Button) css selectors.

--- a/apps/docs/docs/reference/ui/molecules/LoadingButton.mdx
+++ b/apps/docs/docs/reference/ui/molecules/LoadingButton.mdx
@@ -30,6 +30,6 @@ import { LoadingButton } from '@faststore/ui'
 
 ## Customization
 
-`data-store-loading-button`
+`data-fs-loading-button`
 
 This component inherits [Button](/reference/ui/atoms/Button) css selectors.

--- a/apps/docs/docs/reference/ui/molecules/Modal.mdx
+++ b/apps/docs/docs/reference/ui/molecules/Modal.mdx
@@ -44,6 +44,6 @@ function Component() {
 
 ## Customization
 
-`data-store-modal-content`
+`data-fs-modal-content`
 
 `data-modal-overlay`

--- a/apps/docs/docs/reference/ui/molecules/PaymentMethods.mdx
+++ b/apps/docs/docs/reference/ui/molecules/PaymentMethods.mdx
@@ -113,6 +113,6 @@ function Component() {
 
 ## Customization
 
-`data-store-payment-methods`
+`data-fs-payment-methods`
 
 `data-payment-methods-flags`

--- a/apps/docs/docs/reference/ui/molecules/PriceRange.mdx
+++ b/apps/docs/docs/reference/ui/molecules/PriceRange.mdx
@@ -42,7 +42,7 @@ function Component () {
 
 ## Customization
 
-`data-store-price-range`
+`data-fs-price-range`
 
 `data-price-range-values`
 

--- a/apps/docs/docs/reference/ui/molecules/ProductCard.mdx
+++ b/apps/docs/docs/reference/ui/molecules/ProductCard.mdx
@@ -63,17 +63,17 @@ Use the `ProductCard` to:
 
 ## Customization
 
-`data-store-product-card`
+`data-fs-product-card`
 
 `data-product-card-content`
 
 `data-product-card-actions`
 
-`data-store-price`
+`data-fs-price`
 
-`data-store-badge`
+`data-fs-badge`
 
-`data-store-button`
+`data-fs-button`
 
 ## Best practices
 

--- a/apps/docs/docs/reference/ui/molecules/QuantitySelector.mdx
+++ b/apps/docs/docs/reference/ui/molecules/QuantitySelector.mdx
@@ -83,7 +83,7 @@ function() {
 
 ## Customization
 
-`data-store-quantity-selector`
+`data-fs-quantity-selector`
 
 `data-quantity-selector-input`
 

--- a/apps/docs/docs/reference/ui/molecules/RadioGroup.mdx
+++ b/apps/docs/docs/reference/ui/molecules/RadioGroup.mdx
@@ -51,6 +51,6 @@ function Component () {
 
 ## Customization
 
-`data-store-radio-option`
+`data-fs-radio-option`
 
-`data-store-radio-option-item`
+`data-fs-radio-option-item`

--- a/apps/docs/docs/reference/ui/molecules/SearchInput.mdx
+++ b/apps/docs/docs/reference/ui/molecules/SearchInput.mdx
@@ -40,6 +40,6 @@ import { SearchInput } from '@faststore/ui'
 
 ## Customization
 
-`data-store-search-input`
+`data-fs-search-input`
 
 This component inherits [Input](/reference/ui/atoms/Input), [Button](/reference/ui/atoms/Button), [Icon](/reference/ui/atoms/Icon) css selectors.

--- a/apps/docs/docs/reference/ui/molecules/Table.mdx
+++ b/apps/docs/docs/reference/ui/molecules/Table.mdx
@@ -120,11 +120,11 @@ All table-related components support all attributes also supported by their resp
 
 ## Customization
 
-`data-store-table`
+`data-fs-table`
 
 `data-table-head`
 
-`data-store-table-row`
+`data-fs-table-row`
 
 `data-table-footer`
 

--- a/apps/docs/docs/reference/ui/organisms/Hero.mdx
+++ b/apps/docs/docs/reference/ui/organisms/Hero.mdx
@@ -55,7 +55,7 @@ import { Hero, HeroImage, HeroHeading } from '@faststore/ui'
   <TabItem value="css" label="CSS">
 
 ```css
-[data-store-hero] {
+[data-fs-hero] {
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -96,7 +96,7 @@ import { Hero, HeroImage, HeroHeading } from '@faststore/ui'
 }
 
 @media only screen and (min-width: 769px) {
-  [data-store-hero] {
+  [data-fs-hero] {
     flex-direction: row-reverse;
   }
   [data-hero-heading] {
@@ -133,11 +133,11 @@ All hero-related components support all attributes also supported by the `<div>`
 
 ## Customization
 
-`data-store-hero`
+`data-fs-hero`
 
-`data-store-hero-image`
+`data-fs-hero-image`
 
-`data-store-hero-heading`
+`data-fs-hero-heading`
 
 ## Best practices
 

--- a/apps/docs/docs/reference/ui/organisms/OutOfStock.mdx
+++ b/apps/docs/docs/reference/ui/organisms/OutOfStock.mdx
@@ -48,29 +48,29 @@ import { OutOfStock, OutOfStockTitle, OutOfStockMessage } from '@faststore/ui'
   <TabItem value="css" label="CSS">
 
 ```css
-[data-store-out-of-stock] [data-out-of-stock-form] {
+[data-fs-out-of-stock] [data-out-of-stock-form] {
   display: flex;
   align-items: center;
   flex-direction: column;
 }
 
-[data-store-out-of-stock] [data-out-of-stock-title] {
+[data-fs-out-of-stock] [data-out-of-stock-title] {
   margin-bottom: .25rem;
   font-size: inherit;
   font-weight: inherit;
 }
 
-[data-store-out-of-stock] [data-out-of-stock-message] {
+[data-fs-out-of-stock] [data-out-of-stock-message] {
   align-items: center;
   margin-bottom: 1rem;
 }
 
-[data-out-of-stock-form] [data-store-button] {
+[data-out-of-stock-form] [data-fs-button] {
   width: 100%;
   margin-top: 1rem;
 }
 
-[data-out-of-stock-form] [data-store-input] {
+[data-out-of-stock-form] [data-fs-input] {
   width: 100%;
   margin-top: 0.25rem;
   max-width: initial;
@@ -85,7 +85,7 @@ import { OutOfStock, OutOfStockTitle, OutOfStockMessage } from '@faststore/ui'
 <PropsSection name="OutOfStock" />
 
 ## Customization
-`data-store-out-of-stock`
+`data-fs-out-of-stock`
 
 `data-out-of-stock-form`
 

--- a/apps/docs/docs/templates/ui-components.md
+++ b/apps/docs/docs/templates/ui-components.md
@@ -55,7 +55,7 @@ _Replace `ComponentName` with the component name._
 
 ## Customization
 
-_Add CSS handles (e.g., `data-store-badge`)._
+_Add CSS handles (e.g., `data-fs-badge`)._
 
 ## Best practices
 

--- a/apps/docs/docs/tutorials/gatsby/06 - Styling components.mdx
+++ b/apps/docs/docs/tutorials/gatsby/06 - Styling components.mdx
@@ -100,13 +100,13 @@ As an example, let's change all FastStore UI Buttons of our website by adding th
 @tailwind components;
 @tailwind utilities;
 
-[data-store-button]{
+[data-fs-button]{
     @apply rounded-md bg-primary-300 text-primary-800;
 }
 ```
 
 :::note
-Don't know from where `data-store-button` is coming? Check the reference documentation of the [Button](/reference/ui/atoms/Button) component.
+Don't know from where `data-fs-button` is coming? Check the reference documentation of the [Button](/reference/ui/atoms/Button) component.
 :::
 
 

--- a/apps/docs/src/components/FeedbackButton/FeedbackButton.module.css
+++ b/apps/docs/src/components/FeedbackButton/FeedbackButton.module.css
@@ -9,7 +9,7 @@
   @apply brightness-150;
 }
 
-[data-store-modal-content] {
+[data-fs-modal-content] {
   @apply bg-background p-10  !important;
   width: 500px;
   min-height: 360px;

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -399,15 +399,15 @@
    @apply align-top;
  }
  
- [data-store-aggregate-rating]{
+ [data-fs-aggregate-rating]{
    @apply ml-0 mb-4  !important
  }
  
- [data-store-aggregate-rating] li{
+ [data-fs-aggregate-rating] li{
    @apply list-none mt-0 text-2xl !important
  }
  
- li[data-store-aggregate-rating-item] {
+ li[data-fs-aggregate-rating-item] {
    color: #ff6d75 !important
  }
  

--- a/apps/docs/src/theme/ReactLiveScope/index.tsx
+++ b/apps/docs/src/theme/ReactLiveScope/index.tsx
@@ -13,7 +13,7 @@ const value = 3
 const decimalValue = 3.5
 
 const FireIcon = (props) => {
-  const conditionalClass = props["data-store-aggregate-rating-item"] === "full" ? "text-orange-500" : "text-details"
+  const conditionalClass = props["data-fs-aggregate-rating-item"] === "full" ? "text-orange-500" : "text-details"
   return (
     <i className={`fa fa-fire mr-1 text-2xl ${conditionalClass}`}></i>
   )
@@ -43,7 +43,7 @@ const RatingIcon = (props) => {
         d="M20.388,10.918L32,12.118l-8.735,7.749L25.914,
              31.4l-9.893-6.088L6.127,31.4l2.695-11.533L0,
              12.118l11.547-1.2L16.026,0.6L20.388,10.918z"
-        fill={fillColor[props['data-store-aggregate-rating-item']!]}
+        fill={fillColor[props['data-fs-aggregate-rating-item']!]}
         strokeWidth="2"
         stroke="#ffb100"
       />

--- a/generators/templates/Component.tsx.hbs
+++ b/generators/templates/Component.tsx.hbs
@@ -17,7 +17,7 @@ const {{pascalCase name}} = forwardRef<HTMLDivElement, {{pascalCase name}}Props>
     return (
       <div
         ref={ref}
-        data-store-{{kebabCase name}}
+        data-fs-{{kebabCase name}}
         data-testid={testId}
         {...otherProps}
       >

--- a/generators/templates/stories.mdx.hbs
+++ b/generators/templates/stories.mdx.hbs
@@ -15,6 +15,6 @@ import {{pascalCase name}} from '../{{pascalCase name}}'
 ## CSS Selectors
 
 ```css
-[data-store-{{kebabCase name}}] {
+[data-fs-{{kebabCase name}}] {
 }
 ```

--- a/generators/templates/style.css.hbs
+++ b/generators/templates/style.css.hbs
@@ -1,3 +1,3 @@
-[data-store-{{kebabCase name}}] {
+[data-fs-{{kebabCase name}}] {
 
 }

--- a/generators/templates/test.tsx.hbs
+++ b/generators/templates/test.tsx.hbs
@@ -5,10 +5,10 @@ import React from 'react'
 import {{pascalCase name}} from './{{pascalCase name}}'
 
 describe('{{pascalCase name}}', () => {
-  it('should have `data-store-{{kebabCase name}}` attribute', () => {
+  it('should have `data-fs-{{kebabCase name}}` attribute', () => {
     const { getByTestId } = render(<{{pascalCase name}}>Testing</{{pascalCase name}}>)
 
-    expect(getByTestId('store-{{kebabCase name}}')).toHaveAttribute('data-store-{{kebabCase name}}')
+    expect(getByTestId('store-{{kebabCase name}}')).toHaveAttribute('data-fs-{{kebabCase name}}')
   })
 
   describe('Accessibility', () => {

--- a/packages/styles/src/atoms/badge.css
+++ b/packages/styles/src/atoms/badge.css
@@ -1,4 +1,4 @@
-[data-store-badge] {
+[data-fs-badge] {
   @apply bg-pink-700 text-white;
   display: inline-block;
   padding: 0.4rem;

--- a/packages/styles/src/atoms/button.css
+++ b/packages/styles/src/atoms/button.css
@@ -1,4 +1,4 @@
-[data-store-button] {
+[data-fs-button] {
   @apply px-6 py-2 rounded border-0 cursor-pointer;
   @apply bg-blue-800 text-white;
   @apply text-lg;

--- a/packages/styles/src/atoms/icon.css
+++ b/packages/styles/src/atoms/icon.css
@@ -1,4 +1,4 @@
-[data-store-icon] {
+[data-fs-icon] {
   @apply inline-block align-middle ml-2;
   line-height: 0;
 }

--- a/packages/styles/src/atoms/incentive.css
+++ b/packages/styles/src/atoms/incentive.css
@@ -1,3 +1,3 @@
-[data-store-incentive] {
+[data-fs-incentive] {
   @apply flex flex-col m-2 float-left items-center;
 }

--- a/packages/styles/src/atoms/input.css
+++ b/packages/styles/src/atoms/input.css
@@ -1,15 +1,15 @@
-[data-store-input] {
+[data-fs-input] {
   @apply w-80 h-10 border px-4 py-1 my-2;
   @apply border-black text-gray-700;
   @apply text-base font-normal no-underline;
 }
 
-[data-store-input][data-success], [data-store-input][data-success]:focus {
+[data-fs-input][data-success], [data-fs-input][data-success]:focus {
   @apply outline-none;
   @apply border-green-600;
 }
 
-[data-store-input][data-error], [data-store-input][data-error]:focus {
+[data-fs-input][data-error], [data-fs-input][data-error]:focus {
   @apply outline-none;
   @apply border-red-600;
 }

--- a/packages/styles/src/atoms/label.css
+++ b/packages/styles/src/atoms/label.css
@@ -1,3 +1,3 @@
-[data-store-label] {
+[data-fs-label] {
   @apply text-base
 }

--- a/packages/styles/src/atoms/link.css
+++ b/packages/styles/src/atoms/link.css
@@ -1,11 +1,11 @@
-a[data-store-link] {
+a[data-fs-link] {
   @apply underline;
 }
 
-div[data-store-link] {
+div[data-fs-link] {
   @apply flex flex-col;
 }
 
-[data-store-link] a {
+[data-fs-link] a {
   @apply whitespace-nowrap max-w-min px-2 py-1 mt-2 underline;
 }

--- a/packages/styles/src/atoms/overlay.css
+++ b/packages/styles/src/atoms/overlay.css
@@ -2,15 +2,15 @@
   height: calc(100vh + 150px);
 }
 
-[data-store-overlay] {
+[data-fs-overlay] {
   @apply z-50 fixed inset-0;
   @apply flex justify-center items-center;
 }
 
-[data-store-overlay][data-green] {
+[data-fs-overlay][data-green] {
   @apply bg-green-500 bg-opacity-50;
 }
 
-[data-store-overlay][data-black], [data-modal-overlay] {
+[data-fs-overlay][data-black], [data-modal-overlay] {
   @apply bg-gray-500 bg-opacity-50;
 }

--- a/packages/styles/src/atoms/popover.css
+++ b/packages/styles/src/atoms/popover.css
@@ -1,4 +1,4 @@
-[data-store-popover] {
+[data-fs-popover] {
   @apply border my-2 py-2 px-4;
   @apply border-black;
 }

--- a/packages/styles/src/atoms/price.css
+++ b/packages/styles/src/atoms/price.css
@@ -1,30 +1,30 @@
-[data-store-price] {
+[data-fs-price] {
   @apply text-base;
 }
 
-[data-store-price][data-variant='listing'] {
+[data-fs-price][data-variant='listing'] {
   @apply text-gray-700;
   @apply line-through;
 }
 
-[data-store-price][data-variant='savings'] {
+[data-fs-price][data-variant='savings'] {
   @apply text-green-800;
 }
 
-[data-store-price][data-variant='selling'] {
+[data-fs-price][data-variant='selling'] {
   @apply text-gray-700;
   @apply font-normal;
 }
 
-[data-store-price][data-variant='spot'] {
+[data-fs-price][data-variant='spot'] {
   @apply font-bold text-4xl;
 }
 
-[data-store-price][data-variant='installment'] {
+[data-fs-price][data-variant='installment'] {
   @apply text-gray-700;
   @apply font-normal;
 }
 
-[data-store-price] [data-store-price-integer] {
+[data-fs-price] [data-fs-price-integer] {
   @apply font-bold;
 }

--- a/packages/styles/src/atoms/skeleton.css
+++ b/packages/styles/src/atoms/skeleton.css
@@ -1,3 +1,3 @@
-[data-store-skeleton] {
+[data-fs-skeleton] {
   @apply animate-pulse rounded bg-gray-400 h-14 w-96;
 }

--- a/packages/styles/src/atoms/slider.css
+++ b/packages/styles/src/atoms/slider.css
@@ -1,4 +1,4 @@
-[data-store-slider] {
+[data-fs-slider] {
   @apply bg-gray-200 rounded-full relative h-2 w-full;
 }
 

--- a/packages/styles/src/atoms/spinner.css
+++ b/packages/styles/src/atoms/spinner.css
@@ -1,4 +1,4 @@
-[data-store-spinner] {
+[data-fs-spinner] {
   @apply block animate-spin text-xs relative;
 
   border-top: 0.2em solid rgba(0, 0, 0, 0.2);
@@ -7,7 +7,7 @@
   border-left: 0.2em solid #000000;
 }
 
-[data-store-spinner], [data-store-spinner]:after {
+[data-fs-spinner], [data-fs-spinner]:after {
   @apply h-4 w-4;
   border-radius: 50%;
 }

--- a/packages/styles/src/atoms/textarea.css
+++ b/packages/styles/src/atoms/textarea.css
@@ -1,15 +1,15 @@
-[data-store-textarea] {
+[data-fs-textarea] {
   @apply w-80 border-solid border-2 px-4 py-1 my-2;
   @apply text-gray-700 border-black border-opacity-5;
   @apply font-normal text-base;
 }
 
-[data-store-textarea][data-success], [data-store-textarea][data-success]:focus {
+[data-fs-textarea][data-success], [data-fs-textarea][data-success]:focus {
   @apply outline-none;
   @apply border-green-600 border-opacity-20;
 }
 
-[data-store-textarea][data-error], [data-store-textarea][data-error]:focus {
+[data-fs-textarea][data-error], [data-fs-textarea][data-error]:focus {
   @apply outline-none;
   @apply border-red-600 border-opacity-20;
 }

--- a/packages/styles/src/molecules/accordion.css
+++ b/packages/styles/src/molecules/accordion.css
@@ -7,7 +7,7 @@
   color: #db2777;
 }
 
-[data-accordion-button] [data-store-icon] {
+[data-accordion-button] [data-fs-icon] {
   margin-left: 0.5rem;
   vertical-align: middle;
 }
@@ -16,7 +16,7 @@
   color: #db2777;
 }
 
-[data-accordion-button][aria-expanded='true'] [data-store-icon] {
+[data-accordion-button][aria-expanded='true'] [data-fs-icon] {
   transform: rotate(180deg);
   transition: transform .8s ease-in-out;
 }

--- a/packages/styles/src/molecules/aggregate-rating.css
+++ b/packages/styles/src/molecules/aggregate-rating.css
@@ -1,24 +1,24 @@
-[data-store-aggregate-rating] {
+[data-fs-aggregate-rating] {
   @apply flex;
 }
 
-[data-store-aggregate-rating] svg[data-store-aggregate-rating-item] {
+[data-fs-aggregate-rating] svg[data-fs-aggregate-rating-item] {
   @apply w-6 mr-2;
 }
 
-li[data-store-aggregate-rating-item], span[data-store-aggregate-rating-item] {
+li[data-fs-aggregate-rating-item], span[data-fs-aggregate-rating-item] {
   color: #ffb100;
 }
 
 /* Using CSS to insert icons */
 
-[data-store-aggregate-rating] span[data-store-aggregate-rating-item="full"]:after,
-[data-store-aggregate-rating] span[data-store-aggregate-rating-item="partial"]:after {
+[data-fs-aggregate-rating] span[data-fs-aggregate-rating-item="full"]:after,
+[data-fs-aggregate-rating] span[data-fs-aggregate-rating-item="partial"]:after {
   content: "★";
   display: block;
 }
 
-[data-store-aggregate-rating] span[data-store-aggregate-rating-item="empty"]:after {
+[data-fs-aggregate-rating] span[data-fs-aggregate-rating-item="empty"]:after {
   content: "☆";
   display: block;
 }

--- a/packages/styles/src/molecules/alert.css
+++ b/packages/styles/src/molecules/alert.css
@@ -1,8 +1,8 @@
-[data-store-alert] {
+[data-fs-alert] {
   @apply flex items-center p-1;
   @apply bg-pink-700 text-white text-sm;
 }
 
-[data-store-alert] [data-store-icon] {
+[data-fs-alert] [data-fs-icon] {
   @apply m-0 px-2;
 }

--- a/packages/styles/src/molecules/banner.css
+++ b/packages/styles/src/molecules/banner.css
@@ -1,20 +1,20 @@
-[data-store-banner='vertical'] {
+[data-fs-banner='vertical'] {
   @apply flex flex-col;
 }
 
-[data-store-banner='vertical'] [data-banner-link] {
+[data-fs-banner='vertical'] [data-banner-link] {
   @apply ml-auto;
 }
 
-[data-store-banner='horizontal'] {
+[data-fs-banner='horizontal'] {
   @apply grid grid-cols-2;
 }
 
-[data-store-banner='horizontal'] [data-banner-content] {
+[data-fs-banner='horizontal'] [data-banner-content] {
   @apply flex-col justify-between;
 }
 
-[data-store-banner='horizontal'] [data-banner-link] {
+[data-fs-banner='horizontal'] [data-banner-link] {
   @apply mr-auto;
 }
 
@@ -40,6 +40,6 @@
   @apply text-lg;
 }
 
-[data-banner-link] [data-store-icon] {
+[data-banner-link] [data-fs-icon] {
   @apply m-auto ml-2 align-middle;
 }

--- a/packages/styles/src/molecules/bullets.css
+++ b/packages/styles/src/molecules/bullets.css
@@ -1,16 +1,16 @@
-[data-store-bullets] {
+[data-fs-bullets] {
   @apply box-border py-2 justify-center flex;
 }
 
-[data-store-bullets] [data-bullet-item] {
+[data-fs-bullets] [data-bullet-item] {
   @apply inline-block;
 }
 
-[data-store-bullets] [data-bullet-item][data-store-button] {
+[data-fs-bullets] [data-bullet-item][data-fs-button] {
   @apply box-border min-w-0 cursor-pointer inline-block rounded-full m-3 border-0 outline-none h-3 w-3 min-h-0 p-0;
   @apply bg-gray-400;
 }
 
-[data-store-bullets] [data-bullet-item][aria-selected="true"] {
+[data-fs-bullets] [data-bullet-item][aria-selected="true"] {
   @apply bg-pink-700;
 }

--- a/packages/styles/src/molecules/card.css
+++ b/packages/styles/src/molecules/card.css
@@ -1,4 +1,4 @@
-[data-store-card] {
+[data-fs-card] {
   max-width: 20rem;
   height: 100%;
 }

--- a/packages/styles/src/molecules/carousel.css
+++ b/packages/styles/src/molecules/carousel.css
@@ -1,4 +1,4 @@
-[data-store-carousel] {
+[data-fs-carousel] {
   @apply relative flex items-center;
 }
 
@@ -6,7 +6,7 @@
   @apply absolute bottom-0 w-full flex justify-center;
 }
 
-[data-store-button][data-arrow] {
+[data-fs-button][data-arrow] {
   @apply bg-transparent absolute text-black;
 }
 

--- a/packages/styles/src/molecules/cart-item.css
+++ b/packages/styles/src/molecules/cart-item.css
@@ -30,20 +30,20 @@
   align-items: baseline;
 }
 
-[data-fs-cart-item-prices] [data-store-price] + [data-store-price] {
+[data-fs-cart-item-prices] [data-fs-price] + [data-fs-price] {
   margin-left: 16px;
 }
 
-[data-fs-cart-item-prices] [data-store-price][data-variant="listing"] {
+[data-fs-cart-item-prices] [data-fs-price][data-variant="listing"] {
   font-size: 0.875rem;
   color: #5d666f;
 }
 
-[data-fs-cart-item-prices] [data-store-price][data-variant="spot"] {
+[data-fs-cart-item-prices] [data-fs-price][data-variant="spot"] {
   font-size: 1.25rem;
 }
 
-[data-fs-cart-item-actions] [data-store-quantity-selector] [data-store-icon] {
+[data-fs-cart-item-actions] [data-fs-quantity-selector] [data-fs-icon] {
   color: #00419e;
 }
 

--- a/packages/styles/src/molecules/dropdown.css
+++ b/packages/styles/src/molecules/dropdown.css
@@ -1,18 +1,18 @@
-[data-store-dropdown-button] {
+[data-fs-dropdown-button] {
   @apply bg-pink-500 text-white text-base w-36 rounded-md p-1;
   @apply focus:bg-pink-700;
 }
 
-[data-store-dropdown-item] {
+[data-fs-dropdown-item] {
   @apply bg-gray-300 p-2 text-base border-2;
   @apply focus:bg-pink-700 focus:text-white focus:border-pink-300  focus:outline-none;
 }
 
-[data-store-dropdown-overlay] {
+[data-fs-dropdown-overlay] {
   @apply bg-transparent;
 }
 
-[data-store-dropdown-menu] {
+[data-fs-dropdown-menu] {
   @apply flex flex-col m-0;
   @apply border border-gray-700;
   padding: 0;

--- a/packages/styles/src/molecules/form.css
+++ b/packages/styles/src/molecules/form.css
@@ -1,23 +1,23 @@
-[data-store-form] {
+[data-fs-form] {
   @apply bg-pink-100 max-w-xl p-10 text-center rounded-lg;
 }
 
-[data-store-form] > h2 {
+[data-fs-form] > h2 {
   @apply text-sm;
 }
 
-[data-store-form] [data-store-label] {
+[data-fs-form] [data-fs-label] {
   @apply px-4;
 }
 
-[data-store-form] [data-store-input] {
+[data-fs-form] [data-fs-input] {
   @apply max-w-min;
 }
 
-[data-store-form] [data-store-checkbox] {
+[data-fs-form] [data-fs-checkbox] {
   @apply my-4;
 }
 
-[data-store-form] [data-store-button] {
+[data-fs-form] [data-fs-button] {
   @apply bg-pink-700;
 }

--- a/packages/styles/src/molecules/gift.css
+++ b/packages/styles/src/molecules/gift.css
@@ -26,13 +26,13 @@
   line-height: 20px;
 }
 
-[data-fs-gift-content] [data-store-price] {
+[data-fs-gift-content] [data-fs-price] {
   margin-right: 6px;
   color: #5d666f;
   text-decoration: line-through;
 }
 
-[data-fs-gift-content] [data-store-badge] {
+[data-fs-gift-content] [data-fs-badge] {
   padding: 4px 12px;
   color: #171a1c;
   text-transform: uppercase;

--- a/packages/styles/src/molecules/icon-button.css
+++ b/packages/styles/src/molecules/icon-button.css
@@ -1,4 +1,4 @@
-[data-store-icon-button] {
+[data-fs-icon-button] {
   @apply inline-flex items-center;
 }
 

--- a/packages/styles/src/molecules/loading-button.css
+++ b/packages/styles/src/molecules/loading-button.css
@@ -1,8 +1,8 @@
-[data-store-loading-button] {
+[data-fs-loading-button] {
   @apply h-11 w-60 items-center justify-center flex;
 }
 
-[data-store-loading-button] [data-store-spinner] {
+[data-fs-loading-button] [data-fs-spinner] {
   border-top: 0.2em solid rgba(255, 255, 255, 0.2);
   border-right: 0.2em solid rgba(255, 255, 255, 0.2);
   border-bottom: 0.2em solid rgba(255, 255, 255, 0.2);

--- a/packages/styles/src/molecules/modal.css
+++ b/packages/styles/src/molecules/modal.css
@@ -1,13 +1,13 @@
-[data-store-overlay][data-modal-overlay] {
+[data-fs-overlay][data-modal-overlay] {
   z-index: 999;
 }
 
-[data-store-modal-content] {
+[data-fs-modal-content] {
   @apply bg-white w-96 font-sans;
   @apply p-5 rounded;
 }
 
-[data-store-modal-content] > [data-action-container] {
+[data-fs-modal-content] > [data-action-container] {
   @apply flex justify-end;
 }
 

--- a/packages/styles/src/molecules/payment-methods.css
+++ b/packages/styles/src/molecules/payment-methods.css
@@ -1,4 +1,4 @@
-[data-store-payment-methods] {
+[data-fs-payment-methods] {
     @apply mt-1 flex-col justify-between text-center;
 }
 

--- a/packages/styles/src/molecules/product-card.css
+++ b/packages/styles/src/molecules/product-card.css
@@ -1,4 +1,4 @@
-[data-store-product-card] {
+[data-fs-product-card] {
   max-width: 20rem;
   height: 100%;
 }
@@ -7,17 +7,17 @@
   padding: 0.5rem;
 }
 
-[data-product-card-content] [data-store-price] {
+[data-product-card-content] [data-fs-price] {
   margin-right: 0.25rem;
   color: #5d666f;
   font-size: 0.875rem;
 }
 
-[data-product-card-content] [data-store-price] + [data-store-price] {
+[data-product-card-content] [data-fs-price] + [data-fs-price] {
   font-weight: bold;
 }
 
-[data-product-card-content] [data-store-badge] {
+[data-product-card-content] [data-fs-badge] {
   color: #171a1c;
   margin-top: 0.5rem;
   border-radius: 100px;
@@ -26,7 +26,7 @@
   line-height: 1rem;
 }
 
-[data-product-card-actions] [data-store-button] {
+[data-product-card-actions] [data-fs-button] {
   float: right;
   margin: 0.5rem;
   font-size: 0.875rem;

--- a/packages/styles/src/molecules/product-title.css
+++ b/packages/styles/src/molecules/product-title.css
@@ -14,7 +14,7 @@
     font-weight: 400;
     line-height: 1.12;
 }
-[data-fs-product-title] [data-fs-product-title-header] [data-store-badge] {
+[data-fs-product-title] [data-fs-product-title-header] [data-fs-badge] {
     white-space: nowrap;
 }
 [data-fs-product-title] [data-fs-product-title-addendum] {

--- a/packages/styles/src/molecules/quantity-selector.css
+++ b/packages/styles/src/molecules/quantity-selector.css
@@ -1,29 +1,29 @@
-[data-store-quantity-selector] [data-store-icon] {
+[data-fs-quantity-selector] [data-fs-icon] {
   @apply m-0;
 }
 
-[data-store-quantity-selector] [data-quantity-selector-input]:focus-visible {
+[data-fs-quantity-selector] [data-quantity-selector-input]:focus-visible {
   @apply outline-none;
 }
 
-[data-store-quantity-selector] [data-quantity-selector-input] {
+[data-fs-quantity-selector] [data-quantity-selector-input] {
   @apply text-center bg-transparent w-full h-full border-0 p-0;
 }
 
-[data-store-quantity-selector] [data-quantity-selector-button] {
+[data-fs-quantity-selector] [data-quantity-selector-button] {
   @apply bg-transparent w-full h-full p-0 flex items-center justify-center;
 }
 
-[data-store-quantity-selector] {
+[data-fs-quantity-selector] {
   @apply h-12 rounded bg-white flex flex-row justify-center items-center;
   width: 8.125rem;
   outline: 1px solid #c4c5ca;
 }
 
-[data-store-quantity-selector]:hover {
+[data-fs-quantity-selector]:hover {
   outline: 0.125rem solid #2953b2;
 }
 
-[data-store-quantity-selector]:focus-within {
+[data-fs-quantity-selector]:focus-within {
   box-shadow: 0 0 0 3px #fff, 0 0 0 5px #8db6fa;
 }

--- a/packages/styles/src/molecules/radio-group.css
+++ b/packages/styles/src/molecules/radio-group.css
@@ -1,27 +1,27 @@
-[data-store-radio-option] {
+[data-fs-radio-option] {
   @apply m-4;
 }
 
-[data-store-radio-option-item] {
+[data-fs-radio-option-item] {
   @apply opacity-0 absolute;
 }
 
-[data-store-radio-option-item]:focus + span {
+[data-fs-radio-option-item]:focus + span {
   @apply border-2 border-pink-300;
 }
 
-[data-store-radio-option-item]:checked + span {
+[data-fs-radio-option-item]:checked + span {
   @apply text-pink-600;
 }
 
-[data-store-radio-option-item] + div {
+[data-fs-radio-option-item] + div {
   @apply inline-block h-16 w-16 border-2 border-gray-300 m-0;
 }
 
-[data-store-radio-option-item]:checked + div {
+[data-fs-radio-option-item]:checked + div {
   @apply bg-pink-600 text-white border-0;
 }
 
-[data-store-radio-option-item]:focus + div {
+[data-fs-radio-option-item]:focus + div {
   @apply border-2 border-pink-300;
 }

--- a/packages/styles/src/molecules/search-input.css
+++ b/packages/styles/src/molecules/search-input.css
@@ -1,9 +1,9 @@
-[data-store-search-input] {
+[data-fs-search-input] {
   @apply box-border m-0 min-w-0 max-w-sm min-h-0 items-center relative w-60 h-11 p-0 flex;
   @apply bg-white border border-gray-400;
 }
 
-[data-store-search-input] [data-store-button] {
+[data-fs-search-input] [data-fs-button] {
   @apply items-center border-0 rounded box-border cursor-pointer flex h-10 justify-center m-0 min-w-0 max-h-10 py-2 px-4 absolute right-0;
   @apply appearance-none bg-transparent text-black;
   @apply text-center no-underline;

--- a/packages/styles/src/molecules/sku-selector.css
+++ b/packages/styles/src/molecules/sku-selector.css
@@ -11,13 +11,13 @@
   margin-bottom: 0.25rem;
 }
 
-[data-store-radio-option] {
+[data-fs-radio-option] {
   position: relative;
   width: 3rem;
   height: 3rem;
 }
 
-[data-store-radio-option] span {
+[data-fs-radio-option] span {
   position: relative;
   display: flex;
   align-items: center;
@@ -30,7 +30,7 @@
   transition: box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
-[data-store-radio-option] [data-fs-sku-selector-option] {
+[data-fs-radio-option] [data-fs-sku-selector-option] {
   position: absolute;
   z-index: 1;
   width: 100%;
@@ -38,30 +38,30 @@
   opacity: 0;
 }
 
-[data-store-radio-option]
+[data-fs-radio-option]
   [data-fs-sku-selector-option]:hover:not(:disabled):not(:checked)
   + span {
   border-color: #00419e;
   border-width: 2px;
 }
 
-[data-store-radio-option] [data-fs-sku-selector-option]:checked + span {
+[data-fs-radio-option] [data-fs-sku-selector-option]:checked + span {
   border-color: #00419e;
   border-width: 2px;
   box-shadow: 0 0 0 3px #8db6fa80;
 }
 
-[data-store-radio-option] [data-fs-sku-selector-option]:disabled {
+[data-fs-radio-option] [data-fs-sku-selector-option]:disabled {
   cursor: not-allowed;
 }
 
-[data-store-radio-option] [data-fs-sku-selector-option]:disabled + span {
+[data-fs-radio-option] [data-fs-sku-selector-option]:disabled + span {
   overflow: hidden;
   color: #5d666f;
   border-color: #5d666f;
 }
 
-[data-store-radio-option] [data-fs-sku-selector-option]:disabled + span::after {
+[data-fs-radio-option] [data-fs-sku-selector-option]:disabled + span::after {
   position: absolute;
   width: 1px;
   height: 160%;

--- a/packages/styles/src/molecules/table.css
+++ b/packages/styles/src/molecules/table.css
@@ -1,4 +1,4 @@
-[data-store-table]{
+[data-fs-table]{
   @apply table-auto divide-y divide-gray-200;
 }
 
@@ -18,7 +18,7 @@
   @apply px-6 py-4;
 }
 
-[data-table-cell] > [data-store-price][data-selling] {
+[data-table-cell] > [data-fs-price][data-selling] {
   @apply text-sm font-medium text-gray-900;
 }
 

--- a/packages/styles/src/organisms/hero.css
+++ b/packages/styles/src/organisms/hero.css
@@ -1,4 +1,4 @@
-[data-store-hero] {
+[data-fs-hero] {
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -39,7 +39,7 @@
 }
 
 @media only screen and (min-width: 769px) {
-  [data-store-hero] {
+  [data-fs-hero] {
     flex-direction: row-reverse;
   }
   [data-hero-heading] {

--- a/packages/styles/src/organisms/out-of-stock.css
+++ b/packages/styles/src/organisms/out-of-stock.css
@@ -1,26 +1,26 @@
-[data-store-out-of-stock] [data-out-of-stock-form] {
+[data-fs-out-of-stock] [data-out-of-stock-form] {
   display: flex;
   align-items: center;
   flex-direction: column;
 }
 
-[data-store-out-of-stock] [data-out-of-stock-title] {
+[data-fs-out-of-stock] [data-out-of-stock-title] {
   margin-bottom: .25rem;
   font-size: inherit;
   font-weight: inherit;
 }
 
-[data-store-out-of-stock] [data-out-of-stock-message] {
+[data-fs-out-of-stock] [data-out-of-stock-message] {
   align-items: center;
   margin-bottom: 1rem;
 }
 
-[data-out-of-stock-form] [data-store-button] {
+[data-out-of-stock-form] [data-fs-button] {
   width: 100%;
   margin-top: 1rem;
 }
 
-[data-out-of-stock-form] [data-store-input] {
+[data-out-of-stock-form] [data-fs-input] {
   width: 100%;
   margin-top: 0.25rem;
   max-width: initial;

--- a/packages/ui/src/atoms/Badge/Badge.test.tsx
+++ b/packages/ui/src/atoms/Badge/Badge.test.tsx
@@ -5,12 +5,12 @@ import { axe } from 'jest-axe'
 import Badge from './Badge'
 
 describe('Badge', () => {
-  it('should have `data-store-badge` attribute', () => {
+  it('should have `data-fs-badge` attribute', () => {
     const { getByText } = render(<Badge>-25%</Badge>)
 
     const renderedBadge = getByText('-25%')
 
-    expect(renderedBadge).toHaveAttribute('data-store-badge')
+    expect(renderedBadge).toHaveAttribute('data-fs-badge')
   })
 
   describe('Accessibility', () => {

--- a/packages/ui/src/atoms/Badge/Badge.tsx
+++ b/packages/ui/src/atoms/Badge/Badge.tsx
@@ -14,7 +14,7 @@ const Badge = forwardRef<HTMLDivElement, BadgeProps>(function Badge(
   ref
 ) {
   return (
-    <div ref={ref} data-store-badge data-testid={testId} {...otherProps}>
+    <div ref={ref} data-fs-badge data-testid={testId} {...otherProps}>
       {children}
     </div>
   )

--- a/packages/ui/src/atoms/Badge/stories/Badge.mdx
+++ b/packages/ui/src/atoms/Badge/stories/Badge.mdx
@@ -14,5 +14,5 @@ import Badge from '../Badge'
 ## CSS Selectors
 
 ```css
-[data-store-badge] {}
+[data-fs-badge] {}
 ```

--- a/packages/ui/src/atoms/Button/Button.test.tsx
+++ b/packages/ui/src/atoms/Button/Button.test.tsx
@@ -4,9 +4,9 @@ import React from 'react'
 import Button from './Button'
 
 describe('Button', () => {
-  it('`data-store-button` is present', () => {
+  it('`data-fs-button` is present', () => {
     const { getByText } = render(<Button>Hello World!</Button>)
 
-    expect(getByText('Hello World!')).toHaveAttribute('data-store-button')
+    expect(getByText('Hello World!')).toHaveAttribute('data-fs-button')
   })
 })

--- a/packages/ui/src/atoms/Button/Button.tsx
+++ b/packages/ui/src/atoms/Button/Button.tsx
@@ -14,7 +14,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   ref
 ) {
   return (
-    <button ref={ref} data-store-button data-testid={testId} {...otherProps}>
+    <button ref={ref} data-fs-button data-testid={testId} {...otherProps}>
       {children}
     </button>
   )

--- a/packages/ui/src/atoms/Button/stories/Button.mdx
+++ b/packages/ui/src/atoms/Button/stories/Button.mdx
@@ -14,5 +14,5 @@ import Button from '../Button'
 ## CSS Selectors
 
 ```css
-[data-store-button] {}
+[data-fs-button] {}
 ```

--- a/packages/ui/src/atoms/Checkbox/Checkbox.test.tsx
+++ b/packages/ui/src/atoms/Checkbox/Checkbox.test.tsx
@@ -5,10 +5,10 @@ import { axe } from 'jest-axe'
 import Checkbox from './Checkbox'
 
 describe('Checkbox', () => {
-  it('data-store-checkbox is present', () => {
+  it('data-fs-checkbox is present', () => {
     const { getByTestId } = render(<Checkbox testId="store-checkbox" />)
 
-    expect(getByTestId('store-checkbox')).toHaveAttribute('data-store-checkbox')
+    expect(getByTestId('store-checkbox')).toHaveAttribute('data-fs-checkbox')
   })
 
   it('type checkbox is present', () => {

--- a/packages/ui/src/atoms/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/atoms/Checkbox/Checkbox.tsx
@@ -16,7 +16,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
   return (
     <input
       ref={ref}
-      data-store-checkbox
+      data-fs-checkbox
       data-testid={testId}
       type="checkbox"
       {...otherProps}

--- a/packages/ui/src/atoms/Checkbox/stories/Checkbox.mdx
+++ b/packages/ui/src/atoms/Checkbox/stories/Checkbox.mdx
@@ -14,5 +14,5 @@ import Checkbox from '../Checkbox'
 ## CSS Selectors
 
 ```css
-[data-store-checkbox] {}
+[data-fs-checkbox] {}
 ```

--- a/packages/ui/src/atoms/Icon/Icon.test.tsx
+++ b/packages/ui/src/atoms/Icon/Icon.test.tsx
@@ -23,12 +23,12 @@ const ShoppingCart = () => (
 )
 
 describe('Icon', () => {
-  it('`data-store-icon` is present', () => {
+  it('`data-fs-icon` is present', () => {
     const { getByTestId } = render(
       <Icon data-testid="store-icon" component={<ShoppingCart />} />
     )
 
-    expect(getByTestId('store-icon')).toHaveAttribute('data-store-icon')
+    expect(getByTestId('store-icon')).toHaveAttribute('data-fs-icon')
   })
 
   describe('Accessibility', () => {

--- a/packages/ui/src/atoms/Icon/Icon.tsx
+++ b/packages/ui/src/atoms/Icon/Icon.tsx
@@ -17,7 +17,7 @@ const Icon = forwardRef<HTMLSpanElement, IconProps>(function Button(
   ref
 ) {
   return (
-    <span ref={ref} data-store-icon data-testid={testId} {...otherProps}>
+    <span ref={ref} data-fs-icon data-testid={testId} {...otherProps}>
       {component}
     </span>
   )

--- a/packages/ui/src/atoms/Icon/stories/Icon.mdx
+++ b/packages/ui/src/atoms/Icon/stories/Icon.mdx
@@ -14,5 +14,5 @@ import Icon from '../Icon'
 ## CSS Selectors
 
 ```css
-[data-store-icon] {}
+[data-fs-icon] {}
 ```

--- a/packages/ui/src/atoms/Incentive/Incentive.test.tsx
+++ b/packages/ui/src/atoms/Incentive/Incentive.test.tsx
@@ -23,8 +23,8 @@ describe('Incentive', () => {
   })
 
   describe('Data attributes', () => {
-    it('should have `data-store-incentive` attribute', () => {
-      expect(incentive).toHaveAttribute('data-store-incentive')
+    it('should have `data-fs-incentive` attribute', () => {
+      expect(incentive).toHaveAttribute('data-fs-incentive')
     })
   })
 

--- a/packages/ui/src/atoms/Incentive/Incentive.tsx
+++ b/packages/ui/src/atoms/Incentive/Incentive.tsx
@@ -14,7 +14,7 @@ const Incentive = forwardRef<HTMLDivElement, IncentiveProps>(function Incentive(
   ref
 ) {
   return (
-    <div ref={ref} data-store-incentive data-testid={testId} {...otherProps}>
+    <div ref={ref} data-fs-incentive data-testid={testId} {...otherProps}>
       {children}
     </div>
   )

--- a/packages/ui/src/atoms/Incentive/stories/Incentive.mdx
+++ b/packages/ui/src/atoms/Incentive/stories/Incentive.mdx
@@ -19,6 +19,6 @@ Besides those attributes, the following props are also supported:
 ## CSS Selectors
 
 ```css
-[data-store-incentive] {
+[data-fs-incentive] {
 }
 ```

--- a/packages/ui/src/atoms/Input/Input.test.tsx
+++ b/packages/ui/src/atoms/Input/Input.test.tsx
@@ -5,13 +5,13 @@ import React from 'react'
 import Input from '.'
 
 describe('Input', () => {
-  it('`data-store-input` is present', () => {
+  it('`data-fs-input` is present', () => {
     const { getByPlaceholderText } = render(
       <Input placeholder="Hello World!" />
     )
 
     expect(getByPlaceholderText('Hello World!')).toHaveAttribute(
-      'data-store-input'
+      'data-fs-input'
     )
   })
 

--- a/packages/ui/src/atoms/Input/Input.tsx
+++ b/packages/ui/src/atoms/Input/Input.tsx
@@ -25,7 +25,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   return (
     <input
       ref={ref}
-      data-store-input
+      data-fs-input
       data-testid={testId}
       {...variants}
       {...otherProps}

--- a/packages/ui/src/atoms/Input/stories/Input.mdx
+++ b/packages/ui/src/atoms/Input/stories/Input.mdx
@@ -14,7 +14,7 @@ import Input from '../Input'
 ## CSS Selectors
 
 ```css
-[data-store-input] {}
+[data-fs-input] {}
 
 [data-success] {}
 

--- a/packages/ui/src/atoms/Label/Label.test.tsx
+++ b/packages/ui/src/atoms/Label/Label.test.tsx
@@ -5,10 +5,10 @@ import React from 'react'
 import Label from '.'
 
 describe('Label', () => {
-  it('`data-store-label` is present', () => {
+  it('`data-fs-label` is present', () => {
     const { getByTestId } = render(<Label />)
 
-    expect(getByTestId('store-label')).toHaveAttribute('data-store-label')
+    expect(getByTestId('store-label')).toHaveAttribute('data-fs-label')
   })
 
   describe('Accessibility', () => {

--- a/packages/ui/src/atoms/Label/Label.tsx
+++ b/packages/ui/src/atoms/Label/Label.tsx
@@ -13,7 +13,7 @@ const Label = forwardRef<HTMLLabelElement, LabelProps>(function Label(
   ref
 ) {
   return (
-    <label ref={ref} data-store-label data-testid={testId} {...otherProps}>
+    <label ref={ref} data-fs-label data-testid={testId} {...otherProps}>
       {children}
     </label>
   )

--- a/packages/ui/src/atoms/Label/stories/Label.mdx
+++ b/packages/ui/src/atoms/Label/stories/Label.mdx
@@ -14,5 +14,5 @@ import Label from '../Label'
 ## CSS Selectors
 
 ```css
-[data-store-label] {}
+[data-fs-label] {}
 ```

--- a/packages/ui/src/atoms/Link/Link.test.tsx
+++ b/packages/ui/src/atoms/Link/Link.test.tsx
@@ -31,14 +31,14 @@ describe('Link', () => {
     )
 
     expect(getByTestId('custom-anchor')).toHaveAttribute('href', '/')
-    expect(getByTestId('store-link')).toHaveAttribute('data-store-link')
+    expect(getByTestId('store-link')).toHaveAttribute('data-fs-link')
   })
 
   describe('Data Attributes', () => {
-    it('should have `data-store-link` attribute', () => {
+    it('should have `data-fs-link` attribute', () => {
       const { getByTestId } = render(<TestLink />)
 
-      expect(getByTestId('store-link')).toHaveAttribute('data-store-link')
+      expect(getByTestId('store-link')).toHaveAttribute('data-fs-link')
     })
   })
 

--- a/packages/ui/src/atoms/Link/Link.tsx
+++ b/packages/ui/src/atoms/Link/Link.tsx
@@ -31,7 +31,7 @@ const Link: LinkComponent = forwardRef(function Link<
   const Component = as ?? 'a'
 
   return (
-    <Component ref={ref} data-store-link data-testid={testId} {...otherProps}>
+    <Component ref={ref} data-fs-link data-testid={testId} {...otherProps}>
       {children}
     </Component>
   )

--- a/packages/ui/src/atoms/Link/stories/Link.mdx
+++ b/packages/ui/src/atoms/Link/stories/Link.mdx
@@ -30,6 +30,6 @@ Besides those attributes, the following props are also supported:
 ## CSS Selectors
 
 ```css
-[data-store-link] {
+[data-fs-link] {
 }
 ```

--- a/packages/ui/src/atoms/List/List.test.tsx
+++ b/packages/ui/src/atoms/List/List.test.tsx
@@ -7,7 +7,7 @@ import List from './List'
 const optionsArray = ['Great', 'Ok', 'Bad']
 
 describe('List', () => {
-  it('should have `data-store-list` attribute', () => {
+  it('should have `data-fs-list` attribute', () => {
     const { getByTestId } = render(
       <List>
         {optionsArray.map((value) => {
@@ -16,7 +16,7 @@ describe('List', () => {
       </List>
     )
 
-    expect(getByTestId('store-list')).toHaveAttribute('data-store-list')
+    expect(getByTestId('store-list')).toHaveAttribute('data-fs-list')
   })
 
   it('should be empty if no children are provided', () => {
@@ -35,7 +35,7 @@ describe('List', () => {
     )
 
     expect(getByTestId('store-list')).toHaveAttribute(
-      'data-store-list',
+      'data-fs-list',
       'ordered'
     )
 
@@ -48,7 +48,7 @@ describe('List', () => {
     )
 
     expect(getByTestId('store-list')).toHaveAttribute(
-      'data-store-list',
+      'data-fs-list',
       'unordered'
     )
 
@@ -61,7 +61,7 @@ describe('List', () => {
     )
 
     expect(getByTestId('store-list')).toHaveAttribute(
-      'data-store-list',
+      'data-fs-list',
       'description'
     )
   })

--- a/packages/ui/src/atoms/List/List.tsx
+++ b/packages/ui/src/atoms/List/List.tsx
@@ -27,7 +27,7 @@ const List = forwardRef<HTMLUListElement, ListProps>(function List(
 ) {
   const dataAttributes = {
     'data-testid': testId,
-    'data-store-list': variant,
+    'data-fs-list': variant,
   }
 
   const Component = MaybeComponent ?? variantToElement[variant] ?? 'ul'

--- a/packages/ui/src/atoms/List/stories/List.mdx
+++ b/packages/ui/src/atoms/List/stories/List.mdx
@@ -28,6 +28,6 @@ import List from '../List'
 ## CSS Selectors
 
 ```css
-[data-store-list] {}
-[data-store-list='(description|ordered|unordered)'] {}
+[data-fs-list] {}
+[data-fs-list='(description|ordered|unordered)'] {}
 ```

--- a/packages/ui/src/atoms/Overlay/Overlay.test.tsx
+++ b/packages/ui/src/atoms/Overlay/Overlay.test.tsx
@@ -7,10 +7,10 @@ import Overlay from './Overlay'
 describe('Overlay', () => {
   const testId = 'store-overlay'
 
-  it('data-store-overlay is present', () => {
+  it('data-fs-overlay is present', () => {
     const { getByTestId } = render(<Overlay testId={testId} />)
 
-    expect(getByTestId(testId)).toHaveAttribute('data-store-overlay')
+    expect(getByTestId(testId)).toHaveAttribute('data-fs-overlay')
   })
 
   describe('Accessibility', () => {

--- a/packages/ui/src/atoms/Overlay/Overlay.tsx
+++ b/packages/ui/src/atoms/Overlay/Overlay.tsx
@@ -15,7 +15,7 @@ const Overlay = forwardRef<HTMLDivElement, Props>(function Overlay(
   return (
     <div
       role="presentation"
-      data-store-overlay
+      data-fs-overlay
       data-testid={testId}
       ref={ref}
       {...otherProps}

--- a/packages/ui/src/atoms/Overlay/stories/Overlay.mdx
+++ b/packages/ui/src/atoms/Overlay/stories/Overlay.mdx
@@ -14,5 +14,5 @@ import Overlay from '../Overlay'
 ## CSS Selectors
 
 ```css
-[data-store-overlay] {}
+[data-fs-overlay] {}
 ```

--- a/packages/ui/src/atoms/Popover/Popover.test.tsx
+++ b/packages/ui/src/atoms/Popover/Popover.test.tsx
@@ -21,10 +21,10 @@ const PopoverTemplate = (props: any) => {
 }
 
 describe('Popover', () => {
-  it('`data-store-popover` is present', () => {
+  it('`data-fs-popover` is present', () => {
     const { getByTestId } = render(<PopoverTemplate />)
 
-    expect(getByTestId('store-popover')).toHaveAttribute('data-store-popover')
+    expect(getByTestId('store-popover')).toHaveAttribute('data-fs-popover')
   })
 
   describe('Accessibility', () => {

--- a/packages/ui/src/atoms/Popover/Popover.tsx
+++ b/packages/ui/src/atoms/Popover/Popover.tsx
@@ -23,7 +23,7 @@ const Popover = ({
 }: PopoverProps) => {
   return (
     <ReachPopover
-      data-store-popover
+      data-fs-popover
       data-testid={testId}
       position={positionDefault}
       targetRef={targetRef}

--- a/packages/ui/src/atoms/Popover/stories/Popover.mdx
+++ b/packages/ui/src/atoms/Popover/stories/Popover.mdx
@@ -14,5 +14,5 @@ import Popover from '../Popover'
 ## CSS Selectors
 
 ```css
-[data-store-popover] {}
+[data-fs-popover] {}
 ```

--- a/packages/ui/src/atoms/Price/Price.test.tsx
+++ b/packages/ui/src/atoms/Price/Price.test.tsx
@@ -5,10 +5,10 @@ import React from 'react'
 import Price from './Price'
 
 describe('Price', () => {
-  it('`data-store-price` is present', () => {
+  it('`data-fs-price` is present', () => {
     const { getByTestId } = render(<Price value={32.5} />)
 
-    expect(getByTestId('store-price')).toHaveAttribute('data-store-price')
+    expect(getByTestId('store-price')).toHaveAttribute('data-fs-price')
   })
 
   it('`data-variant` is equal to `selling` if no variant is defined', () => {

--- a/packages/ui/src/atoms/Price/Price.tsx
+++ b/packages/ui/src/atoms/Price/Price.tsx
@@ -51,7 +51,7 @@ export const Price = forwardRef<Omit<HTMLSpanElement, 'children'>, PriceProps>(
     return (
       <Component
         ref={ref}
-        data-store-price
+        data-fs-price
         data-testid={testId}
         data-variant={variant}
         {...otherProps}

--- a/packages/ui/src/atoms/Price/stories/Price.mdx
+++ b/packages/ui/src/atoms/Price/stories/Price.mdx
@@ -34,7 +34,7 @@ import Price from '../Price'
 ## CSS Selectors
 
 ```css
-[data-store-price] {}
+[data-fs-price] {}
 
 [data-variant='('selling'|'listing'|'spot'|'savings'|'installment')'] {}
 ```

--- a/packages/ui/src/atoms/Price/stories/Price.stories.tsx
+++ b/packages/ui/src/atoms/Price/stories/Price.stories.tsx
@@ -53,7 +53,7 @@ const INTLFormattedToPartsTemplate: Story<PriceProps> = ({
         .formatToParts(price)
         .map((part) => {
           const props = {
-            [`data-store-price-${part.type}`]: true,
+            [`data-fs-price-${part.type}`]: true,
           } as Record<string, unknown>
 
           if (part.type === 'integer') {

--- a/packages/ui/src/atoms/Radio/Radio.test.tsx
+++ b/packages/ui/src/atoms/Radio/Radio.test.tsx
@@ -5,10 +5,10 @@ import { axe } from 'jest-axe'
 import Radio from './Radio'
 
 describe('Radio', () => {
-  it('data-store-radio is present', () => {
+  it('data-fs-radio is present', () => {
     const { getByTestId } = render(<Radio testId="store-radio" />)
 
-    expect(getByTestId('store-radio')).toHaveAttribute('data-store-radio')
+    expect(getByTestId('store-radio')).toHaveAttribute('data-fs-radio')
   })
 
   it('type radio is present', () => {

--- a/packages/ui/src/atoms/Radio/Radio.tsx
+++ b/packages/ui/src/atoms/Radio/Radio.tsx
@@ -13,7 +13,7 @@ const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
   return (
     <input
       ref={ref}
-      data-store-radio
+      data-fs-radio
       data-testid={testId}
       type="radio"
       {...otherProps}

--- a/packages/ui/src/atoms/Radio/stories/Radio.mdx
+++ b/packages/ui/src/atoms/Radio/stories/Radio.mdx
@@ -14,5 +14,5 @@ import Radio from '../Radio'
 ## CSS Selectors
 
 ```css
-[data-store-radio] {}
+[data-fs-radio] {}
 ```

--- a/packages/ui/src/atoms/Select/Select.test.tsx
+++ b/packages/ui/src/atoms/Select/Select.test.tsx
@@ -19,7 +19,7 @@ const mapPairToOption = (value: string, label: string) => {
 }
 
 describe('Select', () => {
-  it('`data-store-select` is present', () => {
+  it('`data-fs-select` is present', () => {
     const { getByTestId } = render(
       <Select testId="store-select">
         {optionsArray.map(([value, label]) => {
@@ -28,7 +28,7 @@ describe('Select', () => {
       </Select>
     )
 
-    expect(getByTestId('store-select')).toHaveAttribute('data-store-select')
+    expect(getByTestId('store-select')).toHaveAttribute('data-fs-select')
   })
 
   it('select is empty when no options are given', () => {

--- a/packages/ui/src/atoms/Select/Select.tsx
+++ b/packages/ui/src/atoms/Select/Select.tsx
@@ -13,7 +13,7 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
   ref
 ) {
   return (
-    <select ref={ref} data-store-select data-testid={testId} {...otherProps}>
+    <select ref={ref} data-fs-select data-testid={testId} {...otherProps}>
       {children}
     </select>
   )

--- a/packages/ui/src/atoms/Select/stories/Select.mdx
+++ b/packages/ui/src/atoms/Select/stories/Select.mdx
@@ -36,5 +36,5 @@ import Select from '../Select'
 ## CSS Selectors
 
 ```css
-[data-store-select] {}
+[data-fs-select] {}
 ```

--- a/packages/ui/src/atoms/Skeleton/Skeleton.test.tsx
+++ b/packages/ui/src/atoms/Skeleton/Skeleton.test.tsx
@@ -4,10 +4,10 @@ import React from 'react'
 import Skeleton from './Skeleton'
 
 describe('Skeleton', () => {
-  it('`data-store-skeleton` is present', () => {
+  it('`data-fs-skeleton` is present', () => {
     const { getByTestId } = render(<Skeleton testId="store-skeleton" />)
     const skeleton = getByTestId('store-skeleton')
 
-    expect(skeleton).toHaveAttribute('data-store-skeleton')
+    expect(skeleton).toHaveAttribute('data-fs-skeleton')
   })
 })

--- a/packages/ui/src/atoms/Skeleton/Skeleton.tsx
+++ b/packages/ui/src/atoms/Skeleton/Skeleton.tsx
@@ -13,7 +13,7 @@ const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(function Skeleton(
   ref
 ) {
   return (
-    <div ref={ref} data-store-skeleton data-testid={testId} {...otherProps} />
+    <div ref={ref} data-fs-skeleton data-testid={testId} {...otherProps} />
   )
 })
 

--- a/packages/ui/src/atoms/Skeleton/stories/Skeleton.mdx
+++ b/packages/ui/src/atoms/Skeleton/stories/Skeleton.mdx
@@ -14,5 +14,5 @@ import Skeleton from '../Skeleton'
 ## CSS Selectors
 
 ```css
-[data-store-skeleton] {}
+[data-fs-skeleton] {}
 ```

--- a/packages/ui/src/atoms/Slider/Slider.test.tsx
+++ b/packages/ui/src/atoms/Slider/Slider.test.tsx
@@ -16,10 +16,10 @@ const props = {
 }
 
 describe('Slider', () => {
-  it('`data-store-slider` is present', () => {
+  it('`data-fs-slider` is present', () => {
     const { getByTestId } = render(<Slider {...props} />)
 
-    expect(getByTestId('store-slider')).toHaveAttribute('data-store-slider')
+    expect(getByTestId('store-slider')).toHaveAttribute('data-fs-slider')
   })
 
   describe('Accessibility', () => {

--- a/packages/ui/src/atoms/Slider/Slider.tsx
+++ b/packages/ui/src/atoms/Slider/Slider.tsx
@@ -120,7 +120,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
     }))
 
     return (
-      <div data-store-slider data-testid={testId} className={className}>
+      <div data-fs-slider data-testid={testId} className={className}>
         <div
           data-slider-range
           style={{

--- a/packages/ui/src/atoms/Slider/stories/Slider.mdx
+++ b/packages/ui/src/atoms/Slider/stories/Slider.mdx
@@ -14,7 +14,7 @@ import Slider from '../Slider'
 # CSS Selectors
 
 ```css
-[data-store-slider] {
+[data-fs-slider] {
 }
 [data-slider-range] {
 }

--- a/packages/ui/src/atoms/Spinner/Spinner.test.tsx
+++ b/packages/ui/src/atoms/Spinner/Spinner.test.tsx
@@ -4,9 +4,9 @@ import React from 'react'
 import Spinner from './Spinner'
 
 describe('Spinner', () => {
-  it('`data-store-spinner` is present', () => {
+  it('`data-fs-spinner` is present', () => {
     const { getByTestId } = render(<Spinner />)
 
-    expect(getByTestId('store-spinner')).toHaveAttribute('data-store-spinner')
+    expect(getByTestId('store-spinner')).toHaveAttribute('data-fs-spinner')
   })
 })

--- a/packages/ui/src/atoms/Spinner/Spinner.tsx
+++ b/packages/ui/src/atoms/Spinner/Spinner.tsx
@@ -11,7 +11,7 @@ export type SpinnerProps = {
 const Spinner = forwardRef<HTMLDivElement, PropsWithChildren<SpinnerProps>>(
   function Spinner({ children, testId = 'store-spinner', ...otherProps }, ref) {
     return (
-      <span ref={ref} data-store-spinner data-testid={testId} {...otherProps} />
+      <span ref={ref} data-fs-spinner data-testid={testId} {...otherProps} />
     )
   }
 )

--- a/packages/ui/src/atoms/Spinner/stories/Spinner.mdx
+++ b/packages/ui/src/atoms/Spinner/stories/Spinner.mdx
@@ -14,5 +14,5 @@ import Spinner from '../Spinner'
 ## CSS Selectors
 
 ```css
-[data-store-spinner] {}
+[data-fs-spinner] {}
 ```

--- a/packages/ui/src/atoms/TextArea/TextArea.test.tsx
+++ b/packages/ui/src/atoms/TextArea/TextArea.test.tsx
@@ -7,10 +7,10 @@ import TextArea from './TextArea'
 const testId = 'store-textarea'
 
 describe('TextArea', () => {
-  it('data-store-textarea is present', () => {
+  it('data-fs-textarea is present', () => {
     const { getByTestId } = render(<TextArea testId={testId} />)
 
-    expect(getByTestId(testId)).toHaveAttribute('data-store-textarea')
+    expect(getByTestId(testId)).toHaveAttribute('data-fs-textarea')
   })
 
   it('state is error', () => {

--- a/packages/ui/src/atoms/TextArea/TextArea.tsx
+++ b/packages/ui/src/atoms/TextArea/TextArea.tsx
@@ -26,7 +26,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     return (
       <textarea
         ref={ref}
-        data-store-textarea
+        data-fs-textarea
         data-testid={testId}
         {...variants}
         {...otherProps}

--- a/packages/ui/src/atoms/TextArea/stories/TextArea.mdx
+++ b/packages/ui/src/atoms/TextArea/stories/TextArea.mdx
@@ -14,7 +14,7 @@ import TextArea from '../TextArea'
 ## CSS Selectors
 
 ```css
-[data-store-textarea] {}
+[data-fs-textarea] {}
 
 [data-success] {}
 

--- a/packages/ui/src/molecules/Accordion/Accordion.test.tsx
+++ b/packages/ui/src/molecules/Accordion/Accordion.test.tsx
@@ -127,8 +127,8 @@ describe('Accordion', () => {
   })
 
   describe('Data attributes', () => {
-    it('`Accordion` component should have `data-store-accordion` attribute', () => {
-      expect(accordion).toHaveAttribute('data-store-accordion')
+    it('`Accordion` component should have `data-fs-accordion` attribute', () => {
+      expect(accordion).toHaveAttribute('data-fs-accordion')
     })
 
     it('`AccordionItem` component should have `data-accordion-item` attribute', () => {

--- a/packages/ui/src/molecules/Accordion/Accordion.tsx
+++ b/packages/ui/src/molecules/Accordion/Accordion.tsx
@@ -50,7 +50,7 @@ const Accordion = forwardRef<HTMLDivElement, AccordionProps>(function Accordion(
     <AccordionContext.Provider value={context}>
       <div
         ref={ref}
-        data-store-accordion
+        data-fs-accordion
         data-testid={testId}
         role="region"
         {...otherProps}

--- a/packages/ui/src/molecules/Accordion/stories/Accordion.mdx
+++ b/packages/ui/src/molecules/Accordion/stories/Accordion.mdx
@@ -53,7 +53,7 @@ Besides those attributes, the following props are also supported:
 ## CSS Selectors
 
 ```css
-[data-store-accordion] {}
+[data-fs-accordion] {}
 [data-accordion-item] {}
 [data-accordion-button] {}
 [data-accordion-panel] {}

--- a/packages/ui/src/molecules/AggregateRating/AggregateRating.test.tsx
+++ b/packages/ui/src/molecules/AggregateRating/AggregateRating.test.tsx
@@ -17,7 +17,7 @@ const fillCheck = (value: number) => {
 }
 
 describe('AggregateRating', () => {
-  it('`data-store-aggregate-rating` is present', () => {
+  it('`data-fs-aggregate-rating` is present', () => {
     const { getByTestId } = render(
       <AggregateRating value={2}>
         <span />
@@ -29,7 +29,7 @@ describe('AggregateRating', () => {
     )
 
     expect(getByTestId('store-aggregate-rating')).toHaveAttribute(
-      'data-store-aggregate-rating'
+      'data-fs-aggregate-rating'
     )
   })
 
@@ -64,7 +64,7 @@ describe('AggregateRating', () => {
         currentItemNumber += 1
       ) {
         expect(ratingItems[currentItemNumber]).toHaveAttribute(
-          'data-store-aggregate-rating-item',
+          'data-fs-aggregate-rating-item',
           fillCheck(value - currentItemNumber)
         )
       }

--- a/packages/ui/src/molecules/AggregateRating/AggregateRating.tsx
+++ b/packages/ui/src/molecules/AggregateRating/AggregateRating.tsx
@@ -16,7 +16,7 @@ export interface AggregateRatingProps extends ListProps<HTMLUListElement> {
 }
 
 export interface RatingItemProps {
-  'data-store-aggregate-rating-item'?: 'full' | 'partial' | 'empty'
+  'data-fs-aggregate-rating-item'?: 'full' | 'partial' | 'empty'
   'data-testid'?: string
 }
 
@@ -56,7 +56,7 @@ const AggregateRating = forwardRef<HTMLUListElement, AggregateRatingProps>(
 
     return (
       <List
-        data-store-aggregate-rating
+        data-fs-aggregate-rating
         variant={variant}
         ref={ref}
         data-testid={testId}
@@ -69,7 +69,7 @@ const AggregateRating = forwardRef<HTMLUListElement, AggregateRatingProps>(
           return (
             <RatingItem
               key={`aggregate-rating-${index}`}
-              data-store-aggregate-rating-item={fill}
+              data-fs-aggregate-rating-item={fill}
               data-testid={`${testId}-item`}
             >
               {child}

--- a/packages/ui/src/molecules/AggregateRating/stories/AggregateRating.mdx
+++ b/packages/ui/src/molecules/AggregateRating/stories/AggregateRating.mdx
@@ -27,7 +27,7 @@ import AggregateRating from '../AggregateRating'
 ## CSS Selectors
 
 ```css
-[data-store-aggregate-rating] {}
+[data-fs-aggregate-rating] {}
 
 [data-aggregate-rating-item=(full|partial|empty)] {}
 ```

--- a/packages/ui/src/molecules/AggregateRating/stories/AggregateRating.stories.tsx
+++ b/packages/ui/src/molecules/AggregateRating/stories/AggregateRating.stories.tsx
@@ -31,7 +31,7 @@ const RatingIcon: FC<RatingItemProps> = (props) => {
         d="M20.388,10.918L32,12.118l-8.735,7.749L25.914,
              31.4l-9.893-6.088L6.127,31.4l2.695-11.533L0,
              12.118l11.547-1.2L16.026,0.6L20.388,10.918z"
-        fill={fillColor[props['data-store-aggregate-rating-item']!]}
+        fill={fillColor[props['data-fs-aggregate-rating-item']!]}
         strokeWidth="2"
         stroke="#ffb100"
       />

--- a/packages/ui/src/molecules/Alert/Alert.test.tsx
+++ b/packages/ui/src/molecules/Alert/Alert.test.tsx
@@ -6,10 +6,10 @@ import Alert from './Alert'
 
 describe('Alert', () => {
   describe('Data attributes', () => {
-    it('should have `data-store-alert` attribute', () => {
+    it('should have `data-fs-alert` attribute', () => {
       const { getByTestId } = render(<Alert>Testing</Alert>)
 
-      expect(getByTestId('store-alert')).toHaveAttribute('data-store-alert')
+      expect(getByTestId('store-alert')).toHaveAttribute('data-fs-alert')
     })
   })
 

--- a/packages/ui/src/molecules/Alert/Alert.tsx
+++ b/packages/ui/src/molecules/Alert/Alert.tsx
@@ -18,7 +18,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(function Alert(
     <div
       ref={ref}
       role="alert"
-      data-store-alert
+      data-fs-alert
       data-testid={testId}
       {...otherProps}
     >

--- a/packages/ui/src/molecules/Alert/stories/Alert.mdx
+++ b/packages/ui/src/molecules/Alert/stories/Alert.mdx
@@ -21,6 +21,6 @@ import Alert from '../Alert'
 ## CSS Selectors
 
 ```css
-[data-store-alert] {
+[data-fs-alert] {
 }
 ```

--- a/packages/ui/src/molecules/Banner/Banner.test.tsx
+++ b/packages/ui/src/molecules/Banner/Banner.test.tsx
@@ -36,8 +36,8 @@ describe('Banner', () => {
     const bannerContent = getByTestId('store-banner-content')
     const bannerLink = getByTestId('store-banner-link')
 
-    it('`Banner` component should have `data-store-banner` attribute', () => {
-      expect(banner).toHaveAttribute('data-store-banner')
+    it('`Banner` component should have `data-fs-banner` attribute', () => {
+      expect(banner).toHaveAttribute('data-fs-banner')
     })
 
     it('`Banner` component should have custom data attribute `data-custom-attribute`', () => {

--- a/packages/ui/src/molecules/Banner/Banner.tsx
+++ b/packages/ui/src/molecules/Banner/Banner.tsx
@@ -19,7 +19,7 @@ const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
   return (
     <article
       ref={ref}
-      data-store-banner={variant}
+      data-fs-banner={variant}
       data-testid={testId}
       {...otherProps}
     >

--- a/packages/ui/src/molecules/Banner/stories/Banner.mdx
+++ b/packages/ui/src/molecules/Banner/stories/Banner.mdx
@@ -50,9 +50,9 @@ Besides those attributes, the following props are also supported:
 ## CSS Selectors
 
 ```css
-[data-store-banner] {
+[data-fs-banner] {
 }
-[data-store-banner='(vertical|horizontal)'] {
+[data-fs-banner='(vertical|horizontal)'] {
 }
 [data-banner-image] {
 }

--- a/packages/ui/src/molecules/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/ui/src/molecules/Breadcrumb/Breadcrumb.test.tsx
@@ -5,11 +5,11 @@ import React from 'react'
 import Breadcrumb from './Breadcrumb'
 
 describe('Breadcrumb', () => {
-  it('`data-store-breadcrumb` is present', () => {
+  it('`data-fs-breadcrumb` is present', () => {
     const { getByTestId } = render(<Breadcrumb />)
 
     expect(getByTestId('store-breadcrumb')).toHaveAttribute(
-      'data-store-breadcrumb'
+      'data-fs-breadcrumb'
     )
   })
 

--- a/packages/ui/src/molecules/Breadcrumb/Breadcrumb.tsx
+++ b/packages/ui/src/molecules/Breadcrumb/Breadcrumb.tsx
@@ -81,7 +81,7 @@ const Breadcrumb = forwardRef<HTMLDivElement, BreadcrumbProps>(
         aria-label="Breadcrumb"
         role="navigation"
         ref={ref}
-        data-store-breadcrumb
+        data-fs-breadcrumb
         data-testid={testId}
         {...otherProps}
       >

--- a/packages/ui/src/molecules/Breadcrumb/stories/Breadcrumb.mdx
+++ b/packages/ui/src/molecules/Breadcrumb/stories/Breadcrumb.mdx
@@ -15,7 +15,7 @@ import Breadcrumb from '../Breadcrumb'
 ## CSS Selectors
 
 ```css
-[data-store-breadcrumb] {}
+[data-fs-breadcrumb] {}
 
 [data-breadcrumb-list] {}
 

--- a/packages/ui/src/molecules/Bullets/Bullets.test.tsx
+++ b/packages/ui/src/molecules/Bullets/Bullets.test.tsx
@@ -5,12 +5,12 @@ import React from 'react'
 import Bullets from './Bullets'
 
 describe('Bullets', () => {
-  it('should have `data-store-bullets` attribute', () => {
+  it('should have `data-fs-bullets` attribute', () => {
     const { getByTestId } = render(
       <Bullets totalQuantity={5} activeBullet={2} onClick={() => null} />
     )
 
-    expect(getByTestId('store-bullets')).toHaveAttribute('data-store-bullets')
+    expect(getByTestId('store-bullets')).toHaveAttribute('data-fs-bullets')
   })
 
   it('should render 5 bullets with `data-bullet-item` attribute', () => {

--- a/packages/ui/src/molecules/Bullets/Bullets.tsx
+++ b/packages/ui/src/molecules/Bullets/Bullets.tsx
@@ -59,7 +59,7 @@ const Bullets = forwardRef<HTMLDivElement, BulletsProps>(function Bullets(
   return (
     <div
       ref={ref}
-      data-store-bullets
+      data-fs-bullets
       data-testid={testId}
       role="tablist"
       {...otherProps}

--- a/packages/ui/src/molecules/Bullets/stories/Bullets.mdx
+++ b/packages/ui/src/molecules/Bullets/stories/Bullets.mdx
@@ -15,7 +15,7 @@ import Bullets from '../Bullets'
 ## CSS Selectors
 
 ```css
-[data-store-bullets] {}
+[data-fs-bullets] {}
 
 [data-bullet-item] {}
 

--- a/packages/ui/src/molecules/Card/Card.test.tsx
+++ b/packages/ui/src/molecules/Card/Card.test.tsx
@@ -43,8 +43,8 @@ describe('Card', () => {
   })
 
   describe('Data attributes', () => {
-    it('`Card` component should have `data-store-card` attribute', () => {
-      expect(card).toHaveAttribute('data-store-card')
+    it('`Card` component should have `data-fs-card` attribute', () => {
+      expect(card).toHaveAttribute('data-fs-card')
     })
 
     it('`CardContent` component should have `data-card-content` attribute', () => {

--- a/packages/ui/src/molecules/Card/Card.tsx
+++ b/packages/ui/src/molecules/Card/Card.tsx
@@ -13,7 +13,7 @@ const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
   ref
 ) {
   return (
-    <article ref={ref} data-store-card data-testid={testId} {...otherProps}>
+    <article ref={ref} data-fs-card data-testid={testId} {...otherProps}>
       {children}
     </article>
   )

--- a/packages/ui/src/molecules/Card/stories/Card.mdx
+++ b/packages/ui/src/molecules/Card/stories/Card.mdx
@@ -43,7 +43,7 @@ All Card-related components support all attributes also supported by the `<div>`
 ## CSS Selectors
 
 ```css
-[data-store-card] {
+[data-fs-card] {
 }
 [data-card-image] {
 }

--- a/packages/ui/src/molecules/Carousel/Carousel.test.tsx
+++ b/packages/ui/src/molecules/Carousel/Carousel.test.tsx
@@ -10,7 +10,7 @@ const wait = (amount = 0) =>
 const SLIDING_TRANSITION_DURATION = 100
 
 describe('Carousel component', () => {
-  it('should have `data-store-carousel` attribute in the section tag', () => {
+  it('should have `data-fs-carousel` attribute in the section tag', () => {
     const { getByTestId } = render(
       <Carousel>
         <div>Slide 1</div>
@@ -21,7 +21,7 @@ describe('Carousel component', () => {
 
     const carouselSection = getByTestId('store-carousel')
 
-    expect(carouselSection).toHaveAttribute('data-store-carousel')
+    expect(carouselSection).toHaveAttribute('data-fs-carousel')
   })
 
   it('should have `data-carousel-track-container` and `data-carousel-track` attributes', () => {

--- a/packages/ui/src/molecules/Carousel/Carousel.tsx
+++ b/packages/ui/src/molecules/Carousel/Carousel.tsx
@@ -141,7 +141,7 @@ function Carousel({
   return (
     <section
       id={id}
-      data-store-carousel
+      data-fs-carousel
       data-testid={testId}
       aria-label="carousel"
       aria-roledescription="carousel"

--- a/packages/ui/src/molecules/Carousel/stories/Carousel.mdx
+++ b/packages/ui/src/molecules/Carousel/stories/Carousel.mdx
@@ -15,7 +15,7 @@ import Carousel from '../Carousel'
 ## CSS Selectors
 
 ```css
-[data-store-carousel] {}
+[data-fs-carousel] {}
 
 [data-carousel-track-container] {}
 
@@ -29,7 +29,7 @@ import Carousel from '../Carousel'
 
 [data-carousel-bullets] {}
 
-[data-carousel-bullets] [data-store-bullets] {}
+[data-carousel-bullets] [data-fs-bullets] {}
 ```
 
 This components inherits [IconButton](?path=/docs/molecules-iconbutton--default#css-selectors), [Bullets](?path=/docs/molecules-bullets--bullets#css-selectors) css selectors.

--- a/packages/ui/src/molecules/Dropdown/DropdownButton.tsx
+++ b/packages/ui/src/molecules/Dropdown/DropdownButton.tsx
@@ -24,7 +24,7 @@ const DropdownButton = forwardRef<HTMLButtonElement, DropdownButtonProps>(
 
     return (
       <button
-        data-store-dropdown-button
+        data-fs-dropdown-button
         onClick={toggle}
         data-testid={testId}
         ref={dropdownButtonRef}

--- a/packages/ui/src/molecules/Dropdown/DropdownItem.tsx
+++ b/packages/ui/src/molecules/Dropdown/DropdownItem.tsx
@@ -49,7 +49,7 @@ const DropdownItem = forwardRef<HTMLButtonElement, DropdownItemProps>(
 
     return (
       <button
-        data-store-dropdown-item
+        data-fs-dropdown-item
         data-testid={testId}
         ref={addToRefs}
         onFocus={onFocusItem}

--- a/packages/ui/src/molecules/Dropdown/DropdownMenu.tsx
+++ b/packages/ui/src/molecules/Dropdown/DropdownMenu.tsx
@@ -115,14 +115,14 @@ const DropdownMenu = ({
     ? createPortal(
         <div
           role="presentation"
-          data-store-dropdown-overlay
+          data-fs-dropdown-overlay
           onKeyDown={handleBackdropKeyDown}
           data-testid={`${testId}-overlay`}
         >
           <div
             role="menu"
             aria-orientation="vertical"
-            data-store-dropdown-menu
+            data-fs-dropdown-menu
             data-testid={testId}
             style={{ ...dropdownPosition, ...style }}
             id={id}

--- a/packages/ui/src/molecules/Dropdown/stories/Dropdown.mdx
+++ b/packages/ui/src/molecules/Dropdown/stories/Dropdown.mdx
@@ -53,11 +53,11 @@ The `Dropdown` uses the [Compound Component](https://kentcdodds.com/blog/compoun
 ## CSS Selectors
 
 ```css
-[data-store-dropdown-button] {}
+[data-fs-dropdown-button] {}
 
-[data-store-dropdown-item] {}
+[data-fs-dropdown-item] {}
 
-[data-store-dropdown-overlay] {}
+[data-fs-dropdown-overlay] {}
 
-[data-store-dropdown-menu] {}
+[data-fs-dropdown-menu] {}
 ```

--- a/packages/ui/src/molecules/Form/Form.test.tsx
+++ b/packages/ui/src/molecules/Form/Form.test.tsx
@@ -37,10 +37,10 @@ const TestForm = ({ onSubmit }: Pick<FormProps, 'onSubmit'>) => (
 )
 
 describe('Form', () => {
-  it('should have `data-store-form` attribute', () => {
+  it('should have `data-fs-form` attribute', () => {
     const { getByTestId } = render(<TestForm />)
 
-    expect(getByTestId('store-form')).toHaveAttribute('data-store-form')
+    expect(getByTestId('store-form')).toHaveAttribute('data-fs-form')
   })
 
   describe('Accessibility', () => {

--- a/packages/ui/src/molecules/Form/Form.tsx
+++ b/packages/ui/src/molecules/Form/Form.tsx
@@ -14,7 +14,7 @@ const Form = forwardRef<HTMLFormElement, FormProps>(function Form(
   ref
 ) {
   return (
-    <form ref={ref} data-store-form data-testid={testId} {...otherProps}>
+    <form ref={ref} data-fs-form data-testid={testId} {...otherProps}>
       {children}
     </form>
   )

--- a/packages/ui/src/molecules/Form/stories/Form.mdx
+++ b/packages/ui/src/molecules/Form/stories/Form.mdx
@@ -19,5 +19,5 @@ Besides those attributes, the following prop is also supported:
 ## CSS Selectors
 
 ```css
-[data-store-form] {}
+[data-fs-form] {}
 ```

--- a/packages/ui/src/molecules/IconButton/IconButton.test.tsx
+++ b/packages/ui/src/molecules/IconButton/IconButton.test.tsx
@@ -6,7 +6,7 @@ import IconButton from './IconButton'
 describe('IconButton', () => {
   const testId = 'store-icon-button'
 
-  it('data-store-icon-button is present', () => {
+  it('data-fs-icon-button is present', () => {
     const { getByTestId } = render(
       <IconButton testId={testId} aria-label="foo" icon={<div>foo</div>} />
     )
@@ -14,7 +14,7 @@ describe('IconButton', () => {
     const iconButton = getByTestId(testId)
 
     expect(iconButton).toBeInTheDocument()
-    expect(iconButton).toHaveAttribute('data-store-icon-button')
+    expect(iconButton).toHaveAttribute('data-fs-icon-button')
   })
 
   it('icon is present', () => {

--- a/packages/ui/src/molecules/IconButton/IconButton.tsx
+++ b/packages/ui/src/molecules/IconButton/IconButton.tsx
@@ -26,7 +26,7 @@ const IconButton = forwardRef<HTMLButtonElement, Props>(function IconButton(
   ref
 ) {
   return (
-    <Button ref={ref} data-store-icon-button testId={testId} {...buttonProps}>
+    <Button ref={ref} data-fs-icon-button testId={testId} {...buttonProps}>
       <Icon component={icon} />
     </Button>
   )

--- a/packages/ui/src/molecules/IconButton/stories/IconButton.mdx
+++ b/packages/ui/src/molecules/IconButton/stories/IconButton.mdx
@@ -21,7 +21,7 @@ import IconButton from '../IconButton'
 
 ## CSS Selectors
 ```css
-[data-store-icon-button] {}
+[data-fs-icon-button] {}
 ```
 
 This component inherits [Button](?path=/docs/atoms-button--button#css-selectors) css selectors.

--- a/packages/ui/src/molecules/LoadingButton/LoadingButton.test.tsx
+++ b/packages/ui/src/molecules/LoadingButton/LoadingButton.test.tsx
@@ -4,11 +4,11 @@ import React from 'react'
 import LoadingButton from './LoadingButton'
 
 describe('Loading Button', () => {
-  it('`data-store-loading-button` is present', () => {
+  it('`data-fs-loading-button` is present', () => {
     const { getByTestId } = render(<LoadingButton loading />)
 
     expect(getByTestId('store-loading-button')).toHaveAttribute(
-      'data-store-loading-button'
+      'data-fs-loading-button'
     )
   })
 })

--- a/packages/ui/src/molecules/LoadingButton/LoadingButton.tsx
+++ b/packages/ui/src/molecules/LoadingButton/LoadingButton.tsx
@@ -23,7 +23,7 @@ const LoadingButton = forwardRef<HTMLButtonElement, LoadingButtonProps>(
     return (
       <Button
         ref={ref}
-        data-store-loading-button
+        data-fs-loading-button
         testId={testId}
         {...otherProps}
       >

--- a/packages/ui/src/molecules/LoadingButton/stories/LoadingButton.mdx
+++ b/packages/ui/src/molecules/LoadingButton/stories/LoadingButton.mdx
@@ -14,7 +14,7 @@ import LoadingButton from '../LoadingButton'
 ## CSS Selectors
 
 ```css
-[data-store-loading-button] {}
+[data-fs-loading-button] {}
 ```
 
 This component inherits [Button](?path=/docs/atoms-button--button#css-selectors) css selectors.

--- a/packages/ui/src/molecules/Modal/Modal.test.tsx
+++ b/packages/ui/src/molecules/Modal/Modal.test.tsx
@@ -41,7 +41,7 @@ const TestModal = ({
 }
 
 describe('Modal', () => {
-  it('The attribute data-store-modal-content should be present', () => {
+  it('The attribute data-fs-modal-content should be present', () => {
     const { getByTestId } = render(
       <Modal aria-label="test modal" testId="store-modal" isOpen>
         Foo
@@ -49,7 +49,7 @@ describe('Modal', () => {
     )
 
     expect(getByTestId('store-modal')).toHaveAttribute(
-      'data-store-modal-content'
+      'data-fs-modal-content'
     )
   })
 

--- a/packages/ui/src/molecules/Modal/ModalContent.tsx
+++ b/packages/ui/src/molecules/Modal/ModalContent.tsx
@@ -36,7 +36,7 @@ const ModalContentPure = ({
         aria-hidden="true"
       />
       <div
-        data-store-modal-content
+        data-fs-modal-content
         data-testid={testId}
         ref={trapFocusRef}
         aria-modal="true"

--- a/packages/ui/src/molecules/Modal/stories/Modal.mdx
+++ b/packages/ui/src/molecules/Modal/stories/Modal.mdx
@@ -14,7 +14,7 @@ import Modal from '../Modal'
 ## CSS Selectors
 
 ```css
-[data-store-modal-content] {}
+[data-fs-modal-content] {}
 
 [data-modal-overlay] {}
 ```

--- a/packages/ui/src/molecules/PaymentMethods/PaymentMethods.test.tsx
+++ b/packages/ui/src/molecules/PaymentMethods/PaymentMethods.test.tsx
@@ -17,8 +17,8 @@ describe('Payment methods', () => {
     paymentMethodsData = getByTestId('store-payment-methods')
   })
 
-  it('should have `data-store-payment-methods` attribute', () => {
-    expect(paymentMethodsData).toHaveAttribute('data-store-payment-methods')
+  it('should have `data-fs-payment-methods` attribute', () => {
+    expect(paymentMethodsData).toHaveAttribute('data-fs-payment-methods')
   })
 
   it('Should render PaymentMethods Children', () => {

--- a/packages/ui/src/molecules/PaymentMethods/PaymentMethods.tsx
+++ b/packages/ui/src/molecules/PaymentMethods/PaymentMethods.tsx
@@ -38,7 +38,7 @@ const PaymentMethods = forwardRef<HTMLDivElement, PaymentMethodsProps>(
     return (
       <div
         ref={ref}
-        data-store-payment-methods
+        data-fs-payment-methods
         data-testid={testId}
         {...otherProps}
       >

--- a/packages/ui/src/molecules/PaymentMethods/stories/PaymentMethods.mdx
+++ b/packages/ui/src/molecules/PaymentMethods/stories/PaymentMethods.mdx
@@ -14,6 +14,6 @@ import PaymentMethods from '../PaymentMethods'
 ## CSS Selectors
 
 ```css
-[data-store-payment-methods] {}
+[data-fs-payment-methods] {}
 [data-payment-methods-flags] {}
 ```

--- a/packages/ui/src/molecules/PriceRange/PriceRange.test.tsx
+++ b/packages/ui/src/molecules/PriceRange/PriceRange.test.tsx
@@ -25,11 +25,11 @@ const props = {
 }
 
 describe('PriceRange', () => {
-  it('`data-store-price-range` is present', () => {
+  it('`data-fs-price-range` is present', () => {
     const { getByTestId } = render(<PriceRange {...props} />)
 
     expect(getByTestId('store-price-range')).toHaveAttribute(
-      'data-store-price-range'
+      'data-fs-price-range'
     )
   })
 

--- a/packages/ui/src/molecules/PriceRange/PriceRange.tsx
+++ b/packages/ui/src/molecules/PriceRange/PriceRange.tsx
@@ -57,7 +57,7 @@ const PriceRange = forwardRef<PriceRangeRefType | undefined, PriceRangeProps>(
     }))
 
     return (
-      <div data-store-price-range data-testid={testId} className={className}>
+      <div data-fs-price-range data-testid={testId} className={className}>
         <Slider
           ref={sliderRef}
           min={min}

--- a/packages/ui/src/molecules/PriceRange/stories/PriceRange.mdx
+++ b/packages/ui/src/molecules/PriceRange/stories/PriceRange.mdx
@@ -15,7 +15,7 @@ import PriceRange from '../PriceRange'
 # CSS Selectors
 
 ```css
-[data-store-price-range] {
+[data-fs-price-range] {
 }
 [data-price-range-values] {
 }

--- a/packages/ui/src/molecules/ProductCard/ProductCard.test.tsx
+++ b/packages/ui/src/molecules/ProductCard/ProductCard.test.tsx
@@ -42,8 +42,8 @@ describe('ProductCard', () => {
   })
 
   describe('Data attributes', () => {
-    it('`ProductCard` component should have `data-store-product-card` attribute', () => {
-      expect(productCard).toHaveAttribute('data-store-product-card')
+    it('`ProductCard` component should have `data-fs-product-card` attribute', () => {
+      expect(productCard).toHaveAttribute('data-fs-product-card')
     })
 
     it('`ProductCardContent` component should have `data-product-card-content` attribute', () => {

--- a/packages/ui/src/molecules/ProductCard/ProductCard.tsx
+++ b/packages/ui/src/molecules/ProductCard/ProductCard.tsx
@@ -16,7 +16,7 @@ const ProductCard = forwardRef<HTMLDivElement, ProductCardProps>(function Card(
   return (
     <article
       ref={ref}
-      data-store-product-card
+      data-fs-product-card
       data-testid={testId}
       {...otherProps}
     >

--- a/packages/ui/src/molecules/ProductCard/stories/ProductCard.mdx
+++ b/packages/ui/src/molecules/ProductCard/stories/ProductCard.mdx
@@ -41,7 +41,7 @@ All Product Card related components support all attributes also supported by the
 ## CSS Selectors
 
 ```css
-[data-store-product-card] {
+[data-fs-product-card] {
 }
 
 [data-product-card-image] {

--- a/packages/ui/src/molecules/QuantitySelector/QuantitySelector.tsx
+++ b/packages/ui/src/molecules/QuantitySelector/QuantitySelector.tsx
@@ -50,7 +50,7 @@ const QuantitySelector = forwardRef<HTMLDivElement, QuantitySelectorProps>(
   ) {
     return (
       <div
-        data-store-quantity-selector
+        data-fs-quantity-selector
         data-testid={testId}
         ref={ref}
         {...otherProps}

--- a/packages/ui/src/molecules/QuantitySelector/stories/QuantitySelector.mdx
+++ b/packages/ui/src/molecules/QuantitySelector/stories/QuantitySelector.mdx
@@ -17,7 +17,7 @@ import QuantitySelector from '../QuantitySelector'
 # CSS Selectors
 
 ```css
-[data-store-quantity-selector] {
+[data-fs-quantity-selector] {
 }
 [data-quantity-selector-input] {
 }

--- a/packages/ui/src/molecules/RadioGroup/RadioOption.tsx
+++ b/packages/ui/src/molecules/RadioGroup/RadioOption.tsx
@@ -29,9 +29,9 @@ const RadioOption = forwardRef<HTMLInputElement, RadioOptionProps>(
     const { name, selectedValue, onChange } = useRadioGroup()
 
     return (
-      <label aria-label={label} data-store-radio-option>
+      <label aria-label={label} data-fs-radio-option>
         <Radio
-          data-store-radio-option-item
+          data-fs-radio-option-item
           ref={ref}
           name={name}
           checked={value === selectedValue}

--- a/packages/ui/src/molecules/RadioGroup/stories/RadioGroup.mdx
+++ b/packages/ui/src/molecules/RadioGroup/stories/RadioGroup.mdx
@@ -34,6 +34,6 @@ import RadioOption from '../RadioOption.tsx'
 ## CSS Selectors
 
 ```css
-[data-store-radio-option] {}
-[data-store-radio-option-item] {}
+[data-fs-radio-option] {}
+[data-fs-radio-option-item] {}
 ```

--- a/packages/ui/src/molecules/SearchInput/SearchInput.test.tsx
+++ b/packages/ui/src/molecules/SearchInput/SearchInput.test.tsx
@@ -10,11 +10,11 @@ const Wrapper = (props: Partial<SearchInputProps>) => (
 )
 
 describe('SearchInput', () => {
-  it('`data-store-search-input` is present', () => {
+  it('`data-fs-search-input` is present', () => {
     const { getByTestId } = render(<Wrapper />)
 
     expect(getByTestId('search-input')).toHaveAttribute(
-      'data-store-search-input'
+      'data-fs-search-input'
     )
   })
 

--- a/packages/ui/src/molecules/SearchInput/SearchInput.tsx
+++ b/packages/ui/src/molecules/SearchInput/SearchInput.tsx
@@ -85,7 +85,7 @@ const SearchInput = forwardRef<SearchInputRef | null, SearchInputProps>(
     return (
       <Form
         ref={formRef}
-        data-store-search-input
+        data-fs-search-input
         data-testid={testId}
         onSubmit={handleSubmit}
         role="search"

--- a/packages/ui/src/molecules/SearchInput/stories/SearchInput.mdx
+++ b/packages/ui/src/molecules/SearchInput/stories/SearchInput.mdx
@@ -22,7 +22,7 @@ import CustomIcon from './assets/CustomIcon'
 
 ## CSS Selectors
 ```css
-[data-store-search-input] {}
+[data-fs-search-input] {}
 ```
 
 This component inherits [Input](?path=/docs/atoms-input--input#css-selectors), [Button](?path=/docs/atoms-button--button#css-selectors), [Icon](?path=/docs/atoms-icon--icon#css-selectors) css selectors.

--- a/packages/ui/src/molecules/Table/Table.test.tsx
+++ b/packages/ui/src/molecules/Table/Table.test.tsx
@@ -41,7 +41,7 @@ describe('Table', () => {
 
       const table = getByTestId('store-table')
 
-      expect(table).toHaveAttribute('data-store-table')
+      expect(table).toHaveAttribute('data-fs-table')
 
       const tableHead = getByTestId('store-table-head')
 

--- a/packages/ui/src/molecules/Table/Table.tsx
+++ b/packages/ui/src/molecules/Table/Table.tsx
@@ -14,7 +14,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(function Table(
   ref
 ) {
   return (
-    <table ref={ref} data-store-table data-testid={testId} {...otherProps}>
+    <table ref={ref} data-fs-table data-testid={testId} {...otherProps}>
       {children}
     </table>
   )

--- a/packages/ui/src/molecules/Table/stories/Table.mdx
+++ b/packages/ui/src/molecules/Table/stories/Table.mdx
@@ -57,7 +57,7 @@ Besides those attributes, the following props are also supported:
 ## CSS Selectors
 
 ```css
-[data-store-table] {}
+[data-fs-table] {}
 
 [data-table-head] {}
 

--- a/packages/ui/src/organisms/Hero/Hero.test.tsx
+++ b/packages/ui/src/organisms/Hero/Hero.test.tsx
@@ -32,8 +32,8 @@ describe('Hero', () => {
     const heroImage = getByTestId('store-hero-image')
     const heroHeading = getByTestId('store-hero-heading')
 
-    it('`Hero` component should have `data-store-hero` attribute', () => {
-      expect(hero).toHaveAttribute('data-store-hero')
+    it('`Hero` component should have `data-fs-hero` attribute', () => {
+      expect(hero).toHaveAttribute('data-fs-hero')
     })
 
     it('`Hero` component should have custom data attribute `data-custom-attribute`', () => {

--- a/packages/ui/src/organisms/Hero/Hero.tsx
+++ b/packages/ui/src/organisms/Hero/Hero.tsx
@@ -14,7 +14,7 @@ const Hero = forwardRef<HTMLDivElement, HeroProps>(function Hero(
   ref
 ) {
   return (
-    <article ref={ref} data-store-hero data-testid={testId} {...otherProps}>
+    <article ref={ref} data-fs-hero data-testid={testId} {...otherProps}>
       {children}
     </article>
   )

--- a/packages/ui/src/organisms/Hero/stories/Hero.mdx
+++ b/packages/ui/src/organisms/Hero/stories/Hero.mdx
@@ -39,7 +39,7 @@ Besides those attributes, the following props are also supported:
 ## CSS Selectors
 
 ```css
-[data-store-hero] {
+[data-fs-hero] {
 }
 [data-hero-image] {
 }

--- a/packages/ui/src/organisms/OutOfStock/OutOfStock.test.tsx
+++ b/packages/ui/src/organisms/OutOfStock/OutOfStock.test.tsx
@@ -32,7 +32,7 @@ describe('OutOfStock', () => {
     const outOfStockMessage = screen.getByTestId('store-out-of-stock-message')
     const outOfStockForm = screen.getByTestId('store-out-of-stock-form')
 
-    expect(outOfStock).toHaveAttribute('data-store-out-of-stock')
+    expect(outOfStock).toHaveAttribute('data-fs-out-of-stock')
     expect(outOfStockForm).toHaveAttribute('data-out-of-stock-form')
     expect(outOfStockTitle).toHaveAttribute('data-out-of-stock-title')
     expect(outOfStockMessage).toHaveAttribute('data-out-of-stock-message')

--- a/packages/ui/src/organisms/OutOfStock/OutOfStock.tsx
+++ b/packages/ui/src/organisms/OutOfStock/OutOfStock.tsx
@@ -28,7 +28,7 @@ const OutOfStock = ({
   ...otherProps
 }: OutOfStockProps) => {
   return (
-    <section data-store-out-of-stock data-testid={testId}>
+    <section data-fs-out-of-stock data-testid={testId}>
       <Form data-out-of-stock-form testId={`${testId}-form`} {...otherProps}>
         {children}
       </Form>

--- a/packages/ui/src/organisms/OutOfStock/stories/OutOfStock.mdx
+++ b/packages/ui/src/organisms/OutOfStock/stories/OutOfStock.mdx
@@ -23,7 +23,7 @@ The `OutOfStock` uses the [Compound Component](https://kentcdodds.com/blog/compo
 ## CSS Selectors
 
 ```css
-[data-store-out-of-stock] {
+[data-fs-out-of-stock] {
 }
 
 [data-out-of-stock-form] {


### PR DESCRIPTION
## What's the purpose of this pull request?

The new components are using the data attribute `data-fs` as the prefix, but the legacy components are using `data-store`, this pr has proposed to update all legacy components in order to use the new prefix.

## How it works?

All `data-store` attributes are renamed to `data-fs`.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

https://github.com/vtex-sites/nextjs.store/pull/265

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
