### PR TITLE
fix: add metadata to search query

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -23,6 +23,7 @@ import type {
 import type { CategoryTree } from "../clients/commerce/types/CategoryTree"
 import type { Context } from "../index"
 import { isValidSkuId, pickBestSku } from "../utils/sku"
+import { SearchArgs } from "../clients/search"
 
 export const Query = {
   product: async (_: unknown, { locator }: QueryProductArgs, ctx: Context) => {
@@ -147,15 +148,17 @@ export const Query = {
     }
 
     const after = maybeAfter ? Number(maybeAfter) : 0
-    const searchArgs = {
+    const searchArgs: Omit<SearchArgs, 'type'> = {
       page: Math.ceil(after / first),
       count: first,
-      query,
+      query: query ?? undefined,
       sort: SORT_MAP[sort ?? 'score_desc'],
       selectedFacets: selectedFacets?.flatMap(transformSelectedFacet) ?? [],
     }
 
-    return searchArgs
+    const productSearchPromise = ctx.clients.search.products(searchArgs)
+
+    return { searchArgs, productSearchPromise }
   },
   allProducts: async (
     _: unknown,

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -151,6 +151,20 @@ type StoreSuggestions {
 """
 Search result.
 """
+type SearchMetadata {
+  """
+  Indicates if the search term was misspelled.
+  """
+  isTermMisspelled: Boolean!
+  """
+  Logical operator used to run the search.
+  """
+  logicalOperator: String!
+}
+
+"""
+Search result.
+"""
 type StoreSearchResult {
   """
   Search result products.
@@ -164,6 +178,10 @@ type StoreSearchResult {
   Search result suggestions.
   """
   suggestions: StoreSuggestions!
+  """
+  Search result metadata. Additional data can be used to send analytics events.
+  """
+  metadata: SearchMetadata
 }
 
 type Query {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12906,9 +12906,9 @@ prettier@^1.19.1:
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 prettier@latest:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
-  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
+  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
 
 pretty-bytes@^5.3.0:
   version "5.6.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR solves blank intelligent search reports

## How it works?

Returns necessary info so the event can be sent on the front end, instead of the API. This makes for more accurate events, fired the correct amount of times with the appropriate data attached to them.

## How to test it?

Filter network calls by "sp" and use the search bar on the website. You should see events with the term and other query information.

https://github.com/vtex-sites/nextjs.store/pull/373