### PR TITLE
Docs: Adds `Hero` component doc + Updates docs overview section

### DIFF
--- a/apps/site/pages/components/atoms/button.mdx
+++ b/apps/site/pages/components/atoms/button.mdx
@@ -76,6 +76,9 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
 <OverviewSection>
   <Button variant="primary">Add to Cart</Button>
 </OverviewSection>
+```tsx
+<Button variant="primary">Add to Cart</Button>
+```
 
 ---
 
@@ -134,6 +137,11 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
     {'Add to Cart'}
   </Button>
 </OverviewSection>
+```tsx
+<Button variant="primary" icon={<ShoppingCart />} iconPosition="left">
+  Add to Cart
+</Button>
+```
 
 <TokenTable>
   <TokenRow token="--fs-button-icon-padding" value="0 var(--fs-spacing-1)" />
@@ -146,6 +154,9 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
 <OverviewSection>
   <Button variant="primary">Button</Button>
 </OverviewSection>
+```tsx
+<Button variant="primary">Button</Button>
+```
 
 <TokenTable>
   <TokenRow
@@ -212,6 +223,12 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
   </Button>
 </OverviewSection>
 
+```tsx
+<Button inverse variant="primary">
+  Button
+</Button>
+```
+
 <TokenTable>
   <TokenRow
     token="--fs-button-primary-inverse-text-color"
@@ -276,6 +293,9 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
 <OverviewSection>
   <Button variant="secondary">Button</Button>
 </OverviewSection>
+```tsx
+<Button variant="secondary">Button</Button>
+```
 
 <TokenTable>
   <TokenRow
@@ -343,6 +363,11 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
     Button
   </Button>
 </OverviewSection>
+```tsx
+<Button inverse variant="secondary">
+  Button
+</Button>
+```
 
 <TokenTable>
   <TokenRow
@@ -412,6 +437,9 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
 <OverviewSection>
   <Button variant="tertiary">Button</Button>
 </OverviewSection>
+```tsx
+<Button variant="tertiary">Button</Button>
+```
 
 <TokenTable>
   <TokenRow
@@ -472,11 +500,16 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
 
 #### Tertiary Inverse
 
-<div style={{ backgroundColor: '#171a1c', padding: '1rem' }}>
+<OverviewSection dark>
   <Button inverse variant="tertiary">
     Button
   </Button>
-</div>
+</OverviewSection>
+```tsx
+<Button inverse variant="tertiary">
+  Button
+</Button>
+```
 
 <TokenTable>
   <TokenRow
@@ -551,6 +584,12 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
   </Button>
 </OverviewSection>
 
+```tsx
+<Button variant="primary" disabled>
+  Button
+</Button>
+```
+
 <TokenTable>
   <TokenRow
     token="--fs-button-disabled-bkg-color"
@@ -571,6 +610,12 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
     {'Button'}
   </Button>
 </OverviewSection>
+
+```tsx
+<Button variant="primary" disabled>
+  Button
+</Button>
+```
 
 <TokenTable>
   <TokenRow

--- a/apps/site/pages/components/atoms/label.mdx
+++ b/apps/site/pages/components/atoms/label.mdx
@@ -21,6 +21,9 @@ A label allows the user to understand a single element. It is often in the form 
 <OverviewSection>
   <Label>Label</Label>
 </OverviewSection>
+```tsx
+<Label>Label</Label>
+```
 
 ---
 

--- a/apps/site/pages/components/atoms/select.mdx
+++ b/apps/site/pages/components/atoms/select.mdx
@@ -8,6 +8,7 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Select___8842f3b6522c3e8db0a887b3f216a6ab.png
 ---
 
+import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
@@ -24,25 +25,50 @@ Select components allow users to pick an option from a predefined list. The Sele
 
 ## Overview
 
