### PR TITLE
feat: Add seller dimension to channel

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -165,7 +165,7 @@ export const VtexCommerce = (
         postalCode,
         country,
         salesChannel,
-      }: RegionInput): Promise<Region> => {
+      }: RegionInput): Promise<Region[]> => {
         return fetchAPI(
           `${base}/api/checkout/pub/regions/?postalCode=${postalCode}&country=${country}&sc=${
             salesChannel ?? ''

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Region.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Region.ts
@@ -1,7 +1,16 @@
 export interface RegionInput {
-  postalCode: string
-  country: string
-  salesChannel?: string | null
+  postalCode: string;
+  country: string;
+  salesChannel?: string | null;
 }
 
-export type Region = Array<{ id: string }>
+export interface Seller {
+  id: string; // storeframework01
+  name: string; // My Awsome Seller
+  logo: string;
+}
+
+export interface Region {
+  id: string;
+  sellers: Seller[];
+}

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -83,16 +83,16 @@ export const IntelligentSearch = (
   const addDefaultFacets = (facets: SelectedFacet[]) => {
     const withDefaltFacets = facets.filter(({ key }) => !CHANNEL_KEYS.has(key))
 
-    const policyFacet = 
+    const policyFacet =
       facets.find(({ key }) => key === POLICY_KEY) ?? getPolicyFacet()
 
-    const regionFacet = 
+    const regionFacet =
       facets.find(({ key }) => key === REGION_KEY) ?? getRegionFacet()
-    
+
     if (policyFacet !== null) {
       withDefaltFacets.push(policyFacet)
     }
-    
+
     if (regionFacet !== null) {
       withDefaltFacets.push(regionFacet)
     }

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -67,7 +67,7 @@ export const IntelligentSearch = (
 
   const getRegionFacet = (): IStoreSelectedFacet | null => {
     const { regionId, seller } = ctx.storage.channel
-    const sellerRegionId = seller ? btoa(`SW#${seller}`) : null
+    const sellerRegionId = seller ? Buffer.from(`SW#${seller}`).toString('base64') : null
     const facet = sellerRegionId ?? regionId
 
     if (!facet) {

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -66,31 +66,33 @@ export const IntelligentSearch = (
   }
 
   const getRegionFacet = (): IStoreSelectedFacet | null => {
-    const { regionId } = ctx.storage.channel
+    const { regionId, seller } = ctx.storage.channel
+    const sellerRegionId = seller ? btoa(`SW#${seller}`) : null
+    const facet = sellerRegionId ?? regionId
 
-    if (!regionId) {
+    if (!facet) {
       return null
     }
 
     return {
       key: REGION_KEY,
-      value: regionId,
+      value: facet,
     }
   }
 
   const addDefaultFacets = (facets: SelectedFacet[]) => {
     const withDefaltFacets = facets.filter(({ key }) => !CHANNEL_KEYS.has(key))
 
-    const policyFacet =
+    const policyFacet = 
       facets.find(({ key }) => key === POLICY_KEY) ?? getPolicyFacet()
 
-    const regionFacet =
+    const regionFacet = 
       facets.find(({ key }) => key === REGION_KEY) ?? getRegionFacet()
-
+    
     if (policyFacet !== null) {
       withDefaltFacets.push(policyFacet)
     }
-
+    
     if (regionFacet !== null) {
       withDefaltFacets.push(regionFacet)
     }

--- a/packages/api/src/platforms/vtex/resolvers/offer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/offer.ts
@@ -57,10 +57,10 @@ export const StoreOffer: Record<string, Resolver<Root>> = {
 
     return null
   },
-  seller: (root) => {
+  seller: (root, _, ctx) => {
     if (isSearchItem(root)) {
       return {
-        identifier: root.seller.sellerId ?? '',
+        identifier: ctx.storage.channel?.seller || root.seller.sellerId || '',
       }
     }
 

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -29,6 +29,9 @@ export const validateSession = async (
 
   const profile = sessionData?.namespaces.profile ?? null
   const store = sessionData?.namespaces.store ?? null
+  const region = regionData?.[0]
+  // Set seller only if it's inside a region
+  const seller = region?.sellers.find(seller => channel.seller === seller.id)
 
   const newSession = {
     ...oldSession,
@@ -39,7 +42,8 @@ export const validateSession = async (
     country: store?.countryCode.value ?? oldSession.country,
     channel: ChannelMarshal.stringify({
       salesChannel: store?.channel?.value ?? channel.salesChannel,
-      regionId: regionData?.[0]?.id ?? channel.regionId,
+      regionId: region?.id ?? channel.regionId,
+      seller: seller?.id
     }),
     person: profile?.id
       ? {

--- a/packages/api/src/platforms/vtex/utils/channel.ts
+++ b/packages/api/src/platforms/vtex/utils/channel.ts
@@ -1,4 +1,5 @@
 export interface Channel {
+  seller?: string
   regionId?: string
   salesChannel?: string
 }
@@ -9,6 +10,7 @@ export default class ChannelMarshal {
       const parsedChannel = JSON.parse(channelString) as Channel
 
       return {
+        seller: parsedChannel.seller ?? '',
         regionId: parsedChannel.regionId ?? '',
         salesChannel: parsedChannel.salesChannel ?? '',
       }

--- a/packages/api/src/platforms/vtex/utils/facets.ts
+++ b/packages/api/src/platforms/vtex/utils/facets.ts
@@ -1,4 +1,3 @@
-import ChannelMarshal from './channel'
 import type { Maybe } from '../../../__generated__/schema'
 import { BadRequestError } from '../../errors'
 
@@ -27,27 +26,12 @@ export const FACET_CROSS_SELLING_MAP = {
  * */
 export const transformSelectedFacet = ({ key, value }: SelectedFacet) => {
   switch (key) {
-    case 'channel': {
-      const channel = ChannelMarshal.parse(value)
-      const channelFacets = [
-        { key: 'trade-policy', value: channel.salesChannel },
-      ]
-
-      if (channel.regionId) {
-        channelFacets.push({ key: 'region-id', value: channel.regionId })
-      }
-
-      return channelFacets
-    }
-
-    case 'locale': {
-      return [] // remove this facet from search
-    }
-
     case 'price': {
       return { key, value: value.replace('-to-', ':') }
     }
-
+    
+    case 'channel': 
+    case 'locale': 
     case "buy":
     case "view":
     case "similars":

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR makes it possible to use `@faststore/api` by selecting a specific seller. This seller is kept both during add to cart and navigation.

## How it works?
A new dimension was added to `channel` called `seller`.  When `seller` is selected, all navigation will be done given this seller. Add to cart will also use the given seller from session.

To convert your store to this behavior, check out how it's done in [here](https://github.com/vtex-sites/casinofr.store/blob/f6a1bfc653d209caed33fd3e41f6b41326d9ad74/src/components/regionalization/contexts/RegionalizationContext.tsx#L123) 

### How to test it?
Open this [preview](https://sfj-f6a1bfc--casinofr.preview.vtex.app/). Select a give store. Make sure prices and cart are kept consistent across the buying process.

### Starters Deploy Preview
- https://github.com/vtex-sites/nextjs.store/pull/294

