### PR TITLE
Feat: Beautify CLI messages with chalk

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
     "@oclif/core": "^1.16.4",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-not-found": "^2.3.3",
+    "chalk": "~4.1.2",
     "chokidar": "^3.5.3",
     "deepmerge": "^4.2.2",
     "fs-extra": "^10.1.0",
@@ -36,6 +37,10 @@
     "ts-node": "^10.9.1",
     "tslib": "^2.3.1",
     "typescript": "^4.8.4"
+  },
+  "volta": {
+    "node": "16.18.0",
+    "yarn": "1.19.1"
   },
   "oclif": {
     "bin": "faststore",

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -153,17 +153,16 @@ function mergeCMSFiles() {
 function createNodeModulesSymbolicLink() {
   try {
     symlinkSync(userNodeModulesDir, tmpNodeModulesDir)
+    console.log(
+      `${chalk.green('success')} - Symbolic ${chalk.dim(
+        'node_modules'
+      )} link created from ${chalk.dim(userNodeModulesDir)} to ${chalk.dim(
+        tmpNodeModulesDir
+      )}`
+    )
   } catch (err) {
     console.error(`${chalk.red('error')} - ${err}`)
   }
-
-  console.log(
-    `${chalk.green('success')} - Symbolic ${chalk.dim(
-      'node_modules'
-    )} link created from ${chalk.dim(userNodeModulesDir)} to ${chalk.dim(
-      tmpNodeModulesDir
-    )}`
-  )
 }
 
 export async function generate(options?: GenerateOptions) {

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -44,9 +44,13 @@ function createTmpFolder() {
 
     mkdirsSync(tmpDir)
   } catch (err) {
-    console.error(err)
+    console.error(`${chalk.red('error')} - ${err}`)
   } finally {
-    console.log(`Temporary folder ${tmpFolderName} created`)
+    console.log(
+      `${chalk.green('success')} - Temporary folder ${chalk.dim(
+        tmpFolderName
+      )} created`
+    )
   }
 }
 
@@ -65,7 +69,7 @@ function copyCoreFiles() {
   } catch (e) {
     console.error(e)
   } finally {
-    console.log(`Core files copied`)
+    console.log(`${chalk.green('success')} - Core files copied`)
   }
 }
 
@@ -73,9 +77,9 @@ function copyUserSrcToCustomizations() {
   try {
     copySync(userSrcDir, tmpCustomizationsDir)
   } catch (err) {
-    console.error(err)
+    console.error(`${chalk.red('error')} - ${err}`)
   } finally {
-    console.log('Copied custom files')
+    console.log(`${chalk.green('success')} - Custom files copied`)
   }
 }
 
@@ -88,9 +92,9 @@ async function copyTheme() {
       tmpThemesCustomizationsFileDir
     )
   } catch (err) {
-    console.error(err)
+    console.error(`${chalk.red('error')} - ${err}`)
   } finally {
-    console.log('Copied custom styles')
+    console.log(`${chalk.green('success')} - Custom styles copied`)
   }
 }
 
@@ -105,9 +109,11 @@ function mergeCMSFile(fileName: string) {
   try {
     writeFileSync(`${tmpCMSDir}/${fileName}`, JSON.stringify(mergeContentTypes))
   } catch (err) {
-    console.error(err)
+    console.error(`${chalk.red('error')} - ${err}`)
   } finally {
-    console.log(`CMS file ${fileName} created`)
+    console.log(
+      `${chalk.green('success')} - CMS file ${chalk.dim(fileName)} created`
+    )
   }
 }
 
@@ -130,9 +136,11 @@ async function copyStoreConfig() {
       generateStoreConfigFile(mergedStoreConfig)
     )
   } catch (err) {
-    console.error(err)
+    console.error(`${chalk.red('error')} - ${err}`)
   } finally {
-    console.log(`File store.config.js copied`)
+    console.log(
+      `${chalk.green('success')} - File ${chalk.dim('store.config.js')} copied`
+    )
   }
 }
 
