### PR TITLE
chore: Healdess CMS with projects and REST API

### DIFF
--- a/apps/docs/docs/tutorials/cms/01 - Configuring your VTEX account.md
+++ b/apps/docs/docs/tutorials/cms/01 - Configuring your VTEX account.md
@@ -58,11 +58,11 @@ Now you can check the VTEX Headless CMS interface by accessing the VTEX Admin an
 Next, let's configure the URLs of the webhooks used by the VTEX Headless CMS app.
 
 1. Access the **VTEX Admin.**
-2. Go to **Account Settings > Apps > My apps.**
-3. Look for the **CMS (alpha)** app and click on **Settings.**
-4. Select **Add More**.
+2. Go to **Storefront > Headless CMS.**
+3. Select **Create new**.
+4. Fill the name of your Project with "Faststore".
 5. Fill in the **Builder ID** field with `faststore`.
-6. Fill in the **Build Webhook URL** field with the following value. _Replace the values between curly brackets according to your scenario._
+6. If you're using the VTEX CI/CD, you must fill in the **Build Webhook URL** field with the following value. _Replace the values between curly brackets according to your scenario._
 
    ```
    https://app.io.vtex.com/vtex.cms-builder-sf-jamstack/v1/{account}/{workspace}/build-releases
@@ -72,22 +72,22 @@ Next, let's configure the URLs of the webhooks used by the VTEX Headless CMS app
    When an editor clicks to publish a page using the VTEX Headless CMS interface, the CMS calls the **Build Webhook URL**, which changes the status of that page to `publishing`. The CMS, then, waits for the content to be built in the background.
    :::
 
-7. Now, fill in the **Production base URL** filed with the following value. _Replace the values between curly brackets according to your scenario._
+7. Now, fill in the **Production base URL** filed with your production URL. _Replace the values between curly brackets according to your scenario._
 
 ```
-https://{account}.vtex.com/
+https://www.{account}.com/
 ```
 
-8. Click on **Save.**
+8. Click on **Create.**
 
 ![CMS Settings](https://vtexhelp.vtexassets.com/assets/docs/src/cms-settings2___54ec9a22584b5aad09d0b403993cbee2.png)
 
 ### Step 4 - Communicating WebOps updates to the Headless CMS
 
-Now, if you are developing your FastStore project with WebOps and VTEX Headless CMS, you must ensure that WebOps is aware of every CMS update performed via the VTEX Admin. To do so, you must configure the WebOps webhooks responsible for communicating with the VTEX Headless CMS as in the following.
+Now, if you are developing your FastStore project with CI/CD and VTEX Headless CMS, you must ensure that CI/CD is aware of every CMS update performed via the VTEX Admin. To do so, you must configure the WebOps webhooks responsible for communicating with the VTEX Headless CMS as in the following.
 
 1. Open your FastStore project in any code editor of your preference.
-2. Create the `cms-webhook-urls.json` file in the root directory of your project.
+2. Edit the `cms-webhook-urls.json` file in the root directory of your project.
 3. Add the webhooks corresponding to your store website as in the following:
 
    ```json title="cms-webhook-urls.json"
@@ -95,10 +95,6 @@ Now, if you are developing your FastStore project with WebOps and VTEX Headless 
      "urls": ["https://{account}.myvtex.com/cms-releases/webhook-releases"]
    }
    ```
-
-   :::caution
-   If applicable, specify the [production workspace](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-workspace) you are using to develop your FastStore project in the webhook URL as in the following: `https://{workspace}--{account}.myvtex.com/cms-releases/webhook-releases`
-   :::
 
 4. Open a Pull Request including the previous changes.
 5. Merge the Pull Request.

--- a/apps/docs/docs/tutorials/cms/02 - Setting up the VTEX Headless CMS in your FastStore project.md
+++ b/apps/docs/docs/tutorials/cms/02 - Setting up the VTEX Headless CMS in your FastStore project.md
@@ -20,90 +20,104 @@ By the end of this part of this tutorial, you will be able to see your first def
 ### Step 1 - Creating the CMS folder
 
 1. Open the terminal and change to the root directory of your FastStore project.
+
 2. Create a new folder named `cms` at the root of your FastStore project:
-   ```
-   mkdir cms
-   ```
-3. Inside the `cms` folder, create the three following files:
 
