### PR TITLE
Improve resiliency of mergeCMSFile

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -128,32 +128,25 @@ function mergeCMSFile(fileName: string) {
   const coreFilePath = `${coreCMSDir}/${fileName}`
 
   const coreFile = readFileSync(coreFilePath, 'utf8')
-  const coreJSON = JSON.parse(coreFile)
-
-  let output = []
+  const output = [...JSON.parse(coreFile)]
 
   // TODO: create a validation when has the cms files but doesn't have a component for then
   if (existsSync(customFilePath)) {
     const customFile = readFileSync(customFilePath, 'utf8');
-    let customJSON;
-
+    
     try {
-      customJSON = JSON.parse(customFile)
-    } catch(SyntaxError) {
-      console.info(
-        `${chalk.red(
-          'error'
-        )} - ${fileName} is a malformed JSON file, ignoring its contents.`
-      )
-      customJSON = []
+      output.push(...JSON.parse(customFile))
+    } catch(err) {
+      if (err instanceof SyntaxError) {
+        console.info(
+          `${chalk.red(
+            'error'
+          )} - ${fileName} is a malformed JSON file, ignoring its contents.`
+        )
+      } else {
+        throw err
+      }
     }
-
-    output = [
-      ...coreJSON,
-      ...customJSON,
-    ]
-  } else {
-    output = coreJSON
   }
 
   try {

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -124,29 +124,48 @@ async function copyTheme() {
 }
 
 function mergeCMSFile(fileName: string) {
-  // TODO: create a validation when has the cms files but doesn't have a component for then
-  if (existsSync(userCMSDir) && readdirSync(userCMSDir).length > 0) {
-    const coreContentTypes = readFileSync(`${coreCMSDir}/${fileName}`, 'utf8')
-    const customContentTypes = readFileSync(`${userCMSDir}/${fileName}`, 'utf8')
-    const coreContentTypesJSON = JSON.parse(coreContentTypes)
-    const customContentTypesJSON = JSON.parse(customContentTypes)
+  const customFilePath = `${userCMSDir}/${fileName}`
+  const coreFilePath = `${coreCMSDir}/${fileName}`
 
-    const mergeContentTypes = [
-      ...coreContentTypesJSON,
-      ...customContentTypesJSON,
-    ]
+  const coreFile = readFileSync(coreFilePath, 'utf8')
+  const coreJSON = JSON.parse(coreFile)
+
+  let output = []
+
+  // TODO: create a validation when has the cms files but doesn't have a component for then
+  if (existsSync(customFilePath)) {
+    const customFile = readFileSync(customFilePath, 'utf8');
+    let customJSON;
 
     try {
-      writeFileSync(
-        `${tmpCMSDir}/${fileName}`,
-        JSON.stringify(mergeContentTypes)
+      customJSON = JSON.parse(customFile)
+    } catch(SyntaxError) {
+      console.info(
+        `${chalk.red(
+          'error'
+        )} - ${fileName} is a malformed JSON file, ignoring its contents.`
       )
-      console.log(
-        `${chalk.green('success')} - CMS file ${chalk.dim(fileName)} created`
-      )
-    } catch (err) {
-      console.error(`${chalk.red('error')} - ${err}`)
+      customJSON = []
     }
+
+    output = [
+      ...coreJSON,
+      ...customJSON,
+    ]
+  } else {
+    output = coreJSON
+  }
+
+  try {
+    writeFileSync(
+      `${tmpCMSDir}/${fileName}`,
+      JSON.stringify(output)
+    )
+    console.log(
+      `${chalk.green('success')} - CMS file ${chalk.dim(fileName)} created`
+    )
+  } catch (err) {
+    console.error(`${chalk.red('error')} - ${err}`)
   }
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Improves the resiliency of `mergeCMSFiles`, by checking if the file CMS exists before attempting to read it, and showing an error if the JSON file is malformed.

## How to test it?

On a new fork of [starter.store](https://github.com/vtex-sites/starter.store), run `yarn dev` then create an empty `cms` folder. It should break the `dev`. Restart it and create an empty `cms/faststore/sections.json`. It will break the `dev` command as well.

Now install the version of this commit, and remove the files created in the previous steps. Then repeat steps above and you should get no errors.

