### PR TITLE
Add Intelligent Search redirect to search query

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -923,6 +923,8 @@ export type StoreSearchResult = {
   metadata?: Maybe<SearchMetadata>;
   /** Search result products. */
   products: StoreProductConnection;
+  /** Search result redirect. Used to redirect search terms or filters to specific pages */
+  redirect?: Maybe<Scalars['String']>;
   /** Search result suggestions. */
   suggestions: StoreSuggestions;
 };

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -107,4 +107,13 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
       logicalOperator: productSearchResult.operator,
     }
   },
+  redirect: async ({ searchArgs, productSearchPromise }) => {
+    if (!searchArgs.query) {
+      return null
+    }
+
+    const { redirect } = await productSearchPromise
+
+    return redirect ?? null
+  },
 }

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -182,6 +182,10 @@ type StoreSearchResult {
   Search result metadata. Additional data can be used to send analytics events.
   """
   metadata: SearchMetadata
+  """
+  Search result redirect. Used to redirect search terms or filters to specific pages
+  """
+  redirect: String
 }
 
 type Query {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR exposes the redirect value from the IS when a redirect is found for a specific term/facet

## How it works?

If a term or facet has a redirect, the value of the `redirect` field will be an URL; this can later be used to redirect the user to an internal or external URL.

<img width="1440" alt="" src="https://user-images.githubusercontent.com/50715158/232778202-8983d485-054b-4d1c-ad59-e6e94ae428fd.png">

<img width="1440" alt="" src="https://user-images.githubusercontent.com/50715158/232778218-ef5886d7-9729-4153-a89a-8ef3d0909203.png">

## How to test it?

- You can either open your desired starter or run the `@faststore/api` package individually.
- If the latter, you can modify the /local/server file and change the account for `arcaplanet`
- Browse localhost/graphql
- Run the search query with a term that is active in `/admin/search/v4/redirects/`
- For arcaplanet's example, you can use the term `test_vtex_gustavo`
