### PR TITLE
Fix/add context variables cart mutation 1.x

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -17,6 +17,7 @@ import type {
   OrderFormItem,
 } from '../clients/commerce/types/OrderForm'
 import type { Context } from '..'
+import { mutateChannelContext, mutateLocaleContext } from '../utils/contex'
 type Indexed<T> = T & { index?: number }
 
 const isAttachment = (value: IStorePropertyValue) =>
@@ -254,6 +255,17 @@ export const validateCart = async (
     clients: { commerce },
     loaders: { skuLoader },
   } = ctx
+
+  const channel = session?.channel
+  const locale = session?.locale
+
+  if (channel) {
+    mutateChannelContext(ctx, channel)
+  }
+
+  if (locale) {
+    mutateLocaleContext(ctx, locale)
+  }
 
   // Step1: Get OrderForm from VTEX Commerce
   const orderForm = await getOrderForm(orderNumber, session, ctx)

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -145,7 +145,7 @@ const orderFormToCart = async (
       orderNumber: form.orderFormId,
       acceptedOffer: form.items.map(async (item) => ({
         ...item,
-        product: await skuLoader.load(item.id), // TODO: add channel
+        product: await skuLoader.load(item.id),
       })),
     },
     messages: form.messages.map(({ text, status }) => ({


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes an inconsistency in the validateCart mutation. If you had added an item to the cart while it was available for your region, then you changed to a region where the item would be unavailable, the API would still return available offers for the item.

This happened because while we were using the Intelligent Search to fetch the items, we were not passing the right region parameters to it (because it was not in the context storage). To avoid future discrepancies, I've also added the locale parameter.

## How it works?

Adds the channel (which contains the region) and locale to the context storage.

## How to test it?

Go to https://sfj-9bb2a74--jamstacktata.preview.vtex.app/suprema-de-pollo-en-bandeja-600-g-3883/p and add it to the cart
Now go to the Locator again and choose "Artigas". On the PDP and minicart you can see (correctly) that the product's not longer available.

In production, it'd still be available on the minicart.