### PR TITLE
feat: implement redirect query

### DIFF
--- a/packages/api/mocks/RedirectQuery.ts
+++ b/packages/api/mocks/RedirectQuery.ts
@@ -1,0 +1,38 @@
+export const RedirectQueryTermTech = `query RedirectSearch {
+    redirect(term: "tech") 
+  }
+  `
+
+export const redirectTermTechFetch = {
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=2&count=1&query=tech&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
+  init: undefined,
+  result: {
+    products: [],
+    recordsFiltered: 0,
+    fuzzy: 'auto',
+    operator: 'and',
+    redirect: '/technology',
+    translated: false,
+    pagination: {
+      count: 1,
+      current: {
+        index: 0,
+      },
+      before: [],
+      after: [],
+      perPage: 0,
+      next: {
+        index: 0,
+      },
+      previous: {
+        index: 0,
+      },
+      first: {
+        index: 0,
+      },
+      last: {
+        index: 0,
+      },
+    },
+  },
+}

--- a/packages/api/mocks/RedirectQuery.ts
+++ b/packages/api/mocks/RedirectQuery.ts
@@ -1,5 +1,7 @@
 export const RedirectQueryTermTech = `query RedirectSearch {
-    redirect(term: "tech") 
+  redirect(term: "tech") {
+    url
+    }
   }
   `
 

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -393,6 +393,8 @@ export type Query = {
   collection: StoreCollection;
   /** Returns the details of a product based on the specified locator. */
   product: StoreProduct;
+  /** Returns if there's a redirect tied to a search. */
+  redirect?: Maybe<Scalars['String']>;
   /** Returns the result of a product, facet, or suggestion search. */
   search: StoreSearchResult;
   /** Returns information about shipping simulation. */
@@ -419,6 +421,12 @@ export type QueryCollectionArgs = {
 
 export type QueryProductArgs = {
   locator: Array<IStoreSelectedFacet>;
+};
+
+
+export type QueryRedirectArgs = {
+  selectedFacets?: Maybe<Array<IStoreSelectedFacet>>;
+  term?: Maybe<Scalars['String']>;
 };
 
 

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -393,8 +393,8 @@ export type Query = {
   collection: StoreCollection;
   /** Returns the details of a product based on the specified locator. */
   product: StoreProduct;
-  /** Returns if there's a redirect tied to a search. */
-  redirect?: Maybe<Scalars['String']>;
+  /** Returns if there's a redirect for a search. */
+  redirect?: Maybe<StoreRedirect>;
   /** Returns the result of a product, facet, or suggestion search. */
   search: StoreSearchResult;
   /** Returns information about shipping simulation. */
@@ -902,6 +902,16 @@ export type StorePropertyValue = {
   value: Scalars['ObjectOrString'];
   /** Specifies the nature of the value */
   valueReference: Scalars['String'];
+};
+
+/**
+ * Redirect informations, including url returned by the query.
+ * https://schema.org/Thing
+ */
+export type StoreRedirect = {
+  __typename?: 'StoreRedirect';
+  /** URL to redirect */
+  url?: Maybe<Scalars['String']>;
 };
 
 /** Information of a given review. */

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -19,6 +19,7 @@ import type {
   QueryProductArgs,
   QuerySearchArgs,
   QueryShippingArgs,
+  QueryRedirectArgs
 } from "../../../__generated__/schema"
 import type { CategoryTree } from "../clients/commerce/types/CategoryTree"
 import type { Context } from "../index"
@@ -272,5 +273,23 @@ export const Query = {
       ...simulation,
       address,
     }
+  },
+  redirect: async (
+    _: unknown,
+    { term, selectedFacets }: QueryRedirectArgs,
+    ctx: Context
+  ) => {
+    if (!term && !selectedFacets) {
+      return null
+    }
+
+    const { redirect } = await ctx.clients.search.products({
+      page: 1,
+      count: 1,
+      query: term ?? undefined,
+      selectedFacets: selectedFacets?.flatMap(transformSelectedFacet) ?? [],
+    })
+
+    return redirect
   },
 }

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -279,7 +279,7 @@ export const Query = {
     { term, selectedFacets }: QueryRedirectArgs,
     ctx: Context
   ) => {
-    if (!term && !selectedFacets) {
+    if (!term && (!selectedFacets || !selectedFacets.length)) {
       return null
     }
 

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -143,9 +143,8 @@ export const Query = {
         productId: crossSelling.value,
       })
 
-      query = `product:${
-        products.map((x) => x.productId).slice(0, first).join(";")
-      }`
+      query = `product:${products.map((x) => x.productId).slice(0, first).join(";")
+        }`
     }
 
     const after = maybeAfter ? Number(maybeAfter) : 0
@@ -279,6 +278,8 @@ export const Query = {
     { term, selectedFacets }: QueryRedirectArgs,
     ctx: Context
   ) => {
+    // Currently the search redirection can be done through a search term or filter (facet) so we limit the redirect query to always have one of these values otherwise we do not execute it.
+    // https://help.vtex.com/en/tracks/vtex-intelligent-search--19wrbB7nEQcmwzDPl1l4Cb/4Gd2wLQFbCwTsh8RUDwSoL?&utm_source=autocomplete
     if (!term && (!selectedFacets || !selectedFacets.length)) {
       return null
     }
@@ -290,6 +291,8 @@ export const Query = {
       selectedFacets: selectedFacets?.flatMap(transformSelectedFacet) ?? [],
     })
 
-    return redirect
+    return {
+      url: redirect
+    }
   },
 }

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -282,4 +282,19 @@ type Query {
     country: String!
   ): ShippingData
     @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