-<OverviewSection>
-  <Select
-    id="select-overview-default"
-    options={{
-      great: 'Great',
-      ok: 'Ok',
-      bad: 'Bad',
-    }}
-  />
-  <Select
-    id="select-overview-disabled"
-    options={{
-      great: 'Great',
-      ok: 'Ok',
-      bad: 'Bad',
-    }}
-    disabled
-  />
-</OverviewSection>
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <Select
+        id="select-overview-default"
+        options={{
+          great: 'Great',
+          ok: 'Ok',
+          bad: 'Bad',
+        }}
+      />
+      <Select
+        id="select-overview-disabled"
+        options={{
+          great: 'Great',
+          ok: 'Ok',
+          bad: 'Bad',
+        }}
+        disabled
+      />
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Select
+      id="select-overview-default"
+      options={{
+        great: 'Great',
+        ok: 'Ok',
+        bad: 'Bad',
+      }}
+    />
+    <Select
+      id="select-overview-disabled"
+      options={{
+        great: 'Great',
+        ok: 'Ok',
+        bad: 'Bad',
+      }}
+      disabled
+    />
+    ```
+  </Tab>
+</Tabs>
 
 ---
 

--- a/apps/site/pages/components/molecules/checkbox-field.mdx
+++ b/apps/site/pages/components/molecules/checkbox-field.mdx
@@ -4,6 +4,7 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Checkbox___5dfb3d931c093ee7ebfac8bc388e68b5.png
 ---
 
+import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
@@ -18,18 +19,40 @@ Checkbox Field wraps a [Checkbox](/components/atoms/checkbox) input and its corr
 
 ## Overview
 
-<OverviewSection>
-  <CheckboxField label="Default" id="checkboxfield-default" />
-  <CheckboxField label="Checked" id="checkboxfield-checked" checked readOnly />
-  <CheckboxField label="Disabled" id="checkboxfield-disabled" disabled />
-  <CheckboxField
-    label="Checked & Partial"
-    id="checkboxfield-checked-partial"
-    checked
-    partial
-    readOnly
-  />
-</OverviewSection>
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <CheckboxField label="Default" id="checkboxfield-default" />
+      <CheckboxField
+        label="Checked"
+        id="checkboxfield-checked"
+        checked
+        readOnly
+      />
+      <CheckboxField label="Disabled" id="checkboxfield-disabled" disabled />
+      <CheckboxField
+        label="Checked & Partial"
+        id="checkboxfield-checked-partial"
+        checked
+        partial
+        readOnly
+      />
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <CheckboxField label="Default" id="checkboxfield-default" />
+    <CheckboxField label="Checked" id="checkboxfield-checked" checked />
+    <CheckboxField label="Disabled" id="checkboxfield-disabled" disabled />
+    <CheckboxField
+      label="Checked & Partial"
+      id="checkboxfield-checked-partial"
+      checked
+      partial
+    />
+    ```
+  </Tab>
+</Tabs>
 
 ---
 

--- a/apps/site/pages/components/molecules/discount-badge.mdx
+++ b/apps/site/pages/components/molecules/discount-badge.mdx
@@ -8,6 +8,7 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Badge___bcedffeb307527c1606be224a7fb5ac1.png
 ---
 
+import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
@@ -23,12 +24,24 @@ A custom `Badge` that display product's discounts.
 
 ## Overview
 
