### PR TITLE
transform null in expected empty array

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -19,6 +19,8 @@ import { getCookie } from '../../utils/getCookies'
 import type { SalesChannel } from './types/SalesChannel'
 import { MasterDataResponse } from './types/Newsletter'
 import type { Address, AddressInput } from './types/Address'
+import { ShippingDataBody } from './types/ShippingData'
+
 
 type ValueOf<T> = T extends Record<string, infer K> ? K : never
 
@@ -94,10 +96,10 @@ export const VtexCommerce = (
         body,
       }: {
         id: string
-        body: any
+        body: ShippingDataBody
       }): Promise<OrderForm> => {
         if (body.selectedAddresses) {
-          body.selectedAddresses.forEach((address: { geoCoordinates: never[] | null }) => {
+          body.selectedAddresses.forEach((address) => {
             if (address.geoCoordinates === null) {
               address.geoCoordinates = [];
             }

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -94,8 +94,15 @@ export const VtexCommerce = (
         body,
       }: {
         id: string
-        body: unknown
+        body: any
       }): Promise<OrderForm> => {
+        if (body.selectedAddresses) {
+          body.selectedAddresses.forEach((address: { geoCoordinates: never[] | null }) => {
+            if (address.geoCoordinates === null) {
+              address.geoCoordinates = [];
+            }
+          });
+        }
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm/${id}/attachments/shippingData`,
           {
@@ -188,9 +195,9 @@ export const VtexCommerce = (
         postalCode
           ? params.append('postalCode', postalCode)
           : params.append(
-              'geoCoordinates',
-              `${geoCoordinates?.longitude};${geoCoordinates?.latitude}`
-            )
+            'geoCoordinates',
+            `${geoCoordinates?.longitude};${geoCoordinates?.latitude}`
+          )
 
         const url = `${base}/api/checkout/pub/regions/?${params.toString()}`
         return fetchAPI(url)

--- a/packages/api/src/platforms/vtex/clients/commerce/types/ShippingData.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/ShippingData.ts
@@ -1,0 +1,31 @@
+export interface ShippingDataBody {
+    clearAddressIfPostalCodeNotFound?: boolean;
+    selectedAddresses?: SelectedAddress[];
+    logisticsInfo?: LogisticsInfo[];
+}
+
+export interface SelectedAddress {
+    addressType?: string;
+    receiverName?: string;
+    postalCode?: string | null;
+    city?: string;
+    state?: string;
+    country?: string;
+    street?: string;
+    number?: string;
+    neighborhood?: string;
+    complement?: string;
+    reference?: string;
+    geoCoordinates?: GeoCoordinates | null | [];
+}
+
+export interface GeoCoordinates {
+    latitude: GLfloat;
+    longitude: GLfloat;
+}
+
+export interface LogisticsInfo {
+    itemIndex?: number;
+    selectedDeliveryChannel?: string;
+    selectedSla?: string;
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the shipping data request when the geoCoordinate is null

<img width="1071" alt="image" src="https://github.com/vtex/faststore/assets/67066494/03e90ccc-eb03-4063-a694-79d6275ce5e3">

Checkout awaits an empty array so for the address used if there is no geoCoordinate we transform it into an empty array.
https://developers.vtex.com/docs/api-reference/checkout-api#post-/api/checkout/pub/orderForm/-orderFormId-/attachments/shippingData

## How it works?

Validation to use the checkout correct format.

<img width="1071" alt="image" src="https://github.com/vtex/faststore/assets/67066494/c533e1a6-3f77-408b-951b-cd4fbdd9eecb">


## How to test it?

You can run locally this version and use the modal component at check it works
Do the same process in master and see it breaks the shipping attachment at the Order Form.


