### PR TITLE
fix: Starter's Integration tests

### DIFF
--- a/packages/components/src/molecules/SelectField/SelectField.tsx
+++ b/packages/components/src/molecules/SelectField/SelectField.tsx
@@ -1,8 +1,8 @@
 import React, { forwardRef } from 'react'
 import type { PropsWithChildren } from 'react'
-import Select from '../../atoms/Select'
-import type {SelectProps} from '../../atoms/Select'
-import Label from '../../atoms/Label'
+
+import { Label, Select } from '../..'
+import type { SelectProps } from '../../atoms/Select'
 
 export interface SelectFieldProps extends SelectProps {
   /**
@@ -11,18 +11,21 @@ export interface SelectFieldProps extends SelectProps {
   label: string
 }
 
-const SelectField = forwardRef<HTMLDivElement, PropsWithChildren<SelectFieldProps>>(
-  function SelectField(
-    { id, label, options, testId = 'fs-select-field', ...otherProps },
-    ref
-  ) {
-    return (
-      <div ref={ref} data-fs-select-field data-testid={testId}>
-        <Label data-fs-select-field-label htmlFor={id}>{label}</Label>
-        <Select id={id} options={options} {...otherProps} />
-      </div>
-    )
-  }
-)
+const SelectField = forwardRef<
+  HTMLDivElement,
+  PropsWithChildren<SelectFieldProps>
+>(function SelectField(
+  { id, label, options, testId = 'fs-select-field', ...otherProps },
+  ref
+) {
+  return (
+    <div ref={ref} data-fs-select-field>
+      <Label data-fs-select-field-label htmlFor={id}>
+        {label}
+      </Label>
+      <Select id={id} options={options} data-testid={testId} {...otherProps} />
+    </div>
+  )
+})
 
 export default SelectField


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix `nextjs.store` integration tests by passing `data-testid` to the right component in `SelectField`.

### Starters Deploy Preview

[Nextjs.store PR #323](https://github.com/vtex-sites/nextjs.store/pull/323)