-<OverviewSection>
-  <DiscountBadge listPrice={45} spotPrice={40} />
-  <DiscountBadge listPrice={65} spotPrice={40} />
-  <DiscountBadge listPrice={80} spotPrice={40} />
-  <DiscountBadge listPrice={45} spotPrice={40} size="big" />
-</OverviewSection>
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <DiscountBadge listPrice={45} spotPrice={40} />
+      <DiscountBadge listPrice={65} spotPrice={40} />
+      <DiscountBadge listPrice={80} spotPrice={40} />
+      <DiscountBadge listPrice={45} spotPrice={40} size="big" />
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <DiscountBadge listPrice={45} spotPrice={40} />
+    <DiscountBadge listPrice={65} spotPrice={40} />
+    <DiscountBadge listPrice={80} spotPrice={40} />
+    <DiscountBadge listPrice={45} spotPrice={40} size="big" />
+    ```
+  </Tab>
+</Tabs>
 
 ---
 

--- a/apps/site/pages/components/molecules/input-field.mdx
+++ b/apps/site/pages/components/molecules/input-field.mdx
@@ -4,6 +4,7 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Input___77d0e7a8079b7d310e8223dd9e1994f6.png
 ---
 
+import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
@@ -19,22 +20,44 @@ Input Field wraps an [Input](/components/atoms/input) and its corresponding [Lab
 
 ## Overview
 
-<OverviewSection direction="column">
-  <InputField label="Label" id="inputfield-default" />
-  <InputField
-    label="Input w/ Error Message"
-    id="inputfield-error"
-    error="Error Message"
-  />
-  <InputField label="Input w/ Action" id="inputfield-action" actionable />
-  <InputField
-    label="Input w/ Action and Error"
-    id="inputfield-action-error"
-    actionable
-    error="Error Message"
-  />
-  <InputField label="Input Disabled" id="inputfield-disabled" disabled />
-</OverviewSection>
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection direction="column">
+      <InputField label="Label" id="inputfield-default" />
+      <InputField
+        label="Input w/ Error Message"
+        id="inputfield-error"
+        error="Error Message"
+      />
+      <InputField label="Input w/ Action" id="inputfield-action" actionable />
+      <InputField
+        label="Input w/ Action and Error"
+        id="inputfield-action-error"
+        actionable
+        error="Error Message"
+      />
+      <InputField label="Input Disabled" id="inputfield-disabled" disabled />
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <InputField label="Label" id="inputfield-default" />
+    <InputField
+      label="Input w/ Error Message"
+      id="inputfield-error"
+      error="Error Message"
+    />
+    <InputField label="Input w/ Action" id="inputfield-action" actionable />
+    <InputField
+      label="Input w/ Action and Error"
+      id="inputfield-action-error"
+      actionable
+      error="Error Message"
+    />
+    <InputField label="Input Disabled" id="inputfield-disabled" disabled />
+    ```
+  </Tab>
+</Tabs>
 
 ---
 

--- a/apps/site/pages/components/molecules/radio-field.mdx
+++ b/apps/site/pages/components/molecules/radio-field.mdx
@@ -4,6 +4,7 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/RadioLabel___b3fc3b7a139796e4921349df5aaa270c.png
 ---
 
+import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
@@ -19,18 +20,35 @@ Radio Field wraps a [Radio](/components/atoms/radio) input and its corresponding
 
 ## Overview
 
-<OverviewSection>
-  <RadioField label="Default" id="radiofield-default" />
-  <RadioField label="Checked" id="radiofield-checked" checked readOnly />
-  <RadioField label="Disabled" id="radiofield-disabled" disabled />
-  <RadioField
-    label="Checked & Disabled"
-    id="radiofield-checked-disabled"
-    checked
-    disabled
-    readOnly
-  />
-</OverviewSection>
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <RadioField label="Default" id="radiofield-default" />
+      <RadioField label="Checked" id="radiofield-checked" checked readOnly />
+      <RadioField label="Disabled" id="radiofield-disabled" disabled />
+      <RadioField
+        label="Checked & Disabled"
+        id="radiofield-checked-disabled"
+        checked
+        disabled
+        readOnly
+      />
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <RadioField label="Default" id="radiofield-default" />
+    <RadioField label="Checked" id="radiofield-checked" checked />
+    <RadioField label="Disabled" id="radiofield-disabled" disabled />
+    <RadioField
+      label="Checked & Disabled"
+      id="radiofield-checked-disabled"
+      checked
+      disabled
+    />
+    ```
+  </Tab>
+</Tabs>
 
 ---
 

--- a/apps/site/pages/components/molecules/select-field.mdx
+++ b/apps/site/pages/components/molecules/select-field.mdx
@@ -4,6 +4,7 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Select___8842f3b6522c3e8db0a887b3f216a6ab.png
 ---
 
+import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
@@ -19,27 +20,54 @@ Select Field wraps a [Select](/components/atoms/select) input and its correspond
 
 ## Overview
 
-<OverviewSection>
-  <SelectField
-    id="select-overview-default"
-    label="Select a Status:"
-    options={{
-      great: 'Great',
-      ok: 'Ok',
-      bad: 'Bad',
-    }}
-  />
-  <SelectField
-    id="select-overview-disabled"
-    label="Select a Status:"
-    options={{
-      great: 'Great',
-      ok: 'Ok',
-      bad: 'Bad',
-    }}
-    disabled
-  />
-</OverviewSection>
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <SelectField
+        id="select-overview-default"
+        label="Select a Status:"
+        options={{
+          great: 'Great',
+          ok: 'Ok',
+          bad: 'Bad',
+        }}
+      />
+      <SelectField
+        id="select-overview-disabled"
+        label="Select a Status:"
+        options={{
+          great: 'Great',
+          ok: 'Ok',
+          bad: 'Bad',
+        }}
+        disabled
+      />
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <SelectField
+      id="select-overview-default"
+      label="Select a Status:"
+      options={{
+        great: 'Great',
+        ok: 'Ok',
+        bad: 'Bad',
+      }}
+    />
+    <SelectField
+      id="select-overview-disabled"
+      label="Select a Status:"
+      options={{
+        great: 'Great',
+        ok: 'Ok',
+        bad: 'Bad',
+      }}
+      disabled
+    />
+    ```
+  </Tab>
+</Tabs>
 
 ---
 

