### PR TITLE
Fix/move assets to component package

### DIFF
--- a/packages/components/src/assets/ShoppingCart.tsx
+++ b/packages/components/src/assets/ShoppingCart.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import type { FC } from 'react'
+
+// Icon from Phosphor Icons
+const ShoppingCart: FC = () => (
+  <svg
+    id="ShoppingCart"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 256 256"
+    strokeWidth="16"
+    width={24}
+    height={24}
+  >
+    <rect width="256" height="256" fill="none"></rect>
+    <path
+      d="M184,184H69.81818L41.92162,30.56892A8,8,0,0,0,34.05066,24H16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    ></path>
+    <circle
+      cx="80"
+      cy="204"
+      r="20"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    ></circle>
+    <circle
+      cx="184"
+      cy="204"
+      r="20"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    ></circle>
+    <path
+      d="M62.54543,144H188.10132a16,16,0,0,0,15.74192-13.13783L216,64H48"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    ></path>
+  </svg>
+)
+
+export default ShoppingCart

--- a/packages/components/src/assets/X.tsx
+++ b/packages/components/src/assets/X.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import type { FC } from 'react'
+
+// Icon from Phosphor Icons
+const X: FC = () => (
+  <svg
+    id="X"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 256 256"
+    strokeWidth="16"
+    width={24}
+    height={24}
+  >
+    <rect width="256" height="256" fill="none"></rect>
+    <line
+      x1="200"
+      y1="56"
+      x2="56"
+      y2="200"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    ></line>
+    <line
+      x1="200"
+      y1="200"
+      x2="56"
+      y2="56"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    ></line>
+  </svg>
+)
+
+export default X

--- a/packages/components/src/assets/index.ts
+++ b/packages/components/src/assets/index.ts
@@ -1,0 +1,2 @@
+export { default as X } from './X'
+export { default as ShoppingCart } from './ShoppingCart'

--- a/packages/components/src/molecules/Tag/Tag.tsx
+++ b/packages/components/src/molecules/Tag/Tag.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 import type { ReactNode } from 'react'
 import { Icon } from '../..'
 import { Badge, BadgeProps } from '../..'
-import { X } from '@faststore/ui/src/assets'
+import { X } from '../../assets'
 
 export interface TagProps extends BadgeProps {
   /**

--- a/packages/ui/src/assets/index.ts
+++ b/packages/ui/src/assets/index.ts
@@ -1,2 +1,0 @@
-export { default as ShoppingCart } from './ShoppingCart'
-export { default as X } from './X'


### PR DESCRIPTION
## What's the purpose of this pull request?

This pr moves the folder assets to package components, expecting solve this error:

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/51174217/205933462-f9c7574a-07d7-4898-914d-a21bf2dc3d78.png">
