### PR TITLE
fix: checks best sku existence

### DIFF
--- a/packages/api/src/platforms/vtex/utils/sku.ts
+++ b/packages/api/src/platforms/vtex/utils/sku.ts
@@ -19,7 +19,7 @@ export const pickBestSku = (skus: Item[]) => {
     bestOfferFirst(o1, o2)
   )
 
-  return best.sku
+  return best ? best.sku : skus[0]
 }
 
 export const isValidSkuId = (skuId: string) =>


### PR DESCRIPTION
## What's the purpose of this pull request?

Error 
<img width="966" alt="Screen Shot 2023-02-01 at 16 17 55" src="https://user-images.githubusercontent.com/11325562/216141331-b0728dbb-7cbc-4fb3-a186-f3bcdb0b336c.png">

Sometimes the items returned by the product query flow don't have sellers, and this function is broken with the error aforementioned on [this line](https://github.com/vtex/faststore/blob/main/packages/api/src/platforms/vtex/utils/sku.ts#L22). 

More details about how to debug [here in this document](https://docs.google.com/document/d/1MTLWhGS5f97YoHtvEOTD2EAONQIOZGcAq-sJVwr5qPc/edit).

## How to test it?

More details about how to debug [here in this document](https://docs.google.com/document/d/1MTLWhGS5f97YoHtvEOTD2EAONQIOZGcAq-sJVwr5qPc/edit).
