### PR TITLE
fix: removes global alert content type and page + fix core build.

### DIFF
--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -1,10 +1,5 @@
 [
   {
-    "id": "globalAlert",
-    "name": "Global Alert Page",
-    "configurationSchemaSets": []
-  },
-  {
     "id": "globalSections",
     "name": "Global Sections",
     "configurationSchemaSets": [],

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -42,15 +42,16 @@ function Page({ page: { sections, settings }, globalSections }: Props) {
     <GlobalSections {...globalSections}>
       {/* SEO */}
       <NextSeo
-        title={settings.seo.title}
-        description={settings.seo.description}
-        titleTemplate={storeConfig.seo.titleTemplate}
-        canonical={settings.seo.canonical ?? storeConfig.storeUrl}
+        title={settings?.seo?.title ?? storeConfig.seo.title}
+        description={settings?.seo?.description ?? storeConfig.seo?.description}
+        titleTemplate={storeConfig.seo?.titleTemplate ?? storeConfig.seo?.title}
+        canonical={settings?.seo?.canonical ?? storeConfig.storeUrl}
         openGraph={{
           type: 'website',
           url: storeConfig.storeUrl,
-          title: settings.seo.title,
-          description: settings.seo.description,
+          title: settings?.seo?.title ?? storeConfig.seo.title,
+          description:
+            settings?.seo?.description ?? storeConfig.seo.description,
         }}
       />
       <SiteLinksSearchBoxJsonLd


### PR DESCRIPTION
## What's the purpose of this pull request?

- [x] removes global alert content type.
- [x] fix the build adding optional chain and default values for SEO from `faststore.config` .

remember to CMS sync after this PR is merged

|Before|After|
|-|-|
|<img width="1028" alt="Screenshot 2023-05-12 at 12 32 01" src="https://github.com/vtex/faststore/assets/11325562/b3eb278f-948e-4b43-8a8d-97b73fc9c438">|<img width="1027" alt="Screenshot 2023-05-12 at 12 32 11" src="https://github.com/vtex/faststore/assets/11325562/21285b72-2f69-4317-baf9-8696d61d410b">|

## How it works?

We are not using this content type anymore. Now we use the Global Sections.

## How to test it?

create a new workspace, run CMS sync and check the pages in admin, Global Alert should be gone.