--- a/apps/site/pages/components/molecules/tag.mdx
+++ b/apps/site/pages/components/molecules/tag.mdx
@@ -8,6 +8,7 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Badge___bcedffeb307527c1606be224a7fb5ac1.png
 ---
 
+import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
@@ -23,12 +24,34 @@ Tags are an interactive `Badge.` By default, its have a close button.
 
 ## Overview
 
-<OverviewSection>
-  <Tag variant="neutral" label="Tag" onClose={() => {}} />
-  <Tag variant="warning" label="Warning Tag" onClose={() => {}} />
-  <Tag variant="danger" label="Danger Tag" onClose={() => {}} />
-  <Tag variant="neutral" size="big" label="Neutral & Big" onClose={() => {}} />
-</OverviewSection>
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <Tag variant="neutral" label="Tag" onClose={() => {}} />
+      <Tag variant="warning" label="Warning Tag" onClose={() => {}} />
+      <Tag variant="danger" label="Danger Tag" onClose={() => {}} />
+      <Tag
+        variant="neutral"
+        size="big"
+        label="Neutral & Big"
+        onClose={() => {}}
+      />
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Tag variant="neutral" label="Tag" onClose={() => {}} />
+    <Tag variant="warning" label="Warning Tag" onClose={() => {}} />
+    <Tag variant="danger" label="Danger Tag" onClose={() => {}} />
+    <Tag
+      variant="neutral"
+      size="big"
+      label="Neutral & Big"
+      onClose={() => {}}
+    />
+    ```
+  </Tab>
+</Tabs>
 
 ---
 

--- a/apps/site/pages/components/molecules/toggle-field.mdx
+++ b/apps/site/pages/components/molecules/toggle-field.mdx
@@ -4,6 +4,7 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/RadioLabel___b3fc3b7a139796e4921349df5aaa270c.png
 ---
 
+import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
@@ -19,13 +20,32 @@ Toggle Field wraps a [Toggle](/components/molecules/toggle) input and its corres
 
 ## Overview
 
-<OverviewSection>
-  <ToggleField id="toggle-field-default" label="Label" />
-  <ToggleField id="toggle-field-labeless" label="Toggle" displayLabel={false} />
-  <ToggleField id="toggle-field-checked" label="Checked" checked readOnly />
-  <ToggleField id="toggle-field-checked" label="Disabled" disabled />
-</OverviewSection>
-
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <ToggleField id="toggle-field-default" label="Label" />
+      <ToggleField
+        id="toggle-field-labeless"
+        label="Toggle"
+        displayLabel={false}
+      />
+      <ToggleField id="toggle-field-checked" label="Checked" checked readOnly />
+      <ToggleField id="toggle-field-checked" label="Disabled" disabled />
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <ToggleField id="toggle-field-default" label="Label" />
+    <ToggleField
+      id="toggle-field-labeless"
+      label="Toggle"
+      displayLabel={false}
+    />
+    <ToggleField id="toggle-field-checked" label="Checked" checked />
+    <ToggleField id="toggle-field-checked" label="Disabled" disabled />
+    ```
+  </Tab>
+</Tabs>
 ---
 
 ## Import

--- a/apps/site/pages/components/molecules/toggle.mdx
+++ b/apps/site/pages/components/molecules/toggle.mdx
@@ -4,6 +4,7 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/RadioLabel___b3fc3b7a139796e4921349df5aaa270c.png
 ---
 
+import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
@@ -20,12 +21,24 @@ The Toggle is a customized checkbox input styled to look like a switch button.
 
 ## Overview
 