@@ -140,9 +148,9 @@ function mergeCMSFiles() {
   try {
     mkdirsSync(`${tmpDir}/cms`)
   } catch (err) {
-    console.error(err)
+    console.error(`${chalk.red('error')} - ${err}`)
   } finally {
-    console.log(`CMS file created`)
+    console.log(`${chalk.green('success')} - CMS folder created`)
   }
 
   mergeCMSFile('content-types.json')
@@ -153,11 +161,15 @@ function createNodeModulesSymbolicLink() {
   try {
     symlinkSync(userNodeModulesDir, tmpNodeModulesDir)
   } catch (err) {
-    console.error(err)
+    console.error(`${chalk.red('error')} - ${err}`)
   }
 
   console.log(
-    `node_modules symbolic link created from ${userNodeModulesDir} to ${tmpNodeModulesDir}`
+    `${chalk.green('success')} - Symbolic ${chalk.dim(
+      'node_modules'
+    )} link created from ${chalk.dim(userNodeModulesDir)} to ${chalk.dim(
+      tmpNodeModulesDir
+    )}`
   )
 }
 

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -1,32 +1,34 @@
+import deepmerge from 'deepmerge'
 import {
   copyFileSync,
   copySync,
+  existsSync,
   mkdirsSync,
   readFileSync,
-  writeFileSync,
-  existsSync,
   removeSync,
   symlinkSync,
+  writeFileSync,
 } from 'fs-extra'
-import deepmerge from 'deepmerge'
 
 import {
   coreCMSDir,
-  userCMSDir,
-  tmpCMSDir,
   coreDir,
-  tmpCustomizationsDir,
-  userSrcDir,
-  userStoreConfigFileDir,
   coreStoreConfigFileDir,
-  tmpStoreConfigFileDir,
-  tmpThemesCustomizationsFileDir,
-  userThemesFileDir,
+  tmpCMSDir,
+  tmpCustomizationsDir,
   tmpDir,
   tmpFolderName,
-  userNodeModulesDir,
   tmpNodeModulesDir,
+  tmpStoreConfigFileDir,
+  tmpThemesCustomizationsFileDir,
+  userCMSDir,
+  userNodeModulesDir,
+  userSrcDir,
+  userStoreConfigFileDir,
+  userThemesFileDir,
 } from './directory'
+
+import chalk from 'chalk'
 
 interface GenerateOptions {
   setup?: boolean

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -43,14 +43,13 @@ function createTmpFolder() {
     }
 
     mkdirsSync(tmpDir)
-  } catch (err) {
-    console.error(`${chalk.red('error')} - ${err}`)
-  } finally {
     console.log(
       `${chalk.green('success')} - Temporary folder ${chalk.dim(
         tmpFolderName
       )} created`
     )
+  } catch (err) {
+    console.error(`${chalk.red('error')} - ${err}`)
   }
 }
 
@@ -66,20 +65,18 @@ function copyCoreFiles() {
         return shouldCopy
       },
     })
+    console.log(`${chalk.green('success')} - Core files copied`)
   } catch (e) {
     console.error(e)
-  } finally {
-    console.log(`${chalk.green('success')} - Core files copied`)
   }
 }
 
 function copyUserSrcToCustomizations() {
   try {
     copySync(userSrcDir, tmpCustomizationsDir)
+    console.log(`${chalk.green('success')} - Custom files copied`)
   } catch (err) {
     console.error(`${chalk.red('error')} - ${err}`)
-  } finally {
-    console.log(`${chalk.green('success')} - Custom files copied`)
   }
 }
 
@@ -91,10 +88,9 @@ async function copyTheme() {
       `${userThemesFileDir}/${storeConfig.theme}.scss`,
       tmpThemesCustomizationsFileDir
     )
+    console.log(`${chalk.green('success')} - Custom styles copied`)
   } catch (err) {
     console.error(`${chalk.red('error')} - ${err}`)
-  } finally {
-    console.log(`${chalk.green('success')} - Custom styles copied`)
   }
 }
 
@@ -108,12 +104,11 @@ function mergeCMSFile(fileName: string) {
 
   try {
     writeFileSync(`${tmpCMSDir}/${fileName}`, JSON.stringify(mergeContentTypes))
-  } catch (err) {
-    console.error(`${chalk.red('error')} - ${err}`)
-  } finally {
     console.log(
       `${chalk.green('success')} - CMS file ${chalk.dim(fileName)} created`
     )
+  } catch (err) {
+    console.error(`${chalk.red('error')} - ${err}`)
   }
 }
 
@@ -135,22 +130,20 @@ async function copyStoreConfig() {
       tmpStoreConfigFileDir,
       generateStoreConfigFile(mergedStoreConfig)
     )
-  } catch (err) {
-    console.error(`${chalk.red('error')} - ${err}`)
-  } finally {
     console.log(
       `${chalk.green('success')} - File ${chalk.dim('store.config.js')} copied`
     )
+  } catch (err) {
+    console.error(`${chalk.red('error')} - ${err}`)
   }
 }
 
 function mergeCMSFiles() {
   try {
     mkdirsSync(`${tmpDir}/cms`)
+    console.log(`${chalk.green('success')} - CMS folder created`)
   } catch (err) {
     console.error(`${chalk.red('error')} - ${err}`)
-  } finally {
-    console.log(`${chalk.green('success')} - CMS folder created`)
   }
 
   mergeCMSFile('content-types.json')

--- a/yarn.lock
+++ b/yarn.lock
@@ -12023,7 +12023,7 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.2, chalk@^4.1.1, chalk@^4.1.2:
+chalk@^4.0.2, chalk@^4.1.1, chalk@^4.1.2, chalk@~4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to use chalk lib to make our faststore cli messages beautiful.
It also organizes the messages and sorts some imports alphabetically.

|Before|After|
|-|-|
|<img width="575" alt="Screen Shot 2022-12-08 at 20 13 13" src="https://user-images.githubusercontent.com/11325562/206586563-1ba8f428-747b-4d56-be7f-8dad35cda408.png">|<img width="544" alt="Screen Shot 2022-12-08 at 20 12 25" src="https://user-images.githubusercontent.com/11325562/206586483-ef6677dd-b53d-4751-9c7c-303b57f4ca97.png">|


## How to test it?

- you can run locally by running `yarn build` inside the cli package, adding the bin folder to your `$PATH`, and running `run dev` inside the `starter.store`.


## References

Chalk - https://github.com/chalk/chalk
Starter store - https://github.com/vtex-sites/starter.store

