### PR TITLE
Fix: `PaymentMethods` Flag size

### DIFF
--- a/apps/site/pages/components/organisms/payment-methods.mdx
+++ b/apps/site/pages/components/organisms/payment-methods.mdx
@@ -119,7 +119,14 @@ export const flags = [
 #### Flag
 
 <TokenTable>
-  <TokenRow token="--fs-payment-methods-flag-width" value="2.125rem" />
+  <TokenRow
+    token="--fs-payment-methods-flag-width"
+    value="var(--fs-spacing-5)"
+  />
+  <TokenRow
+    token="--fs-payment-methods-flag-height"
+    value="var(--fs-spacing-4)"
+  />
   <TokenRow
     token="--fs-payment-methods-flag-border-width"
     value="var(--fs-border-width)"

--- a/apps/site/pages/components/organisms/payment-methods.mdx
+++ b/apps/site/pages/components/organisms/payment-methods.mdx
@@ -25,6 +25,36 @@ import {
   ApplePay,
 } from '@faststore/components'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const paymentMethodsPath = path.resolve(__filename)
+  const components = ['PaymentMethods.tsx']
+  const [paymentMethodsProps] = getComponentPropsFrom(
+    paymentMethodsPath,
+    components
+  )
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        paymentMethodsProps,
+      },
+    },
+  }
+}
+
+export const PaymentMethodsPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { paymentMethodsProps } = useSSG()
+  return {
+    PaymentMethods: <PropsSection propsList={paymentMethodsProps} />,
+  }[component]
+}
+
 <header>
 
 # PaymentMethods
@@ -81,9 +111,25 @@ export const flags = [
 
 ## Props
 
-<PropsSection name="PaymentMethods" />
+<PaymentMethodsPropsSection component="PaymentMethods" />
 
----
+export const propsFlag = [
+  {
+    name: 'image',
+    type: 'ReactNode',
+    description: 'A React component that will represent the flag image.',
+  },
+  {
+    name: 'text',
+    type: 'string',
+    description:
+      'Description of the flag image to be also used for accessibility purposes.',
+  },
+]
+
+## Flag
+
+<PropsSection propsList={propsFlag} />
 
 ## Design Tokens
 

--- a/packages/ui/src/components/organisms/PaymentMethods/styles.scss
+++ b/packages/ui/src/components/organisms/PaymentMethods/styles.scss
@@ -12,6 +12,7 @@
 
   // Flag
   --fs-payment-methods-flag-width           : 2.125rem;
+  --fs-payment-methods-flag-height          : var(--fs-spacing-4);
   --fs-payment-methods-flag-border-width    : var(--fs-border-width);
   --fs-payment-methods-flag-border-color    : var(--fs-color-neutral-3);
   --fs-payment-methods-flag-border-radius   : var(--fs-border-radius-small);

--- a/packages/ui/src/components/organisms/PaymentMethods/styles.scss
+++ b/packages/ui/src/components/organisms/PaymentMethods/styles.scss
@@ -11,7 +11,7 @@
   --fs-payment-methods-title-line-height     : 1.25;
 
   // Flag
-  --fs-payment-methods-flag-width           : 2.125rem;
+  --fs-payment-methods-flag-width           : var(--fs-spacing-5);
   --fs-payment-methods-flag-height          : var(--fs-spacing-4);
   --fs-payment-methods-flag-border-width    : var(--fs-border-width);
   --fs-payment-methods-flag-border-color    : var(--fs-color-neutral-3);


### PR DESCRIPTION
## What's the purpose of this pull request?

The `--fs-payment-methods-flag-height` token was missing. So the flags images was not showing when using safari.

Before|After
|-|-|
|![image](https://user-images.githubusercontent.com/3356699/228670879-b8f6d768-e932-487b-bf6f-c9da6642a373.png)|![image](https://user-images.githubusercontent.com/3356699/228670755-95de3b21-38e0-41a7-aa9e-3339ca4427e5.png)

Also:
- Updates flag width size
- Adds `PaymentMethods` props list to its documentation page.

## How to test it?

1. Open the [doc preview link](https://faststore-site-git-fix-payment-methods-flag-size-faststore.vercel.app/components/organisms/payment-methods#usage) using Safari
2. You should see the flags images.

