### PR TITLE
chore: test images serving from CMS and Catolog + new thumbor url

### DIFF
--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -9,6 +9,13 @@ const nextConfig = {
     locales: ['en-US'],
     defaultLocale: 'en-US',
   },
+  images: {
+    // formats: ['image/webp'],
+    domains: [
+      'storeframework.vtexassets.com',
+      'mercafefaststore.vtexassets.com',
+    ],
+  },
   webpack: (config, { isServer, dev }) => {
     // https://github.com/vercel/next.js/discussions/11267#discussioncomment-2479112
     // camel-case style names from css modules

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,7 @@
     "react-intersection-observer": "^8.32.5",
     "sass": "^1.44.0",
     "sass-loader": "^12.6.0",
+    "sharp": "^0.31.3",
     "style-loader": "^3.3.1",
     "swr": "^1.3.0",
     "tsconfig-paths-webpack-plugin": "^3.5.2",

--- a/packages/core/src/components/ui/Image/Image.tsx
+++ b/packages/core/src/components/ui/Image/Image.tsx
@@ -1,8 +1,8 @@
-import { forwardRef, memo } from 'react'
 import Head from 'next/head'
+import { forwardRef, memo } from 'react'
 
-import { useImage } from './useImage'
 import type { ImageOptions } from './useImage'
+import { useImage } from './useImage'
 
 // React still don't have imageSizes declared on its types. Somehow,
 // it generated the right html

--- a/packages/core/src/components/ui/Image/MixedImage.tsx
+++ b/packages/core/src/components/ui/Image/MixedImage.tsx
@@ -1,0 +1,30 @@
+import { memo } from 'react'
+
+import NextImage, { ImageProps } from 'next/image'
+import { useImage } from './useImage'
+
+function MixedImage({ src, width, height, ...otherProps }: ImageProps) {
+  const imgProps = useImage({
+    src: String(src),
+    width: Number(width),
+    height: Number(height),
+    useNewThumborUrl: true,
+    factor: 3,
+  })
+
+  const { src: thumborSrc } = imgProps
+
+  return (
+    <NextImage
+      loader={() => thumborSrc}
+      src={thumborSrc}
+      data-fs-image
+      width={Number(width)}
+      height={Number(height)}
+      {...otherProps}
+      alt={imgProps.alt}
+    />
+  )
+}
+
+export default memo(MixedImage)

--- a/packages/core/src/components/ui/Image/thumborUrlBuilder.ts
+++ b/packages/core/src/components/ui/Image/thumborUrlBuilder.ts
@@ -1,3 +1,5 @@
+import storeConfig from '../../../../faststore.config'
+
 export type FilterValue = boolean | string | string[] | number[]
 
 export interface Box {
@@ -20,6 +22,7 @@ export interface ThumborOptions {
 }
 
 const THUMBOR_SERVER = 'https://assets.vtex.app'
+const THUMBOR_SERVER_NEW = `https://${storeConfig.api.storeId}.vtexassets.com`
 
 const cropSection = ({ left, top, right, bottom }: Box) =>
   `${left}x${top}:${right}x${bottom}`
@@ -50,8 +53,13 @@ function filtersURIComponent(filters: Record<string, FilterValue>) {
   return elements.join(':')
 }
 
-export const urlBuilder = (baseUrl: string, options: ThumborOptions) => {
-  const preSizeComponents = [THUMBOR_SERVER, 'unsafe']
+export const urlBuilder = (
+  baseUrl: string,
+  options: ThumborOptions,
+  useNewThumborUrl: boolean
+) => {
+  const SERVER_URL = useNewThumborUrl ? THUMBOR_SERVER_NEW : THUMBOR_SERVER
+  const preSizeComponents = [SERVER_URL, 'unsafe']
   const postSizeComponents: string[] = []
 
   // Add the trim parameter after unsafe if appliable

--- a/packages/core/src/components/ui/Image/useImage.ts
+++ b/packages/core/src/components/ui/Image/useImage.ts
@@ -1,14 +1,15 @@
-import { useMemo } from 'react'
 import type { ImgHTMLAttributes } from 'react'
+import { useMemo } from 'react'
 
-import { urlBuilder } from './thumborUrlBuilder'
 import type { ThumborOptions } from './thumborUrlBuilder'
+import { urlBuilder } from './thumborUrlBuilder'
 
 export interface ImageOptions extends ImgHTMLAttributes<HTMLImageElement> {
   src: string
   width: number
   height: number
   options?: ThumborOptions
+  useNewThumborUrl?: boolean
 }
 
 const FACTORS = [1, 2, 3]
@@ -19,10 +20,11 @@ export const useImage = ({
   width,
   height,
   options = {},
+  useNewThumborUrl,
   ...rest
 }: ImageOptions): ImgHTMLAttributes<HTMLImageElement> => {
   const { srcSet, src } = useMemo(() => {
-    const builder = urlBuilder(baseUrl, options)
+    const builder = urlBuilder(baseUrl, options, useNewThumborUrl)
 
     const srcs = FACTORS.map((factor) => {
       const rescaledWidth = width * factor

--- a/packages/core/src/components/ui/Image/useImage.ts
+++ b/packages/core/src/components/ui/Image/useImage.ts
@@ -10,6 +10,7 @@ export interface ImageOptions extends ImgHTMLAttributes<HTMLImageElement> {
   height: number
   options?: ThumborOptions
   useNewThumborUrl?: boolean
+  factor?: 1 | 2 | 3
 }
 
 const FACTORS = [1, 2, 3]
@@ -21,6 +22,7 @@ export const useImage = ({
   height,
   options = {},
   useNewThumborUrl,
+  factor = 3,
   ...rest
 }: ImageOptions): ImgHTMLAttributes<HTMLImageElement> => {
   const { srcSet, src } = useMemo(() => {
@@ -33,10 +35,10 @@ export const useImage = ({
     })
 
     return {
-      src: builder(width * LARGE_FACTOR, height * LARGE_FACTOR),
+      src: builder(width * factor, height * factor),
       srcSet: srcs.join(', '),
     }
-  }, [height, options, baseUrl, width])
+  }, [baseUrl, options, useNewThumborUrl, width, factor, height])
 
   return {
     src,

--- a/packages/core/src/pages/image-fs-new.tsx
+++ b/packages/core/src/pages/image-fs-new.tsx
@@ -15,7 +15,7 @@ function Page() {
         width={360}
         height={360}
         loading="eager"
-        preload
+        useNewThumborUrl
       />
       <p>
         Catalog Arquivos PNG -
@@ -29,6 +29,7 @@ function Page() {
         width={360}
         height={360}
         loading="eager"
+        useNewThumborUrl
       />
       <p>
         CMS file-manager JPG -
@@ -42,6 +43,7 @@ function Page() {
         width={384}
         height={384}
         loading="eager"
+        useNewThumborUrl
       />
       <p>
         CMS file-manager PNG -
@@ -55,6 +57,7 @@ function Page() {
         width={360}
         height={360}
         loading="eager"
+        useNewThumborUrl
       />
     </>
   )

--- a/packages/core/src/pages/image-fs-old.tsx
+++ b/packages/core/src/pages/image-fs-old.tsx
@@ -1,0 +1,62 @@
+import { Image } from 'src/components/ui/Image'
+
+function Page() {
+  return (
+    <>
+      <p>
+        Catalog Arquivos JPG -
+        https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg
+      </p>
+      <Image
+        src={
+          'https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg'
+        }
+        alt={'Tests'}
+        width={360}
+        height={360}
+        loading="eager"
+      />
+      <p>
+        Catalog Arquivos PNG -
+        https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233
+      </p>
+      <Image
+        src={
+          'https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233'
+        }
+        alt={'Tests'}
+        width={360}
+        height={360}
+        loading="eager"
+      />
+      <p>
+        CMS file-manager JPG -
+        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg
+      </p>
+      <Image
+        src={
+          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg'
+        }
+        alt={'Tests'}
+        width={384}
+        height={384}
+        loading="eager"
+      />
+      <p>
+        CMS file-manager PNG -
+        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png
+      </p>
+      <Image
+        src={
+          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png'
+        }
+        alt={'Tests'}
+        width={360}
+        height={360}
+        loading="eager"
+      />
+    </>
+  )
+}
+
+export default Page

--- a/packages/core/src/pages/image-fs.tsx
+++ b/packages/core/src/pages/image-fs.tsx
@@ -1,0 +1,63 @@
+import { Image } from 'src/components/ui/Image'
+
+function Page() {
+  return (
+    <>
+      <p>
+        Catalog Arquivos JPG -
+        https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg
+      </p>
+      <Image
+        src={
+          'https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg'
+        }
+        alt={'Tests'}
+        width={360}
+        height={360}
+        loading="eager"
+        preload
+      />
+      <p>
+        Catalog Arquivos PNG -
+        https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233
+      </p>
+      <Image
+        src={
+          'https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233'
+        }
+        alt={'Tests'}
+        width={360}
+        height={360}
+        loading="eager"
+      />
+      <p>
+        CMS file-manager JPG -
+        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg
+      </p>
+      <Image
+        src={
+          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg'
+        }
+        alt={'Tests'}
+        width={384}
+        height={384}
+        loading="eager"
+      />
+      <p>
+        CMS file-manager PNG -
+        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png
+      </p>
+      <Image
+        src={
+          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png'
+        }
+        alt={'Tests'}
+        width={360}
+        height={360}
+        loading="eager"
+      />
+    </>
+  )
+}
+
+export default Page

--- a/packages/core/src/pages/image-mix.tsx
+++ b/packages/core/src/pages/image-mix.tsx
@@ -1,0 +1,66 @@
+import MixedImage from 'src/components/ui/Image/MixedImage'
+
+function Page() {
+  return (
+    <>
+      <p>
+        Catalog Arquivos JPG -
+        https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg
+      </p>
+      <MixedImage
+        src={
+          'https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg'
+        }
+        alt={'Tests'}
+        width="360"
+        height="360"
+        quality="95"
+        loading="eager"
+      />
+      <p>
+        Catalog Arquivos PNG -
+        https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233
+      </p>
+      <MixedImage
+        src={
+          'https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233'
+        }
+        alt={'Tests'}
+        width="360"
+        height="360"
+        quality="95"
+        loading="eager"
+      />
+      <p>
+        CMS file-manager JPG -
+        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg
+      </p>
+      <MixedImage
+        src={
+          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg'
+        }
+        alt={'Tests'}
+        width="384"
+        height="384"
+        quality="95"
+        loading="eager"
+      />
+      <p>
+        CMS file-manager PNG -
+        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png
+      </p>
+      <MixedImage
+        src={
+          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png'
+        }
+        alt={'Tests'}
+        width="360"
+        height="360"
+        quality="95"
+        loading="eager"
+      />
+    </>
+  )
+}
+
+export default Page

--- a/packages/core/src/pages/image-next.tsx
+++ b/packages/core/src/pages/image-next.tsx
@@ -1,0 +1,79 @@
+import NextImage from 'next/future/image'
+
+function Page() {
+  return (
+    <>
+      <p>
+        Catalog Arquivos JPG -
+        https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg
+      </p>
+      <NextImage
+        src={
+          'https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg'
+        }
+        alt={'Tests'}
+        width="360"
+        height="360"
+        quality="95"
+        loading="eager"
+      />
+      <p>
+        Catalog Arquivos PNG -
+        https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233
+      </p>
+      <NextImage
+        src={
+          'https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233'
+        }
+        alt={'Tests'}
+        width="360"
+        height="360"
+        quality="95"
+        loading="eager"
+      />
+      <p>
+        CMS file-manager JPG -
+        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg
+      </p>
+      <NextImage
+        src={
+          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg'
+        }
+        alt={'Tests'}
+        width="384"
+        height="384"
+        quality="95"
+        loading="eager"
+      />
+      <p>
+        CMS file-manager PNG -
+        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png
+      </p>
+      <NextImage
+        src={
+          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png'
+        }
+        alt={'Tests'}
+        width="360"
+        height="360"
+        quality="95"
+        loading="eager"
+      />
+
+      {/*
+        WARNING: Do not import or render components from any
+        other folder than '../components/sections' in here.
+
+        This is necessary to keep the integration with the CMS
+        easy and consistent, enabling the change and reorder
+        of elements on this page.
+
+        If needed, wrap your component in a <Section /> component
+        (not the HTML tag) before rendering it here.
+      */}
+      {/* <RenderPageSections sections={sections} components={COMPONENTS} /> */}
+    </>
+  )
+}
+
+export default Page

--- a/packages/core/src/pages/image-next.tsx
+++ b/packages/core/src/pages/image-next.tsx
@@ -1,4 +1,4 @@
-import NextImage from 'next/future/image'
+import NextImage from 'next/image'
 
 function Page() {
   return (
@@ -59,19 +59,6 @@ function Page() {
         quality="95"
         loading="eager"
       />
-
-      {/*
-        WARNING: Do not import or render components from any
-        other folder than '../components/sections' in here.
-
-        This is necessary to keep the integration with the CMS
-        easy and consistent, enabling the change and reorder
-        of elements on this page.
-
-        If needed, wrap your component in a <Section /> component
-        (not the HTML tag) before rendering it here.
-      */}
-      {/* <RenderPageSections sections={sections} components={COMPONENTS} /> */}
     </>
   )
 }

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -3,7 +3,8 @@ import type { GetStaticProps } from 'next'
 import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
 import type { ComponentType } from 'react'
 
-import RenderPageSections from 'src/components/cms/RenderPageSections'
+// import RenderPageSections from 'src/components/cms/RenderPageSections'
+import NextImage from 'next/future/image'
 import BannerText from 'src/components/sections/BannerText'
 import Hero from 'src/components/sections/Hero'
 import IncentivesHeader from 'src/components/sections/Incentives/IncentivesHeader'
@@ -55,6 +56,62 @@ function Page({ sections, settings }: Props) {
           },
         ]}
       />
+      <p>
+        Catalog Arquivos JPG -
+        https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg
+      </p>
+      <NextImage
+        src={
+          'https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg'
+        }
+        alt={'Tests'}
+        width="360"
+        height="360"
+        quality="95"
+        loading="eager"
+      />
+      <p>
+        Catalog Arquivos PNG -
+        https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233
+      </p>
+      <NextImage
+        src={
+          'https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233'
+        }
+        alt={'Tests'}
+        width="360"
+        height="360"
+        quality="95"
+        loading="eager"
+      />
+      <p>
+        CMS file-manager JPG -
+        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg
+      </p>
+      <NextImage
+        src={
+          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg'
+        }
+        alt={'Tests'}
+        width="384"
+        height="384"
+        quality="95"
+        loading="eager"
+      />
+      <p>
+        CMS file-manager PNG -
+        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png
+      </p>
+      <NextImage
+        src={
+          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png'
+        }
+        alt={'Tests'}
+        width="360"
+        height="360"
+        quality="95"
+        loading="eager"
+      />
 
       {/*
         WARNING: Do not import or render components from any
@@ -67,7 +124,7 @@ function Page({ sections, settings }: Props) {
         If needed, wrap your component in a <Section /> component
         (not the HTML tag) before rendering it here.
       */}
-      <RenderPageSections sections={sections} components={COMPONENTS} />
+      {/* <RenderPageSections sections={sections} components={COMPONENTS} /> */}
     </>
   )
 }

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -4,7 +4,6 @@ import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
 import type { ComponentType } from 'react'
 
 // import RenderPageSections from 'src/components/cms/RenderPageSections'
-import NextImage from 'next/future/image'
 import BannerText from 'src/components/sections/BannerText'
 import Hero from 'src/components/sections/Hero'
 import IncentivesHeader from 'src/components/sections/Incentives/IncentivesHeader'
@@ -16,6 +15,7 @@ import { mark } from 'src/sdk/tests/mark'
 import type { PageContentType } from 'src/server/cms'
 import { getPage } from 'src/server/cms'
 
+import RenderPageSections from 'src/components/cms/RenderPageSections'
 import storeConfig from '../../faststore.config'
 
 /* A list of components that can be used in the CMS. */
@@ -56,62 +56,6 @@ function Page({ sections, settings }: Props) {
           },
         ]}
       />
-      <p>
-        Catalog Arquivos JPG -
-        https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg
-      </p>
-      <NextImage
-        src={
-          'https://mercafefaststore.vtexassets.com/arquivos/ids/158658/20039314_01.jpg'
-        }
-        alt={'Tests'}
-        width="360"
-        height="360"
-        quality="95"
-        loading="eager"
-      />
-      <p>
-        Catalog Arquivos PNG -
-        https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233
-      </p>
-      <NextImage
-        src={
-          'https://mercafefaststore.vtexassets.com/arquivos/ids/526372/SKU-Capp-Capsula.png?v=1763654233'
-        }
-        alt={'Tests'}
-        width="360"
-        height="360"
-        quality="95"
-        loading="eager"
-      />
-      <p>
-        CMS file-manager JPG -
-        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg
-      </p>
-      <NextImage
-        src={
-          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/12ea02ba-dd7d-4d91-8547-eb6809c4a30e___3858c213bede843e801934ac436d80ac.jpg'
-        }
-        alt={'Tests'}
-        width="384"
-        height="384"
-        quality="95"
-        loading="eager"
-      />
-      <p>
-        CMS file-manager PNG -
-        https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png
-      </p>
-      <NextImage
-        src={
-          'https://mercafefaststore.vtexassets.com/assets/vtex.file-manager-graphql/images/ea491eac-e9b6-43b5-8275-135d07ceeb99___f1a637818ab5b0c64ea58753e24b4278.png'
-        }
-        alt={'Tests'}
-        width="360"
-        height="360"
-        quality="95"
-        loading="eager"
-      />
 
       {/*
         WARNING: Do not import or render components from any
@@ -124,7 +68,7 @@ function Page({ sections, settings }: Props) {
         If needed, wrap your component in a <Section /> component
         (not the HTML tag) before rendering it here.
       */}
-      {/* <RenderPageSections sections={sections} components={COMPONENTS} /> */}
+      <RenderPageSections sections={sections} components={COMPONENTS} />
     </>
   )
 }

--- a/packages/ui/src/base/layout.scss
+++ b/packages/ui/src/base/layout.scss
@@ -69,9 +69,3 @@ body {
   }
 }
 
-// Image
-[data-fs-image] {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8686,15 +8686,31 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
 
 color-support@^1.1.2, color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colord@^2.9.3:
   version "2.9.3"
@@ -9954,6 +9970,11 @@ detect-indent@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
+
+detect-libc@^2.0.0, detect-libc@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
+  integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -11231,6 +11252,11 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
@@ -12205,6 +12231,11 @@ gitconfiglocal@^1.0.0:
   integrity sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==
   dependencies:
     ini "^1.3.2"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
 github-slugger@^1.0.0, github-slugger@^1.5.0:
   version "1.5.0"
@@ -13611,6 +13642,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -16964,6 +17000,11 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
 mkdirp-infer-owner@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz#55d3b368e7d89065c38f32fd38e638f0ab61d316"
@@ -17126,6 +17167,11 @@ nanospinner@^1.0.0:
   dependencies:
     picocolors "^1.0.0"
 
+napi-build-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
+  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -17282,10 +17328,22 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-abi@^3.3.0:
+  version "3.33.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.33.0.tgz#8b23a0cec84e1c5f5411836de6a9b84bccf26e7f"
+  integrity sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==
+  dependencies:
+    semver "^7.3.5"
+
 node-addon-api@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
+node-addon-api@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
+  integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
 
 node-dir@^0.1.10:
   version "0.1.17"
@@ -18920,6 +18978,24 @@ postcss@^8.2.15, postcss@^8.3.11, postcss@^8.4.19, postcss@^8.4.4:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+prebuild-install@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
+  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
 preferred-pm@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/preferred-pm/-/preferred-pm-3.0.3.tgz#1b6338000371e3edbce52ef2e4f65eb2e73586d6"
@@ -19361,7 +19437,7 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-rc@1.2.8, rc@^1.2.8:
+rc@1.2.8, rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -20633,6 +20709,20 @@ shallowequal@^1.1.0:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
+sharp@^0.31.3:
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.31.3.tgz#60227edc5c2be90e7378a210466c99aefcf32688"
+  integrity sha512-XcR4+FCLBFKw1bdB+GEhnUNXNXvnt0tDo4WsBsraKymuo/IAuPuCBVAL2wIkUw2r/dwFW5Q5+g66Kwl2dgDFVg==
+  dependencies:
+    color "^4.2.3"
+    detect-libc "^2.0.1"
+    node-addon-api "^5.0.0"
+    prebuild-install "^7.1.1"
+    semver "^7.3.8"
+    simple-get "^4.0.1"
+    tar-fs "^2.1.1"
+    tunnel-agent "^0.6.0"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -20711,6 +20801,27 @@ signedsource@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
   integrity sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0, simple-get@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -21046,8 +21157,6 @@ ssri@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
   integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
-  dependencies:
-    figgy-pudding "^3.5.1"
 
 ssri@^8.0.0, ssri@^8.0.1:
   version "8.0.1"
@@ -21707,7 +21816,17 @@ tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tar-stream@~2.2.0:
+tar-fs@^2.0.0, tar-fs@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4, tar-stream@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
   integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==


### PR DESCRIPTION
4 cenários para testar imagens na FS:

|#|Description|Page|
|-|-|-|
|1| Componente de Imagem da FS com o thumbor em assets.app.vtex.|http://localhost:3000/image-fs-old|
|2| Componente de Imagem da FS com o thumbor em vtexassets. |http://localhost:3000/image-fs-new|
|3| Componente de Imagem do Next.js com loader default (sem thumbor). |http://localhost:3000/image-next|
|4| Componente de Imagem do Next.js com loader custom utilizando o thumbor em vtexassets. |http://localhost:3000/image-mix|

Os pontos 1), 2) e 4) tiveram resultados melhores (time) e bem similares, dando x-cache: Hit from cloudfront com status 200 na primeira request. E depois pegando do cache do disk ou memória da segunda em diante tbm com status 200 e HIT from cloudfront.

O ponto 3) Deu um tempo maior de carregamento em relação as outras, com status 200 na primeira request e:
```
x-cache: Miss from cloudfront
x-envoy-upstream-service-time: 1
x-faststore-cache: HIT
x-nextjs-cache: MISS
```
Da segunda em diante deu status 304 e a mesma resposta de cache acima.

### Starter PR
https://github.com/vtex-sites/starter.store/pull/17