-- `content-types.json` - an array of JSON objects that describes the **Content Types** available for customization at the VTEX Headless CMS app.
-- `sections.json` - an array of JSON objects that describes the content structure of the frontend **Section** components available for customization at the VTEX Headless CMS app.
-- `translation-keys.json` - an array of JSON objects that defines the translation keys of the Sections descriptions.
+    ```bash
+    mkdir cms
+    ```
 
-```
-touch cms/content-types.json cms/sections.json cms/translation-keys.json
-```
+3. Inside the `cms` folder, create a folder for your project:
 
-4. Update the `sections.json` file with an empty array:
-   ```
+    ```bash
+    cd cms
+    mkdir faststore
+    ```
+
+4. Inside the `faststore` folder, create the three following files:
+
+    - `content-types.json` - an array of JSON objects that describes the **Content Types** available for customization at the VTEX Headless CMS app.
+    - `sections.json` - an array of JSON objects that describes the content structure of the frontend **Section** components available for customization at the VTEX Headless CMS app.
+    - `translation-keys.json` - an array of JSON objects that defines the translation keys of the Sections descriptions.
+
+    ```bash
+    touch cms/content-types.json cms/sections.json cms/translation-keys.json
+    ```
+
+5. Update the `sections.json` file with an empty array:
+
+   ```bash
    echo "[]" > cms/sections.json
    ```
-5. Update the `translation-keys.json` file with an empty object:
-   ```
+
+6. Update the `translation-keys.json` file with an empty object:
+
+   ```bash
    echo "{}" > cms/translation-keys.json
    ```
-6. Now, open the `content-types.json` file in any code editor of your choice and add the following code:
 
