### PR TITLE
Fix: `Hero` component

### DIFF
--- a/apps/docs/docs/reference/ui/organisms/Hero.mdx
+++ b/apps/docs/docs/reference/ui/organisms/Hero.mdx
@@ -307,19 +307,15 @@ All hero-related components support all attributes also supported by the `<div>`
 
 `data-fs-hero-info`
 
-`data-fs-hero-variant="primary"`
+`data-fs-hero-variant="primary" | "secondary"`
 
-`data-fs-hero-variant="secondary"`
+`data-fs-hero-color-variant="main" | "light" | "accent"`
 
-`data-fs-hero-color-variant="main"`
-
-`data-fs-hero-color-variant="light"`
-
-`data-fs-hero-color-variant="accent"`
+---
 
 ## Best practices
 
-### ✅ Do's
+### ✅ ‎ Do's
 
 #### Content
 

--- a/apps/docs/docs/reference/ui/organisms/Hero.mdx
+++ b/apps/docs/docs/reference/ui/organisms/Hero.mdx
@@ -315,7 +315,7 @@ All hero-related components support all attributes also supported by the `<div>`
 
 ## Best practices
 
-### ✅ ‎ Do's
+### ✅ Do's
 
 #### Content
 
@@ -334,7 +334,7 @@ All hero-related components support all attributes also supported by the `<div>`
 - Use optimized images for your Hero image to avoid harming your website performance. Notice that if the Hero banners take too long to load, they may lose efficacy.
 - Use an eye-catching image that adds value to your page. Hero images have a significant impact on your brand perception, website traffic, and sales conversion rate.
 
-### ❌ ‎ Don'ts
+### ❌ Don'ts
 
 - Don't exceed 2-3 lines for the Hero headline.
 - Don't use more than one Hero on a web page.

--- a/apps/docs/docs/reference/ui/organisms/Hero.mdx
+++ b/apps/docs/docs/reference/ui/organisms/Hero.mdx
@@ -40,10 +40,12 @@ import '@faststore/ui/src/components/molecules/Hero/styles.scss'
 
 ```tsx live
 <Hero>
-  <HeroImage
-    imageAlt="Controller on a table"
-    imageSrc="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
-  />
+  <HeroImage>
+    <img
+      alt="Controller on a table"
+      src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+    />
+  </HeroImage>
   <HeroHeading
     title="Explore more about our amazing products"
     subtitle="All the amazing products from the brands we partner with."
@@ -128,10 +130,12 @@ All hero-related components support all attributes also supported by the `<div>`
 
 ```tsx live
 <Hero>
-  <HeroImage
-    imageAlt="Controller on a table"
-    imageSrc="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
-  />
+  <HeroImage>
+    <img
+      alt="Controller on a table"
+      src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+    />
+  </HeroImage>
   <HeroHeading
     title="Explore more about our amazing products"
     subtitle="All the amazing products from the brands we partner with."
@@ -154,10 +158,12 @@ All hero-related components support all attributes also supported by the `<div>`
 
 ```tsx live
 <Hero variant="secondary">
-  <HeroImage
-    imageAlt="Controller on a table"
-    imageSrc="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
-  />
+  <HeroImage>
+    <img
+      alt="Controller on a table"
+      src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+    />
+  </HeroImage>
   <HeroHeading
     title="Explore more about our amazing products"
     subtitle="All the amazing products from the brands we partner with."
@@ -186,10 +192,12 @@ All hero-related components support all attributes also supported by the `<div>`
 
 ```tsx live
 <Hero>
-  <HeroImage
-    imageAlt="Controller on a table"
-    imageSrc="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
-  />
+  <HeroImage>
+    <img
+      alt="Controller on a table"
+      src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+    />
+  </HeroImage>
   <HeroHeading
     title="Explore more about our amazing products"
     subtitle="All the amazing products from the brands we partner with."
@@ -216,10 +224,12 @@ All hero-related components support all attributes also supported by the `<div>`
 
 ```tsx live
 <Hero colorVariant="light">
-  <HeroImage
-    imageAlt="Controller on a table"
-    imageSrc="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
-  />
+  <HeroImage>
+    <img
+      alt="Controller on a table"
+      src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+    />
+  </HeroImage>
   <HeroHeading
     title="Explore more about our amazing products"
     subtitle="All the amazing products from the brands we partner with."
@@ -246,10 +256,12 @@ All hero-related components support all attributes also supported by the `<div>`
 
 ```tsx live
 <Hero colorVariant="accent">
-  <HeroImage
-    imageAlt="Controller on a table"
-    imageSrc="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
-  />
+  <HeroImage>
+    <img
+      alt="Controller on a table"
+      src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+    />
+  </HeroImage>
   <HeroHeading
     title="Explore more about our amazing products"
     subtitle="All the amazing products from the brands we partner with."

--- a/apps/docs/docs/reference/ui/organisms/Hero.mdx
+++ b/apps/docs/docs/reference/ui/organisms/Hero.mdx
@@ -334,11 +334,13 @@ All hero-related components support all attributes also supported by the `<div>`
 - Use optimized images for your Hero image to avoid harming your website performance. Notice that if the Hero banners take too long to load, they may lose efficacy.
 - Use an eye-catching image that adds value to your page. Hero images have a significant impact on your brand perception, website traffic, and sales conversion rate.
 
-### ❌ Don'ts
+### ❌ ‎ Don'ts
 
 - Don't exceed 2-3 lines for the Hero headline.
 - Don't use more than one Hero on a web page.
 - Don't use pixelated or blurry images.
+
+---
 
 ## Accessibility
 

--- a/packages/ui/src/components/organisms/Hero/styles.scss
+++ b/packages/ui/src/components/organisms/Hero/styles.scss
@@ -67,6 +67,12 @@
       height: 100%;
       overflow: hidden;
     }
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
   }
 
   [data-fs-hero-heading] {


### PR DESCRIPTION
## What's the purpose of this pull request?

follow-up of https://github.com/vtex/faststore/pull/1556
- Adds missing style
- Fixes Hero image example
- Updates Hero doc page

|Before|After|
|-|-|
|<img width="853" alt="image" src="https://user-images.githubusercontent.com/3356699/208460424-1700b365-fbac-43de-9462-ea016e13a687.png">|<img width="801" alt="image" src="https://user-images.githubusercontent.com/3356699/208460614-908632f9-ff29-4d47-b74b-2cad79e58c5b.png">


## How to test it?

You can test through the [preview link](https://faststore-git-fix-hero-component-faststore.vercel.app/reference/ui/organisms/Hero)