### PR TITLE
Feat: Automatic `PropSection`

### DIFF
--- a/apps/site/components/utilities/propsSection.ts
+++ b/apps/site/components/utilities/propsSection.ts
@@ -1,0 +1,60 @@
+import { parse } from 'react-docgen-typescript'
+
+export const faststoreComponentsFromNodeModules = `node_modules/@faststore/components`
+
+export function mapComponentFromMdxPath(
+  absoluteMdxPath: string,
+  fileName: string
+) {
+  const faststoreMonorepoDir = absoluteMdxPath.split('/apps/site/')[0]
+  const faststoreComponentsSrcFromNodeModules = `${faststoreMonorepoDir}/node_modules/@faststore/components/src`
+
+  const dirs = absoluteMdxPath.split('/')
+
+  // 2 levels before e.g. molecules/accordion.mdx
+  while (dirs.length > 2) {
+    dirs.shift()
+  }
+
+  const atomicDesignType = dirs[0] // atoms, molecules, organisms
+  const componentNameWithoutExtension = dirs[1].split('.')[0] // e.g. accordion.mdx -> accordion
+  const componentFolder =
+    componentNameWithoutExtension.charAt(0).toUpperCase() +
+    componentNameWithoutExtension.slice(1) // e.g. Accordion
+
+  // e.g. <user-path>/faststore/node_modules/@faststore/components/src/molecules/Accordion/Accordion.tsx
+  return [
+    faststoreComponentsSrcFromNodeModules,
+    atomicDesignType,
+    componentFolder,
+    fileName,
+  ].join('/')
+}
+
+export function getComponentPropsFrom(
+  absoluteMdxPath: string,
+  fileName: string
+) {
+  const componentPath = mapComponentFromMdxPath(absoluteMdxPath, fileName)
+  const options = {
+    savePropValueAsString: true,
+    shouldExtractLiteralValuesFromEnum: true,
+    shouldExtractValuesFromUnion: true,
+    propFilter: (prop) =>
+      prop?.parent?.fileName?.includes(faststoreComponentsFromNodeModules),
+  }
+
+  const componentInfo = parse(componentPath, options)
+  const componentProps = componentInfo?.[0]?.props ?? {}
+
+  return Object.keys(componentProps).map((key) => {
+    const prop = componentProps[key]
+    return {
+      name: key,
+      type: prop.type?.name ?? '',
+      required: prop.required,
+      default: prop.defaultValue?.value ?? '',
+      description: prop.description ?? '',
+    }
+  })
+}

