### PR TITLE
Feat: add build command

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,7 +1,16 @@
 import { Command } from '@oclif/core'
+import { spawnSync } from 'child_process'
+import { tmpDir } from '../utils/directory'
+import { generate } from '../utils/generate'
 
 export default class Build extends Command {
   async run() {
-    console.log('running build command')
+    await generate({ setup: true })
+
+    return spawnSync(`yarn build`, {
+     shell: true,
+     cwd: tmpDir,
+     stdio: 'inherit',
+   })
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds build command to the CLI

## How it works?

It calls the generate function and spawns the build process.

## How to test it?
Run yarn add `https://pkg.csb.dev/vtex/faststore/commit/f5b0b51/@faststore/cli` and then `yarn build`. The build process should run and you should be able to see the build inside the `.faststore/.next` folder.
