### PR TITLE
add geoCoordinates to calculate regionalization

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -144,6 +144,13 @@ export type IStoreCurrency = {
   symbol: Scalars['String'];
 };
 
+export type IStoreGeoCoordinates = {
+  /** The latitude of the geographic coordinates. */
+  latitude: Scalars['Float'];
+  /** The longitude of the geographic coordinates. */
+  longitude: Scalars['Float'];
+};
+
 /** Image input. */
 export type IStoreImage = {
   /** Alias for the input image. */
@@ -233,9 +240,11 @@ export type IStoreSession = {
   country: Scalars['String'];
   /** Session input currency. */
   currency: IStoreCurrency;
+  /** Session input geoCoordinates. */
+  geoCoordinates?: Maybe<IStoreGeoCoordinates>;
   /** Session input locale. */
   locale: Scalars['String'];
-  /** Session input postal code. */
+  /** Session input person. */
   person?: Maybe<IStorePerson>;
   /** Session input postal code. */
   postalCode?: Maybe<Scalars['String']>;
@@ -724,6 +733,15 @@ export type StoreFacetValueRange = {
   selected: Scalars['Float'];
 };
 
+/** Geographic coordinates information. */
+export type StoreGeoCoordinates = {
+  __typename?: 'StoreGeoCoordinates';
+  /** The latitude of the geographic coordinates. */
+  latitude: Scalars['Float'];
+  /** The longitude of the geographic coordinates. */
+  longitude: Scalars['Float'];
+};
+
 /** Image. */
 export type StoreImage = {
   __typename?: 'StoreImage';
@@ -953,9 +971,11 @@ export type StoreSession = {
   country: Scalars['String'];
   /** Session currency. */
   currency: StoreCurrency;
+  /** Session input geoCoordinates. */
+  geoCoordinates?: Maybe<StoreGeoCoordinates>;
   /** Session locale. */
   locale: Scalars['String'];
-  /** Session postal code. */
+  /** Session input person. */
   person?: Maybe<StorePerson>;
   /** Session postal code. */
   postalCode?: Maybe<Scalars['String']>;

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -180,11 +180,20 @@ export const VtexCommerce = (
         country,
         salesChannel,
       }: RegionInput): Promise<Region[]> => {
-        let queryParams = `country=${country}&sc=${salesChannel ?? ''}`
-        geoCoordinates
-          ? (queryParams += `&geoCoordinates=${geoCoordinates.longitude};${geoCoordinates.latitude}`)
-          : (queryParams += `&postalCode=${postalCode}`)
-        return fetchAPI(`${base}/api/checkout/pub/regions/?${queryParams}`)
+        const params = new URLSearchParams({
+          country: country,
+          sc: salesChannel ?? '',
+        })
+
+        postalCode
+          ? params.append('postalCode', postalCode)
+          : params.append(
+              'geoCoordinates',
+              `${geoCoordinates?.longitude};${geoCoordinates?.latitude}`
+            )
+
+        const url = `${base}/api/checkout/pub/regions/?${params.toString()}`
+        return fetchAPI(url)
       },
       address: async ({
         postalCode,

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -176,14 +176,15 @@ export const VtexCommerce = (
       },
       region: async ({
         postalCode,
+        geoCoordinates,
         country,
         salesChannel,
       }: RegionInput): Promise<Region[]> => {
-        return fetchAPI(
-          `${base}/api/checkout/pub/regions/?postalCode=${postalCode}&country=${country}&sc=${
-            salesChannel ?? ''
-          }`
-        )
+        let queryParams = `country=${country}&sc=${salesChannel ?? ''}`
+        geoCoordinates
+          ? (queryParams += `&geoCoordinates=${geoCoordinates.longitude};${geoCoordinates.latitude}`)
+          : (queryParams += `&postalCode=${postalCode}`)
+        return fetchAPI(`${base}/api/checkout/pub/regions/?${queryParams}`)
       },
       address: async ({
         postalCode,

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Region.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Region.ts
@@ -1,16 +1,22 @@
 export interface RegionInput {
-  postalCode: string;
-  country: string;
-  salesChannel?: string | null;
+  postalCode: string
+  geoCoordinates: GeoCoordinates | null
+  country: string
+  salesChannel?: string | null
 }
 
 export interface Seller {
-  id: string; // storeframework01
-  name: string; // My Awsome Seller
-  logo: string;
+  id: string // storeframework01
+  name: string // My Awsome Seller
+  logo: string
+}
+
+export interface GeoCoordinates {
+  latitude: GLfloat
+  longitude: GLfloat
 }
 
 export interface Region {
-  id: string;
-  sellers: Seller[];
+  id: string
+  sellers: Seller[]
 }

--- a/packages/api/src/typeDefs/session.graphql
+++ b/packages/api/src/typeDefs/session.graphql
@@ -24,6 +24,31 @@ input IStoreCurrency {
 }
 
 """
+Geographic coordinates information.
+"""
+type StoreGeoCoordinates {
+  """
+  The latitude of the geographic coordinates.
+  """
+  latitude: Float!
+  """
+  The longitude of the geographic coordinates.
+  """
+  longitude: Float!
+}
+
+input IStoreGeoCoordinates {
+  """
+  The latitude of the geographic coordinates.
+  """
+  latitude: Float!
+  """
+  The longitude of the geographic coordinates.
+  """
+  longitude: Float!
+}
+
+"""
 Session information.
 """
 type StoreSession {
@@ -48,7 +73,11 @@ type StoreSession {
   """
   postalCode: String
   """
-  Session postal code.
+  Session input geoCoordinates.
+  """
+  geoCoordinates: StoreGeoCoordinates
+  """
+  Session input person.
   """
   person: StorePerson
 }
@@ -78,7 +107,11 @@ input IStoreSession {
   """
   postalCode: String
   """
-  Session input postal code.
+  Session input geoCoordinates.
+  """
+  geoCoordinates: IStoreGeoCoordinates
+  """
+  Session input person.
   """
   person: IStorePerson
 }

--- a/packages/sdk/src/session/index.ts
+++ b/packages/sdk/src/session/index.ts
@@ -1,28 +1,34 @@
-import { createStore } from "./../store/composed";
+import { createStore } from './../store/composed'
 
 export interface Currency {
-  code: string; // Ex: USD
-  symbol: string; // Ex: $
+  code: string // Ex: USD
+  symbol: string // Ex: $
+}
+
+export interface Geocoordinates {
+  latitude: GLfloat
+  longitude: GLfloat
 }
 
 export interface Person {
-  id: string;
-  email: string;
-  givenName: string;
-  familyName: string;
+  id: string
+  email: string
+  givenName: string
+  familyName: string
 }
 
 export interface Session {
-  locale: string; // en-US
-  currency: Currency;
-  country: string; // BRA
-  channel: string | null;
-  postalCode: string | null;
-  person: Person | null;
+  locale: string // en-US
+  currency: Currency
+  country: string // BRA
+  channel: string | null
+  postalCode: string | null
+  geoCoordinates: Geocoordinates | null
+  person: Person | null
 }
 
 export const createSessionStore = (
   defaultSession: Session,
   onValidate?: (value: Session) => Promise<Session | null>,
-  namespace = "fs::session",
-) => createStore(defaultSession, namespace, onValidate);
+  namespace = 'fs::session'
+) => createStore(defaultSession, namespace, onValidate)

--- a/packages/sdk/src/session/index.ts
+++ b/packages/sdk/src/session/index.ts
@@ -5,7 +5,7 @@ export interface Currency {
   symbol: string // Ex: $
 }
 
-export interface Geocoordinates {
+export interface GeoCoordinates {
   latitude: GLfloat
   longitude: GLfloat
 }
@@ -23,7 +23,7 @@ export interface Session {
   country: string // BRA
   channel: string | null
   postalCode: string | null
-  geoCoordinates: Geocoordinates | null
+  geoCoordinates: GeoCoordinates | null
   person: Person | null
 }
 

--- a/packages/sdk/test/session/index.test.tsx
+++ b/packages/sdk/test/session/index.test.tsx
@@ -12,6 +12,7 @@ const initialSession = {
   locale: 'en-US',
   channel: 'test-channel',
   postalCode: null,
+  geoCoordinates: null,
   person: null,
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

The validateSession was not accepting and handling geoCoordinates for regionalization. At VTEX we can do a regionalization using zipCodes or geoCoordinates and that's a common scenarium when we are using seller Whitelabels because they're logistics are usually set up using geoCoordinates to improve precision.

## How it works?

The geoCoordinate is saved at indexedDB:

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/67066494/234260985-05af2f6a-6d74-4b4a-8689-cbb9cd078be6.png">

//default session inside faststore.config.js
<img width="396" alt="image" src="https://user-images.githubusercontent.com/67066494/234261158-ce82e2f9-11fb-4c39-8732-b6952eae5771.png">

## How to test it?

Pass the "geoCoordinates":{"latitude": {{Float}} , "longitude": {{Float}} } at the validateSession:

<img width="825" alt="image" src="https://user-images.githubusercontent.com/67066494/234261694-70e7655e-0323-44e7-92e7-20869666768d.png">

<img width="643" alt="image" src="https://user-images.githubusercontent.com/67066494/234261747-d613b59b-5345-4d1e-bd91-65c3cceaa458.png">

It also works for ZipCodes as before:
<img width="809" alt="image" src="https://user-images.githubusercontent.com/67066494/234261913-0f94dea4-bc6a-4c7d-abba-d7a9f6f0aa15.png">

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/67066494/234261969-59c149f0-9fa4-436f-825b-50dc84c3757f.png">

It's import to mention that we are using a market protocol latitude (north or south) always precedes longitude (east or west) but to call the checkout we have to invert the notations:

<img width="612" alt="image" src="https://user-images.githubusercontent.com/67066494/234262367-d94410c0-568f-4a9b-87c9-09fa3088b3d8.png">

### Starters Deploy Preview

-

