### PR TITLE
fix: Bad postal code on shipping data

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -215,6 +215,7 @@ const getOrderForm = async (
   }
 
   const shouldUpdateShippingData =
+    typeof session.postalCode === 'string' &&
     orderForm.shippingData?.address?.postalCode != session.postalCode;
 
   if (shouldUpdateShippingData) {


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes the following flow:
1. User adds item to cart
2. User goes to checkout
3. User fills shipping address
4. User goes back to the store and adds more items to cart

## How it works?
Before this PR, we only checked the difference between previous and current postal code. Turns out, that we also need to check for the validity of this postal code. This PR does just that and only changes the shipping address if it's defined, fixing the aforementioned issue.

## How to test it?
The images bellow show the validateCart mutation before/after this PR is applied. To reproduce it, follow the flow described on the first section.
![image](https://user-images.githubusercontent.com/1753396/196780325-9a6f7ebb-1fc5-4d69-b480-49bea266f726.png)

![image](https://user-images.githubusercontent.com/1753396/196780716-89e2a4fb-3ea7-405b-8988-acd0bb2bd49b.png)

### Starters Deploy Preview
- https://github.com/vtex-sites/nextjs.store/pull/279