### PR TITLE
Fix/UI improvements buttons img

### DIFF
--- a/packages/core/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/packages/core/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -35,7 +35,7 @@ const ImageGallery = ({ images, ...otherProps }: ImageGalleryProps) => {
         <Image
           src={currentImage.url}
           alt={currentImage.alternateName}
-          sizes="(max-width: 768px) 25vw, 30vw"
+          sizes="(max-width: 360px) 50vw, (max-width: 768px) 90vw, 50vw"
           width={691}
           height={691 * (3 / 4)}
           loading="eager"

--- a/packages/ui/src/components/molecules/Carousel/styles.scss
+++ b/packages/ui/src/components/molecules/Carousel/styles.scss
@@ -68,10 +68,6 @@
           border-radius: var(--fs-carousel-controls-border-radius);
           box-shadow: var(--fs-carousel-controls-box-shadow);
           transform: translateY(-50%);
-
-          &:hover [data-fs-button-wrapper] {
-            background-color: transparent;
-          }
         }
 
         [data-fs-carousel-control="left"] {

--- a/packages/ui/src/components/molecules/Carousel/styles.scss
+++ b/packages/ui/src/components/molecules/Carousel/styles.scss
@@ -68,6 +68,10 @@
           border-radius: var(--fs-carousel-controls-border-radius);
           box-shadow: var(--fs-carousel-controls-box-shadow);
           transform: translateY(-50%);
+
+          &:hover [data-fs-button-wrapper] {
+            background-color: transparent;
+          }
         }
 
         [data-fs-carousel-control="left"] {

--- a/packages/ui/src/components/organisms/ImageGallery/styles.scss
+++ b/packages/ui/src/components/organisms/ImageGallery/styles.scss
@@ -199,9 +199,10 @@
       box-shadow: var(--fs-image-gallery-selector-control-shadow);
     }
 
-    &:hover [data-fs-button-wrapper] { box-shadow: var(--fs-image-gallery-selector-control-shadow); }
-
-    &:hover { box-shadow: var(--fs-image-gallery-selector-control-shadow); }
+    &:hover [data-fs-button-wrapper] { 
+      background-color: var(--fs-image-gallery-selector-control-bkg-color);
+      box-shadow: var(--fs-image-gallery-selector-control-shadow); 
+    }
 
     @include media(">=notebook") {
       transform: rotate(90deg);

--- a/packages/ui/src/components/organisms/ImageGallery/styles.scss
+++ b/packages/ui/src/components/organisms/ImageGallery/styles.scss
@@ -199,10 +199,7 @@
       box-shadow: var(--fs-image-gallery-selector-control-shadow);
     }
 
-    &:hover [data-fs-button-wrapper] { 
-      background-color: var(--fs-image-gallery-selector-control-bkg-color);
-      box-shadow: var(--fs-image-gallery-selector-control-shadow); 
-    }
+    &:hover [data-fs-button-wrapper] { box-shadow: var(--fs-image-gallery-selector-control-shadow); }
 
     @include media(">=notebook") {
       transform: rotate(90deg);

--- a/packages/ui/src/components/organisms/Newsletter/styles.scss
+++ b/packages/ui/src/components/organisms/Newsletter/styles.scss
@@ -92,6 +92,7 @@
     margin-top: var(--fs-spacing-4);
 
     [data-fs-button-inverse] {
+      width: 100%;
       margin-top: var(--fs-spacing-3);
     }
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

Some adjustments were left behind in rebase between branches. This PR aims to quick fix it but we need to refine yet.

- Tweaks UI controls button from ImageGallery.
- <strike>Tweaks UI controls button from Carousel.</strike> Will be done in another PR (@renatamottam )
- Improves PDP Image quality.
- Tweaks Newsletter subscribe button.

||Before|After|
|-|-|-|
||<img width="381" alt="Screenshot 2023-05-10 at 21 42 10" src="https://github.com/vtex/faststore/assets/11325562/1a24b1f2-293e-43c3-ba87-a95dc055cce5">|<img width="255" alt="Screenshot 2023-05-10 at 21 45 41" src="https://github.com/vtex/faststore/assets/11325562/c9b4fc35-e0bc-432b-a763-3c43dc007670">|
||<img width="257" alt="Screenshot 2023-05-10 at 21 42 36" src="https://github.com/vtex/faststore/assets/11325562/43eae7db-0c82-4695-8088-5475a26c9060">|<img width="237" alt="Screenshot 2023-05-10 at 21 46 38" src="https://github.com/vtex/faststore/assets/11325562/4caf08b2-11f2-48a1-a60b-6e7e5386f4d8">|
||<img width="490" alt="Screenshot 2023-05-10 at 21 43 02" src="https://github.com/vtex/faststore/assets/11325562/3e24a7b9-729d-4c54-872c-7afa06498f63">|<img width="453" alt="Screenshot 2023-05-10 at 21 48 34" src="https://github.com/vtex/faststore/assets/11325562/ee36a582-512a-49f5-bc6d-a14196e3438c">|
|PDP Image quality|<img width="480" alt="Screenshot 2023-05-10 at 21 43 42" src="https://github.com/vtex/faststore/assets/11325562/2eba8a33-1781-4616-9770-0abbc495291a">|<img width="467" alt="Screenshot 2023-05-10 at 21 47 30" src="https://github.com/vtex/faststore/assets/11325562/ea41f635-976d-46ef-81d8-ffc187bb4c4d">|


## How to test it?

- run `yarn dev` locally in faststore/core package.
