### PR TITLE
feat: adds start command to serve stores

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,7 +1,20 @@
 import { Command } from '@oclif/core'
+import { spawn } from 'child_process'
+import fse from 'fs-extra'
+import { tmpDir } from '../utils/directory'
 
 export default class Start extends Command {
   async run() {
-    console.log('running start command')
+    if (!fse.existsSync(tmpDir)) {
+      throw Error(
+        'The ".faststore" directory could not be found. If you are trying to serve your store, run "faststore build" first.'
+      )
+    }
+
+    return spawn(`yarn serve`, {
+      shell: true,
+      cwd: tmpDir,
+      stdio: 'inherit',
+    })
   }
 }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,11 +1,11 @@
 import { Command } from '@oclif/core'
 import { spawn } from 'child_process'
-import fse from 'fs-extra'
+import { existsSync } from 'fs-extra'
 import { tmpDir } from '../utils/directory'
 
 export default class Start extends Command {
   async run() {
-    if (!fse.existsSync(tmpDir)) {
+    if (!existsSync(tmpDir)) {
       throw Error(
         'The ".faststore" directory could not be found. If you are trying to serve your store, run "faststore build" first.'
       )


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds start command to the CLI

## How it works?

It checks if the `.faststore` folder exists and spawns the `serve` process.

## How to test it?

Run yarn add `https://pkg.csb.dev/vtex/faststore/commit/2724d45/@faststore/cli` and then `yarn start`. The local server should be spawned and you should be able to browse your production build at `localhost:3000`.