-<OverviewSection>
-  <Toggle id="toggle-default" />
-  <Toggle id="toggle-default-checked" checked readOnly />
-  <Toggle id="toggle-default-disabled" disabled />
-  <Toggle id="toggle-default-checked-disabled" disabled checked readOnly />
-</OverviewSection>
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <Toggle id="toggle-default" />
+      <Toggle id="toggle-default-checked" checked readOnly />
+      <Toggle id="toggle-default-disabled" disabled />
+      <Toggle id="toggle-default-checked-disabled" disabled checked readOnly />
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Toggle id="toggle-default" />
+    <Toggle id="toggle-default-checked" checked />
+    <Toggle id="toggle-default-disabled" disabled />
+    <Toggle id="toggle-default-checked-disabled" disabled checked />
+    ```
+  </Tab>
+</Tabs>
 
 ---
 

--- a/apps/site/pages/components/organisms/hero.mdx
+++ b/apps/site/pages/components/organisms/hero.mdx
@@ -1,0 +1,500 @@
+---
+description: Hero displays a full-width banner at the top of a webpage.
+keywords:
+  - UI library
+  - ecommerce
+  - react
+sidebar_custom_props:
+  image: https://vtexhelp.vtexassets.com/assets/docs/src/Hero___c73fdfe80ce87c2ccc4701c07e9d5398.png
+---
+
+import { Tab, Tabs } from 'nextra-theme-docs'
+import PropsSection from 'site/components/PropsSection'
+import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
+import { OverviewSection } from 'site/components/OverviewSection'
+import { SectionItem, SectionList } from 'site/components/SectionItem'
+import { House } from '@faststore/components'
+import { Hero, HeroImage, HeroHeading } from '@faststore/ui'
+
+<header>
+
+# Hero
+
+The `Hero` component is a full-width banner presented on the above-the-fold section of a web page. It serves as the first glimpse of your brand's identity and messaging.
+
+</header>
+
+The `Hero` component is a compound of the following:
+
+- `HeroImage`: wraps the Hero image.
+- `HeroHeading`: wraps the Hero textual content. It may contain a title, description, and a call-to-action button.
+
+---
+
+## Import
+
+Import the component from <a href="https://www.faststore.dev/reference/ui/get-started-faststore-ui">@faststore/ui</a>
+
+```tsx
+import { Hero, HeroImage, HeroHeading } from '@faststore/ui'
+```
+
+Import Styles
+
+```tsx
+import '@faststore/ui/src/components/molecules/Hero/styles.scss'
+```
+
+---
+
+## Usage
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <Hero>
+        <HeroImage>
+          <img
+            alt="Controller on a table"
+            src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+          />
+        </HeroImage>
+        <HeroHeading
+          title="Explore more about our amazing products"
+          subtitle="All the amazing products from the brands we partner with."
+          link="/"
+          linkText="See more"
+        />
+      </Hero>
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Hero>
+      <HeroImage>
+        <img
+          alt="Controller on a table"
+          src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+        />
+      </HeroImage>
+      <HeroHeading
+        title="Explore more about our amazing products"
+        subtitle="All the amazing products from the brands we partner with."
+        link="/"
+        linkText="See more"
+      />
+    </Hero>
+    ```
+  </Tab>
+</Tabs>
+
+---
+
+## Props
+
+All hero-related components support all attributes also supported by the `<div>` tag.
+Besides those attributes, the following props are also supported:
+
+### Hero
+
+<PropsSection name="Hero" />
+
+### HeroImage
+
+<PropsSection name="HeroImage" />
+
+### HeroHeading
+
+<PropsSection name="HeroHeading" />
+
+---
+
+## Design Tokens
+
+<TokenTable>
+  <TokenRow token="--fs-hero-text-size" value="var(--fs-text-size-lead)" />
+  <TokenRow token="--fs-hero-text-line-height" value="1.33" />
+</TokenTable>
+
+### Nested Elements
+
+#### Image
+
+<TokenTable>
+  <TokenRow token="--fs-hero-image-border-radius" value="0" />
+</TokenTable>
+
+#### Title
+
+<TokenTable>
+  <TokenRow
+    token="--fs-hero-title-padding"
+    value="var(--fs-spacing-5) 0 var(--fs-spacing-6)"
+  />
+  <TokenRow
+    token="--fs-hero-title-weight"
+    value="var(--fs-text-weight-black)"
+  />
+  <TokenRow token="--fs-hero-title-line-height" value="1.1" />
+</TokenTable>
+
+#### Subtitle
+
+<TokenTable>
+  <TokenRow
+    token="--fs-hero-subtitle-margin-top-mobile"
+    value="var(--fs-spacing-2)"
+  />
+  <TokenRow
+    token="--fs-hero-subtitle-margin-top-tablet"
+    value="var(--fs-spacing-4)"
+  />
+  <TokenRow token="--fs-hero-subtitle-size" value="var(--fs-hero-text-size)" />
+  <TokenRow
+    token="--fs-hero-subtitle-line-height"
+    value="var(--fs-hero-text-line-height)"
+  />
+</TokenTable>
+
+### Hierarchy
+
+#### Primary
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <Hero>
+        <HeroImage>
+          <img
+            alt="Controller on a table"
+            src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+          />
+        </HeroImage>
+        <HeroHeading
+          title="Explore more about our amazing products"
+          subtitle="All the amazing products from the brands we partner with."
+          link="/"
+          linkText="See more"
+        />
+      </Hero>
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Hero>
+      <HeroImage>
+        <img
+          alt="Controller on a table"
+          src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+        />
+      </HeroImage>
+      <HeroHeading
+        title="Explore more about our amazing products"
+        subtitle="All the amazing products from the brands we partner with."
+        link="/"
+        linkText="See more"
+      />
+    </Hero>
+    ```
+  </Tab>
+</Tabs>
+
+<TokenTable>
+  <TokenRow token="--fs-hero-primary-image-height-mobile" value="15rem" />
+  <TokenRow token="--fs-hero-primary-image-height-desktop" value="29rem" />
+  <TokenRow
+    token="--fs-hero-primary-title-size"
+    value="var(--fs-text-size-title-huge)"
+  />
+</TokenTable>
+
+#### Secondary
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <Hero variant="secondary">
+        <HeroImage>
+          <img
+            alt="Controller on a table"
+            src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+          />
+        </HeroImage>
+        <HeroHeading
+          title="Explore more about our amazing products"
+          subtitle="All the amazing products from the brands we partner with."
+          link="/"
+          linkText="See more"
+          icon={<House />}
+        />
+      </Hero>
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Hero variant="secondary">
+      <HeroImage>
+        <img
+          alt="Controller on a table"
+          src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+        />
+      </HeroImage>
+      <HeroHeading
+        title="Explore more about our amazing products"
+        subtitle="All the amazing products from the brands we partner with."
+        link="/"
+        linkText="See more"
+        icon={<House />}
+      />
+    </Hero>
+    ```
+  </Tab>
+</Tabs>
+
+<TokenTable>
+  <TokenRow token="--fs-hero-secondary-image-height-mobile" value="11.25rem" />
+  <TokenRow
+    token="--fs-hero-secondary-image-height-desktop"
+    value="14.188rem"
+  />
+  <TokenRow
+    token="--fs-hero-secondary-title-size"
+    value="var(--fs-text-size-title-page)"
+  />
+</TokenTable>
+
+---
+
+### Variants
+
+#### Main
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <Hero>
+        <HeroImage>
+          <img
+            alt="Controller on a table"
+            src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+          />
+        </HeroImage>
+        <HeroHeading
+          title="Explore more about our amazing products"
+          subtitle="All the amazing products from the brands we partner with."
+          link="/"
+          linkText="See more"
+        />
+      </Hero>
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Hero>
+      <HeroImage>
+        <img
+          alt="Controller on a table"
+          src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+        />
+      </HeroImage>
+      <HeroHeading
+        title="Explore more about our amazing products"
+        subtitle="All the amazing products from the brands we partner with."
+        link="/"
+        linkText="See more"
+      />
+    </Hero>
+    ```
+  </Tab>
+</Tabs>
+
+<TokenTable>
+  <TokenRow
+    token="--fs-hero-main-bkg-color"
+    value="var(--fs-color-primary-bkg)"
+    isColor
+  />
+  <TokenRow
+    token="--fs-hero-main-text-color"
+    value="var(--fs-color-primary-text)"
+    isColor
+  />
+</TokenTable>
+
+#### Light
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <Hero colorVariant="light">
+        <HeroImage>
+          <img
+            alt="Controller on a table"
+            src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+          />
+        </HeroImage>
+        <HeroHeading
+          title="Explore more about our amazing products"
+          subtitle="All the amazing products from the brands we partner with."
+          link="/"
+          linkText="See more"
+        />
+      </Hero>
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Hero colorVariant="light">
+      <HeroImage>
+        <img
+          alt="Controller on a table"
+          src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+        />
+      </HeroImage>
+      <HeroHeading
+        title="Explore more about our amazing products"
+        subtitle="All the amazing products from the brands we partner with."
+        link="/"
+        linkText="See more"
+      />
+    </Hero>
+    ```
+  </Tab>
+</Tabs>
+
+<TokenTable>
+  <TokenRow
+    token="--fs-hero-light-bkg-color"
+    value="var(--fs-color-secondary-bkg-light)"
+    isColor
+  />
+  <TokenRow
+    token="--fs-hero-light-text-color"
+    value="var(--fs-color-text-display)"
+    isColor
+  />
+</TokenTable>
+
+#### Accent
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <Hero colorVariant="accent">
+        <HeroImage>
+          <img
+            alt="Controller on a table"
+            src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+          />
+        </HeroImage>
+        <HeroHeading
+          title="Explore more about our amazing products"
+          subtitle="All the amazing products from the brands we partner with."
+          link="/"
+          linkText="See more"
+        />
+      </Hero>
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Hero colorVariant="accent">
+      <HeroImage>
+        <img
+          alt="Controller on a table"
+          src="https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg"
+        />
+      </HeroImage>
+      <HeroHeading
+        title="Explore more about our amazing products"
+        subtitle="All the amazing products from the brands we partner with."
+        link="/"
+        linkText="See more"
+      />
+    </Hero>
+    ```
+  </Tab>
+</Tabs>
+
+<TokenTable>
+  <TokenRow
+    token="--fs-hero-accent-bkg-color"
+    value="var(--fs-color-highlighted-bkg)"
+    isColor
+  />
+  <TokenRow
+    token="--fs-hero-accent-text-color"
+    value="var(--fs-hero-light-text-color)"
+    globalValue="var(--fs-color-text-display)"
+    isColor
+  />
+</TokenTable>
+
+---
+
+## Use cases
+
+Use the `Hero` component as the first element of your Home, brand, or collections pages.
+
+---
+
+## Customization
+
+`data-fs-hero`
+
+`data-fs-hero-image`
+
+`data-fs-hero-heading`
+
+`data-fs-hero-wrapper`
+
+`data-fs-hero-title`
+
+`data-fs-hero-subtitle`
+
+`data-fs-hero-icon`
+
+`data-fs-hero-heading`
+
+`data-fs-hero-info`
+
+`data-fs-hero-variant="primary" | "secondary"`
+
+`data-fs-hero-color-variant="main" | "light" | "accent"`
+
+---
+
+## Best Practices
+
+### ✅ Do's
+
+#### Content
+
+- Draw a clear connection between the Hero image and text.
+- Ensure the copy is legible on the top of the imagery.
+- Keep your message clear and connected with your visuals.
+
+#### Visual
+
+- Use strong contrasts to make call-to-action buttons stand out.
+- Follow your brand identity and guidelines. Remember that this is the first touchpoint shoppers will have with your brand.
+- Make your Hero component responsive.
+
+#### Image
+
+- Use optimized images for your Hero image to avoid harming your website performance. Notice that if the Hero banners take too long to load, they may lose efficacy.
+- Use an eye-catching image that adds value to your page. Hero images have a significant impact on your brand perception, website traffic, and sales conversion rate.
+
+### ❌ Don'ts
+
+- Don't exceed 2-3 lines for the Hero headline.
+- Don't use more than one Hero on a web page.
+- Don't use pixelated or blurry images.
+
+---
+
+## Accessibility
+
+- Use an `h1` or `h2` heading level for the headline.
+- Choose a hero image with a strong point of focus.
+- Ensure high color contrast for text over images


### PR DESCRIPTION
## What's the purpose of this pull request?

- Adds missing `Hero` component doc page
- Updates docs overview section (with code example tabs)

## How to test it?

[Hero doc page preview](https://faststore-site-git-docs-add-hero-component-doc-faststore.vercel.app/components/organisms/hero)
