### PR TITLE
add disableAutoCompletion

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -99,16 +99,16 @@ export const VtexCommerce = (
       },
       orderForm: ({
         id,
-        refreshOutdatedData = true,
+        disableAutoCompletion = true,
         channel = ctx.storage.channel,
       }: {
         id: string
-        refreshOutdatedData?: boolean
+        disableAutoCompletion?: boolean
         channel?: Required<Channel>
       }): Promise<OrderForm> => {
         const { salesChannel } = channel
         const params = new URLSearchParams({
-          refreshOutdatedData: refreshOutdatedData.toString(),
+          disableAutoCompletion: disableAutoCompletion.toString(),
           sc: salesChannel,
         })
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Avoid orderform recalculation pipeline during validate cart

## How it works?

The param disableAutoCompletion set to true will avoid the pipeline to run avoiding the rewriting of information when getting the order form.

More informations here:
https://developers.vtex.com/docs/guides/asynchronous-integration#implementing-asynchronous-integration

## How to test it?

Open the url of the subdomain and the main domain with the same Order Form in different tabs and make changes to the order form. The same will be overwritten!


Uploading update-orderform.mov…