+
+  """
+  Returns if there's a redirect tied to a search.
+  """
+  redirect(
+    """
+    Search term.
+    """
+    term: String
+    """
+    Array of selected search facets.
+    """
+    selectedFacets: [IStoreSelectedFacet!]
+  ): String
+    @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
 }

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -295,6 +295,17 @@ type Query {
     Array of selected search facets.
     """
     selectedFacets: [IStoreSelectedFacet!]
-  ): String
+  ): StoreRedirect
     @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
+}
+
+"""
+Redirect informations, including url returned by the query.
+https://schema.org/Thing
+"""
+type StoreRedirect {
+  """
+  URL to redirect
+  """
+  url: String
 }

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -284,7 +284,7 @@ type Query {
     @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
 
   """
-  Returns if there's a redirect tied to a search.
+  Returns if there's a redirect for a search.
   """
   redirect(
     """

--- a/packages/api/test/__snapshots__/queries.test.ts.snap
+++ b/packages/api/test/__snapshots__/queries.test.ts.snap
@@ -1167,3 +1167,11 @@ Object {
   },
 }
 `;
+
+exports[`\`redirect\` query 1`] = `
+Object {
+  "data": Object {
+    "redirect": "/technology",
+  },
+}
+`;

--- a/packages/api/test/__snapshots__/queries.test.ts.snap
+++ b/packages/api/test/__snapshots__/queries.test.ts.snap
@@ -1171,7 +1171,9 @@ Object {
 exports[`\`redirect\` query 1`] = `
 Object {
   "data": Object {
-    "redirect": "/technology",
+    "redirect": Object {
+      "url": "/technology",
+    },
   },
 }
 `;

--- a/packages/api/test/queries.test.ts
+++ b/packages/api/test/queries.test.ts
@@ -34,6 +34,10 @@ import {
   addressFetch,
   ShippingSimulationQueryResult,
 } from '../mocks/ShippingQuery'
+import {
+  RedirectQueryTermTech,
+  redirectTermTechFetch,
+} from '../mocks/RedirectQuery'
 
 const apiOptions = {
   platform: 'vtex',
@@ -226,6 +230,27 @@ test('`shipping` query', async () => {
   const response = await run(ShippingSimulationQueryResult)
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
+
+  fetchAPICalls.forEach((fetchAPICall) => {
+    expect(mockedFetch).toHaveBeenCalledWith(
+      fetchAPICall.info,
+      fetchAPICall.init
+    )
+  })
+
+  expect(response).toMatchSnapshot()
+})
+
+test('`redirect` query', async () => {
+  const fetchAPICalls = [redirectTermTechFetch]
+
+  mockedFetch.mockImplementation((info, init) =>
+    pickFetchAPICallResult(info, init, fetchAPICalls)
+  )
+
+  const response = await run(RedirectQueryTermTech)
+
+  expect(mockedFetch).toHaveBeenCalledTimes(1)
 
   fetchAPICalls.forEach((fetchAPICall) => {
     expect(mockedFetch).toHaveBeenCalledWith(

--- a/packages/api/test/schema.test.ts
+++ b/packages/api/test/schema.test.ts
@@ -65,6 +65,7 @@ const QUERIES = [
   'allProducts',
   'allCollections',
   'shipping',
+  'redirect',
 ]
 
 const MUTATIONS = ['validateCart', 'validateSession', 'subscribeToNewsletter']


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds a query to solve redirects when performing a search.
In case of VTEX platform, this is solved by the IS api.


## How it works?

When performing a search if a term or facet has a redirect, the value of the `redirect` field should be an URL; this can later be used to redirect the user to an internal or external URL.

From VTEX admin:
<img width="795" alt="Screenshot 2023-05-04 at 17 51 48" src="https://user-images.githubusercontent.com/50715158/236261672-24230b76-3f5e-4f92-8c17-53111fd65f24.png">

It get solved as:
<img width="1474" alt="image" src="https://github.com/vtex/faststore/assets/67066494/4cecfa15-200b-49a0-a070-e4226f57c71e">

## How to test it?

- Run the `@faststore/api` package individually.
- Browse [localhost/graphql](http://localhost:4000/graphql)
- Run the redirect query with a term that is active in `/admin/search/v4/redirects/`
- For storeframework, you can use the term `tech`

PR related at vtex-sites: https://github.com/vtex-sites/nextjs.store/pull/382
PR related 2.x: https://github.com/vtex/faststore/pull/1749