--- a/apps/site/components/utilities/propsSection.ts
+++ b/apps/site/components/utilities/propsSection.ts
@@ -4,8 +4,8 @@ export const faststoreComponentsFromNodeModules = `node_modules/@faststore/compo
 
 export function mapComponentFromMdxPath(
   absoluteMdxPath: string,
-  fileName: string
-) {
+  components: string[]
+): string[] {
   const faststoreMonorepoDir = absoluteMdxPath.split('/apps/site/')[0]
   const faststoreComponentsSrcFromNodeModules = `${faststoreMonorepoDir}/node_modules/@faststore/components/src`
 
@@ -23,19 +23,25 @@ export function mapComponentFromMdxPath(
     componentNameWithoutExtension.slice(1) // e.g. Accordion
 
   // e.g. <user-path>/faststore/node_modules/@faststore/components/src/molecules/Accordion/Accordion.tsx
-  return [
-    faststoreComponentsSrcFromNodeModules,
-    atomicDesignType,
-    componentFolder,
-    fileName,
-  ].join('/')
+  return components?.map((component: string) => {
+    return [
+      faststoreComponentsSrcFromNodeModules,
+      atomicDesignType,
+      componentFolder,
+      component,
+    ].join('/')
+  })
 }
 
 export function getComponentPropsFrom(
   absoluteMdxPath: string,
-  fileName: string
+  componentsName: string[]
 ) {
-  const componentPath = mapComponentFromMdxPath(absoluteMdxPath, fileName)
+  const components: string[] = mapComponentFromMdxPath(
+    absoluteMdxPath,
+    componentsName
+  )
+
   const options = {
     savePropValueAsString: true,
     shouldExtractLiteralValuesFromEnum: true,
@@ -44,17 +50,19 @@ export function getComponentPropsFrom(
       prop?.parent?.fileName?.includes(faststoreComponentsFromNodeModules),
   }
 
-  const componentInfo = parse(componentPath, options)
-  const componentProps = componentInfo?.[0]?.props ?? {}
+  return components.map((componentPath) => {
+    const componentInfo = parse(componentPath, options)
+    const componentProps = componentInfo?.[0]?.props ?? {}
 
-  return Object.keys(componentProps).map((key) => {
-    const prop = componentProps[key]
-    return {
-      name: key,
-      type: prop.type?.name ?? '',
-      required: prop.required,
-      default: prop.defaultValue?.value ?? '',
-      description: prop.description ?? '',
-    }
+    return Object.keys(componentProps).map((key) => {
+      const prop = componentProps[key]
+      return {
+        name: key,
+        type: prop.type?.name ?? '',
+        required: prop.required,
+        default: prop.defaultValue?.value ?? '',
+        description: prop.description ?? '',
+      }
+    })
   })
 }

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -22,6 +22,7 @@
     "@faststore/eslint-config": "^2.0.79-alpha.0",
     "@types/node": "^18.11.16",
     "eslint": "7.32.0",
+    "react-docgen-typescript": "^2.2.2",
     "typescript": "^4.9.4"
   }
 }

--- a/apps/site/pages/components/molecules/accordion.mdx
+++ b/apps/site/pages/components/molecules/accordion.mdx
@@ -4,6 +4,8 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Accordion___66012e5367e86c5b4422ff8d6974b8cd.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
@@ -17,6 +19,52 @@ import {
   List,
 } from '@faststore/ui'
 import { useState } from 'react'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const accordionPath = path.resolve(__filename)
+  const accordionProps = getComponentPropsFrom(accordionPath, 'Accordion.tsx')
+  const accordionItemProps = getComponentPropsFrom(
+    accordionPath,
+    'AccordionItem.tsx'
+  )
+  const accordionButtonProps = getComponentPropsFrom(
+    accordionPath,
+    'AccordionButton.tsx'
+  )
+  const accordionPanelProps = getComponentPropsFrom(
+    accordionPath,
+    'AccordionPanel.tsx'
+  )
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        accordionProps,
+        accordionItemProps,
+        accordionButtonProps,
+        accordionPanelProps,
+      },
+    },
+  }
+}
+
+export const AccordionPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const {
+    accordionProps,
+    accordionItemProps,
+    accordionButtonProps,
+    accordionPanelProps,
+  } = useSSG()
+  return {
+    Accordion: <PropsSection propsList={accordionProps} />,
+    AccordionItem: <PropsSection propsList={accordionItemProps} />,
+    AccordionButton: <PropsSection propsList={accordionButtonProps} />,
+    AccordionPanel: <PropsSection propsList={accordionPanelProps} />,
+  }[component]
+}
 
 <header>
 
@@ -189,30 +237,7 @@ Besides those attributes, the following props are also supported:
 
 ### Accordion
 
-export const propsAccordion = [
-  {
-    name: 'testId',
-    type: 'string',
-    description:
-      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
-    default: 'fs-accordion',
-  },
-  {
-    name: 'indices',
-    type: 'Iterable<number>',
-    description: 'Indices that indicate which accordion items are opened.',
-    required: true,
-  },
-  {
-    name: 'onChange',
-    type: '(index: number) => void',
-    description:
-      'Function that is triggered when an accordion item is opened/closed.',
-    required: true,
-  },
-]
-
-<PropsSection propsList={propsAccordion} />
+<AccordionPropsSection component="Accordion" />
 
 ### Accordion Item
 
@@ -241,43 +266,11 @@ export const propsAccordionItem = [
 
 ### Accordion Button
 
-export const propsAccordionButton = [
-  {
-    name: 'testId',
-    type: 'string',
-    description:
-      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
-    default: 'fs-accordion-button',
-  },
-  {
-    name: 'expandedIcon',
-    type: 'ReactNode',
-    description:
-      'A React component is rendered as an icon when the accordion is expanded.',
-  },
-  {
-    name: 'collapsedIcon',
-    type: 'ReactNode',
-    description:
-      'A React component is rendered as an icon when the accordion is collapsed.',
-  },
-]
-
-<PropsSection propsList={propsAccordionButton} />
+<AccordionPropsSection component="AccordionButton" />
 
 ### Accordion Panel
 
-export const propsAccordionPanel = [
-  {
-    name: 'testId',
-    type: 'string',
-    description:
-      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
-    default: 'fs-accordion-panel',
-  },
-]
-
-<PropsSection propsList={propsAccordionPanel} />
+<AccordionPropsSection component="AccordionPanel" />
 
 ---
 

--- a/apps/site/pages/components/molecules/accordion.mdx
+++ b/apps/site/pages/components/molecules/accordion.mdx
@@ -23,15 +23,13 @@ import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
 
 export const getStaticProps = () => {
   const accordionPath = path.resolve(__filename)
-  const accordionProps = getComponentPropsFrom(accordionPath, 'Accordion.tsx')
-  const accordionButtonProps = getComponentPropsFrom(
-    accordionPath,
-    'AccordionButton.tsx'
-  )
-  const accordionPanelProps = getComponentPropsFrom(
-    accordionPath,
-    'AccordionPanel.tsx'
-  )
+  const components = [
+    'Accordion.tsx',
+    'AccordionButton.tsx',
+    'AccordionPanel.tsx',
+  ]
+  const [accordionProps, accordionButtonProps, accordionPanelProps] =
+    getComponentPropsFrom(accordionPath, components)
   return {
     props: {
       // We add an `ssg` field to the page props,
@@ -47,11 +45,7 @@ export const getStaticProps = () => {
 
 export const AccordionPropsSection = ({ component }) => {
   // Get the data from SSG, and render it as a component.
-  const {
-    accordionProps,
-    accordionButtonProps,
-    accordionPanelProps,
-  } = useSSG()
+  const { accordionProps, accordionButtonProps, accordionPanelProps } = useSSG()
   return {
     Accordion: <PropsSection propsList={accordionProps} />,
     AccordionButton: <PropsSection propsList={accordionButtonProps} />,

--- a/apps/site/pages/components/molecules/accordion.mdx
+++ b/apps/site/pages/components/molecules/accordion.mdx
@@ -24,10 +24,6 @@ import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
 export const getStaticProps = () => {
   const accordionPath = path.resolve(__filename)
   const accordionProps = getComponentPropsFrom(accordionPath, 'Accordion.tsx')
-  const accordionItemProps = getComponentPropsFrom(
-    accordionPath,
-    'AccordionItem.tsx'
-  )
   const accordionButtonProps = getComponentPropsFrom(
     accordionPath,
     'AccordionButton.tsx'
@@ -42,7 +38,6 @@ export const getStaticProps = () => {
       // which will be provided to the Nextra `useSSG` hook.
       ssg: {
         accordionProps,
-        accordionItemProps,
         accordionButtonProps,
         accordionPanelProps,
       },
@@ -54,13 +49,11 @@ export const AccordionPropsSection = ({ component }) => {
   // Get the data from SSG, and render it as a component.
   const {
     accordionProps,
-    accordionItemProps,
     accordionButtonProps,
     accordionPanelProps,
   } = useSSG()
   return {
     Accordion: <PropsSection propsList={accordionProps} />,
-    AccordionItem: <PropsSection propsList={accordionItemProps} />,
     AccordionButton: <PropsSection propsList={accordionButtonProps} />,
     AccordionPanel: <PropsSection propsList={accordionPanelProps} />,
   }[component]

--- a/yarn.lock
+++ b/yarn.lock
@@ -19285,7 +19285,7 @@ rc@1.2.8, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-docgen-typescript@^2.1.1:
+react-docgen-typescript@^2.1.1, react-docgen-typescript@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
   integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==
@@ -20960,6 +20960,8 @@ ssri@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
   integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
+  dependencies:
+    figgy-pudding "^3.5.1"
 
 ssri@^8.0.0, ssri@^8.0.1:
   version "8.0.1"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds automatic `PropSection` feature.

It also adds this feature to `Accordion` Component.
In some cases, the lib used to get the props ([react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript)) do not manage to extract all props from components. **In this case we need to mock the values (e.g. Polymorphic AccordionItem)**.

## How it works?
1. We need to use Next.js `getStaticProps` so that we can run functions from the server side as `fs` and `path` from node.
2. Then, we use the ([react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript)) to parse each component props from @faststore/components inside the faststore monorepo `node_modules` based on the path from the current markdown component. 

|From|To|
|-|-|
|apps/site/pages/components/**molecules/accordion**.mdx | <Faststore-monorepo>/node_modules/@faststore/components/src/**molecules/Accordion**/Accordion.tsx|

### It's required to keep the same path pattern: 
molecules/accordion.mdx -> molecules/Accordion/
The filename you must pass as param (e.g. _Accordion.tsx_ or _AccordionButton.tsx_) in the `getComponentPropsFrom` utility function.

3. Finally, it's necessary to pass the props inside `ssg` object, that are going to be retrieved from `useSSG()` as mapped for the related component (e.g. `AccordionPropsSection`). You can use as:
```js
<AccordionPropsSection component="Accordion" />
```
or

```js
<AccordionPropsSection component="AccordionButton" />
```

## How to test it?
You can see the [Accordion doc page Props Section](https://faststore-site-git-feat-automatic-prop-section-faststore.vercel.app/components/molecules/accordion#props) from the preview.

## References

https://github.com/styleguidist/react-docgen-typescript
