### PR TITLE
Docs: Adds overview section classes

### DIFF
--- a/apps/docs/docs/reference/ui/atoms/Badge.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Badge.mdx
@@ -16,16 +16,20 @@ Badges are status descriptors used to emphasize an item's state.
 ## Overview
 
 ```tsx live
-<div style={{ display: 'flex', columnGap: '16px', alignItems: 'center' }}>
-  <Badge variant="neutral">Neutral</Badge>
-  <Badge variant="info">Info</Badge>
-  <Badge variant="highlighted">Highlighted</Badge>
-  <Badge variant="success">Success</Badge>
-  <Badge variant="warning">Warning</Badge>
-  <Badge variant="danger">Danger</Badge>
-  <Badge variant="neutral" size="big">
-    Neutral & Big
-  </Badge>
+<div className="overviewSectionColumn">
+  <div className="overviewSection">
+    <Badge variant="neutral">Neutral</Badge>
+    <Badge variant="info">Info</Badge>
+    <Badge variant="highlighted">Highlighted</Badge>
+    <Badge variant="neutral" size="big">
+      Neutral & Big
+    </Badge>
+  </div>
+  <div className="overviewSection">
+    <Badge variant="success">Success</Badge>
+    <Badge variant="warning">Warning</Badge>
+    <Badge variant="danger">Danger</Badge>
+  </div>
 </div>
 ```
 

--- a/apps/docs/docs/reference/ui/atoms/Button.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Button.mdx
@@ -18,7 +18,7 @@ Buttons indicate actions that users can take, such as adding an item to the cart
 ## Overview
 
 ```tsx live
-<div style={{ display: 'flex', columnGap: '16px', alignItems: 'center' }}>
+<div className="overviewSection">
   <Button variant="primary">Primary</Button>
   <Button variant="secondary">Secondary</Button>
   <Button variant="tertiary">Tertiary</Button>

--- a/apps/docs/docs/reference/ui/atoms/Checkbox.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Checkbox.mdx
@@ -14,7 +14,7 @@ Checkboxes allow users to toggle an option on or off.
 ## Overview
 
 ```tsx live
-<div style={{ display: 'flex', columnGap: '16px' }}>
+<div className="overviewSection">
   <Checkbox />
   <Checkbox checked readOnly />
   <Checkbox disabled />

--- a/apps/docs/docs/reference/ui/atoms/Radio.mdx
+++ b/apps/docs/docs/reference/ui/atoms/Radio.mdx
@@ -14,7 +14,7 @@ Radios allow users to select one option from a set.
 ## Overview
 
 ```tsx live
-<div style={{ display: 'flex', columnGap: '16px' }}>
+<div className="overviewSection">
   <Radio />
   <Radio checked readOnly />
   <Radio disabled />

--- a/apps/docs/docs/reference/ui/molecules/CheckboxField.mdx
+++ b/apps/docs/docs/reference/ui/molecules/CheckboxField.mdx
@@ -14,7 +14,7 @@ CheckboxField wraps a [Checkbox](/reference/ui/atoms/Checkbox) input and its cor
 ## Overview
 
 ```tsx live
-<div style={{ display: 'flex', columnGap: '22px' }}>
+<div className="overviewSection">
   <CheckboxField label="Default" id="checkboxfield-default" />
   <CheckboxField label="Checked" id="checkboxfield-checked" checked readOnly />
   <CheckboxField label="Disabled" id="checkboxfield-disabled" disabled />

--- a/apps/docs/docs/reference/ui/molecules/IconButton.mdx
+++ b/apps/docs/docs/reference/ui/molecules/IconButton.mdx
@@ -13,7 +13,7 @@ Icon Buttons are icons that trigger some sort of action, such as adding an item 
 ## Overview
 
 ```tsx live
-<div style={{ display: 'flex', columnGap: '22px' }}>
+<div className="overviewSection">
   <IconButton icon={<ShoppingCart />} aria-label="Buy" />
   <IconButton icon={<ShoppingCart />} aria-label="Buy" variant="primary" />
 </div>

--- a/apps/docs/docs/reference/ui/molecules/RadioField.mdx
+++ b/apps/docs/docs/reference/ui/molecules/RadioField.mdx
@@ -14,7 +14,7 @@ RadioField wraps a [Radio](/reference/ui/atoms/Radio) input and its correspondin
 ## Overview
 
 ```tsx live
-<div style={{ display: 'flex', columnGap: '22px' }}>
+<div className="overviewSection">
   <RadioField label="Default" id="radiofield-default" />
   <RadioField label="Checked" id="radiofield-checked" checked readOnly />
   <RadioField label="Disabled" id="radiofield-disabled" disabled />

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -431,8 +431,16 @@
   @apply bg-brandlessBlue
  }
 
+/* Overview section */
+
  .overviewSection {
   display: flex;
   column-gap: 16px;
   align-items: center;
+ }
+
+ .overviewSectionColumn {
+  display: flex;
+  flex-direction: column;
+  row-gap: 16px;
  }

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -430,3 +430,9 @@
  .customizingCard{
   @apply bg-brandlessBlue
  }
+
+ .overviewSection {
+  display: flex;
+  column-gap: 16px;
+  align-items: center;
+ }


### PR DESCRIPTION
## What's the purpose of this pull request?

To improve the readability of the example provided in our documentation. I added specific classes to style the overview section instead of using inline CSS.

Before|After|
|-|-|
|<img width="664" alt="image" src="https://user-images.githubusercontent.com/3356699/205959452-16fd9215-786e-42f0-ade1-1f6b7c67021a.png">|<img width="608" alt="image" src="https://user-images.githubusercontent.com/3356699/205959541-b8091d79-0638-4fb9-b845-d055899595fe.png">|
