### PR TITLE
feat: change dominantVariant to optional

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -503,16 +503,16 @@ export type SkuVariants = {
    * `dominantVariantName` property. Returns all available options for the
    * dominant property, and only options that can be combined with its current
    * value for other properties.
-   * In case of the dominantVariantName is not passed, the first variant will be
-   * used as the dominant.
+   * If `dominantVariantName` is not present, the first variant will be
+   * considered the dominant one.
    */
   availableVariations?: Maybe<Scalars['FormattedVariants']>;
   /**
    * Maps property value combinations to their respective SKU's slug. Enables
    * us to retrieve the slug for the SKU that matches the currently selected
    * variations in O(1) time.
-   * In case of the dominantVariantName is not passed, the first variant will be
-   * used as the dominant.
+   * If `dominantVariantName` is not present, the first variant will be
+   * considered the dominant one.
    */
   slugsMap?: Maybe<Scalars['SlugsMap']>;
 };

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -503,24 +503,28 @@ export type SkuVariants = {
    * `dominantVariantName` property. Returns all available options for the
    * dominant property, and only options that can be combined with its current
    * value for other properties.
+   * In case of the dominantVariantName is not passed, the first variant will be
+   * used as the dominant.
    */
   availableVariations?: Maybe<Scalars['FormattedVariants']>;
   /**
    * Maps property value combinations to their respective SKU's slug. Enables
    * us to retrieve the slug for the SKU that matches the currently selected
    * variations in O(1) time.
+   * In case of the dominantVariantName is not passed, the first variant will be
+   * used as the dominant.
    */
   slugsMap?: Maybe<Scalars['SlugsMap']>;
 };
 
 
 export type SkuVariantsAvailableVariationsArgs = {
-  dominantVariantName: Scalars['String'];
+  dominantVariantName?: Maybe<Scalars['String']>;
 };
 
 
 export type SkuVariantsSlugsMapArgs = {
-  dominantVariantName: Scalars['String'];
+  dominantVariantName?: Maybe<Scalars['String']>;
 };
 
 /** Aggregate offer information, for a given SKU that is available to be fulfilled by multiple sellers. */

--- a/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
+++ b/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
@@ -24,14 +24,14 @@ export const SkuVariants: Record<string, Resolver<Root>> = {
       root.isVariantOf.items,
       // Since `dominantVariantProperty` is a required argument, we can safely
       // access it.
-      (args as SlugsMapArgs).dominantVariantName,
+      (args as SlugsMapArgs).dominantVariantName ?? root.variations[0]?.name,
       root.isVariantOf.linkText
     ),
 
   availableVariations: (root, args) => {
     // Since `dominantVariantProperty` is a required argument, we can safely
     // access it.
-    const dominantVariantName = (args as SlugsMapArgs).dominantVariantName
+    const dominantVariantName = (args as SlugsMapArgs).dominantVariantName ?? root.variations[0]?.name
     const activeVariations = getActiveSkuVariations(root.variations)
 
     const activeDominantVariationValue = activeVariations[dominantVariantName]

--- a/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
+++ b/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
@@ -22,15 +22,11 @@ export const SkuVariants: Record<string, Resolver<Root>> = {
   slugsMap: (root, args) =>
     createSlugsMap(
       root.isVariantOf.items,
-      // Since `dominantVariantProperty` is a required argument, we can safely
-      // access it.
       (args as SlugsMapArgs).dominantVariantName ?? root.variations[0]?.name,
       root.isVariantOf.linkText
     ),
 
   availableVariations: (root, args) => {
-    // Since `dominantVariantProperty` is a required argument, we can safely
-    // access it.
     const dominantVariantName = (args as SlugsMapArgs).dominantVariantName ?? root.variations[0]?.name
     const activeVariations = getActiveSkuVariations(root.variations)
 

--- a/packages/api/src/typeDefs/skuVariants.graphql
+++ b/packages/api/src/typeDefs/skuVariants.graphql
@@ -11,8 +11,8 @@ type SkuVariants {
   Maps property value combinations to their respective SKU's slug. Enables
   us to retrieve the slug for the SKU that matches the currently selected
   variations in O(1) time.
-  In case of the dominantVariantName is not passed, the first variant will be
-  used as the dominant.
+  If `dominantVariantName` is not present, the first variant will be 
+  considered the dominant one.
   """
   slugsMap(dominantVariantName: String): SlugsMap
   """
@@ -20,8 +20,8 @@ type SkuVariants {
   `dominantVariantName` property. Returns all available options for the
   dominant property, and only options that can be combined with its current
   value for other properties.
-  In case of the dominantVariantName is not passed, the first variant will be
-  used as the dominant.
+  If `dominantVariantName` is not present, the first variant will be 
+  considered the dominant one.
   """
   availableVariations(dominantVariantName: String): FormattedVariants
 }

--- a/packages/api/src/typeDefs/skuVariants.graphql
+++ b/packages/api/src/typeDefs/skuVariants.graphql
@@ -11,22 +11,26 @@ type SkuVariants {
   Maps property value combinations to their respective SKU's slug. Enables
   us to retrieve the slug for the SKU that matches the currently selected
   variations in O(1) time.
+  In case of the dominantVariantName is not passed, the first variant will be
+  used as the dominant.
   """
-  slugsMap(dominantVariantName: String!): SlugsMap
+  slugsMap(dominantVariantName: String): SlugsMap
   """
   Available options for each varying SKU property, taking into account the
-  `dominantVariantName` property. Returns all available options for the 
+  `dominantVariantName` property. Returns all available options for the
   dominant property, and only options that can be combined with its current
   value for other properties.
+  In case of the dominantVariantName is not passed, the first variant will be
+  used as the dominant.
   """
-  availableVariations(dominantVariantName: String!): FormattedVariants
+  availableVariations(dominantVariantName: String): FormattedVariants
 }
 
 """
-Example: 
+Example:
 
 ```json
-{ 
+{
   'Color-Red-Size-40': 'classic-shoes-37'
 }
 ```
@@ -54,18 +58,18 @@ Example:
 """
 scalar VariantsByName
 """
-Example: 
+Example:
 
 ```json
 {
   Color: [
-    { 
+    {
       src: "https://storecomponents.vtexassets.com/...",
       alt: "...",
       label: "...",
       value: "..."
     },
-    { 
+    {
       src: "https://storecomponents.vtexassets.com/...",
       alt: "...",
       label: "...",
@@ -73,7 +77,7 @@ Example:
     }
   ],
   Size: [
-    { 
+    {
       src: "https://storecomponents.vtexassets.com/...",
       alt: "...",
       label: "...",
@@ -84,4 +88,3 @@ Example:
 ```
 """
 scalar FormattedVariants
-


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR sets dominantVariantName as optional in slugsMap and availableVariations.
When the dominantVariantName tVariant is not passed, the first variant will be used as the dominant.

This change is necessary because sometimes we haven't the dominantValue to set in a query dynamically so the firs option solve this problem.