### PR TITLE
fix: add url to sp event

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -33,6 +33,12 @@ export interface SearchArgs {
   hideUnavailableItems?: boolean
 }
 
+export type SearchArgsWithEventArgs = SearchArgs & {
+  event: {
+    referrer: string
+  }
+}
+
 export interface ProductLocator {
   field: 'id' | 'slug'
   value: string

--- a/packages/api/src/platforms/vtex/clients/sp/index.ts
+++ b/packages/api/src/platforms/vtex/clients/sp/index.ts
@@ -38,6 +38,7 @@ export type SearchEvent = {
   match: number
   operator: 'and' | 'or'
   locale: string
+  url: string
   session?: string
   anonymous?: string
 }

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -23,6 +23,7 @@ import type {
 import type { CategoryTree } from "../clients/commerce/types/CategoryTree"
 import type { Context } from "../index"
 import { isValidSkuId, pickBestSku } from "../utils/sku"
+import { SearchArgsWithEventArgs } from "../clients/search"
 
 export const Query = {
   product: async (_: unknown, { locator }: QueryProductArgs, ctx: Context) => {
@@ -147,12 +148,15 @@ export const Query = {
     }
 
     const after = maybeAfter ? Number(maybeAfter) : 0
-    const searchArgs = {
+    const referrer = ctx.headers.referrer
+
+    const searchArgs: Omit<SearchArgsWithEventArgs, 'type'> = {
       page: Math.ceil(after / first),
       count: first,
-      query,
+      query: query ?? undefined,
       sort: SORT_MAP[sort ?? 'score_desc'],
       selectedFacets: selectedFacets?.flatMap(transformSelectedFacet) ?? [],
+      event: { referrer },
     }
 
     return searchArgs

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -148,7 +148,7 @@ export const Query = {
     }
 
     const after = maybeAfter ? Number(maybeAfter) : 0
-    const referrer = ctx.headers.referrer
+    const referrer = ctx.headers.referer
 
     const searchArgs: Omit<SearchArgsWithEventArgs, 'type'> = {
       page: Math.ceil(after / first),

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -1,9 +1,9 @@
 import { enhanceSku } from '../utils/enhanceSku'
 import type { Resolver } from '..'
-import type { SearchArgs } from '../clients/search'
+import type { SearchArgsWithEventArgs } from '../clients/search'
 import type { Facet } from '../clients/search/types/FacetSearchResult'
 
-type Root = Omit<SearchArgs, 'type'>
+type Root = Omit<SearchArgsWithEventArgs , 'type'>
 
 const isRootFacet = (facet: Facet) => facet.key === 'category-1'
 
@@ -44,10 +44,12 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
       products: skus,
     }
   },
-  products: async (searchArgs, _, ctx) => {
+  products: async (searchArgsWithEventArgs, _, ctx) => {
     const {
       clients: { search, sp },
     } = ctx
+
+    const { event: eventArgs, ...searchArgs } = searchArgsWithEventArgs
 
     const products = await search.products(searchArgs)
 
@@ -61,6 +63,7 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
         match: products.recordsFiltered,
         operator: products.operator,
         locale: ctx.storage.locale,
+        url: eventArgs.referrer,
       }).catch(console.error)
     }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR solves blank intelligent search reports

## How it works?

Adds missing `url` field on SP event using the referrer as the value

## How to test it?

On it

### Starters Deploy Preview

On it