### PR TITLE
Update ProductSearchResult.ts

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
+++ b/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
@@ -12,6 +12,7 @@ export interface ProductSearchResult {
   query: string
   operator: 'and' | 'or'
   fuzzy: string
+  redirect?: string
   correction?: Correction
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?
We're trying to get the `redirect` property as the example below:
``` curl
curl --location --request GET 'https://carrefourbrfood.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/?query=4k' \
```

```json
{
    "products": [],
    "recordsFiltered": 0,
    "fuzzy": "0",
    "operator": "and",
    "redirect": "https://www.carrefour.com.br/busca/4K", # This property
    "translated": false,
    "pagination": {
        "count": 1,
        "current": {
            "index": 0
        },
        "before": [],
        "after": [],
        "perPage": 0,
        "next": {
            "index": 0
        },
        "previous": {
            "index": 0
        },
        "first": {
            "index": 0
        },
        "last": {
            "index": 0
        }
    }
}
```
The problem is, the response of the `search` resolver is missing the field `redirect`.

**We will also need to extend the type of StoreSearchResult to contain the redirect field.**

<img width="302" alt="Captura de Tela 2023-02-28 às 15 35 21" src="https://user-images.githubusercontent.com/4602864/221947390-6d31201a-aa70-44ca-ad63-ded94870158a.png">


## How it works?
Look for the interface ProductSearchResult and is missing a key.

## How to test it?
Look for the curl as the example above.