-```json title="cms/content-types.json"
-[
-  {
-    "id": "home",
-    "name": "Home Page",
-    "configurationSchemaSets": []
-  },
-  {
-    "id": "institutionalPage",
-    "name": "Institutional page",
-    "configurationSchemaSets": [
+7. Now, open the `content-types.json` file in any code editor of your choice and add the following code:
+
+    ```json title="cms/content-types.json"
+    [
       {
-        "name": "SEO",
-        "configurations": [
+        "id": "home",
+        "name": "Home Page",
+        "configurationSchemaSets": []
+      },
+      {
+        "id": "institutionalPage",
+        "name": "Institutional page",
+        "configurationSchemaSets": [
           {
-            "name": "siteMetadataWithSlug",
-            "schema": {
-              "title": "Site Metadata",
-              "description": "Configure global site metadata",
-              "type": "object",
-              "widget": {
-                "ui:ObjectFieldTemplate": "GoogleSeoPreview"
-              },
-              "properties": {
-                "title": {
-                  "title": "Default page title",
-                  "description": "Display this title when no other tile is available",
-                  "type": "string",
-                  "default": "Store Theme | VTEX SFJ"
-                },
-                "description": {
-                  "title": "Meta tag description",
-                  "type": "string",
-                  "default": "A beautifully designed site for general VTEX stores"
-                },
-                "titleTemplate": {
-                  "title": "Title template to be used in category/product pages",
-                  "type": "string",
-                  "default": "%s | Store Theme"
-                },
-                "slug": {
-                  "title": "URL Slug",
-                  "type": "string",
-                  "default": "/landing-page-url"
+            "name": "SEO",
+            "configurations": [
+              {
+                "name": "siteMetadataWithSlug",
+                "schema": {
+                  "title": "Site Metadata",
+                  "description": "Configure global site metadata",
+                  "type": "object",
+                  "widget": {
+                    "ui:ObjectFieldTemplate": "GoogleSeoPreview"
+                  },
+                  "properties": {
+                    "title": {
+                      "title": "Default page title",
+                      "description": "Display this title when no other tile is available",
+                      "type": "string",
+                      "default": "Store Theme | VTEX SFJ"
+                    },
+                    "description": {
+                      "title": "Meta tag description",
+                      "type": "string",
+                      "default": "A beautifully designed site for general VTEX stores"
+                    },
+                    "titleTemplate": {
+                      "title": "Title template to be used in category/product pages",
+                      "type": "string",
+                      "default": "%s | Store Theme"
+                    },
+                    "slug": {
+                      "title": "URL Slug",
+                      "type": "string",
+                      "default": "/landing-page-url"
+                    }
+                  }
                 }
               }
-            }
+            ]
           }
         ]
       }
     ]
-  }
-]
-```
+    ```
 
-:::info
-Don't worry about the structure of this file for now, as we'll learn more about it later in this tutorial. However, notice that we have defined two different Content Types: the **Home Page** and the **Institutional Page**.
-:::
+    :::info
+    Don't worry about the structure of this file for now, as we'll learn more about it later in this tutorial. However, notice that we have defined two different Content Types: the **Home Page** and the **Institutional Page**.
+    :::
 
-7. Save your changes in the `content-types.json` file.
+8. Save your changes in the `content-types.json` file.
 
 ### Step 2 - Syncing your changes
 
@@ -112,7 +126,7 @@ Let's now sync our changes with the VTEX Headless CMS app and see what happens.
 1. Open the terminal and log in to your VTEX account.
 2. Create a new development workspace by running the following command.
 
-   ```sh
+   ```bash
    vtex use {workspace}
    ```
 
@@ -126,21 +140,23 @@ Let's now sync our changes with the VTEX Headless CMS app and see what happens.
 
 3. Change to the root directory of your FastStore project.
 4. Sync your changes in the `cms` folder with the VTEX Headless CMS app:
-   ```sh
+
+   ```bash
    vtex cms sync
    ```
 
 Once your changes are synced with the VTEX Headless CMS, the terminal will show the following message.
 
-```sh
-CMS synced successfully...
-```
+  ```bash
+  CMS synced successfully...
+  ```
 
 ### Step 3 - Checking your changes
 
 1. Access the VTEX Admin using the workspace you previously created (e.g., `https://{workspace}--{account}.myvtex.com/admin`).
-2. Go to **Store Development > CMS (Alpha) > Pages (Alpha)**.
-3. Click on **Create New**.
+2. Go to **Storefront > Headless CMS**.
+3. Select your Faststore project.
+4. Click on **Create New**.
 
 You should now see the Content Type we created in the previous step available for use at the VTEX Headless CMS app. However, no sections or translation keys will be available yet. We'll learn more about this in the following part of this tutorial.
 

--- a/apps/docs/docs/tutorials/cms/03 - Adding Content Types and Sections to the VTEX Headless CMS.md
+++ b/apps/docs/docs/tutorials/cms/03 - Adding Content Types and Sections to the VTEX Headless CMS.md
@@ -5,9 +5,6 @@ sidebar_label: '3. Adding Content Types and Sections to the VTEX Headless CMS'
 pagination_label: Part 3
 ---
 
-import Tabs from '@theme/Tabs'
-import TabItem from '@theme/TabItem'
-
 # Part 3: Adding Content Types and Sections to the VTEX Headless CMS
 
 ## Introduction
@@ -22,15 +19,18 @@ Now that you have created your `cms` folder and have an overall understanding of
 
 Before we start creating more complex definitions of Content Types and Sections, go to the root of your FastStore project and run the following command to automatically sync your changes in the `cms` folder with the VTEX Headless CMS app. _Remember to use a development workspace._
 
-```sh
+```bash
 vtex cms sync --watch
 ```
 
-Open the **VTEX Admin** at **Pages (alpha)** and keep it next to your code to see your changes while editing the `cms` folder. Notice that refreshing the Admin may be necessary to see your changes.
+Open the **VTEX Admin** at **Headless CMS** and keep it next to your code to see your changes while editing the `cms` folder. Notice that refreshing the Admin may be necessary to see your changes.
 
 ### Step 2 - Adding Content Types to the VTEX Headless CMS
 
 We already know that the `content-types.json` file is an array of JSON objects that describes the types of pages available for customization at the VTEX Headless CMS. Therefore, to create new Content Types, we just need to declare a new JSON object for each of our Content Types in the `content-types.json` file. However, we still need to discover which props these objects expect. So let's get back to our previous example.
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
 
 <Tabs
 defaultValue="code"
@@ -39,7 +39,6 @@ values={[
 {label: 'CMS', value: 'CMS'},
 ]}>
 <TabItem value="code">
-
 <div>
 
 ```json title="cms/content-types.json"
@@ -98,10 +97,11 @@ values={[
 ```
 
 </div>
-  </TabItem>
-  <TabItem value="CMS">
+</TabItem>
+
+<TabItem value="CMS">
   <img src="https://vtexhelp.vtexassets.com/assets/docs/src/contenttypes2___1747bd4670cc21204a6314053928c44f.png" width="40%" />
-  </TabItem>
+</TabItem>
 </Tabs>
 
 Notice that, to declare a new Content Type, you must specify at least the following three parameters:

--- a/apps/docs/docs/tutorials/cms/04 - Querying the CMS data.md
+++ b/apps/docs/docs/tutorials/cms/04 - Querying the CMS data.md
@@ -11,200 +11,39 @@ pagination_label: Part 4
 
 After syncing your Section and Content Type definitions with the VTEX Headless CMS, each Content Type will have a corresponding type on the Gatsby GraphQL layer.
 
-In this section, we'll see how to query for this data using the Graph*i*QL IDE and how to adapt our `pages` components to consume this data.
+In this section, we'll see how to query for this data using the REST API and how to adapt our `pages` components to consume this data.
 
 ---
 
 ## Step by step
 
-### Step 1 - Installing the `gatsby-source-cms` plugin
+### Step 1 - The Headless CMS API
 
-To fetch data from the VTEX Headless CMS data layer into your FastStore project, you'll need to install the `@vtex/gatsby-source-cms` plugin.
+To fetch data from the VTEX Headless CMS data layer into your FastStore project, you'll need to fetch the data from the Headless CMS API.
 
-1. Open the terminal and change to the source directory of your FastStore project.
-2. Install the VTEX Headless CMS plugin.
-
-```sh
-yarn add @vtex/gatsby-source-cms
-```
-
-3. Open the `gatsby-config.js` file and add the following configurations for the `@vtex/gatsby-source-cms` plugin.
-
-```diff {5-11} title=gatsby-config.js
-module.exports = {
-  ...,
-  plugins: [
-    ...,
-+    {
-+      resolve: '@vtex/gatsby-source-cms',
-+      options: {
-+        workspace: '{workspace}', //replace with the VTEX IO workspace in use - generally, use master.
-+        tenant: '{account}',      //replace with the name of your VTEX account
-+      },
-+    },
-  ],
-}
-```
-
-:::caution
-Remember to replace the values between curly brackets according to your scenario.
+:::info
+For more information about the CMS API, check the [`CMS API Reference`](https://developers.vtex.com/docs/api-reference/headless-cms-api#get-/_v/cms/api/-builderId-/-content-type-).
 :::
 
-### Step 2 - Querying the CMS data in GraphiQL
+### Step 2 - Rendering the CMS content
 
-Before we query the CMS data in our `pages` components, let's verify how our data is structured using the GraphiQL IDE.
-
-1. Open the terminal and change to the working directory of your project.
-2. Start a development server.
-   ```sh
-   yarn develop
-   ```
-3. Open the GraphiQL IDE at [http://localhost:8000/\_\_graphql](http://localhost:8000/__graphql). Notice that a corresponding type on the GraphQL data layer is available for each content type that you have defined (e.g., `cmsHome`, `cmsInstitutionalPage`).
-4. Test some queries and check what they return. For example, for the `home` content type, try the following query:
-  ```gql
-  query MyQuery {
-   cmsHome {
-     sections {
-       name
-       data
-     }
-   }
-  }
-  ```
-
-  This will return a JSON object as in the following example:
-
-  ```json
-  {
-    "data": {
-      "cmsHome": {
-        "sections": [
-          {
-            "name": "DynamicShelf",
-            "props": {
-              "searchParams": {
-                "hideUnavailableItems": true,
-                "from": 0,
-                "to": 11,
-                "collection": "143"
-              },
-              "title": "Special Offers"
-            }
-          }
-        ]
-      }
-    },
-    "extensions": {
-      "enableRefresh": "true"
-    }
-  }
-  ```
-
-Next, we'll query this data inside our React components and use it to update their contents.
-
-### Step 3 - Querying the CMS data in the `pages` components
-
-Let's now query the CMS data in our `pages` so we can update our React components with the CMS content.
-
-1. Open your project in the code editor of your preference.
-2. Open the corresponding `pages` component of a Content Type you're integrating with the VTEX Headless CMS. For example, for the Home Page, open `/src/pages/index.tsx`.
-3. Update the GraphQL query of your content type to fetch the desired data from the CMS. Take the following example.
-
-```graphql {10-15} title=src/pages/index.tsx
-export const query = graphql`
-  query HomePageQuery(
-    site {
-      siteMetadata {
-        title
-        description
-        titleTemplate
-      }
-    }
-    cmsHome {
-      sections {
-        name
-        data
-      }
-    }
-    ...
-`
-```
-
-### Step 4 - Rendering the CMS content
-
-Finally, let's update our components to present the content submitted via the VTEX Headless CMS app. To do that, take the following steps:
+Let's update our components to present the content submitted via the VTEX Headless CMS app. To do that, take the following steps:
 
 1. Open your FastStore project in any code editor of your preference.
-2. Go to the `src/components` folder and create a new file named `RenderCMS.tsx`.
-3. Copy and paste the following code into the `RenderCMS.tsx` file.
+2. Go to the `src/pages/index.tsx` file.
+3. Import the React components corresponding to the Sections you previously created in the CMS (e.g., `RichText`, `Shelf`) and add it to `COMPONENTS`. For example:
 
-```tsx title="src/components/RenderCMS.tsx"
-import React from 'react'
-import Shelf from 'src/components/sections/Shelf'
-import type { ComponentType } from 'react'
+    ```tsx {3,8} title="src/components/RenderCMS.tsx"
+    import Shelf from 'src/components/sections/Shelf'
+    import RichText from 'src/components/sections/RichText'
 
-/**
- * Sections: Components imported from '../components/sections' only.
- * Do not import or render components from any other folder in here.
- */
-const COMPONENTS: Record<string, ComponentType<any>> = {
-  Shelf,
-}
+    const COMPONENTS: Record<string, ComponentType<any>> = {
+      Shelf,
+      RichText,
+    }
+    ```
 
-interface Props {
-  sections?: Array<{ name: string; data: unknown }>
-}
-
-function RenderCMS({ sections }: Props) {
-  return (
-    <>
-      {sections?.map(({ name, data }, index) => {
-        const Component = COMPONENTS[name]
-
-        if (!Component) {
-          throw new Error(
-            `Could not find component for block ${name}. Add a new component for this block or remove it from the CMS`
-          )
-        }
-
-        return <Component key={`cms-section-${index}`} {...data} />
-      })}
-    </>
-  )
-}
-
-export default RenderCMS
-```
-
-4. Import the React components corresponding to the Sections you previously created in the CMS (e.g., `RichText`, `Shelf`) and add it to `COMPONENTS`. For example:
-
-```tsx {3,8} title="src/components/RenderCMS.tsx"
-import React from 'react'
-import Shelf from 'src/components/sections/Shelf'
-import RichText from 'src/components/sections/RichText'
-import type { ComponentType } from 'react'
-
-const COMPONENTS: Record<string, ComponentType<any>> = {
-  Shelf,
-  RichText,
-}
-```
-
-5. Save your changes.
-6. Now, go to the `pages` component corresponding to the Content Type you are integrating with the CMS. For example, for the **Home Page**, go to the `src/pages/index.tsx` file.
-7. Import the `RenderCMS` component.
-
-```tsx
-import RenderCMS from 'src/components/RenderCMS'
-```
-
-8. Add the `RenderCMS` component to your page as in the following example.
-
-```tsx title="src/pages/index.tsx"
-<RenderCMS sections={cmsHome?.sections} />
-```
-
-9. Save your changes.
+4. Save your changes.
 
 ---
 

--- a/apps/docs/docs/tutorials/cms/05 - Adapting the views components.md
+++ b/apps/docs/docs/tutorials/cms/05 - Adapting the views components.md
@@ -22,11 +22,14 @@ After adapting your `pages` components and querying for the CMS data, open a Pul
 Now, if you are happy with your Content Type, Section and Translation Keys definitions, you can put them on production by taking the following steps:
 
 1. Open the terminal and switch to the master workspace.
-   ```sh
+
+   ```bash
    vtex use master
    ```
+
 2. Change to the root directory of your FastStore project and sync your changes in the `cms` folder with the VTEX Headless CMS app.
-   ```sh
+
+   ```bash
    vtex cms sync
    ```
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Updates the Headless CMS tutorial to include the new "Projects" feature. It also removes the Graphql and gatsby source integration to add the REST API "way of consuming" data from the CMS for NextJS new base store.

One more thing, it simplifies the tutorial removing the extra steps need before creating the Render file, it's not needed anymore since the Faststore included it by default on the base store.

## How it works?

It only updates docs.

## How to test it?

You can test it locally by running the docs, or consuming it via the preview.

## References

Headless CMS API reference: https://developers.vtex.com/docs/api-reference/headless-cms-api#get-/_v/cms/api/-builderId-/-content-type-

Next JS base store: https://github.com/vtex-sites/nextjs.store/blob/main/src/pages/index.tsx#L6
