### PR TITLE
fix: `OrderSummary` and `AggregateRating` interfaces

### DIFF
--- a/packages/ui/src/components/molecules/AggregateRating/AggregateRating.tsx
+++ b/packages/ui/src/components/molecules/AggregateRating/AggregateRating.tsx
@@ -1,10 +1,9 @@
 import React, { forwardRef } from 'react'
-import type { FC, PropsWithChildren } from 'react'
+import type { FC, PropsWithChildren, HTMLAttributes } from 'react'
 
 import { List } from '@faststore/components'
-import type { ListProps } from '@faststore/components'
 
-export interface AggregateRatingProps extends ListProps {
+export interface AggregateRatingProps extends HTMLAttributes<HTMLUListElement> {
   /**
    * The current value of the rating, based on the quantity of child elements.
    */

--- a/packages/ui/src/components/molecules/AggregateRating/AggregateRating.tsx
+++ b/packages/ui/src/components/molecules/AggregateRating/AggregateRating.tsx
@@ -4,7 +4,7 @@ import type { FC, PropsWithChildren } from 'react'
 import { List } from '@faststore/components'
 import type { ListProps } from '@faststore/components'
 
-export interface AggregateRatingProps extends ListProps<'ul'> {
+export interface AggregateRatingProps extends ListProps {
   /**
    * The current value of the rating, based on the quantity of child elements.
    */

--- a/packages/ui/src/components/molecules/OrderSummary/OrderSummary.tsx
+++ b/packages/ui/src/components/molecules/OrderSummary/OrderSummary.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef } from 'react'
-import { List } from '@faststore/components'
-import type { ListProps } from '@faststore/components'
+import type { HTMLAttributes } from 'react'
 
-export interface OrderSummaryProps
-  extends Omit<ListProps, 'nonce' | 'onResize' | 'onResizeCapture'> {
+import { List } from '@faststore/components'
+
+export interface OrderSummaryProps extends HTMLAttributes<HTMLUListElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress,
    * testing-library, and jest).

--- a/packages/ui/src/components/molecules/OrderSummary/OrderSummary.tsx
+++ b/packages/ui/src/components/molecules/OrderSummary/OrderSummary.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 import { List } from '@faststore/components'
 import type { ListProps } from '@faststore/components'
 
-export interface OrderSummaryProps extends ListProps<'ul'> {
+export interface OrderSummaryProps extends ListProps {
   /**
    * ID to find this component in testing tools (e.g.: cypress,
    * testing-library, and jest).

--- a/packages/ui/src/components/molecules/OrderSummary/OrderSummary.tsx
+++ b/packages/ui/src/components/molecules/OrderSummary/OrderSummary.tsx
@@ -34,77 +34,72 @@ export interface OrderSummaryProps extends ListProps {
   totalValue?: string
 }
 
-const OrderSummary = forwardRef<HTMLUListElement, OrderSummaryProps>(
-  function OrderSummary(
-    {
-      testId = 'store-order-summary',
-      children,
-      subtotalLabel,
-      subtotalValue,
-      discountLabel,
-      discountValue,
-      totalLabel,
-      totalValue,
-      ...otherProps
-    },
-    ref
-  ) {
-    return (
-      <List
-        ref={ref}
-        data-fs-order-summary
-        data-testid={testId}
-        {...otherProps}
-      >
-        {subtotalValue ? (
-          <li data-fs-order-summary-subtotal>
-            <span
-              data-fs-order-summary-subtotal-label
-              data-testid={`${testId}-subtotal-label`}
-            >
-              {subtotalLabel}
-            </span>
-            <span
-              data-fs-order-summary-subtotal-value
-              data-testid={`${testId}-subtotal-value`}
-            >
-              {subtotalValue}
-            </span>
-          </li>
-        ) : null}
-        {discountValue ? (
-          <li data-fs-order-summary-discount>
-            <span
-              data-fs-order-summary-discount-label
-              data-testid={`${testId}-discount-label`}
-            >
-              {discountLabel}
-            </span>
-            <span
-              data-fs-order-summary-discount-value
-              data-testid={`${testId}-discount-value`}
-            >
-              {discountValue}
-            </span>
-          </li>
-        ) : null}
-        <li data-fs-order-summary-total>
+const OrderSummary = forwardRef<
+  Omit<HTMLUListElement, 'nonce' | 'onResize' | 'onResizeCapture'>,
+  OrderSummaryProps
+>(function OrderSummary(
+  {
+    testId = 'store-order-summary',
+    subtotalLabel,
+    subtotalValue,
+    discountLabel,
+    discountValue,
+    totalLabel,
+    totalValue,
+    ...otherProps
+  },
+  ref
+) {
+  return (
+    <List ref={ref} data-fs-order-summary data-testid={testId} {...otherProps}>
+      {subtotalValue ? (
+        <li data-fs-order-summary-subtotal>
           <span
-            data-fs-order-summary-total-label
-            data-testid={`${testId}-total-label`}
+            data-fs-order-summary-subtotal-label
+            data-testid={`${testId}-subtotal-label`}
           >
-            {totalLabel}
+            {subtotalLabel}
           </span>
           <span
-            data-fs-order-summary-total-value
-            data-testid={`${testId}-total-value`}
+            data-fs-order-summary-subtotal-value
+            data-testid={`${testId}-subtotal-value`}
           >
-            {totalValue}
+            {subtotalValue}
           </span>
         </li>
-      </List>
-    )
-  }
-)
+      ) : null}
+      {discountValue ? (
+        <li data-fs-order-summary-discount>
+          <span
+            data-fs-order-summary-discount-label
+            data-testid={`${testId}-discount-label`}
+          >
+            {discountLabel}
+          </span>
+          <span
+            data-fs-order-summary-discount-value
+            data-testid={`${testId}-discount-value`}
+          >
+            {discountValue}
+          </span>
+        </li>
+      ) : null}
+      <li data-fs-order-summary-total>
+        <span
+          data-fs-order-summary-total-label
+          data-testid={`${testId}-total-label`}
+        >
+          {totalLabel}
+        </span>
+        <span
+          data-fs-order-summary-total-value
+          data-testid={`${testId}-total-value`}
+        >
+          {totalValue}
+        </span>
+      </li>
+    </List>
+  )
+})
 
 export default OrderSummary

--- a/packages/ui/src/components/molecules/OrderSummary/OrderSummary.tsx
+++ b/packages/ui/src/components/molecules/OrderSummary/OrderSummary.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef } from 'react'
 import { List } from '@faststore/components'
 import type { ListProps } from '@faststore/components'
 
-export interface OrderSummaryProps extends ListProps {
+export interface OrderSummaryProps
+  extends Omit<ListProps, 'nonce' | 'onResize' | 'onResizeCapture'> {
   /**
    * ID to find this component in testing tools (e.g.: cypress,
    * testing-library, and jest).
@@ -34,72 +35,76 @@ export interface OrderSummaryProps extends ListProps {
   totalValue?: string
 }
 
-const OrderSummary = forwardRef<
-  Omit<HTMLUListElement, 'nonce' | 'onResize' | 'onResizeCapture'>,
-  OrderSummaryProps
->(function OrderSummary(
-  {
-    testId = 'store-order-summary',
-    subtotalLabel,
-    subtotalValue,
-    discountLabel,
-    discountValue,
-    totalLabel,
-    totalValue,
-    ...otherProps
-  },
-  ref
-) {
-  return (
-    <List ref={ref} data-fs-order-summary data-testid={testId} {...otherProps}>
-      {subtotalValue ? (
-        <li data-fs-order-summary-subtotal>
+const OrderSummary = forwardRef<HTMLUListElement, OrderSummaryProps>(
+  function OrderSummary(
+    {
+      testId = 'store-order-summary',
+      subtotalLabel,
+      subtotalValue,
+      discountLabel,
+      discountValue,
+      totalLabel,
+      totalValue,
+      ...otherProps
+    },
+    ref
+  ) {
+    return (
+      <List
+        ref={ref}
+        data-fs-order-summary
+        data-testid={testId}
+        {...otherProps}
+      >
+        {subtotalValue ? (
+          <li data-fs-order-summary-subtotal>
+            <span
+              data-fs-order-summary-subtotal-label
+              data-testid={`${testId}-subtotal-label`}
+            >
+              {subtotalLabel}
+            </span>
+            <span
+              data-fs-order-summary-subtotal-value
+              data-testid={`${testId}-subtotal-value`}
+            >
+              {subtotalValue}
+            </span>
+          </li>
+        ) : null}
+        {discountValue ? (
+          <li data-fs-order-summary-discount>
+            <span
+              data-fs-order-summary-discount-label
+              data-testid={`${testId}-discount-label`}
+            >
+              {discountLabel}
+            </span>
+            <span
+              data-fs-order-summary-discount-value
+              data-testid={`${testId}-discount-value`}
+            >
+              {discountValue}
+            </span>
+          </li>
+        ) : null}
+        <li data-fs-order-summary-total>
           <span
-            data-fs-order-summary-subtotal-label
-            data-testid={`${testId}-subtotal-label`}
+            data-fs-order-summary-total-label
+            data-testid={`${testId}-total-label`}
           >
-            {subtotalLabel}
+            {totalLabel}
           </span>
           <span
-            data-fs-order-summary-subtotal-value
-            data-testid={`${testId}-subtotal-value`}
+            data-fs-order-summary-total-value
+            data-testid={`${testId}-total-value`}
           >
-            {subtotalValue}
+            {totalValue}
           </span>
         </li>
-      ) : null}
-      {discountValue ? (
-        <li data-fs-order-summary-discount>
-          <span
-            data-fs-order-summary-discount-label
-            data-testid={`${testId}-discount-label`}
-          >
-            {discountLabel}
-          </span>
-          <span
-            data-fs-order-summary-discount-value
-            data-testid={`${testId}-discount-value`}
-          >
-            {discountValue}
-          </span>
-        </li>
-      ) : null}
-      <li data-fs-order-summary-total>
-        <span
-          data-fs-order-summary-total-label
-          data-testid={`${testId}-total-label`}
-        >
-          {totalLabel}
-        </span>
-        <span
-          data-fs-order-summary-total-value
-          data-testid={`${testId}-total-value`}
-        >
-          {totalValue}
-        </span>
-      </li>
-    </List>
-  )
-})
+      </List>
+    )
+  }
+)
 
 export default OrderSummary


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the `OrderSummary` and `AggregateRating` interfaces, extending them from the HTML `ul` element instead of `ListProps`.

This is necessary because each of these components works like regular lists, they use the `List` component, but they have their own specificities and don't require to extend from our base `List` component.

### Starters Deploy Preview

[chore: Replace Table using FSUI #341](https://github.com/vtex-sites/nextjs.store/pull/341)