### PR TITLE
Windows-fix: use path instead of `/` for handling paths

### DIFF
--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+
 export const getRoot = () => {
   if (process.env.OCLIF_COMPILATION) {
     return ''
@@ -7,32 +9,32 @@ export const getRoot = () => {
 }
 
 export const userDir = getRoot()
-export const faststoreDir = `${userDir}/node_modules/@faststore`
+export const faststoreDir = path.join(userDir, 'node_modules', '@faststore')
 
 export const tmpFolderName = '.faststore'
-export const tmpDir = `${userDir}/${tmpFolderName}`
+export const tmpDir = path.join(userDir, tmpFolderName)
 
 export const coreFolderName = 'core'
-export const coreDir = `${faststoreDir}/${coreFolderName}`
+export const coreDir = path.join(faststoreDir, coreFolderName)
 
 export const srcFolderName = 'src'
-export const userSrcDir = `${userDir}/${srcFolderName}`
+export const userSrcDir = path.join(userDir, srcFolderName)
 
 export const customizationsFolderName = 'customizations'
-export const tmpCustomizationsDir = `${tmpDir}/src/${customizationsFolderName}`
+export const tmpCustomizationsDir = path.join(tmpDir, 'src', customizationsFolderName)
 
-export const userThemesFileDir = `${userSrcDir}/themes`
-export const tmpThemesCustomizationsFileDir = `${tmpCustomizationsDir}/themes/index.scss`
+export const userThemesFileDir = path.join(userSrcDir, 'themes')
+export const tmpThemesCustomizationsFileDir = path.join(tmpCustomizationsDir, 'themes', 'index.scss')
 
-export const cmsFolderName = 'cms/faststore'
-export const tmpCMSDir = `${tmpDir}/${cmsFolderName}`
-export const coreCMSDir = `${coreDir}/${cmsFolderName}`
-export const userCMSDir = `${userDir}/${cmsFolderName}`
+export const cmsFolderName = path.join('cms', 'faststore')
+export const tmpCMSDir = path.join(tmpDir, cmsFolderName)
+export const coreCMSDir = path.join(coreDir, cmsFolderName)
+export const userCMSDir = path.join(userDir, cmsFolderName)
 
 export const configFileName = 'faststore.config.js'
-export const userStoreConfigFileDir = `${userDir}/${configFileName}`
-export const coreStoreConfigFileDir = `${coreDir}/${configFileName}`
-export const tmpStoreConfigFileDir = `${tmpDir}/${configFileName}`
+export const userStoreConfigFileDir = path.join(userDir, configFileName)
+export const coreStoreConfigFileDir = path.join(coreDir, configFileName)
+export const tmpStoreConfigFileDir = path.join(tmpDir, configFileName)
 
-export const userNodeModulesDir = `${userDir}/node_modules`
-export const tmpNodeModulesDir = `${tmpDir}/node_modules`
+export const userNodeModulesDir = path.join(userDir, 'node_modules')
+export const tmpNodeModulesDir = path.join(tmpDir, 'node_modules')

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -11,6 +11,8 @@ import {
   writeFileSync,
 } from 'fs-extra'
 
+import path from 'path'
+
 import {
   configFileName,
   coreCMSDir,
@@ -60,7 +62,7 @@ function copyCoreFiles() {
   try {
     copySync(coreDir, tmpDir, {
       filter(src) {
-        const fileOrDirName = src.split('/').pop()
+        const fileOrDirName = path.basename(src)
         const shouldCopy = fileOrDirName
           ? !ignorePaths.includes(fileOrDirName)
           : true
@@ -88,7 +90,7 @@ function copyUserSrcToCustomizations() {
 async function copyTheme() {
   const storeConfig = await import(userStoreConfigFileDir)
   if (storeConfig.theme) {
-    const customTheme = `${userThemesFileDir}/${storeConfig.theme}.scss`
+    const customTheme = path.join(userThemesFileDir, `${storeConfig.theme}.scss`)
     if (existsSync(customTheme)) {
       try {
         copyFileSync(customTheme, tmpThemesCustomizationsFileDir)
@@ -124,8 +126,8 @@ async function copyTheme() {
 }
 
 function mergeCMSFile(fileName: string) {
-  const customFilePath = `${userCMSDir}/${fileName}`
-  const coreFilePath = `${coreCMSDir}/${fileName}`
+  const customFilePath = path.join(userCMSDir, fileName)
+  const coreFilePath = path.join(coreCMSDir, fileName)
 
   const coreFile = readFileSync(coreFilePath, 'utf8')
   const output = [...JSON.parse(coreFile)]
@@ -151,7 +153,7 @@ function mergeCMSFile(fileName: string) {
 
   try {
     writeFileSync(
-      `${tmpCMSDir}/${fileName}`,
+      path.join(tmpCMSDir, fileName),
       JSON.stringify(output)
     )
     console.log(

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -1,6 +1,5 @@
 // @ts-check
 const storeConfig = require('./faststore.config')
-const path = require('path')
 
 /**
  * @type {import('next').NextConfig}
@@ -36,9 +35,6 @@ const nextConfig = {
     }
 
     return config
-  },
-  sassOptions: {
-    includePaths: [path.join(__dirname, 'node_modules')],
   },
 }
 

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -1,5 +1,6 @@
 // @ts-check
 const storeConfig = require('./faststore.config')
+const path = require('path')
 
 /**
  * @type {import('next').NextConfig}
@@ -35,6 +36,9 @@ const nextConfig = {
     }
 
     return config
+  },
+  sassOptions: {
+    includePaths: [path.join(__dirname, 'node_modules')],
   },
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

To ensure that our starter works on Windows computers.

## How it works?

I've had to do two different things. One was to use the `path` library to manipulate filenames and paths, instead of directly using `/`. The other was to explicitly add the node_modules to the SASS load path, so our library can use 

## How to test it?

Find a windows machine, fork the starter, use this PR's version of faststore/core and faststore/cli and run it. It should work just fine.

```package.json
"@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/c66c0743/@faststore/core",
....
"@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/c66c0743/@faststore/cli",
```

You can use the starter PR and test de scripts locally as mentioned in starter PR.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/56

## References

NA
