### PR TITLE
Fix: `Button` sizing respecting Lighthouse limit

### DIFF
--- a/apps/site/components/SectionItem/section-item.module.css
+++ b/apps/site/components/SectionItem/section-item.module.css
@@ -57,7 +57,7 @@
 
 .sectionItem > article [data-fs-button] {
   position: relative;
-  left: calc(-1 * var(--fs-spacing-1));
+  left: calc(-1 * var(--fs-spacing-3));
   margin-top: var(--fs-spacing-3);
 }
 

--- a/apps/site/pages/components/atoms/button.mdx
+++ b/apps/site/pages/components/atoms/button.mdx
@@ -60,7 +60,7 @@ Buttons indicate actions that users can take, such as adding an item to the cart
       <Button variant="primary" icon={<Icon name="ShoppingCart" />} iconPosition="left">
         {'Button w/ Icon'}
       </Button>
-      <Button variant="primary" size="small">
+      <Button variant="primary" icon={<Icon name="ShoppingCart" />} size="small">
         {'Small'}
       </Button>
     </OverviewSection>

--- a/apps/site/pages/components/molecules/icon-button.mdx
+++ b/apps/site/pages/components/molecules/icon-button.mdx
@@ -24,12 +24,16 @@ Icon Buttons are icons that trigger some sort of action, such as adding an item 
     <OverviewSection>
       <IconButton icon={<Icon name="ShoppingCart" />} aria-label="Buy" />
       <IconButton icon={<Icon name="ShoppingCart" />} aria-label="Buy" variant="primary" />
+      <IconButton icon={<Icon name="ShoppingCart" />} aria-label="Buy" size="small" />
+      <IconButton icon={<Icon name="ShoppingCart" />} aria-label="Buy" variant="primary" size="small" />
     </OverviewSection>
   </Tab>
   <Tab>
     ```tsx
     <IconButton icon={<Icon name="ShoppingCart" />} aria-label="Buy" />
     <IconButton icon={<Icon name="ShoppingCart" />} aria-label="Buy" variant="primary" />
+    <IconButton icon={<Icon name="ShoppingCart" />} aria-label="Buy" size="small" />
+    <IconButton icon={<Icon name="ShoppingCart" />} aria-label="Buy" variant="primary" size="small" />
     ```
   </Tab>
 </Tabs>

--- a/apps/site/pages/components/molecules/navbar-links.mdx
+++ b/apps/site/pages/components/molecules/navbar-links.mdx
@@ -124,15 +124,6 @@ import '@faststore/ui/src/components/molecules/NavbarLinks/styles.scss'
 
 <TokenTable>
   <TokenRow
-    token="--fs-navbar-links-padding-top-notebook"
-    value="var(--fs-spacing-1)"
-  />
-  <TokenRow
-    token="--fs-navbar-links-padding-bottom-notebook"
-    value="var(--fs-navbar-links-padding-top-notebook)"
-  />
-  <TokenDivider />
-  <TokenRow
     token="--fs-navbar-links-bkg-color"
     value="--fs-color-body-bkg"
     isColor

--- a/apps/site/pages/components/molecules/region-bar.mdx
+++ b/apps/site/pages/components/molecules/region-bar.mdx
@@ -160,7 +160,7 @@ return (
   <TokenRow token="--fs-region-bar-width" value="100%" />
   <TokenRow
     token="--fs-region-bar-padding"
-    value="var(--fs-spacing-0) var(--fs-spacing-3)"
+    value="var(--fs-spacing-0) var(--fs-spacing-1) var(--fs-spacing-1) var(--fs-spacing-2)"
   />
   <TokenDivider />
   <TokenRow

--- a/apps/site/pages/components/molecules/search-input-field.mdx
+++ b/apps/site/pages/components/molecules/search-input-field.mdx
@@ -92,6 +92,7 @@ import '@faststore/ui/src/components/molecules/SearchInputField/styles.scss'
     token="--fs-search-input-field-height-desktop"
     value="var(--fs-spacing-6)"
   />
+  <TokenDivider />
   <TokenRow
     token="--fs-search-input-field-transition-timing"
     value="var(--fs-transition-timing)"
@@ -105,26 +106,17 @@ import '@faststore/ui/src/components/molecules/SearchInputField/styles.scss'
 
 <TokenTable>
   <TokenRow
-    token="--fs-search-input-field-button-width"
-    value="var(--fs-spacing-7)"
-  />
-  <TokenRow
     token="--fs-search-input-field-button-min-height"
     value="var(--fs-search-input-height-desktop)"
   />
-  <TokenRow
-    token="--fs-search-input-field-button-bkg-color"
-    value="transparent"
-    isColor
-  />
   <TokenDivider />
   <TokenRow
-    token="--fs-search-input-field-button-height-mobile"
-    value="var(--fs-search-input-field-button-width)"
+    token="--fs-search-input-field-button-padding-top-desktop"
+    value="var(--fs-spacing-0)"
   />
   <TokenRow
-    token="--fs-search-input-field-button-height-desktop"
-    value="var(--fs-search-input-field-height-desktop)"
+    token="--fs-search-input-field-button-padding-bottom-desktop"
+    value="var(--fs-search-input-field-button-padding-top-desktop)"
   />
 </TokenTable>
 
@@ -139,19 +131,6 @@ import '@faststore/ui/src/components/molecules/SearchInputField/styles.scss'
     token="--fs-search-input-field-input-bkg-color"
     value="var(--fs-color-body-bkg)"
     isColor
-  />
-</TokenTable>
-
-#### Icon
-
-<TokenTable>
-  <TokenRow
-    token="--fs-search-input-field-icon-width"
-    value="var(--fs-spacing-4)"
-  />
-  <TokenRow
-    token="--fs-search-input-field-icon-height"
-    value="var(--fs-search-input-field-icon-width)"
   />
 </TokenTable>
 

--- a/apps/site/pages/components/organisms/image-gallery.mdx
+++ b/apps/site/pages/components/organisms/image-gallery.mdx
@@ -268,7 +268,11 @@ export const propsImageElementData = [
     value="var(--fs-spacing-2)"
   />
   <TokenRow
-    token="--fs-image-gallery-selector-elements-padding"
+    token="--fs-image-gallery-selector-elements-padding-mobile"
+    value="var(--fs-spacing-0) var(--fs-grid-padding)"
+  />
+  <TokenRow
+    token="--fs-image-gallery-selector-elements-padding-notebook"
     value="var(--fs-spacing-0) 0"
   />
 </TokenTable>

--- a/apps/site/pages/components/organisms/image-gallery.mdx
+++ b/apps/site/pages/components/organisms/image-gallery.mdx
@@ -269,7 +269,7 @@ export const propsImageElementData = [
   />
   <TokenRow
     token="--fs-image-gallery-selector-elements-padding"
-    value="var(--fs-spacing-0) var(--fs-spacing-2)"
+    value="var(--fs-spacing-0) 0"
   />
 </TokenTable>
 

--- a/packages/components/src/atoms/Button/Button.tsx
+++ b/packages/components/src/atoms/Button/Button.tsx
@@ -73,17 +73,19 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       data-testid={testId}
       {...otherProps}
     >
-      {loading && (
-        <p data-fs-button-loading-label>
-          {loadingLabel}
-          <Loader
-            variant={variant === 'primary' && !inverse ? 'light' : 'dark'}
-          />
-        </p>
-      )}
-      {React.isValidElement(icon) && iconPosition === 'left' && <span data-fs-button-icon>{icon}</span>}
-      {children && <span>{children}</span>}
-      {React.isValidElement(icon) && iconPosition === 'right' && <span data-fs-button-icon>{icon}</span>}
+      <div data-fs-button-wrapper>
+        {loading && (
+          <p data-fs-button-loading-label>
+            {loadingLabel}
+            <Loader
+              variant={variant === 'primary' && !inverse ? 'light' : 'dark'}
+            />
+          </p>
+        )}
+        {React.isValidElement(icon) && iconPosition === 'left' && <span data-fs-button-icon>{icon}</span>}
+        {children && <span>{children}</span>}
+        {React.isValidElement(icon) && iconPosition === 'right' && <span data-fs-button-icon>{icon}</span>}
+      </div>
     </button>
   )
 })

