### PR TITLE
Fix: Automatic props PropSection path

### DIFF
--- a/apps/site/components/utilities/propsSection.ts
+++ b/apps/site/components/utilities/propsSection.ts
@@ -3,6 +3,7 @@ import { parse } from 'react-docgen-typescript'
 export const faststoreComponentsFromNodeModules = `node_modules/@faststore/components`
 
 function toPascalCase(string) {
+  // matches one or more non-alphanumeric characters ([^a-zA-Z0-9]+) followed by any character ((.)) and replaces the following character with its uppercase version using a callback function.
   return (' ' + string).toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => {
     return chr.toUpperCase()
   })

--- a/apps/site/components/utilities/propsSection.ts
+++ b/apps/site/components/utilities/propsSection.ts
@@ -2,6 +2,12 @@ import { parse } from 'react-docgen-typescript'
 
 export const faststoreComponentsFromNodeModules = `node_modules/@faststore/components`
 
+function toPascalCase(string) {
+  return (' ' + string).toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => {
+    return chr.toUpperCase()
+  })
+}
+
 export function mapComponentFromMdxPath(
   absoluteMdxPath: string,
   components: string[]
@@ -18,9 +24,7 @@ export function mapComponentFromMdxPath(
 
   const atomicDesignType = dirs[0] // atoms, molecules, organisms
   const componentNameWithoutExtension = dirs[1].split('.')[0] // e.g. accordion.mdx -> accordion
-  const componentFolder =
-    componentNameWithoutExtension.charAt(0).toUpperCase() +
-    componentNameWithoutExtension.slice(1) // e.g. Accordion
+  const componentFolder = toPascalCase(componentNameWithoutExtension) // e.g. Accordion
 
   // e.g. <user-path>/faststore/node_modules/@faststore/components/src/molecules/Accordion/Accordion.tsx
   return components?.map((component: string) => {

--- a/apps/site/pages/components/molecules/discount-badge.mdx
+++ b/apps/site/pages/components/molecules/discount-badge.mdx
@@ -14,6 +14,36 @@ import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { DiscountBadge } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const discountBadgePath = path.resolve(__filename)
+  const components = ['DiscountBadge.tsx']
+  const [discountBadgeProps] = getComponentPropsFrom(
+    discountBadgePath,
+    components
+  )
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        discountBadgeProps,
+      },
+    },
+  }
+}
+
+export const DiscountBadgePropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { discountBadgeProps } = useSSG()
+  return {
+    DiscountBadge: <PropsSection propsList={discountBadgeProps} />,
+  }[component]
+}
+
 <header>
 
 # Discount Badge
@@ -75,7 +105,7 @@ import '@faststore/ui/src/components/molecules/DiscountBadge/styles.scss'
 
 ## Props
 
-<PropsSection name="DiscountBadge" />
+<DiscountBadgePropsSection component="DiscountBadge" />
 
 ---
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Follow-up of https://github.com/vtex/faststore/pull/1673

The component path was incorrect when the component name has more than 1 word, so it couldn't find the component, and the props list returned empty. 

Solution: Convent string path to PascalCase

Before:
`faststore/node_modules/@faststore/components/src/molecules/Discount-badge/DiscountBadge.tsx`

After
`faststore/node_modules/@faststore/components/src/molecules/DiscountBadge/DiscountBadge.tsx`

## How to test it?

[Discount Badge](https://faststore-site-git-fix-automatic-props-faststore.vercel.app/components/molecules/discount-badge#props) props should display correct in the page