### PR TITLE
feat: adds develop command when running faststore dev

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,6 +2,7 @@
   "buildCommand": "turbo run build --filter=./packages/* --filter=!./packages/shared",
   "packages": [
     "packages/api",
+    "packages/cli",
     "packages/graphql-utils",
     "packages/lighthouse",
     "packages/sdk",

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -29,15 +29,15 @@ const defaultIgnored = [
 const devAbortController = new AbortController()
 
 async function storeDev() {
-  const bunDevProcess = spawn('bun develop', {
+  const devProcess = spawn('yarn develop', {
     shell: true,
     cwd: tmpDir,
     signal: devAbortController.signal,
     stdio: 'inherit',
   })
 
-  bunDevProcess.on('close', (code) => {
-    console.log(`Development server closed with code ${code}`)
+  devProcess.on('close', () => {
+    devAbortController.abort()
   })
 }
 
@@ -61,6 +61,10 @@ export default class Dev extends Command {
       usePolling: process.platform === 'win32',
     })
 
+    devAbortController.signal.addEventListener('abort', () => {
+      watcher.close()
+    })
+
     await generate({ setup: true })
     storeDev()
 
@@ -74,7 +78,6 @@ export default class Dev extends Command {
           reject()
         })
         .on('ready', resolve)
-        .on('close', resolve)
     })
   }
 }

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -66,6 +66,7 @@ export default class Dev extends Command {
     })
 
     await generate({ setup: true })
+    
     storeDev()
 
     return await new Promise((resolve, reject) => {

--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -33,3 +33,6 @@ export const storeConfigFileName = 'store.config.js'
 export const userStoreConfigFileDir = `${userDir}/${storeConfigFileName}`
 export const coreStoreConfigFileDir = `${coreDir}/${storeConfigFileName}`
 export const tmpStoreConfigFileDir = `${tmpDir}/${storeConfigFileName}`
+
+export const userNodeModulesDir = `${userDir}/node_modules`
+export const tmpNodeModulesDir = `${tmpDir}/node_modules`


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR makes the faststore dev command run a NextJS development server on the starter.
## How it works?

It calls bun develop in the generated folder as a subprocess, which gives us a live store.

## How to test it?
Run this CLI (`yarn add https://pkg.csb.dev/vtex/faststore/commit/3d59496/@faststore/cli` and then `yarn dev`) on the [starter.store](https://github.com/vtex-sites/starter.store) repo. You should see a local NextJS development server spawned.
