### PR TITLE
fix: Send missing `colorVariant` attribute to `BannerText`

### DIFF
--- a/packages/core/src/components/sections/BannerText/BannerText.tsx
+++ b/packages/core/src/components/sections/BannerText/BannerText.tsx
@@ -30,6 +30,7 @@ function BannerText({
         caption={caption}
         actionPath={link?.url}
         actionLabel={link?.text}
+        colorVariant={colorVariant}
       />
     </Section>
   )


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to pass down the `colorVariant` to the `BannerText` component.

## How to test it?

Everything should work as before.