### PR TITLE
fix: Rename `SearchInput`'s form data-attribute

### DIFF
--- a/apps/docs/docs/reference/ui/molecules/SearchInput.mdx
+++ b/apps/docs/docs/reference/ui/molecules/SearchInput.mdx
@@ -40,6 +40,6 @@ import { SearchInput } from '@faststore/ui'
 
 ## Customization
 
-`data-fs-search-input`
+`data-fs-search-input-form`
 
 This component inherits [Input](/reference/ui/atoms/Input), [Button](/reference/ui/atoms/Button), [Icon](/reference/ui/atoms/Icon) css selectors.

--- a/packages/styles/src/molecules/search-input.css
+++ b/packages/styles/src/molecules/search-input.css
@@ -1,9 +1,9 @@
-[data-fs-search-input] {
+[data-fs-search-input-form] {
   @apply box-border m-0 min-w-0 max-w-sm min-h-0 items-center relative w-60 h-11 p-0 flex;
   @apply bg-white border border-gray-400;
 }
 
-[data-fs-search-input] [data-fs-button] {
+[data-fs-search-input-form] [data-fs-button] {
   @apply items-center border-0 rounded box-border cursor-pointer flex h-10 justify-center m-0 min-w-0 max-h-10 py-2 px-4 absolute right-0;
   @apply appearance-none bg-transparent text-black;
   @apply text-center no-underline;

--- a/packages/ui/src/molecules/SearchInput/SearchInput.test.tsx
+++ b/packages/ui/src/molecules/SearchInput/SearchInput.test.tsx
@@ -6,7 +6,7 @@ import type { SearchInputProps } from './SearchInput'
 import SearchInput from './SearchInput'
 
 const Wrapper = (props: Partial<SearchInputProps>) => (
-  <SearchInput {...props} onSubmit={(value) => value} testId="search-input" />
+  <SearchInput testId="search-input" onSubmit={(value) => value} {...props} />
 )
 
 describe('SearchInput', () => {
@@ -16,6 +16,12 @@ describe('SearchInput', () => {
     expect(getByTestId('search-input')).toHaveAttribute(
       'data-fs-search-input-form'
     )
+  })
+
+  it('`data-fs-search-input` is present and applied to `Input`', () => {
+    const { getByTestId } = render(<Wrapper data-fs-search-input />)
+
+    expect(getByTestId('store-input')).toHaveAttribute('data-fs-search-input')
   })
 
   describe('Accessibility', () => {

--- a/packages/ui/src/molecules/SearchInput/SearchInput.test.tsx
+++ b/packages/ui/src/molecules/SearchInput/SearchInput.test.tsx
@@ -10,11 +10,11 @@ const Wrapper = (props: Partial<SearchInputProps>) => (
 )
 
 describe('SearchInput', () => {
-  it('`data-fs-search-input` is present', () => {
+  it('`data-fs-search-input-form` is present', () => {
     const { getByTestId } = render(<Wrapper />)
 
     expect(getByTestId('search-input')).toHaveAttribute(
-      'data-fs-search-input'
+      'data-fs-search-input-form'
     )
   })
 

--- a/packages/ui/src/molecules/SearchInput/SearchInput.tsx
+++ b/packages/ui/src/molecules/SearchInput/SearchInput.tsx
@@ -85,7 +85,7 @@ const SearchInput = forwardRef<SearchInputRef | null, SearchInputProps>(
     return (
       <Form
         ref={formRef}
-        data-fs-search-input
+        data-fs-search-input-form
         data-testid={testId}
         onSubmit={handleSubmit}
         role="search"

--- a/packages/ui/src/molecules/SearchInput/stories/SearchInput.mdx
+++ b/packages/ui/src/molecules/SearchInput/stories/SearchInput.mdx
@@ -22,7 +22,7 @@ import CustomIcon from './assets/CustomIcon'
 
 ## CSS Selectors
 ```css
-[data-fs-search-input] {}
+[data-fs-search-input-form] {}
 ```
 
 This component inherits [Input](?path=/docs/atoms-input--input#css-selectors), [Button](?path=/docs/atoms-button--button#css-selectors), [Icon](?path=/docs/atoms-icon--icon#css-selectors) css selectors.


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to rename the `SearchInput`s form data-attribute to avoid duplicates in the stores.