### PR TITLE
feat: Add watch capability to dev command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,9 @@
   "dependencies": {
     "@oclif/core": "^1.16.4",
     "@oclif/plugin-help": "^5",
-    "@oclif/plugin-not-found": "^2.3.3"
+    "@oclif/plugin-not-found": "^2.3.3",
+    "chokidar": "^3.5.3",
+    "path": "^0.12.7"
   },
   "devDependencies": {
     "@types/chai": "^4",

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -23,8 +23,6 @@ const defaultIgnored = [
   'node_modules/**',
   '**/node_modules/**',
   '.git/**',
-  'cypress/videos/**',
-  'cypress/screenshots/**',
   '.faststore/**',
   '**/.faststore/**',
 ]

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,7 +1,112 @@
 import { Command } from '@oclif/core'
+import { readFileSync } from 'fs'
+import { Readable } from 'stream'
+import { resolve as resolvePath, sep } from 'path'
+import chokidar from 'chokidar'
+
+export interface ChangeToSend {
+  path: string | null
+  content: string | Readable | Buffer | NodeJS.ReadableStream
+  byteSize: number
+}
+
+const getRoot = () => {
+  if (process.env.OCLIF_COMPILATION) {
+    return ''
+  }
+
+  return process.cwd()
+}
+
+const stabilityThreshold = process.platform === 'darwin' ? 100 : 200
+
+const defaultPatterns = [
+  '*/**',
+  'store.config.js'
+]
+
+const defaultIgnored = [
+  '.DS_Store',
+  'README.md',
+  '.gitignore',
+  'package.json',
+  'node_modules/**',
+  '**/node_modules/**',
+  '.git/**',
+  'cypress/videos/**',
+  'cypress/screenshots/**',
+]
 
 export default class Dev extends Command {
   async run() {
-    console.log('running dev command')
+    const root = getRoot()
+
+    console.log(getRoot())
+    const changeQueue: ChangeToSend[] = []
+
+    const pathToChange = (path: string, remove?: boolean): ChangeToSend => {
+      const content = remove
+        ? ''
+        : readFileSync(resolvePath(root, path)).toString('base64')
+
+      const byteSize = remove ? 0 : Buffer.byteLength(content)
+
+      return {
+        content,
+        byteSize,
+        path: path.split(sep).join('/'),
+      }
+    }
+
+    const queueChange = (path: string, remove?: boolean) => {
+      // console.log(
+      //   `${chalk.gray(moment().format('HH:mm:ss:SSS'))} - ${
+      //     remove ? DELETE_SIGN : UPDATE_SIGN
+      //   } ${path}`
+      // )
+
+
+      console.log(path)
+
+      changeQueue.push(pathToChange(path, remove))
+      copyChanges()
+    }
+
+    const copyChanges = () => {
+      /** copy changes to .faststore */
+    }
+
+    const addIgnoreNodeModulesRule = (
+      paths: Array<string | ((path: string) => boolean)>
+    ) =>
+      paths.concat([
+        (path: string) => path.includes('node_modules'),
+        (path: string) => path.includes('.faststore'),
+        (path: string) => path.includes('.git'),
+      ])
+
+    const watcher = chokidar.watch(
+      [...defaultPatterns],
+      {
+        atomic: stabilityThreshold,
+        awaitWriteFinish: {
+          stabilityThreshold,
+        },
+        cwd: root,
+        ignoreInitial: true,
+        ignored: addIgnoreNodeModulesRule(defaultIgnored),
+        persistent: true,
+        usePolling: process.platform === 'win32',
+      }
+    )
+
+    await new Promise((resolve, reject) => {
+      watcher
+        .on('add', (file) => queueChange(file))
+        .on('change', (file) => queueChange(file))
+        .on('unlink', (file) => queueChange(file, true))
+        .on('error', reject)
+        .on('ready', resolve)
+    })
   }
 }

--- a/packages/cli/src/utils/root.ts
+++ b/packages/cli/src/utils/root.ts
@@ -1,0 +1,7 @@
+export const getRoot = () => {
+  if (process.env.OCLIF_COMPILATION) {
+    return ''
+  }
+
+  return process.cwd()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -22017,6 +22017,14 @@ path-type@^4.0.0:
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+path@^0.12.7:
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
+  integrity sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==
+  dependencies:
+    process "^0.11.1"
+    util "^0.10.3"
+
 pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz"
@@ -23086,7 +23094,7 @@ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.11.10:
+process@^0.11.1, process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
@@ -27960,6 +27968,13 @@ util@0.10.3:
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
+
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
 
 util@^0.11.0:
   version "0.11.1"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds watch capability to the dev command.

## How it works?

It uses [chokidar](https://www.npmjs.com/package/chokidar), a library that wraps the default `fs.watch` function and fixes its issues. We followed the same logic [VTEX Toolbelt](https://github.com/vtex/toolbelt) uses to watch for file changes while a project is linked.

Currently, it does nothing with those changes besides logging it into the terminal.

## How to test it?

Add a `console.log` call in the `queueChange` function to see the `path` variable. Build the project, add the bin folder to the PATH variable of your terminal and then execute `run dev` on your FastStore Store. Whenever you change your code, you'll be able to see the path of the file you changed logged in the terminal. The same is valid for file creation and removal. 
