### PR TITLE
fix: checks for session existance before trying to update shipping data

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -205,8 +205,17 @@ const getOrderForm = async (
     id,
   });
 
+  // Stores that are not yet providing the session while validating the cart
+  // should not be able to update the shipping data
+  //
+  // This was causing errors while validating regionalizated carts
+  // because the following code was trying to change the shippingData to an undefined address/session
+  if(!session) {
+    return orderForm
+  }
+
   const shouldUpdateShippingData =
-    orderForm.shippingData?.address?.postalCode != session?.postalCode;
+    orderForm.shippingData?.address?.postalCode != session.postalCode;
 
   if (shouldUpdateShippingData) {
     return commerce.checkout.shippingData({


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes a null pointer exception call on the update shipping data request. If the session was null or undefined, the `validateCart` mutation would try to update it anyways.

## How it works?

It checks if the session is null, and if so, returns the orderform, which was the previous behavior of the API.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
