### PR TITLE
docs: Adds `Icon` component page

### DIFF
--- a/apps/site/components/Icon/Icon.tsx
+++ b/apps/site/components/Icon/Icon.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+import React from 'react'
+import styles from './icon.module.css'
+
+export type IconProps = {
+  icon: ReactNode
+  name: string
+}
+
+const Icon = ({ icon, name }: IconProps) => {
+  return (
+    <li className={styles.icon}>
+      <div className={styles.iconItem}>{icon}</div>
+      <p>{name}</p>
+    </li>
+  )
+}
+
+export default Icon

--- a/apps/site/components/Icon/IconList.tsx
+++ b/apps/site/components/Icon/IconList.tsx
@@ -1,0 +1,8 @@
+import React, { PropsWithChildren } from 'react'
+import styles from './icon.module.css'
+
+const IconList = ({ children }: PropsWithChildren) => {
+  return <ul className={styles.iconList}>{children}</ul>
+}
+
+export default IconList

--- a/apps/site/components/Icon/icon.module.css
+++ b/apps/site/components/Icon/icon.module.css
@@ -8,7 +8,7 @@
 }
 
 .iconItem {
-  box-shadow: var(--fs-shadow-darker);
+  box-shadow: 0 0 5px rgb(0 0 0 / 20%);
   padding: var(--fs-spacing-1);
   border-radius: var(--fs-border-radius-medium);
   background-color: var(--fs-color-neutral-0);

--- a/apps/site/components/Icon/icon.module.css
+++ b/apps/site/components/Icon/icon.module.css
@@ -1,25 +1,31 @@
 .icon {
   display: flex;
+  flex-direction: row;
+  flex: 0 25%;
   align-items: center;
   column-gap: var(--fs-spacing-3);
-  flex: 0 20%;
+  font-size: var(--fs-text-size-1);
 }
 
 .iconItem {
   box-shadow: var(--fs-shadow-darker);
-  padding: var(--fs-spacing-2);
+  padding: var(--fs-spacing-1);
   border-radius: var(--fs-border-radius-medium);
   background-color: var(--fs-color-neutral-0);
 }
 .icon svg {
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
 }
 
 .iconList {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  column-gap: var(--fs-spacing-4);
-  row-gap: var(--fs-spacing-3);
+  display: grid;
+  row-gap: var(--fs-spacing-4);
+}
+
+@media screen and (min-width: 1000px) {
+  .iconList {
+    grid-template-columns: repeat(4, 1fr);
+    row-gap: var(--fs-spacing-4);
+  }
 }

--- a/apps/site/components/Icon/icon.module.css
+++ b/apps/site/components/Icon/icon.module.css
@@ -1,0 +1,25 @@
+.icon {
+  display: flex;
+  align-items: center;
+  column-gap: var(--fs-spacing-3);
+  flex: 0 20%;
+}
+
+.iconItem {
+  box-shadow: var(--fs-shadow-darker);
+  padding: var(--fs-spacing-2);
+  border-radius: var(--fs-border-radius-medium);
+  background-color: var(--fs-color-neutral-0);
+}
+.icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.iconList {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  column-gap: var(--fs-spacing-4);
+  row-gap: var(--fs-spacing-3);
+}

--- a/apps/site/components/Icon/index.ts
+++ b/apps/site/components/Icon/index.ts
@@ -1,0 +1,2 @@
+export { default as Icon } from './Icon'
+export { default as IconList } from './IconList'

--- a/apps/site/pages/components/atoms/icon.mdx
+++ b/apps/site/pages/components/atoms/icon.mdx
@@ -15,6 +15,8 @@ import { ShoppingCart } from '@faststore/components'
 
 Icons are simplified graphics used to represent concepts and help users navigate the UI.
 
+This project has a [set of icons](../../docs/icons) that uses SVGs from [Phosphor icons](https://phosphoricons.com).
+
 </header>
 
 ## Overview

--- a/apps/site/pages/components/atoms/icon.mdx
+++ b/apps/site/pages/components/atoms/icon.mdx
@@ -1,0 +1,68 @@
+---
+description: Icons are simplified graphics used to represent concepts and help users navigate the UI.
+sidebar_custom_props:
+  image: https://vtexhelp.vtexassets.com/assets/docs/src/Icon___9437da8db13517090534a38f4870d702.png
+---
+
+import PropsSection from 'site/components/PropsSection'
+import { OverviewSection } from 'site/components/OverviewSection'
+import { Icon } from '@faststore/ui'
+import { ShoppingCart } from '@faststore/components'
+
+<header>
+
+# Icon
+
+Icons are simplified graphics used to represent concepts and help users navigate the UI.
+
+</header>
+
+## Overview
+
+<OverviewSection>
+  <Icon component={<ShoppingCart />} />
+</OverviewSection>
+```tsx
+<Icon component={<ShoppingCart />} />
+```
+
+---
+
+## Import
+
+Import the component from <a href="https://www.faststore.dev/reference/ui/get-started-faststore-ui">@faststore/ui</a>
+
+```tsx
+import { Label } from '@faststore/ui'
+```
+
+Import Styles
+
+```tsx
+import '@faststore/ui/src/components/atoms/Icon/styles.scss'
+```
+
+---
+
+## Usage
+
+<OverviewSection>
+  <Icon component={<ShoppingCart />} />
+</OverviewSection>
+```tsx
+<Icon component={<ShoppingCart />} />
+```
+
+---
+
+## Props
+
+<PropsSection name="Icon" />
+
+---
+
+## Customization
+
+For further customization, you can use the following data attributes:
+
+`data-fs-icon`

--- a/apps/site/pages/docs/_meta.json
+++ b/apps/site/pages/docs/_meta.json
@@ -27,5 +27,9 @@
       "layout": "full"
     }
   },
