### PR TITLE
Feat: Updates `PropsSection`

### DIFF
--- a/apps/site/components/PropsSection/PropsSection.tsx
+++ b/apps/site/components/PropsSection/PropsSection.tsx
@@ -11,6 +11,7 @@ export interface RowItem {
 }
 
 export interface PropsSectionProps {
+  // TODO: Change this prop to `required` once all the components are updated with the new PropsSection
   propsList?: RowItem[]
 }
 

--- a/apps/site/components/PropsSection/PropsSection.tsx
+++ b/apps/site/components/PropsSection/PropsSection.tsx
@@ -1,3 +1,4 @@
+import type { HTMLAttributes } from 'react'
 import React from 'react'
 
 import styles from './props-section.module.css'
@@ -10,7 +11,7 @@ export interface RowItem {
   required: boolean
 }
 
-export interface PropsSectionProps {
+export interface PropsSectionProps extends HTMLAttributes<HTMLDivElement> {
   propsList?: RowItem[]
 }
 

--- a/apps/site/components/PropsSection/PropsSection.tsx
+++ b/apps/site/components/PropsSection/PropsSection.tsx
@@ -1,9 +1,58 @@
 import React from 'react'
 
+import styles from './props-section.module.css'
 
-const PropsSection = () => {
+export interface RowItem {
+  name: string
+  type: string | []
+  description: string
+  default: string
+  required: boolean
+}
+
+export interface PropsSectionProps {
+  propsList?: RowItem[]
+}
+
+const PropsSection = ({ propsList }: PropsSectionProps) => {
   return (
-    <i>Coming Soon</i>
+    <table className={styles.propsSection}>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Description</th>
+          <th>Default</th>
+        </tr>
+      </thead>
+      <tbody>
+        {propsList.map((prop) => {
+          return (
+            <tr key={prop.name}>
+              <td data-nx-props-section-name>
+                <strong>
+                  {prop.name}
+                  {prop.required && <span>*</span>}
+                </strong>
+              </td>
+              <td data-nx-props-section-type>
+                {prop.type instanceof Array ? (
+                  <span>
+                    {prop.type.map((option) => {
+                      return <code key={option}>{option}</code>
+                    })}
+                  </span>
+                ) : (
+                  <code>{prop.type}</code>
+                )}
+              </td>
+              <td>{prop.description}</td>
+              <td>{prop.default && <code>{prop.default}</code>}</td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
   )
 }
 

--- a/apps/site/components/PropsSection/PropsSection.tsx
+++ b/apps/site/components/PropsSection/PropsSection.tsx
@@ -14,7 +14,7 @@ export interface PropsSectionProps {
   propsList?: RowItem[]
 }
 
-const PropsSection = ({ propsList }: PropsSectionProps) => {
+const PropsSection = ({ propsList }) => {
   return (
     <table className={styles.propsSection}>
       <thead>

--- a/apps/site/components/PropsSection/PropsSection.tsx
+++ b/apps/site/components/PropsSection/PropsSection.tsx
@@ -16,49 +16,59 @@ export interface PropsSectionProps {
 
 const PropsSection = ({ propsList }) => {
   return (
-    <table className={styles.propsSection}>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Description</th>
-          <th>Default</th>
-        </tr>
-      </thead>
-      <tbody>
-        {propsList ? (
-          propsList.map((prop) => {
-            return (
-              <tr key={prop.name}>
-                <td data-nx-props-section-name>
-                  <strong>
-                    {prop.name}
-                    {prop.required && <span>*</span>}
-                  </strong>
-                </td>
-                <td data-nx-props-section-type>
-                  {prop.type instanceof Array ? (
-                    <span>
-                      {prop.type.map((option) => {
-                        return <code key={option}>{option}</code>
-                      })}
-                    </span>
-                  ) : (
-                    <code>{prop.type}</code>
-                  )}
-                </td>
-                <td>{prop.description}</td>
-                <td>{prop.default && <code>{prop.default}</code>}</td>
-              </tr>
-            )
-          })
-        ) : (
+    <section className={styles.propsSection}>
+      <table>
+        <colgroup>
+          <col data-nx-props-section-name />
+          <col data-nx-props-section-type />
+          <col data-nx-props-section-description />
+          <col data-nx-props-section-default />
+        </colgroup>
+        <thead>
           <tr>
-            <td>Coming Soon</td>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Default</th>
           </tr>
-        )}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {propsList ? (
+            propsList.map((prop) => {
+              return (
+                <tr key={prop.name}>
+                  <td data-nx-props-section-name>
+                    <strong>
+                      {prop.name}
+                      {prop.required && <span title="Required">*</span>}
+                    </strong>
+                  </td>
+                  <td data-nx-props-section-type>
+                    {prop.type instanceof Array ? (
+                      <span>
+                        {prop.type.map((option) => {
+                          return <code key={option}>{option}</code>
+                        })}
+                      </span>
+                    ) : (
+                      <code>{prop.type}</code>
+                    )}
+                  </td>
+                  <td data-nx-props-section-description>{prop.description}</td>
+                  <td data-nx-props-section-default>
+                    {prop.default && <code>{prop.default}</code>}
+                  </td>
+                </tr>
+              )
+            })
+          ) : (
+            <tr>
+              <td>Coming Soon</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </section>
   )
 }
 

--- a/apps/site/components/PropsSection/PropsSection.tsx
+++ b/apps/site/components/PropsSection/PropsSection.tsx
@@ -1,4 +1,3 @@
-import type { HTMLAttributes } from 'react'
 import React from 'react'
 
 import styles from './props-section.module.css'
@@ -11,7 +10,7 @@ export interface RowItem {
   required: boolean
 }
 
-export interface PropsSectionProps extends HTMLAttributes<HTMLDivElement> {
+export interface PropsSectionProps {
   propsList?: RowItem[]
 }
 

--- a/apps/site/components/PropsSection/PropsSection.tsx
+++ b/apps/site/components/PropsSection/PropsSection.tsx
@@ -27,31 +27,37 @@ const PropsSection = ({ propsList }) => {
         </tr>
       </thead>
       <tbody>
-        {propsList.map((prop) => {
-          return (
-            <tr key={prop.name}>
-              <td data-nx-props-section-name>
-                <strong>
-                  {prop.name}
-                  {prop.required && <span>*</span>}
-                </strong>
-              </td>
-              <td data-nx-props-section-type>
-                {prop.type instanceof Array ? (
-                  <span>
-                    {prop.type.map((option) => {
-                      return <code key={option}>{option}</code>
-                    })}
-                  </span>
-                ) : (
-                  <code>{prop.type}</code>
-                )}
-              </td>
-              <td>{prop.description}</td>
-              <td>{prop.default && <code>{prop.default}</code>}</td>
-            </tr>
-          )
-        })}
+        {propsList ? (
+          propsList.map((prop) => {
+            return (
+              <tr key={prop.name}>
+                <td data-nx-props-section-name>
+                  <strong>
+                    {prop.name}
+                    {prop.required && <span>*</span>}
+                  </strong>
+                </td>
+                <td data-nx-props-section-type>
+                  {prop.type instanceof Array ? (
+                    <span>
+                      {prop.type.map((option) => {
+                        return <code key={option}>{option}</code>
+                      })}
+                    </span>
+                  ) : (
+                    <code>{prop.type}</code>
+                  )}
+                </td>
+                <td>{prop.description}</td>
+                <td>{prop.default && <code>{prop.default}</code>}</td>
+              </tr>
+            )
+          })
+        ) : (
+          <tr>
+            <td>Coming Soon</td>
+          </tr>
+        )}
       </tbody>
     </table>
   )

--- a/apps/site/components/PropsSection/props-section.module.css
+++ b/apps/site/components/PropsSection/props-section.module.css
@@ -60,6 +60,7 @@
   padding: var(--fs-spacing-3) var(--fs-spacing-2);
   font-size: var(--fs-text-size-legend);
   line-height: 1.2;
+  vertical-align: top;
 }
 
 .propsSection td code {

--- a/apps/site/components/PropsSection/props-section.module.css
+++ b/apps/site/components/PropsSection/props-section.module.css
@@ -1,8 +1,17 @@
 .propsSection {
   width: 100%;
-  display: table;
+  overflow-x: auto;
+}
+
+.propsSection table {
+  width: 100%;
   border-spacing: 0;
   border-collapse: unset;
+  overflow: auto;
+}
+
+@media screen and (min-width: 1024px) {
+  .propsSection table { table-layout: fixed; }
 }
 
 .propsSection th {
@@ -19,12 +28,25 @@
 .propsSection tr:last-child td { border-bottom: none; }
 
 .propsSection th,
-.propsSection td { text-align: left; }
+.propsSection td {
+  text-align: left;
+  overflow: hidden;
+}
+
+@media screen and (min-width: 1024px) {
+  .propsSection [data-nx-props-section-name] { width: 20%; }
+  .propsSection [data-nx-props-section-type] { width: 20%; }
+  .propsSection [data-nx-props-section-description] { width: 40%; }
+  .propsSection [data-nx-props-section-default] { width: 20%; }
+}
+
 
 .propsSection td[data-nx-props-section-name] span {
   color: #006be6;
   margin-left: var(--fs-spacing-0);
+  cursor: help;
 }
+
 
 .propsSection td[data-nx-props-section-type] span {
   display: flex;
@@ -41,9 +63,10 @@
 }
 
 .propsSection td code {
-  margin: 0px 2px;
+  max-width: 100%;
+  word-wrap: break-word;
+  margin: 0 2px;
   padding: 3px 5px;
-  white-space: nowrap;
   border-radius: 3px;
   font-size: 13px;
   border: 1px solid rgb(238, 238, 238);

--- a/apps/site/components/PropsSection/props-section.module.css
+++ b/apps/site/components/PropsSection/props-section.module.css
@@ -1,0 +1,54 @@
+.propsSection {
+  width: 100%;
+  display: table;
+  border-spacing: 0;
+  border-collapse: unset;
+}
+
+.propsSection th {
+  color: var(--fs-color-text);
+  padding: var(--fs-spacing-1) var(--fs-spacing-2);
+  font-size: var(--fs-text-size-body);
+  background-color: hsl(var(--nextra-primary-hue)100% 39%/.05);
+}
+
+.propsSection th:first-child { border-radius: 4px 0 0 4px; }
+.propsSection th:last-child { border-radius: 0 4px 4px 0; }
+
+.propsSection tr:first-child td { padding-top: var(--fs-spacing-4); }
+.propsSection tr:last-child td { border-bottom: none; }
+
+.propsSection th,
+.propsSection td { text-align: left; }
+
+.propsSection td[data-nx-props-section-name] span {
+  color: #006be6;
+  margin-left: var(--fs-spacing-0);
+}
+
+.propsSection td[data-nx-props-section-type] span {
+  display: flex;
+  flex-direction: column;
+  align-items: self-start;
+  row-gap: var(--fs-spacing-0);
+}
+
+.propsSection td {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  padding: var(--fs-spacing-3) var(--fs-spacing-2);
+  font-size: var(--fs-text-size-legend);
+  line-height: 1.2;
+}
+
+.propsSection td code {
+  margin: 0px 2px;
+  padding: 3px 5px;
+  white-space: nowrap;
+  border-radius: 3px;
+  font-size: 13px;
+  border: 1px solid rgb(238, 238, 238);
+  color: rgba(51, 51, 51, 0.9);
+  background-color: rgb(248, 248, 248);
+  line-height: 1.3;
+  display: inline-block;
+}

--- a/apps/site/components/utilities/propsSection.ts
+++ b/apps/site/components/utilities/propsSection.ts
@@ -45,7 +45,7 @@ export function getComponentPropsFrom(
   const options = {
     savePropValueAsString: true,
     shouldExtractLiteralValuesFromEnum: true,
-    shouldExtractValuesFromUnion: false,
+    shouldExtractValuesFromUnion: true,
     propFilter: (prop) =>
       prop?.parent?.fileName?.includes(faststoreComponentsFromNodeModules),
   }
@@ -58,7 +58,11 @@ export function getComponentPropsFrom(
       const prop = componentProps[key]
       return {
         name: key,
-        type: prop.type?.name ?? '',
+        type:
+          prop.type?.value?.map(({ value }) => value).join(' | ') ??
+          prop.type?.raw ??
+          prop.type?.name ??
+          '',
         required: prop.required,
         default: prop.defaultValue?.value ?? '',
         description: prop.description ?? '',

--- a/apps/site/components/utilities/propsSection.ts
+++ b/apps/site/components/utilities/propsSection.ts
@@ -45,7 +45,7 @@ export function getComponentPropsFrom(
   const options = {
     savePropValueAsString: true,
     shouldExtractLiteralValuesFromEnum: true,
-    shouldExtractValuesFromUnion: true,
+    shouldExtractValuesFromUnion: false,
     propFilter: (prop) =>
       prop?.parent?.fileName?.includes(faststoreComponentsFromNodeModules),
   }

--- a/apps/site/components/utilities/propsSection.ts
+++ b/apps/site/components/utilities/propsSection.ts
@@ -1,0 +1,68 @@
+import { parse } from 'react-docgen-typescript'
+
+export const faststoreComponentsFromNodeModules = `node_modules/@faststore/components`
+
+export function mapComponentFromMdxPath(
+  absoluteMdxPath: string,
+  components: string[]
+): string[] {
+  const faststoreMonorepoDir = absoluteMdxPath.split('/apps/site/')[0]
+  const faststoreComponentsSrcFromNodeModules = `${faststoreMonorepoDir}/node_modules/@faststore/components/src`
+
+  const dirs = absoluteMdxPath.split('/')
+
+  // 2 levels before e.g. molecules/accordion.mdx
+  while (dirs.length > 2) {
+    dirs.shift()
+  }
+
+  const atomicDesignType = dirs[0] // atoms, molecules, organisms
+  const componentNameWithoutExtension = dirs[1].split('.')[0] // e.g. accordion.mdx -> accordion
+  const componentFolder =
+    componentNameWithoutExtension.charAt(0).toUpperCase() +
+    componentNameWithoutExtension.slice(1) // e.g. Accordion
+
+  // e.g. <user-path>/faststore/node_modules/@faststore/components/src/molecules/Accordion/Accordion.tsx
+  return components?.map((component: string) => {
+    return [
+      faststoreComponentsSrcFromNodeModules,
+      atomicDesignType,
+      componentFolder,
+      component,
+    ].join('/')
+  })
+}
+
+export function getComponentPropsFrom(
+  absoluteMdxPath: string,
+  componentsName: string[]
+) {
+  const components: string[] = mapComponentFromMdxPath(
+    absoluteMdxPath,
+    componentsName
+  )
+
+  const options = {
+    savePropValueAsString: true,
+    shouldExtractLiteralValuesFromEnum: true,
+    shouldExtractValuesFromUnion: true,
+    propFilter: (prop) =>
+      prop?.parent?.fileName?.includes(faststoreComponentsFromNodeModules),
+  }
+
+  return components.map((componentPath) => {
+    const componentInfo = parse(componentPath, options)
+    const componentProps = componentInfo?.[0]?.props ?? {}
+
+    return Object.keys(componentProps).map((key) => {
+      const prop = componentProps[key]
+      return {
+        name: key,
+        type: prop.type?.name ?? '',
+        required: prop.required,
+        default: prop.defaultValue?.value ?? '',
+        description: prop.description ?? '',
+      }
+    })
+  })
+}

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -22,6 +22,7 @@
     "@faststore/eslint-config": "^2.0.79-alpha.0",
     "@types/node": "^18.11.16",
     "eslint": "7.32.0",
+    "react-docgen-typescript": "^2.2.2",
     "typescript": "^4.9.4"
   }
 }

--- a/apps/site/pages/components/atoms/badge.mdx
+++ b/apps/site/pages/components/atoms/badge.mdx
@@ -8,12 +8,37 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Badge___bcedffeb307527c1606be224a7fb5ac1.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { SectionItem, SectionList } from 'site/components/SectionItem'
 import { Badge, DiscountBadge } from '@faststore/ui'
+import { useState } from 'react'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const badgePath = path.resolve(__filename)
+  const components = ['Badge.tsx']
+  const [badgeProps] = getComponentPropsFrom(badgePath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: { badgeProps },
+    },
+  }
+}
+
+export const BadgePropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { badgeProps } = useSSG()
+  return {
+    Badge: <PropsSection propsList={badgeProps} />,
+  }[component]
+}
 
 <header>
 
@@ -92,41 +117,7 @@ import '@faststore/ui/src/components/atoms/Badge/styles.scss'
 
 ## Props
 
-export const propsBadge = [
-  {
-    name: 'testId',
-    type: 'string',
-    description:
-      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
-    default: 'fs-badge',
-  },
-  {
-    name: 'size',
-    type: ['small', 'big'],
-    description: "Sets the component's size.",
-    default: 'small',
-  },
-  {
-    name: 'variant',
-    type: ['info', 'highlighted', 'success', 'neutral', 'warning', 'danger'],
-    description: 'Specifies the component variant.',
-    default: 'neutral',
-  },
-  {
-    name: 'counter',
-    type: 'boolean',
-    description: 'Enables counter badge.',
-    default: 'false',
-  },
-  {
-    name: 'aria-label',
-    type: "AriaAttributes['aria-label']",
-    description:
-      'For accessibility purposes, adds an ARIA label to the element when `counter` is set to `true`.',
-  },
-]
-
-<PropsSection propsList={propsBadge} />
+<BadgePropsSection component="Badge" />
 
 ---
 

--- a/apps/site/pages/components/atoms/badge.mdx
+++ b/apps/site/pages/components/atoms/badge.mdx
@@ -92,7 +92,41 @@ import '@faststore/ui/src/components/atoms/Badge/styles.scss'
 
 ## Props
 
-<PropsSection name="Badge" />
+export const propsBadge = [
+  {
+    name: 'testId',
+    type: 'string',
+    description:
+      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
+    default: 'fs-badge',
+  },
+  {
+    name: 'size',
+    type: ['small', 'big'],
+    description: "Sets the component's size.",
+    default: 'small',
+  },
+  {
+    name: 'variant',
+    type: ['info', 'highlighted', 'success', 'neutral', 'warning', 'danger'],
+    description: 'Specifies the component variant.',
+    default: 'neutral',
+  },
+  {
+    name: 'counter',
+    type: 'boolean',
+    description: 'Enables counter badge.',
+    default: 'false',
+  },
+  {
+    name: 'aria-label',
+    type: "AriaAttributes['aria-label']",
+    description:
+      'For accessibility purposes, adds an ARIA label to the element when `counter` is set to `true`.',
+  },
+]
+
+<PropsSection propsList={propsBadge} />
 
 ---
 

--- a/apps/site/pages/components/atoms/button.mdx
+++ b/apps/site/pages/components/atoms/button.mdx
@@ -8,6 +8,8 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Button___6d6b16886d5d7e2a05dba8c45c075796.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import { ShoppingCart } from '@faststore/components'
 import PropsSection from 'site/components/PropsSection'
@@ -16,6 +18,29 @@ import { OverviewSection } from 'site/components/OverviewSection'
 import { SectionItem, SectionList } from 'site/components/SectionItem'
 import ButtonLoading from 'site/components/Button/ButtonLoading'
 import { Button, IconButton, BuyButton, LinkButton } from '@faststore/ui'
+import { useState } from 'react'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const buttonPath = path.resolve(__filename)
+  const components = ['Button.tsx']
+  const [buttonProps] = getComponentPropsFrom(buttonPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: { buttonProps },
+    },
+  }
+}
+
+export const ButtonPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { buttonProps } = useSSG()
+  return {
+    Button: <PropsSection propsList={buttonProps} />,
+  }[component]
+}
 
 <header>
 
@@ -87,59 +112,7 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
 
 ## Props
 
-export const propsButton = [
-  {
-    name: 'testId',
-    type: 'string',
-    description:
-      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
-    default: 'fs-button',
-  },
-  {
-    name: 'variant',
-    type: ['primary', 'secondary', 'tertiary'],
-    description: 'Specifies the component color variant.',
-  },
-  {
-    name: 'size',
-    type: ['small', 'regular'],
-    description: 'Specifies the size variant.',
-    default: 'regular',
-  },
-  {
-    name: 'inverse',
-    type: 'boolean',
-    description: 'Defines the use of inverted colors.',
-  },
-  {
-    name: 'disabled',
-    type: 'boolean',
-    description: 'Specifies that this button should be disabled.',
-  },
-  {
-    name: 'icon',
-    type: 'ReactNode',
-    description: 'A React component that will be rendered as an icon.',
-  },
-  {
-    name: 'loading',
-    type: 'boolean',
-    description: 'Boolean that represents a loading state.',
-  },
-  {
-    name: 'loadingLabel',
-    type: 'string',
-    description: 'Specifies a label for loading state.',
-  },
-  {
-    name: 'iconPosition',
-    type: ['left', 'right'],
-    description: 'Specifies where the icon should be positioned',
-    default: 'left',
-  },
-]
-
-<PropsSection propsList={propsButton} />
+<ButtonPropsSection component="Button" />
 
 ---
 

--- a/apps/site/pages/components/atoms/button.mdx
+++ b/apps/site/pages/components/atoms/button.mdx
@@ -99,7 +99,6 @@ export const propsButton = [
     name: 'variant',
     type: ['primary', 'secondary', 'tertiary'],
     description: 'Specifies the component color variant.',
-    default: '',
   },
   {
     name: 'size',
@@ -111,31 +110,26 @@ export const propsButton = [
     name: 'inverse',
     type: 'boolean',
     description: 'Defines the use of inverted colors.',
-    default: '',
   },
   {
     name: 'disabled',
     type: 'boolean',
     description: 'Specifies that this button should be disabled.',
-    default: '',
   },
   {
     name: 'icon',
     type: 'ReactNode',
     description: 'A React component that will be rendered as an icon.',
-    default: '',
   },
   {
     name: 'loading',
     type: 'boolean',
     description: 'Boolean that represents a loading state.',
-    default: '',
   },
   {
     name: 'loadingLabel',
     type: 'string',
     description: 'Specifies a label for loading state.',
-    default: '',
   },
   {
     name: 'iconPosition',
@@ -145,7 +139,7 @@ export const propsButton = [
   },
 ]
 
-<PropsSection name="Button" propsList={propsButton} />
+<PropsSection propsList={propsButton} />
 
 ---
 

--- a/apps/site/pages/components/atoms/button.mdx
+++ b/apps/site/pages/components/atoms/button.mdx
@@ -87,7 +87,65 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
 
 ## Props
 
-<PropsSection name="Button" />
+export const propsList = [
+  {
+    name: 'testId',
+    type: 'string',
+    description:
+      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
+    default: 'fs-button',
+  },
+  {
+    name: 'variant',
+    type: ['primary', 'secondary', 'tertiary'],
+    description: 'Specifies the component color variant.',
+    default: '',
+  },
+  {
+    name: 'size',
+    type: ['small', 'regular'],
+    description: 'Specifies the size variant.',
+    default: 'regular',
+  },
+  {
+    name: 'inverse',
+    type: 'boolean',
+    description: 'Defines the use of inverted colors.',
+    default: '',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    description: 'Specifies that this button should be disabled.',
+    default: '',
+  },
+  {
+    name: 'icon',
+    type: 'ReactNode',
+    description: 'A React component that will be rendered as an icon.',
+    default: '',
+  },
+  {
+    name: 'loading',
+    type: 'boolean',
+    description: 'Boolean that represents a loading state.',
+    default: '',
+  },
+  {
+    name: 'loadingLabel',
+    type: 'string',
+    description: 'Specifies a label for loading state.',
+    default: '',
+  },
+  {
+    name: 'iconPosition',
+    type: ['left', 'right'],
+    description: 'Specifies where the icon should be positioned',
+    default: 'left',
+  },
+]
+
+<PropsSection name="Button" propsList={propsList} />
 
 ---
 

--- a/apps/site/pages/components/atoms/button.mdx
+++ b/apps/site/pages/components/atoms/button.mdx
@@ -87,7 +87,7 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
 
 ## Props
 
-export const propsList = [
+export const propsButton = [
   {
     name: 'testId',
     type: 'string',
@@ -145,7 +145,7 @@ export const propsList = [
   },
 ]
 
-<PropsSection name="Button" propsList={propsList} />
+<PropsSection name="Button" propsList={propsButton} />
 
 ---
 

--- a/apps/site/pages/components/atoms/checkbox.mdx
+++ b/apps/site/pages/components/atoms/checkbox.mdx
@@ -4,12 +4,37 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Checkbox___5dfb3d931c093ee7ebfac8bc388e68b5.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { SectionItem, SectionList } from 'site/components/SectionItem'
 import { Checkbox, CheckboxField } from '@faststore/ui'
+import { useState } from 'react'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const checkboxPath = path.resolve(__filename)
+  const components = ['Checkbox.tsx']
+  const [checkboxProps] = getComponentPropsFrom(checkboxPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: { checkboxProps },
+    },
+  }
+}
+
+export const CheckboxPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { checkboxProps } = useSSG()
+  return {
+    Checkbox: <PropsSection propsList={checkboxProps} />,
+  }[component]
+}
 
 <header>
 
@@ -70,22 +95,7 @@ import '@faststore/ui/src/components/atoms/Checkbox/styles.scss'
 
 ## Props
 
-export const propsCheckbox = [
-  {
-    name: 'testId',
-    type: 'string',
-    description:
-      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
-    default: 'fs-checkbox',
-  },
-  {
-    name: 'partial',
-    type: 'boolean',
-    description: 'Boolean that represents a partial state.',
-  },
-]
-
-<PropsSection propsList={propsCheckbox} />
+<CheckboxPropsSection component="Checkbox" />
 
 ---
 

--- a/apps/site/pages/components/atoms/checkbox.mdx
+++ b/apps/site/pages/components/atoms/checkbox.mdx
@@ -70,7 +70,22 @@ import '@faststore/ui/src/components/atoms/Checkbox/styles.scss'
 
 ## Props
 
-<PropsSection name="Checkbox" />
+export const propsCheckbox = [
+  {
+    name: 'testId',
+    type: 'string',
+    description:
+      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
+    default: 'fs-checkbox',
+  },
+  {
+    name: 'partial',
+    type: 'boolean',
+    description: 'Boolean that represents a partial state.',
+  },
+]
+
+<PropsSection propsList={propsCheckbox} />
 
 ---
 

--- a/apps/site/pages/components/molecules/accordion.mdx
+++ b/apps/site/pages/components/molecules/accordion.mdx
@@ -189,19 +189,95 @@ Besides those attributes, the following props are also supported:
 
 ### Accordion
 
-<PropsSection name="Accordion" />
+export const propsAccordion = [
+  {
+    name: 'testId',
+    type: 'string',
+    description:
+      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
+    default: 'fs-accordion',
+  },
+  {
+    name: 'indices',
+    type: 'Iterable<number>',
+    description: 'Indices that indicate which accordion items are opened.',
+    required: true,
+  },
+  {
+    name: 'onChange',
+    type: '(index: number) => void',
+    description:
+      'Function that is triggered when an accordion item is opened/closed.',
+    required: true,
+  },
+]
 
-### AccordionItem
+<PropsSection propsList={propsAccordion} />
 
-<PropsSection name="AccordionItem" />
+### Accordion Item
 
-### AccordionButton
+export const propsAccordionItem = [
+  {
+    name: 'testId',
+    type: 'string',
+    description:
+      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
+    default: 'fs-accordion-item',
+  },
+  {
+    name: 'index',
+    type: 'number',
+    description: 'Index of the current accordion item within the accordion.',
+  },
+  {
+    name: 'prefixId',
+    type: 'string',
+    description:
+      "Namespace ID prefix for the current Accordion item's panel and button to avoid ID duplication when multiple instances are on the same page.",
+  },
+]
 
-<PropsSection name="AccordionButton" />
+<PropsSection propsList={propsAccordionItem} />
 
-### AccordionPanel
+### Accordion Button
 
-<PropsSection name="AccordionPanel" />
+export const propsAccordionButton = [
+  {
+    name: 'testId',
+    type: 'string',
+    description:
+      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
+    default: 'fs-accordion-button',
+  },
+  {
+    name: 'expandedIcon',
+    type: 'ReactNode',
+    description:
+      'A React component is rendered as an icon when the accordion is expanded.',
+  },
+  {
+    name: 'collapsedIcon',
+    type: 'ReactNode',
+    description:
+      'A React component is rendered as an icon when the accordion is collapsed.',
+  },
+]
+
+<PropsSection propsList={propsAccordionButton} />
+
+### Accordion Panel
+
+export const propsAccordionPanel = [
+  {
+    name: 'testId',
+    type: 'string',
+    description:
+      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
+    default: 'fs-accordion-panel',
+  },
+]
+
+<PropsSection propsList={propsAccordionPanel} />
 
 ---
 

--- a/apps/site/pages/components/molecules/accordion.mdx
+++ b/apps/site/pages/components/molecules/accordion.mdx
@@ -4,6 +4,8 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Accordion___66012e5367e86c5b4422ff8d6974b8cd.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
@@ -17,6 +19,39 @@ import {
   List,
 } from '@faststore/ui'
 import { useState } from 'react'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const accordionPath = path.resolve(__filename)
+  const components = [
+    'Accordion.tsx',
+    'AccordionButton.tsx',
+    'AccordionPanel.tsx',
+  ]
+  const [accordionProps, accordionButtonProps, accordionPanelProps] =
+    getComponentPropsFrom(accordionPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        accordionProps,
+        accordionButtonProps,
+        accordionPanelProps,
+      },
+    },
+  }
+}
+
+export const AccordionPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { accordionProps, accordionButtonProps, accordionPanelProps } = useSSG()
+  return {
+    Accordion: <PropsSection propsList={accordionProps} />,
+    AccordionButton: <PropsSection propsList={accordionButtonProps} />,
+    AccordionPanel: <PropsSection propsList={accordionPanelProps} />,
+  }[component]
+}
 
 <header>
 
@@ -189,30 +224,7 @@ Besides those attributes, the following props are also supported:
 
 ### Accordion
 
-export const propsAccordion = [
-  {
-    name: 'testId',
-    type: 'string',
-    description:
-      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
-    default: 'fs-accordion',
-  },
-  {
-    name: 'indices',
-    type: 'Iterable<number>',
-    description: 'Indices that indicate which accordion items are opened.',
-    required: true,
-  },
-  {
-    name: 'onChange',
-    type: '(index: number) => void',
-    description:
-      'Function that is triggered when an accordion item is opened/closed.',
-    required: true,
-  },
-]
-
-<PropsSection propsList={propsAccordion} />
+<AccordionPropsSection component="Accordion" />
 
 ### Accordion Item
 
@@ -241,43 +253,11 @@ export const propsAccordionItem = [
 
 ### Accordion Button
 
-export const propsAccordionButton = [
-  {
-    name: 'testId',
-    type: 'string',
-    description:
-      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
-    default: 'fs-accordion-button',
-  },
-  {
-    name: 'expandedIcon',
-    type: 'ReactNode',
-    description:
-      'A React component is rendered as an icon when the accordion is expanded.',
-  },
-  {
-    name: 'collapsedIcon',
-    type: 'ReactNode',
-    description:
-      'A React component is rendered as an icon when the accordion is collapsed.',
-  },
-]
-
-<PropsSection propsList={propsAccordionButton} />
+<AccordionPropsSection component="AccordionButton" />
 
 ### Accordion Panel
 
-export const propsAccordionPanel = [
-  {
-    name: 'testId',
-    type: 'string',
-    description:
-      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
-    default: 'fs-accordion-panel',
-  },
-]
-
-<PropsSection propsList={propsAccordionPanel} />
+<AccordionPropsSection component="AccordionPanel" />
 
 ---
 

--- a/packages/components/src/atoms/Badge/Badge.tsx
+++ b/packages/components/src/atoms/Badge/Badge.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, HTMLAttributes, AriaAttributes } from 'react'
+import type { HTMLAttributes, AriaAttributes } from 'react'
 import React, { forwardRef } from 'react'
 
 export type BadgeVariants =

--- a/packages/components/src/atoms/Badge/Badge.tsx
+++ b/packages/components/src/atoms/Badge/Badge.tsx
@@ -30,7 +30,6 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
    * For accessibility purposes, adds an ARIA label to the element when `counter` is set to `true`.
    */
   'aria-label'?: AriaAttributes['aria-label']
-  children?: ReactNode
 }
 
 const Badge = forwardRef<HTMLDivElement, BadgeProps>(function Badge(

--- a/yarn.lock
+++ b/yarn.lock
@@ -19285,7 +19285,7 @@ rc@1.2.8, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-docgen-typescript@^2.1.1:
+react-docgen-typescript@^2.1.1, react-docgen-typescript@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
   integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==
@@ -20960,6 +20960,8 @@ ssri@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
   integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
+  dependencies:
+    figgy-pudding "^3.5.1"
 
 ssri@^8.0.0, ssri@^8.0.1:
   version "8.0.1"


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR updates our `PropsSection` to list all the props of a component.

## How to test it?
For now, only these components have the new `PropsSection`:

**Atoms**
- [Badge](https://faststore-site-git-feat-props-section-fs-748-faststore.vercel.app/components/atoms/badge#props)
- [Button](https://faststore-site-git-feat-props-section-fs-748-faststore.vercel.app/components/atoms/button#props)
- [Checkbox](https://faststore-site-git-feat-props-section-fs-748-faststore.vercel.app/components/atoms/checkbox#props)

**Molecules**
- [Accordion](https://faststore-site-git-feat-props-section-fs-748-faststore.vercel.app/components/molecules/accordion#props)

## References
- [Nordhealth](https://nordhealth.design/components/badge/)
- [Radix UI](https://www.radix-ui.com/docs/primitives/components/dialog#api-reference)
