### PR TITLE
add shouldSplitItem at the validateCart

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -133,7 +133,7 @@ export type IShippingItem = {
 
 /** Shopping cart input. */
 export type IStoreCart = {
-  /** Order information, including `orderNumber` and `acceptedOffer`. */
+  /** Order information, including `orderNumber`, `acceptedOffer` and `shouldSplitItem`. */
   order: IStoreOrder;
 };
 
@@ -172,6 +172,8 @@ export type IStoreOrder = {
   acceptedOffer: Array<IStoreOffer>;
   /** ID of the order in [VTEX order management](https://help.vtex.com/en/tutorial/license-manager-resources-oms--60QcBsvWeum02cFi3GjBzg#). */
   orderNumber: Scalars['String'];
+  /** Indicates whether or not items with attachments should be split. */
+  shouldSplitItem?: Maybe<Scalars['Boolean']>;
 };
 
 /** Organization input. */

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -129,11 +129,13 @@ export const VtexCommerce = (
         orderItems,
         allowOutdatedData = 'paymentData',
         salesChannel = ctx.storage.channel.salesChannel,
+        shouldSplitItem = true,
       }: {
         id: string
         orderItems: OrderFormInputItem[]
         allowOutdatedData?: 'paymentData'
         salesChannel?: string
+        shouldSplitItem?: boolean | null
       }): Promise<OrderForm> => {
         const params = new URLSearchParams({
           allowOutdatedData,
@@ -144,7 +146,10 @@ export const VtexCommerce = (
           `${base}/api/checkout/pub/orderForm/${id}/items?${params}`,
           {
             ...BASE_INIT,
-            body: JSON.stringify({ orderItems }),
+            body: JSON.stringify({
+              orderItems,
+              noSplitItem: !shouldSplitItem,
+            }),
             method: 'PATCH',
           }
         )

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -266,7 +266,7 @@ export const validateCart = async (
   { cart: { order }, session }: MutationValidateCartArgs,
   ctx: Context
 ) => {
-  const { orderNumber: orderNumberFromCart, acceptedOffer } = order
+  const { orderNumber:  orderNumberFromCart, acceptedOffer, shouldSplitItem } = order
   const {
     clients: { commerce },
     loaders: { skuLoader },
@@ -363,6 +363,7 @@ export const validateCart = async (
     .updateOrderFormItems({
       id: orderForm.orderFormId,
       orderItems: changes,
+      shouldSplitItem,
     })
     // update orderForm etag so we know last time we touched this orderForm
     .then((form) =>

--- a/packages/api/src/typeDefs/cart.graphql
+++ b/packages/api/src/typeDefs/cart.graphql
@@ -31,7 +31,7 @@ Shopping cart input.
 """
 input IStoreCart {
   """
-  Order information, including `orderNumber` and `acceptedOffer`.
+  Order information, including `orderNumber`, `acceptedOffer` and `shouldSplitItem`.
   """
   order: IStoreOrder!
 }

--- a/packages/api/src/typeDefs/order.graphql
+++ b/packages/api/src/typeDefs/order.graphql
@@ -24,4 +24,8 @@ input IStoreOrder {
   Array with information on each accepted offer.
   """
   acceptedOffer: [IStoreOffer!]!
+  """
+  Indicates whether or not items with attachments should be split.
+  """
+  shouldSplitItem: Boolean
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Add the shouldSplitItem to the mutation of ValidadeCart to pass the noSplitItem at the add to cart. 
This modification is already implemented in version 2.x of faststore api package.

## How it works?

Some stores use this parameter when working with attachments to indicate whether the item can be splitted.

<img width="686" alt="image" src="https://user-images.githubusercontent.com/67066494/231225116-24f7e43a-6547-4fce-a3c9-2ce3f4e10734.png">

## How to test it?

You can test at a store that uses this param like Casino and another that uses the current version 1.x

## References

Reference: https://developers.vtex.com/docs/api-reference/checkout-api#patch-/api/checkout/pub/orderForm/-orderFormId-/items