-  "global-tokens": "Global Tokens"
+  "global-tokens": "Global Tokens",
+  "-- Media --": {
+    "type": "separator",
+    "title": "Media"
+  }
 }

--- a/apps/site/pages/docs/icons.mdx
+++ b/apps/site/pages/docs/icons.mdx
@@ -1,0 +1,97 @@
+import { OverviewSection } from 'site/components/OverviewSection'
+import { Icon, IconList } from 'site/components/Icon'
+import {
+  X,
+  Plus,
+  PlusCircle,
+  Minus,
+  MinusCircle,
+  XCircle,
+  ArrowRight,
+  ArrowElbowDownRight,
+  CaretDown,
+  Checked,
+  House,
+  Star,
+  Heart,
+  DotsThree,
+  Ruler,
+  ShoppingCart,
+  TagIcon,
+  Visa,
+  Diners,
+  Mastercard,
+  EloCard,
+  PayPal,
+  Stripe,
+  GooglePay,
+  ApplePay,
+} from '@faststore/ui'
+
+<header className="hero">
+
+# Icons
+
+This set of icons uses SVGs from [Phosphor icons](https://phosphoricons.com/).
+
+</header>
+
+## Overview
+
+Icons help build web pages by illustrating concepts and improving website navigation. We offer a set of icons that our components use, and you can also use them on your application.
+
+---
+
+## Import
+
+Import the component from <a href="https://www.faststore.dev/reference/ui/get-started-faststore-ui">@faststore/ui</a>
+
+```tsx
+import { ShoppingCart } from '@faststore/ui'
+```
+
+---
+
+### UI Actions
+
+<IconList>
+  <Icon icon={<X />} name="X" />
+  <Icon icon={<Plus />} name="Plus" />
+  <Icon icon={<PlusCircle />} name="PlusCircle" />
+  <Icon icon={<Minus />} name="Minus" />
+  <Icon icon={<MinusCircle />} name="MinusCircle" />
+  <Icon icon={<XCircle />} name="XCircle" />
+  <Icon icon={<ArrowRight />} name="ArrowRight" />
+  <Icon icon={<ArrowElbowDownRight />} name="ArrowElbowDownRight" />
+  <Icon icon={<CaretDown />} name="CaretDown" />
+  <Icon icon={<Checked />} name="Checked" />
+</IconList>
+
+### Payment Flags
+
+<IconList>
+  <Icon icon={<Visa />} name="Visa" />
+  <Icon icon={<Diners />} name="Diners" />
+  <Icon icon={<Mastercard />} name="Mastercard" />
+  <Icon icon={<EloCard />} name="EloCard" />
+  <Icon icon={<PayPal />} name="PayPal" />
+  <Icon icon={<Stripe />} name="Stripe" />
+  <Icon icon={<GooglePay />} name="GooglePay" />
+  <Icon icon={<ApplePay />} name="ApplePay" />
+</IconList>
+
+### Social
+
+TO-ADD
+
+### Others
+
+<IconList>
+  <Icon icon={<House />} name="House" />
+  <Icon icon={<Star />} name="Star" />
+  <Icon icon={<Heart />} name="Heart" />
+  <Icon icon={<DotsThree />} name="DotsThree" />
+  <Icon icon={<Ruler />} name="Ruler" />
+  <Icon icon={<ShoppingCart />} name="ShoppingCart" />
+  <Icon icon={<TagIcon />} name="TagIcon" />
+</IconList>


### PR DESCRIPTION
## What's the purpose of this pull request?

- Adds missing Icon component [doc page](https://faststore-site-git-doc-icon-doc-page-fs-862-faststore.vercel.app/components/atoms/icon)