--- a/packages/components/src/molecules/Alert/Alert.tsx
+++ b/packages/components/src/molecules/Alert/Alert.tsx
@@ -1,7 +1,7 @@
 import type { HTMLAttributes } from 'react'
 import React, { forwardRef, useCallback } from 'react'
 
-import { Button, Icon, Link, LinkProps } from '../../'
+import { IconButton, Icon, Link, LinkProps } from '../../'
 
 import type { MouseEvent, ReactNode } from 'react'
 
@@ -68,11 +68,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(function Alert(
       {link && <Link data-fs-alert-link variant="inline" {...link} />}
 
       {dismissible && (
-        <Button data-fs-alert-button aria-label="Close" onClick={handleClose}>
-          <span>
-            <Icon name="X" />
-          </span>
-        </Button>
+        <IconButton data-fs-alert-button size="small" aria-label="Close" icon={<Icon name="X" />} onClick={handleClose} />
       )}
     </div>
   )

--- a/packages/components/src/molecules/IconButton/IconButton.tsx
+++ b/packages/components/src/molecules/IconButton/IconButton.tsx
@@ -26,6 +26,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
       children,
       testId = 'fs-icon-button',
       'aria-label': ariaLabel,
+      size = 'regular',
       variant,
       ...otherProps
     },
@@ -40,6 +41,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         icon={icon}
         aria-label={ariaLabel}
         testId={testId}
+        size={size}
         {...otherProps}
       >
         {children}

