### PR TITLE
fix: Renames `IncentivesHeader` section to `Incentives`

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -665,9 +665,9 @@
     }
   },
   {
-    "name": "IncentivesHeader",
+    "name": "Incentives",
     "schema": {
-      "title": "Incentives Header",
+      "title": "Incentives",
       "description": "Add Incentives to your shopper",
       "type": "object",
       "properties": {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the missing `IncentivesHeader` section after renaming to `Incentives`.