### PR TITLE
fix: cli copy theme

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -2,6 +2,7 @@ import deepmerge from 'deepmerge'
 import {
   copyFileSync,
   copySync,
+  readdirSync,
   existsSync,
   mkdirsSync,
   readFileSync,
@@ -82,15 +83,39 @@ function copyUserSrcToCustomizations() {
 
 async function copyTheme() {
   const storeConfig = await import(userStoreConfigFileDir)
-
-  try {
-    copyFileSync(
-      `${userThemesFileDir}/${storeConfig.theme}.scss`,
-      tmpThemesCustomizationsFileDir
+  if (storeConfig.theme) {
+    const customTheme = `${userThemesFileDir}/${storeConfig.theme}.scss`
+    if (existsSync(customTheme)) {
+      try {
+        copyFileSync(customTheme, tmpThemesCustomizationsFileDir)
+        console.log(
+          `${chalk.green('success')} - ${
+            storeConfig.theme
+          } theme has been applied`
+        )
+      } catch (err) {
+        console.error(`${chalk.red('error')} - ${err}`)
+      }
+    } else {
+      // TODO: add link to our doc about creating a custom theme on faststore evergreen
+      console.info(
+        `${chalk.blue('info')} - The ${
+          storeConfig.theme
+        } theme was added to config file but the ${
+          storeConfig.theme
+        }.scss file does not exist in the themes folder.`
+      )
+    }
+  } else if (
+    existsSync(userThemesFileDir) &&
+    readdirSync(userThemesFileDir).length > 0
+  ) {
+    // TODO: add link to our doc about creating a custom theme on faststore evergreen
+    console.info(
+      `${chalk.blue(
+        'info'
+      )} - Theme needs to be added in config file to be applied.`
     )
-    console.log(`${chalk.green('success')} - Custom styles copied`)
-  } catch (err) {
-    console.error(`${chalk.red('error')} - ${err}`)
   }
 }
 

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -101,9 +101,9 @@ async function copyTheme() {
       console.info(
         `${chalk.blue('info')} - The ${
           storeConfig.theme
-        } theme was added to config file but the ${
+        } theme was added to the config file but the ${
           storeConfig.theme
-        }.scss file does not exist in the themes folder.`
+        }.scss file does not exist in the themes folder`
       )
     }
   } else if (
@@ -114,7 +114,7 @@ async function copyTheme() {
     console.info(
       `${chalk.blue(
         'info'
-      )} - Theme needs to be added in config file to be applied.`
+      )} - The theme needs to be added to the config file to be applied`
     )
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

When the `src/theme/soft-blue.scss` file does not exist it causes an error in the console:
```cmd
error - Error: ENOENT: no such file or directory, copyfile '/src/theme/soft-blue.scss' -> '.faststore/src/customizations/themes/index.scss'
```

So I solved that problem and added some validations, like:

When you have the file, but it has not been added to the store.config.js file, the terminal displays this message:

```cmd
info - The theme needs to be added to the config file to be applied
```

When you don't have the file, but it is added to store.config.js, the terminal displays this message:

```cmd
info - The soft-blue theme was added to the config file but the soft-blue.scss file does not exist in the themes folder
```

When the file exists and has been added to the configuration, the terminal displays this message:

```cmd
success - soft-blue theme has been applied
```

## How it works?

I add only a few conditions

## How to test it?

Just use the [starter.store](https://github.com/vtex-sites/starter.store) repository for testing.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
