### PR TITLE
Fix: husky pre-commit script + Lint-stage

### DIFF
--- a/packages/core/.husky/pre-commit
+++ b/packages/core/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged
+cd packages/core && yarn lint-staged

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
     "lint": "next lint",
     "stylelint": "stylelint \"**/*.scss\"",
     "stylelint:fix": "stylelint \"**/*.scss\" --fix",
-    "postinstall": "node postinstall.js && (is-ci || husky install) || echo Skipped postinstall step for @faststore/core",
+    "postinstall": "node postinstall.js && (is-ci || (cd ../.. && husky install packages/core/.husky)) || echo Skipped postinstall step for @faststore/core",
     "partytown": "partytown copylib ./public/~partytown",
     "storybook": "start-storybook --docs -p 6006",
     "build-storybook": "build-storybook"


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix husky + lint-staged that runs pre-commit lints for core packages.
|Before|After|
|-|-|
|<img width="833" alt="Screenshot 2023-03-15 at 16 57 30" src="https://user-images.githubusercontent.com/11325562/225429287-ca4e4c1a-b7ac-4921-927a-b667fe24b431.png">|<img width="833" alt="Screenshot 2023-03-15 at 16 57 37" src="https://user-images.githubusercontent.com/11325562/225429495-12efa3bb-bbac-41df-9b86-c7623b93553f.png">|

Should should also see this scripts running pre commits:
<img width="771" alt="Screenshot 2023-03-15 at 17 05 06" src="https://user-images.githubusercontent.com/11325562/225429666-afa29d0c-92f2-414e-858f-8a8e3da41a79.png">

## How to test it?

- run `yarn` command.
- you should see the pre commit lint tasks after a commit as well 😉 

## references

https://github.com/typicode/husky/issues/851