--- a/packages/components/src/molecules/InputField/InputField.tsx
+++ b/packages/components/src/molecules/InputField/InputField.tsx
@@ -107,7 +107,7 @@ const InputField = ({
       {shouldDisplayButton &&
         (displayClearButton || error ? (
           <IconButton
-            data-fs-button-size="small"
+            size="small"
             aria-label="Clear Field"
             icon={<Icon name="XCircle" />}
             onClick={() => {

--- a/packages/components/src/molecules/LinkButton/LinkButton.tsx
+++ b/packages/components/src/molecules/LinkButton/LinkButton.tsx
@@ -40,9 +40,11 @@ function LinkButton({
       data-testid={testId}
       {...otherProps}
     >
-      {React.isValidElement(icon) && iconPosition === 'left' && icon}
-      {children}
-      {React.isValidElement(icon) && iconPosition === 'right' && icon}
+      <div data-fs-button-wrapper>
+        {React.isValidElement(icon) && iconPosition === 'left' && <span data-fs-button-icon>{icon}</span>}
+        {children && <span>{children}</span>}
+        {React.isValidElement(icon) && iconPosition === 'right' && <span data-fs-button-icon>{icon}</span>}
+      </div>
     </a>
   )
 }

--- a/packages/components/src/molecules/RegionBar/RegionBar.tsx
+++ b/packages/components/src/molecules/RegionBar/RegionBar.tsx
@@ -20,7 +20,7 @@ const RegionBar = forwardRef<HTMLDivElement, RegionBarProps>(function RegionBar(
 ) {
   return (
     <div ref={ref} data-fs-region-bar {...otherProps}>
-      <Button onClick={onButtonClick}>
+      <Button onClick={onButtonClick} iconPosition="right" icon={<Icon name="CaretRight" />}>
         <Icon name="MapPin" />
         {postalCode ? (
           <>
@@ -30,7 +30,6 @@ const RegionBar = forwardRef<HTMLDivElement, RegionBarProps>(function RegionBar(
         ) : (
           <span data-fs-region-bar-message>Set your location</span>
         )}
-        <Icon name="CaretRight" />
       </Button>
     </div>
   )

--- a/packages/components/src/molecules/SearchInputField/SearchInputField.tsx
+++ b/packages/components/src/molecules/SearchInputField/SearchInputField.tsx
@@ -88,10 +88,10 @@ const SearchInputField = forwardRef<
         {...otherProps}
       />
       <IconButton
-        data-fs-icon-button="null"
         type="submit"
         aria-label="Submit Search"
         icon={buttonIcon ?? <Icon name="MagnifyingGlass" />}
+        size="small"
         {...buttonProps}
       />
     </form>

--- a/packages/core/src/components/common/Footer/section.module.scss
+++ b/packages/core/src/components/common/Footer/section.module.scss
@@ -2,6 +2,7 @@
 @import "@faststore/ui/src/styles/base/utilities.scss";
 
 .section {
+  @import "@faststore/ui/src/components/atoms/Button/styles.scss";
   @import "@faststore/ui/src/components/atoms/Link/styles.scss";
   @import "@faststore/ui/src/components/atoms/List/styles.scss";
   @import "@faststore/ui/src/components/atoms/Logo/styles.scss";

--- a/packages/core/src/components/region/RegionButton/RegionButton.tsx
+++ b/packages/core/src/components/region/RegionButton/RegionButton.tsx
@@ -11,11 +11,11 @@ function RegionButton() {
     <UIButton
       variant="tertiary"
       size="small"
-      icon={<Icon name="MapPin" width={24} height={24} />}
+      icon={<Icon name="MapPin" width={18} height={18} weight="bold" />}
       iconPosition="left"
       onClick={openModal}
     >
-      <span>{postalCode ?? 'Set your location'}</span>
+      {postalCode ?? 'Set your location'}
     </UIButton>
   )
 }

--- a/packages/core/src/components/sections/BannerNewsletter/section.module.scss
+++ b/packages/core/src/components/sections/BannerNewsletter/section.module.scss
@@ -3,6 +3,7 @@
 
 .section {
   @import "@faststore/ui/src/components/atoms/Button/styles.scss";
+  @import "@faststore/ui/src/components/molecules/LinkButton/styles.scss";
   @import "@faststore/ui/src/components/molecules/Banner/styles.scss";
   @import "@faststore/ui/src/components/organisms/BannerNewsletter/styles.scss";
 }

--- a/packages/core/src/components/ui/Button/ButtonSignIn/ButtonSignIn.tsx
+++ b/packages/core/src/components/ui/Button/ButtonSignIn/ButtonSignIn.tsx
@@ -18,7 +18,7 @@ const ButtonSignIn = () => {
       icon={<Icon name="User" width={18} height={18} weight="bold" />}
       iconPosition="left"
     >
-      <span>{person?.id ? 'My Account' : 'Sign In'}</span>
+      {person?.id ? 'My Account' : 'Sign In'}
     </LinkButton>
   )
 }

--- a/packages/ui/src/components/atoms/Button/styles.scss
+++ b/packages/ui/src/components/atoms/Button/styles.scss
@@ -144,9 +144,20 @@
   // --------------------------------------------------------
 
   &[data-fs-button-variant] {
-    @include focus-ring-visible;
 
-    &:disabled, &[data-fs-button-disabled="true"] [data-fs-button-wrapper] {
+    &:focus, &:focus-visible { box-shadow: none; }
+
+    @media not all and (min-resolution: .001dpcm) {
+      @supports (-webkit-appearance:none) {
+        &:focus [data-fs-button-wrapper],
+        &:focus:hover [data-fs-button-wrapper] { @include focus-ring; }
+      }
+    }
+
+    &:focus-visible [data-fs-button-wrapper],
+    &:focus-visible:hover [data-fs-button-wrapper] { @include focus-ring; }
+
+    &:disabled [data-fs-button-wrapper], &[data-fs-button-disabled="true"] [data-fs-button-wrapper] {
       color: var(--fs-button-disabled-text-color);
       cursor: not-allowed;
       background-color: var(--fs-button-disabled-bkg-color);

--- a/packages/ui/src/components/atoms/Button/styles.scss
+++ b/packages/ui/src/components/atoms/Button/styles.scss
@@ -112,22 +112,31 @@
   // Structural Styles
   // --------------------------------------------------------
 
-  display: inline-flex;
-  column-gap: var(--fs-button-gap);
-  align-items: center;
+  display: flex;
   justify-content: center;
+  align-items: stretch;
   min-height: var(--fs-button-height);
-  padding: var(--fs-button-padding);
-  font-size: var(--fs-button-text-size);
-  font-weight: var(--fs-button-text-weight);
-  line-height: var(--fs-button-text-size);
-  text-decoration: none;
-  cursor: pointer;
-  border: var(--fs-button-border-width) solid var(--fs-button-border-color);
-  border-radius: var(--fs-button-border-radius);
-  outline: none;
-  box-shadow: var(--fs-button-shadow);
-  transition: var(--fs-button-transition-property) var(--fs-button-transition-timing) var(--fs-button-transition-function);
+  padding: 0;
+
+  [data-fs-button-wrapper] {
+    position: relative;
+    display: inline-flex;
+    column-gap: var(--fs-button-gap);
+    align-items: center;
+    justify-content: center;
+    padding: var(--fs-button-padding);
+    font-size: var(--fs-button-text-size);
+    font-weight: var(--fs-button-text-weight);
+    line-height: var(--fs-button-text-size);
+    text-decoration: none;
+    cursor: pointer;
+    border: var(--fs-button-border-width) solid var(--fs-button-border-color);
+    border-radius: var(--fs-button-border-radius);
+    outline: none;
+    box-shadow: var(--fs-button-shadow);
+    transition: var(--fs-button-transition-property) var(--fs-button-transition-timing) var(--fs-button-transition-function);
+  }
+
 
   // --------------------------------------------------------
   // Variants Styles
@@ -136,7 +145,7 @@
   &[data-fs-button-variant] {
     @include focus-ring-visible;
 
-    &:disabled, &[data-fs-button-disabled="true"] {
+    &:disabled, &[data-fs-button-disabled="true"] [data-fs-button-wrapper] {
       color: var(--fs-button-disabled-text-color);
       cursor: not-allowed;
       background-color: var(--fs-button-disabled-bkg-color);
@@ -153,58 +162,66 @@
 
   &[data-fs-button-size="small"] {
     --fs-control-tap-size: var(--fs-button-small-min-height);
+    padding: var(--fs-spacing-1);
 
-    column-gap: var(--fs-button-small-gap);
-    padding: var(--fs-button-small-padding);
+    [data-fs-button-wrapper] {
+      column-gap: var(--fs-button-small-gap);
+      padding: var(--fs-button-small-padding);
+    }
 
+    &:not([data-fs-icon-button="true"]) {
       [data-fs-icon] {
         width: var(--fs-button-small-icon-width);
         height: var(--fs-button-small-icon-height);
       }
-
+    }
   }
 
   &[data-fs-button-variant="primary"] {
-    color: var(--fs-button-primary-text-color);
-    background-color: var(--fs-button-primary-bkg-color);
-    border: var(--fs-button-border-width) solid var(--fs-button-primary-border-color);
+    [data-fs-button-wrapper] {
+      color: var(--fs-button-primary-text-color);
+      background-color: var(--fs-button-primary-bkg-color);
+      border: var(--fs-button-border-width) solid var(--fs-button-primary-border-color);
+    }
 
-    &:hover {
+    &:hover [data-fs-button-wrapper] {
       color: var(--fs-button-primary-text-color-hover);
       background-color: var(--fs-button-primary-bkg-color-hover);
       border-color: var(--fs-button-primary-border-color-hover);
       box-shadow: var(--fs-button-primary-shadow-hover);
     }
 
-    &:focus, &:focus-visible {
+    &:focus [data-fs-button-wrapper], &:focus-visible [data-fs-button-wrapper] {
       color: var(--fs-button-primary-text-color-hover);
       background-color: var(--fs-button-primary-bkg-color-hover);
     }
 
-    &:active {
+    &:active [data-fs-button-wrapper] {
       color: var(--fs-button-primary-text-color-active);
       background-color: var(--fs-button-primary-bkg-color-active);
       border-color: var(--fs-button-primary-border-color-active);
     }
 
     &[data-fs-button-inverse="true"] {
-      color: var(--fs-button-primary-inverse-text-color);
-      background-color: var(--fs-button-primary-inverse-bkg-color);
-      border: var(--fs-button-border-width) solid var(--fs-button-primary-inverse-border-color);
+      [data-fs-button-wrapper] {
+        color: var(--fs-button-primary-inverse-text-color);
+        background-color: var(--fs-button-primary-inverse-bkg-color);
+        border: var(--fs-button-border-width) solid var(--fs-button-primary-inverse-border-color);
+      }
 
-      &:hover {
+      &:hover [data-fs-button-wrapper] {
         color: var(--fs-button-primary-inverse-text-color-hover);
         background-color: var(--fs-button-primary-inverse-bkg-color-hover);
         border-color: var(--fs-button-primary-inverse-border-color-hover);
         box-shadow: var(--fs-button-primary-inverse-shadow-hover);
       }
 
-      &:focus, &:focus-visible {
+      &:focus [data-fs-button-wrapper], &:focus-visible [data-fs-button-wrapper] {
         color: var(--fs-button-primary-inverse-text-color-hover);
         background-color: var(--fs-button-primary-inverse-bkg-color-hover);
       }
 
-      &:active {
+      &:active [data-fs-button-wrapper] {
         color: var(--fs-button-primary-inverse-text-color-active);
         background-color: var(--fs-button-primary-inverse-bkg-color-active);
         border-color: var(--fs-button-primary-inverse-border-color-active);
@@ -213,46 +230,52 @@
   }
 
   &[data-fs-button-variant="secondary"] {
-    color: var(--fs-button-secondary-text-color);
-    background-color: var(--fs-button-secondary-bkg-color);
-    border: var(--fs-button-border-width) solid var(--fs-button-secondary-border-color);
 
-    &:hover {
+    [data-fs-button-wrapper] {
+      color: var(--fs-button-secondary-text-color);
+      background-color: var(--fs-button-secondary-bkg-color);
+      border: var(--fs-button-border-width) solid var(--fs-button-secondary-border-color);
+    }
+
+    &:hover [data-fs-button-wrapper] {
       color: var(--fs-button-secondary-text-color-hover);
       background-color: var(--fs-button-secondary-bkg-color-hover);
       border-color: var(--fs-button-secondary-border-color-hover);
       box-shadow: var(--fs-button-secondary-shadow-hover);
     }
 
-    &:focus, &:focus-visible {
+    &:focus [data-fs-button-wrapper], &:focus-visible [data-fs-button-wrapper] {
       color: var(--fs-button-secondary-text-color-hover);
       background-color: var(--fs-button-secondary-bkg-color-hover);
     }
 
-    &:active {
+    &:active [data-fs-button-wrapper] {
       color: var(--fs-button-secondary-text-color-active);
       background-color: var(--fs-button-secondary-bkg-color-active);
       border-color: var(--fs-button-secondary-border-color-active);
     }
 
     &[data-fs-button-inverse="true"] {
-      color: var(--fs-button-secondary-inverse-text-color);
-      background-color: var(--fs-button-secondary-inverse-bkg-color);
-      border: var(--fs-button-border-width) solid var(--fs-button-secondary-inverse-border-color);
 
-      &:hover {
+      [data-fs-button-wrapper] {
+        color: var(--fs-button-secondary-inverse-text-color);
+        background-color: var(--fs-button-secondary-inverse-bkg-color);
+        border: var(--fs-button-border-width) solid var(--fs-button-secondary-inverse-border-color);
+      }
+
+      &:hover [data-fs-button-wrapper] {
         color: var(--fs-button-secondary-inverse-text-color-hover);
         background-color: var(--fs-button-secondary-inverse-bkg-color-hover);
         border-color: var(--fs-button-secondary-inverse-border-color-hover);
         box-shadow: var(--fs-button-secondary-inverse-shadow-hover);
       }
 
-      &:focus, &:focus-visible {
+      &:focus [data-fs-button-wrapper], &:focus-visible [data-fs-button-wrapper] {
         color: var(--fs-button-secondary-inverse-text-color-hover);
         background-color: var(--fs-button-secondary-inverse-bkg-color-hover);
       }
 
-      &:active {
+      &:active [data-fs-button-wrapper] {
         color: var(--fs-button-secondary-inverse-text-color-active);
         background-color: var(--fs-button-secondary-inverse-bkg-color-active);
         border-color: var(--fs-button-secondary-inverse-border-color-active);
@@ -261,46 +284,52 @@
   }
 
   &[data-fs-button-variant="tertiary"] {
-    color: var(--fs-button-tertiary-text-color);
-    background-color: var(--fs-button-tertiary-bkg-color);
-    border: var(--fs-button-border-width) solid var(--fs-button-tertiary-border-color);
 
-    &:hover {
+    [data-fs-button-wrapper] {
+      color: var(--fs-button-tertiary-text-color);
+      background-color: var(--fs-button-tertiary-bkg-color);
+      border: var(--fs-button-border-width) solid var(--fs-button-tertiary-border-color);
+    }
+
+    &:hover [data-fs-button-wrapper] {
       color: var(--fs-button-tertiary-text-color-hover);
       background-color: var(--fs-button-tertiary-bkg-color-hover);
       border-color: var(--fs-button-tertiary-border-color-hover);
       box-shadow: var(--fs-button-tertiary-shadow-hover);
     }
 
-    &:focus, &:focus-visible {
+    &:focus [data-fs-button-wrapper], &:focus-visible [data-fs-button-wrapper] {
       color: var(--fs-button-tertiary-text-color-hover);
       background-color: var(--fs-button-tertiary-bkg-color-hover);
     }
 
-    &:active {
+    &:active [data-fs-button-wrapper] {
       color: var(--fs-button-tertiary-text-color-active);
       background-color: var(--fs-button-tertiary-bkg-color-active);
       border-color: var(--fs-button-tertiary-border-color-active);
     }
 
     &[data-fs-button-inverse="true"] {
-      color: var(--fs-button-tertiary-inverse-text-color);
-      background-color: var(--fs-button-tertiary-inverse-bkg-color);
-      border: var(--fs-button-border-width) solid var(--fs-button-tertiary-inverse-border-color);
 
-      &:hover {
+      [data-fs-button-wrapper] {
+        color: var(--fs-button-tertiary-inverse-text-color);
+        background-color: var(--fs-button-tertiary-inverse-bkg-color);
+        border: var(--fs-button-border-width) solid var(--fs-button-tertiary-inverse-border-color);
+      }
+
+      &:hover [data-fs-button-wrapper] {
         color: var(--fs-button-tertiary-inverse-text-color-hover);
         background-color: var(--fs-button-tertiary-inverse-bkg-color-hover);
         border-color: var(--fs-button-tertiary-inverse-border-color-hover);
         box-shadow: var(--fs-button-tertiary-inverse-shadow-hover);
       }
 
-      &:focus, &:focus-visible {
+      &:focus [data-fs-button-wrapper], &:focus-visible [data-fs-button-wrapper] {
         color: var(--fs-button-tertiary-inverse-text-color-hover);
         background-color: var(--fs-button-tertiary-inverse-bkg-color-hover);
       }
 
-      &:active {
+      &:active [data-fs-button-wrapper] {
         color: var(--fs-button-tertiary-inverse-text-color-active);
         background-color: var(--fs-button-tertiary-inverse-bkg-color-active);
         border-color: var(--fs-button-tertiary-inverse-border-color-active);
@@ -309,18 +338,17 @@
   }
 
   &[data-fs-icon-button="true"] {
-    position: relative;
-    column-gap: 0;
+    width: var(--fs-button-height);
 
-    &[data-fs-button-variant] {
-      width: var(--fs-button-height);
-      height: var(--fs-button-height);
-      padding: var(--fs-button-icon-padding);
+    [data-fs-button-wrapper] {
+      column-gap: 0;
+      padding: 0;
       border-width: 0;
+      width: 100%;
     }
   }
 
-  &[data-fs-button-loading="true"] {
+  &[data-fs-button-loading="true"] [data-fs-button-wrapper] {
     > * {
       opacity: 0;
       pointer-events: none;

--- a/packages/ui/src/components/atoms/Button/styles.scss
+++ b/packages/ui/src/components/atoms/Button/styles.scss
@@ -113,8 +113,8 @@
   // --------------------------------------------------------
 
   display: flex;
-  justify-content: center;
   align-items: stretch;
+  width: fit-content;
   min-height: var(--fs-button-height);
   padding: 0;
 
@@ -124,6 +124,7 @@
     column-gap: var(--fs-button-gap);
     align-items: center;
     justify-content: center;
+    width: 100%;
     padding: var(--fs-button-padding);
     font-size: var(--fs-button-text-size);
     font-weight: var(--fs-button-text-weight);

--- a/packages/ui/src/components/molecules/Accordion/styles.scss
+++ b/packages/ui/src/components/molecules/Accordion/styles.scss
@@ -37,7 +37,9 @@
     }
   }
 
-  [data-fs-accordion-button] {
+  [data-fs-accordion-button] { width: 100%; }
+
+  [data-fs-accordion-button] [data-fs-button-wrapper] {
     display: inline-flex;
     align-items: center;
     justify-content: space-between;

--- a/packages/ui/src/components/molecules/Alert/styles.scss
+++ b/packages/ui/src/components/molecules/Alert/styles.scss
@@ -76,22 +76,9 @@
   }
 
   [data-fs-alert-button] {
-    min-width: var(--fs-control-tap-size);
-    height: 100%;
-    padding: var(--fs-spacing-0);
     margin-left: auto;
-    color: var(--fs-alert-button-text-color);
-    background-color: var(--fs-alert-button-bkg-color);
 
-    > span {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 100%;
-      height: 100%;
-      background-color: var(--fs-alert-button-bkg-color);
-      border-radius: var(--fs-alert-button-border-radius);
-    }
+    [data-fs-button-wrapper] { color: var(--fs-alert-button-text-color); }
 
     &:hover span {
       filter: brightness(0.95);

--- a/packages/ui/src/components/molecules/Banner/styles.scss
+++ b/packages/ui/src/components/molecules/Banner/styles.scss
@@ -59,7 +59,7 @@
 
   [data-fs-banner-text-link] [data-fs-link-button] {
     min-width: var(--fs-banner-button-link-min-width);
-    margin-top: var(--fs-banner-button-link-margin-top);
+    margin: var(--fs-banner-button-link-margin-top) auto 0;
   }
 
   // --------------------------------------------------------

--- a/packages/ui/src/components/molecules/BuyButton/styles.scss
+++ b/packages/ui/src/components/molecules/BuyButton/styles.scss
@@ -25,22 +25,26 @@
   @include focus-ring-visible;
 
   color: var(--fs-buy-button-text-color);
-  background-color: var(--fs-buy-button-bkg-color);
-  border: var(--fs-button-border-width) solid var(--fs-buy-button-border-color);
 
-  &:hover {
+  [data-fs-button-wrapper] {
+    background-color: var(--fs-buy-button-bkg-color);
+    border: var(--fs-button-border-width) solid var(--fs-buy-button-border-color);
+  }
+
+
+  &:hover [data-fs-button-wrapper] {
     color: var(--fs-buy-button-text-color-hover);
     background-color: var(--fs-buy-button-bkg-color-hover);
     border-color: var(--fs-buy-button-border-color-hover);
     box-shadow: var(--fs-buy-button-shadow-hover);
   }
 
-  &:focus, &:focus-visible {
+  &:focus [data-fs-button-wrapper], &:focus-visible [data-fs-button-wrapper] {
     color: var(--fs-buy-button-text-color-hover);
     background-color: var(--fs-buy-button-bkg-color-hover);
   }
 
-  &:active {
+  &:active [data-fs-button-wrapper] {
     color: var(--fs-buy-button-text-color-hover);
     background-color: var(--fs-buy-button-bkg-color-active);
     border-color: var(--fs-buy-button-border-color-active);

--- a/packages/ui/src/components/molecules/InputField/styles.scss
+++ b/packages/ui/src/components/molecules/InputField/styles.scss
@@ -117,22 +117,16 @@
 
     [data-fs-button] {
       position: absolute;
-      top: var(--fs-spacing-1);
-      right: var(--fs-spacing-1);
+      top: 0;
+      right: 0;
 
-      &::before {
+      [data-fs-button-wrapper]::before {
         position: absolute;
         left: calc(-1 * var(--fs-spacing-1));
         width: 1px;
         height: 80%;
         content: "";
         background-color: var(--fs-input-field-border-color);
-      }
-    }
-
-    [data-fs-button][data-fs-icon-button] {
-      &::before {
-        left: calc(-1 * var(--fs-spacing-1));
       }
     }
   }

--- a/packages/ui/src/components/molecules/LinkButton/styles.scss
+++ b/packages/ui/src/components/molecules/LinkButton/styles.scss
@@ -4,7 +4,5 @@
   // --------------------------------------------------------
   text-decoration: none;
 
-  &:hover { text-decoration: none; }
-
   &:disabled, &[data-fs-button-disabled="true"] { pointer-events: none; }
 }

--- a/packages/ui/src/components/molecules/LinkButton/styles.scss
+++ b/packages/ui/src/components/molecules/LinkButton/styles.scss
@@ -2,8 +2,9 @@
   // --------------------------------------------------------
   // Structural Styles
   // --------------------------------------------------------
+  text-decoration: none;
 
   &:hover { text-decoration: none; }
-    
+
   &:disabled, &[data-fs-button-disabled="true"] { pointer-events: none; }
 }

--- a/packages/ui/src/components/molecules/NavbarLinks/styles.scss
+++ b/packages/ui/src/components/molecules/NavbarLinks/styles.scss
@@ -3,9 +3,6 @@
   // Design Tokens for Navbar Links
   // --------------------------------------------------------
 
-  --fs-navbar-links-padding-top-notebook             : var(--fs-spacing-1);
-  --fs-navbar-links-padding-bottom-notebook          : var(--fs-navbar-links-padding-top-notebook);
-
   --fs-navbar-links-bkg-color                        : var(--fs-color-body-bkg);
 
   --fs-navbar-links-transition-property              : var(--fs-transition-property);
@@ -57,7 +54,7 @@
     margin-left: calc(-1 * var(--fs-spacing-1));
 
     // TODO: remove this after navbar 2.0 is implemented
-    &[data-fs-button-variant="tertiary"] {
+    &[data-fs-button-variant="tertiary"] [data-fs-button-wrapper] {
       color: var(--fs-color-text-display);
     }
 
@@ -67,15 +64,21 @@
   }
 
   @include media(">=notebook") {
-    padding-top: var(--fs-navbar-links-padding-top-notebook);
-    padding-bottom: var(--fs-navbar-links-padding-bottom-notebook);
-
     [data-fs-navbar-links-list] {
+      position: relative;
       display: flex;
+      align-items: center;
       column-gap: var(--fs-spacing-3);
       padding-left: var(--fs-navbar-links-list-padding-left-notebook);
       margin-left: var(--fs-navbar-links-list-margin-left-notebook);
-      border-left: var(--fs-navbar-links-list-border-left-width-notebook) solid var(--fs-navbar-links-list-border-left-color-notebook);
+      &::before {
+        position: absolute;
+        left: calc(-1 * var(--fs-spacing-1));
+        width: var(--fs-navbar-links-list-border-left-width-notebook);
+        height: 60%;
+        content: "";
+        background-color: var(--fs-navbar-links-list-border-left-color-notebook);
+      }
     }
 
     [data-fs-navbar-links-list-item] > [data-fs-link] {

--- a/packages/ui/src/components/molecules/RegionBar/styles.scss
+++ b/packages/ui/src/components/molecules/RegionBar/styles.scss
@@ -5,7 +5,7 @@
 
   // Default properties
   --fs-region-bar-width                    : 100%;
-  --fs-region-bar-padding                  : var(--fs-spacing-0) var(--fs-spacing-2) var(--fs-spacing-0) var(--fs-spacing-3);
+  --fs-region-bar-padding                  : var(--fs-spacing-0) var(--fs-spacing-1) var(--fs-spacing-1) var(--fs-spacing-2);
 
   --fs-region-bar-text-color               : var(--fs-color-text-display);
 
@@ -32,14 +32,18 @@
 
   [data-fs-button] {
     width: var(--fs-region-bar-width);
-    padding: var(--fs-region-bar-padding);
-    color: var(--fs-region-bar-text-color);
-    background-color: var(--fs-region-bar-bkg-color);
-    border-bottom: var(--fs-region-bar-border-bottom-width) solid var(--fs-region-bar-border-bottom-color);
-    border-radius: 0;
 
-    > span {
-      display: contents;
+    [data-fs-button-wrapper]{
+      width: var(--fs-region-bar-width);
+      padding: var(--fs-region-bar-padding);
+      color: var(--fs-region-bar-text-color);
+      background-color: var(--fs-region-bar-bkg-color);
+      border-bottom: var(--fs-region-bar-border-bottom-width) solid var(--fs-region-bar-border-bottom-color);
+      border-radius: 0;
+
+      > span {
+        display: contents;
+      }
     }
   }
 

--- a/packages/ui/src/components/molecules/RegionBar/styles.scss
+++ b/packages/ui/src/components/molecules/RegionBar/styles.scss
@@ -34,7 +34,6 @@
     width: var(--fs-region-bar-width);
 
     [data-fs-button-wrapper]{
-      width: var(--fs-region-bar-width);
       padding: var(--fs-region-bar-padding);
       color: var(--fs-region-bar-text-color);
       background-color: var(--fs-region-bar-bkg-color);

--- a/packages/ui/src/components/molecules/SearchInputField/styles.scss
+++ b/packages/ui/src/components/molecules/SearchInputField/styles.scss
@@ -3,29 +3,20 @@
   // Design Tokens for Search Input Field
   // --------------------------------------------------------
   // Default properties
-  --fs-search-input-height-desktop                : var(--fs-spacing-6);
+  --fs-search-input-field-height-mobile                 : var(--fs-control-tap-size);
+  --fs-search-input-field-height-desktop                : var(--fs-spacing-6);
 
-  --fs-search-input-field-height-mobile           : var(--fs-control-tap-size);
-  --fs-search-input-field-height-desktop          : var(--fs-spacing-6);
-
-  --fs-search-input-field-transition-timing       : var(--fs-transition-timing);
-  --fs-search-input-field-transition-function     : ease;
+  --fs-search-input-field-transition-timing             : var(--fs-transition-timing);
+  --fs-search-input-field-transition-function           : ease;
 
   // Button
-  --fs-search-input-field-button-width            : var(--fs-spacing-7);
-  --fs-search-input-field-button-min-height       : var(--fs-search-input-height-desktop);
-  --fs-search-input-field-button-bkg-color        : transparent;
-
-  --fs-search-input-field-button-height-mobile    : var(--fs-search-input-field-button-width);
-  --fs-search-input-field-button-height-desktop   : var(--fs-search-input-field-height-desktop);
+  --fs-search-input-field-button-min-height             : var(--fs-search-input-field-height-desktop);
+  --fs-search-input-field-button-padding-top-desktop    : var(--fs-spacing-0);
+  --fs-search-input-field-button-padding-bottom-desktop : var(--fs-search-input-field-button-padding-top-desktop);
 
   // Input
-  --fs-search-input-field-input-padding-right     : var(--fs-search-input-field-button-width);
-  --fs-search-input-field-input-bkg-color         : var(--fs-color-body-bkg);
-
-  // Icon
-  --fs-search-input-field-icon-width              : var(--fs-spacing-4);
-  --fs-search-input-field-icon-height             : var(--fs-search-input-field-icon-width);
+  --fs-search-input-field-input-padding-right           : var(--fs-spacing-7);
+  --fs-search-input-field-input-bkg-color               : var(--fs-color-body-bkg);
 
   // --------------------------------------------------------
   // Structural Styles
@@ -41,20 +32,14 @@
   @include media(">=notebook") { height: var(--fs-search-input-field-height-desktop); }
 
   [data-fs-icon-button][data-fs-button-variant] {
-    position: absolute;
-    right: var(--fs-spacing-0);
-    width: var(--fs-search-input-field-button-width);
-    height: var(--fs-search-input-field-button-height-mobile);
-    padding: 0;
-    background-color: var(--fs-search-input-field-button-bkg-color);
-    border: 0;
+    position: relative;
+    right: .125rem;
     @include media(">=notebook") {
-      height: var(--fs-search-input-field-button-height-desktop);
+      position: absolute;
+      padding-top: var(--fs-search-input-field-button-padding-top-desktop);
+      padding-bottom: var(--fs-search-input-field-button-padding-bottom-desktop);
       min-height: var(--fs-search-input-field-button-min-height);
-    }
-    svg {
-      width: var(--fs-search-input-field-icon-width);
-      height: var(--fs-search-input-field-icon-height);
+      right: 0;
     }
   }
 
@@ -63,6 +48,7 @@
     padding-right: var(--fs-search-input-field-input-padding-right);
     background-color: var(--fs-search-input-field-input-bkg-color);
     transition: box-shadow var(--fs-search-input-field-transition-timing) var(--fs-search-input-field-transition-timing), border var(--fs-search-input-field-transition-timing) var(--fs-search-input-field-transition-function);
+    @include media("<notebook") { border: 0; }
   }
 
 }

--- a/packages/ui/src/components/organisms/Hero/styles.scss
+++ b/packages/ui/src/components/organisms/Hero/styles.scss
@@ -107,9 +107,11 @@
   }
 
   [data-fs-button] {
-    justify-content: space-between;
-    min-width: 11.25rem;
     margin-top: var(--fs-spacing-6);
+    [data-fs-button-wrapper] {
+      min-width: 11.25rem;
+      justify-content: space-between;
+    }
   }
 
   [data-fs-hero-icon] {

--- a/packages/ui/src/components/organisms/ImageGallery/styles.scss
+++ b/packages/ui/src/components/organisms/ImageGallery/styles.scss
@@ -102,7 +102,7 @@
     }
   }
 
-  [data-fs-image-gallery-selector-thumbnail] {
+  [data-fs-image-gallery-selector-thumbnail] [data-fs-button-wrapper] {
     flex-shrink: 0;
     width: var(--fs-image-gallery-selector-thumbnail-width-mobile);
     height: var(--fs-image-gallery-selector-thumbnail-height-mobile);

--- a/packages/ui/src/components/organisms/ImageGallery/styles.scss
+++ b/packages/ui/src/components/organisms/ImageGallery/styles.scss
@@ -26,7 +26,7 @@
   // Image Gallery Selector Elements
   --fs-image-gallery-selector-elements-gap                      : var(--fs-spacing-1);
   --fs-image-gallery-selector-elements-gap-notebook             : var(--fs-spacing-2);
-  --fs-image-gallery-selector-elements-padding                  : var(--fs-spacing-0) var(--fs-spacing-2);
+  --fs-image-gallery-selector-elements-padding                  : var(--fs-spacing-0) 0;
 
   // Image Gallery Selector Thumbnail
   --fs-image-gallery-selector-thumbnail-width-mobile            : var(--fs-spacing-8);

--- a/packages/ui/src/components/organisms/ImageGallery/styles.scss
+++ b/packages/ui/src/components/organisms/ImageGallery/styles.scss
@@ -26,7 +26,8 @@
   // Image Gallery Selector Elements
   --fs-image-gallery-selector-elements-gap                      : var(--fs-spacing-1);
   --fs-image-gallery-selector-elements-gap-notebook             : var(--fs-spacing-2);
-  --fs-image-gallery-selector-elements-padding                  : var(--fs-spacing-0) 0;
+  --fs-image-gallery-selector-elements-padding-mobile           : var(--fs-spacing-0) var(--fs-grid-padding);
+  --fs-image-gallery-selector-elements-padding-notebook         : var(--fs-spacing-0) 0;
 
   // Image Gallery Selector Thumbnail
   --fs-image-gallery-selector-thumbnail-width-mobile            : var(--fs-spacing-8);
@@ -89,7 +90,7 @@
   [data-fs-image-gallery-selector-elements] {
     display: flex;
     column-gap: var(--fs-image-gallery-selector-elements-gap);
-    padding: var(--fs-image-gallery-selector-elements-padding);
+    padding: var(--fs-image-gallery-selector-elements-padding-mobile);
     overflow-x: auto;
     scroll-behavior: smooth;
 
@@ -99,32 +100,37 @@
       flex-direction: column;
       row-gap: var(--fs-image-gallery-selector-elements-gap-notebook);
       overflow-y: hidden;
+      align-items: center;
+      width: 100%;
+      padding: var(--fs-image-gallery-selector-elements-padding-notebook);
     }
   }
 
-  [data-fs-image-gallery-selector-thumbnail] [data-fs-button-wrapper] {
-    flex-shrink: 0;
+  [data-fs-image-gallery-selector-thumbnail] {
     width: var(--fs-image-gallery-selector-thumbnail-width-mobile);
     height: var(--fs-image-gallery-selector-thumbnail-height-mobile);
-    padding: 0;
-    overflow: hidden;
-    background-color: transparent;
-    border: var(--fs-image-gallery-selector-thumbnail-border-width) solid transparent;
-    border-radius: var(--fs-image-gallery-selector-thumbnail-border-radius);
-    transition: all var(--fs-image-gallery-transition-timing) var(--fs-image-gallery-transition-function);
 
-    &:hover:not([data-fs-image-gallery-selector-thumbnail="selected"]) {
+    [data-fs-button-wrapper] {
+      padding: 0;
+      overflow: hidden;
+      background-color: transparent;
+      border: var(--fs-image-gallery-selector-thumbnail-border-width) solid transparent;
+      border-radius: var(--fs-image-gallery-selector-thumbnail-border-radius);
+      transition: all var(--fs-image-gallery-transition-timing) var(--fs-image-gallery-transition-function);
+      > span {
+        width: 100%;
+        height: 100%;
+      }
+    }
+
+
+    &:hover:not([data-fs-image-gallery-selector-thumbnail="selected"]) [data-fs-button-wrapper] {
       border-color: var(--fs-image-gallery-selector-thumbnail-selected-border-color);
     }
 
-    &[data-fs-image-gallery-selector-thumbnail="selected"] {
+    &[data-fs-image-gallery-selector-thumbnail="selected"] [data-fs-button-wrapper] {
       border-color: var(--fs-image-gallery-selector-thumbnail-selected-border-color);
       box-shadow: 0 0 0 var(--fs-image-gallery-selector-thumbnail-selected-border-width) var(--fs-color-focus-ring-outline);
-    }
-
-    > span {
-      width: 100%;
-      height: 100%;
     }
 
     [data-fs-image] {
@@ -186,11 +192,14 @@
   }
 
   [data-fs-image-gallery-selector-control-button] {
-    background-color: var(--fs-image-gallery-selector-control-bkg-color);
-    border-radius: var(--fs-image-gallery-selector-control-border-radius);
-    box-shadow: var(--fs-image-gallery-selector-control-shadow);
 
-    &:hover { box-shadow: var(--fs-image-gallery-selector-control-shadow); }
+    [data-fs-button-wrapper] {
+      background-color: var(--fs-image-gallery-selector-control-bkg-color);
+      border-radius: var(--fs-image-gallery-selector-control-border-radius);
+      box-shadow: var(--fs-image-gallery-selector-control-shadow);
+    }
+
+    &:hover [data-fs-button-wrapper] { box-shadow: var(--fs-image-gallery-selector-control-shadow); }
 
     @include media(">=notebook") {
       transform: rotate(90deg);


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR is a huge fix on all elements related to our Button. 

`fs/components` and `fs/ui`
- [x] Updates `Button` component
- [x] Updates `LinkButton` component
- [x] Updates `InputField` component
- [x] Updates `IconButton` component
- [x] Updates `NavbarLinks` component
- [x] Updates `RegionBar` component
- [x] Updates `SearchInputField` component
- [x] Updates `RegionButton` component
- [x] Updates `Accordion` component
- [x] Updates `Hero` component

`fs/core`
- [x] Updates `ButtonSignIn` component
- [x] Adds missing `Button` styles on `Footer` section
- [x] Adds missing `LinkButton` styles on `BannerNewsletter` section

## How it works?
In order to respect LH min sizing of 48x48px, we needed to create a wrapper (`data-fs-button-wrapper`) for the button to have a button small that really looks small. Some images for reference:

| `lh-checks-2` | `this branch` |
|-|-|
|<img width="780" alt="image" src="https://user-images.githubusercontent.com/11613011/236031619-b2b7947d-05d2-4464-aed9-37e1eee8e6f6.png">|<img width="780" alt="image" src="https://user-images.githubusercontent.com/11613011/236031845-fda5ec70-627c-462a-8a52-df910494f57f.png">|
|<img width="754" alt="image" src="https://user-images.githubusercontent.com/11613011/236032220-59dafc61-9cce-4f33-98ac-42982ab4312e.png">|<img width="754" alt="image" src="https://user-images.githubusercontent.com/11613011/236032484-3a3de785-1537-4bec-bf7f-4a2a21ad30af.png">|

## How to test it?
All components should look the same as `main`:
- [Doc](https://evergreen.faststore.dev/)
- [Store](https://starter.vtex.app/)

#### You can test the usage of this component in the `faststore/core` application:
1. Run `yarn dev`
2. Check all pages

#### Or test it using the doc preview link: [Input Field](https://faststore-site-git-fix-button-small-faststore.vercel.app/components/molecules/input-field)
