### PR TITLE
Fix: Takes sales channel in consideration when getting region

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -17,12 +17,13 @@ export const validateSession = async (
   const country = oldSession.country ?? ''
 
   const params = new URLSearchParams(search)
+  const salesChannel = params.get('sc') ?? channel.salesChannel
 
-  params.set('sc', params.get('sc') ?? channel.salesChannel)
+  params.set('sc', salesChannel)
 
   const [regionData, sessionData] = await Promise.all([
     postalCode
-      ? clients.commerce.checkout.region({ postalCode, country })
+      ? clients.commerce.checkout.region({ postalCode, country, salesChannel })
       : Promise.resolve(null),
     clients.commerce.session(params.toString()).catch(() => null),
   ])


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR was created to address a problem found when defining a region with a sales channel. 

Without this change the result of the validateSession mutation for a given region and sales channel was:
```
{
  "data": {
    "validateSession": {
      ...
      "channel": "{\"salesChannel\":\"4\",\"regionId\":\"U1cj\"}",
    }
  }
}
```

While with this change it returns the needed value:

```
{
  "data": {
    "validateSession": {
      ...
      "channel": "{\"salesChannel\":\"4\",\"regionId\":\"U1cjdGF0YXV5c2FsdG87dGF0YXV5c2VsbGVyY3Jvc3NtZXJjYWRv\"}",
    }
  }
}
```

## How it works?
Before this change, the code was not taking in consideration the sales channel at the params to get the region.

## How to test it?
- At `server.ts` use tata configuration as apiOptions:
```
 const apiOptions = {
   platform: 'vtex',
   account: 'tatauy',
   locale: 'en-US',
   environment: 'vtexcommercestable',
   channel: '{"salesChannel":"4","regionId":""}',
 } as Options
 ```
- Use the `yarn workspace @faststore/api develop` command to open the graphiql of faststore.
- Run this mutation:
```
mutation ValidateSession($session: IStoreSession!, $search: String!) {
    validateSession(session: $session, search: $search) {
      locale
      channel
      country
      postalCode
      currency {
        code
        symbol
      }
      person {
        id
        email
        givenName
        familyName
      }
    }
  }
```
With these query variables:
```
{
  "search": "",
  "session": {
  	"locale": "es-UY",
  "channel": "{\"salesChannel\":\"4\",\"regionId\":\"\"}",
  "country": "URY",
  "postalCode": "50000",
  "currency": {
    "code": "$",
    "symbol": "$"
  },
  "person": null  
  }
}
```

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
