### PR TITLE
feat: Adjust `ProductShelf` for CMS

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -1,4 +1,5 @@
 export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
@@ -180,7 +181,7 @@ export type IStoreOrder = {
   /** ID of the order in [VTEX order management](https://help.vtex.com/en/tutorial/license-manager-resources-oms--60QcBsvWeum02cFi3GjBzg#). */
   orderNumber: Scalars['String'];
   /** Indicates whether or not items with attachments should be split. */
-  shouldSplitItem?: Maybe<Scalars['Boolean']>;
+  shouldSplitItem?: InputMaybe<Scalars['Boolean']>;
 };
 
 /** Organization input. */
@@ -204,7 +205,7 @@ export type IStorePerson = {
 /** Product input. Products are variants within product groups, equivalent to VTEX [SKUs](https://help.vtex.com/en/tutorial/what-is-an-sku--1K75s4RXAQyOuGUYKMM68u#). For example, you may have a **Shirt** product group with associated products such as **Blue shirt size L**, **Green shirt size XL** and so on. */
 export type IStoreProduct = {
   /** Custom Product Additional Properties. */
-  additionalProperty?: Maybe<Array<IStorePropertyValue>>;
+  additionalProperty?: InputMaybe<Array<IStorePropertyValue>>;
   /** Array of product images. */
   image: Array<IStoreImage>;
   /** Product name. */
@@ -217,7 +218,7 @@ export type IStorePropertyValue = {
   /** Property name. */
   name: Scalars['String'];
   /** Property id. This propert changes according to the content of the object. */
-  propertyID?: Maybe<Scalars['String']>;
+  propertyID?: InputMaybe<Scalars['String']>;
   /** Property value. May hold a string or the string representation of an object. */
   value: Scalars['ObjectOrString'];
   /** Specifies the nature of the value */
@@ -235,19 +236,19 @@ export type IStoreSelectedFacet = {
 /** Session input. */
 export type IStoreSession = {
   /** Session input channel. */
-  channel?: Maybe<Scalars['String']>;
+  channel?: InputMaybe<Scalars['String']>;
   /** Session input country. */
   country: Scalars['String'];
   /** Session input currency. */
   currency: IStoreCurrency;
   /** Session input geoCoordinates. */
-  geoCoordinates?: Maybe<IStoreGeoCoordinates>;
+  geoCoordinates?: InputMaybe<IStoreGeoCoordinates>;
   /** Session input locale. */
   locale: Scalars['String'];
   /** Session input person. */
-  person?: Maybe<IStorePerson>;
+  person?: InputMaybe<IStorePerson>;
   /** Session input postal code. */
-  postalCode?: Maybe<Scalars['String']>;
+  postalCode?: InputMaybe<Scalars['String']>;
 };
 
 export type LogisticsInfo = {
@@ -332,7 +333,7 @@ export type MutationSubscribeToNewsletterArgs = {
 
 export type MutationValidateCartArgs = {
   cart: IStoreCart;
-  session?: Maybe<IStoreSession>;
+  session?: InputMaybe<IStoreSession>;
 };
 
 
@@ -410,13 +411,13 @@ export type Query = {
 
 
 export type QueryAllCollectionsArgs = {
-  after?: Maybe<Scalars['String']>;
+  after?: InputMaybe<Scalars['String']>;
   first: Scalars['Int'];
 };
 
 
 export type QueryAllProductsArgs = {
-  after?: Maybe<Scalars['String']>;
+  after?: InputMaybe<Scalars['String']>;
   first: Scalars['Int'];
 };
 
@@ -432,11 +433,11 @@ export type QueryProductArgs = {
 
 
 export type QuerySearchArgs = {
-  after?: Maybe<Scalars['String']>;
+  after?: InputMaybe<Scalars['String']>;
   first: Scalars['Int'];
-  selectedFacets?: Maybe<Array<IStoreSelectedFacet>>;
-  sort?: Maybe<StoreSort>;
-  term?: Maybe<Scalars['String']>;
+  selectedFacets?: InputMaybe<Array<IStoreSelectedFacet>>;
+  sort?: InputMaybe<StoreSort>;
+  term?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -528,12 +529,12 @@ export type SkuVariants = {
 
 
 export type SkuVariantsAvailableVariationsArgs = {
-  dominantVariantName?: Maybe<Scalars['String']>;
+  dominantVariantName?: InputMaybe<Scalars['String']>;
 };
 
 
 export type SkuVariantsSlugsMapArgs = {
-  dominantVariantName?: Maybe<Scalars['String']>;
+  dominantVariantName?: InputMaybe<Scalars['String']>;
 };
 
 /** Aggregate offer information, for a given SKU that is available to be fulfilled by multiple sellers. */

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -878,6 +878,11 @@
               "title": "Show discount badge?",
               "type": "boolean",
               "default": true
+            },
+            "bordered": {
+              "title": "Cards should be bordered?",
+              "type": "boolean",
+              "default": true
             }
           }
         }

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -878,16 +878,6 @@
               "title": "Show discount badge?",
               "type": "boolean",
               "default": true
-            },
-            "showBuyButton": {
-              "title": "Show buy button?",
-              "type": "boolean",
-              "default": true
-            },
-            "buyButtonTitle": {
-              "title": "Buy Button Text",
-              "type": "string",
-              "default": "Buy"
             }
           }
         }

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -834,8 +834,8 @@
           ],
           "enumNames": [
             "Discount: higher to lower",
-            "Name: Z-A",
             "Name: A-Z",
+            "Name: Z-A",
             "Orders: higher to lower",
             "Price: lower to higher",
             "Price: higher to lower",

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -27,41 +27,19 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
   ...CUSTOM_COMPONENTS,
 }
 
-const useDividedSections = (sections: Section[]) => {
-  return useMemo(() => {
-    const indexChildren = sections.findIndex(({ name }) => name === 'Children')
-    const hasChildren = indexChildren > -1
-
-    return {
-      hasChildren,
-      firstSections: hasChildren ? sections.slice(0, indexChildren) : sections,
-      ...(hasChildren && { lastSections: sections.slice(indexChildren + 1) }),
-    }
-  }, [sections])
-}
-
 function GlobalSections({
   children,
-  sections,
+  ...otherProps
 }: PropsWithChildren<GlobalSectionsData>) {
-  const { hasChildren, firstSections, lastSections } =
-    useDividedSections(sections)
-
   return (
-    <>
-      <RenderSections sections={firstSections} components={COMPONENTS} />
-
+    <RenderSections components={COMPONENTS} {...otherProps}>
       <Toast />
 
       <main>
         <RegionBar className="display-mobile" />
         {children}
       </main>
-
-      {hasChildren && (
-        <RenderSections sections={lastSections} components={COMPONENTS} />
-      )}
-    </>
+    </RenderSections>
   )
 }
 

--- a/packages/core/src/components/sections/CrossSellingShelf/CrossSellingShelf.tsx
+++ b/packages/core/src/components/sections/CrossSellingShelf/CrossSellingShelf.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react'
 
 import type { ProductDetailsFragment_ProductFragment } from '@generated/graphql'
-
-import ProductShelf from '../ProductShelf'
+import UIProductShelf from 'src/components/ui/ProductShelf'
+import { useInView } from 'react-intersection-observer'
+import styles from '../ProductShelf/section.module.scss'
+import Section from '../Section'
 
 interface Props {
   items: number
@@ -12,13 +14,25 @@ interface Props {
 }
 
 const CrossSellingShelf = ({ items, title, context, kind }: Props) => {
+  const { ref, inView } = useInView()
+
   const selectedFacets = useMemo(
     () => [{ key: kind, value: context.isVariantOf.productGroupID }],
     [kind, context.isVariantOf.productGroupID]
   )
 
   return (
-    <ProductShelf first={items} title={title} selectedFacets={selectedFacets} />
+    <Section
+      className={`${styles.section} section-product-shelf layout__section`}
+      ref={ref}
+    >
+      <UIProductShelf
+        inView={inView}
+        first={items}
+        title={title}
+        selectedFacets={selectedFacets}
+      />
+    </Section>
   )
 }
 

--- a/packages/core/src/components/sections/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/sections/ProductShelf/ProductShelf.tsx
@@ -2,11 +2,11 @@ import { useInView } from 'react-intersection-observer'
 import Section from '../Section'
 
 import styles from './section.module.scss'
-import UIProductShelf, {
-  ProductShelfProps,
-} from 'src/components/ui/ProductShelf'
+import ProductShelf, { ProductShelfProps } from 'src/components/ui/ProductShelf'
 
-function ProductShelf({ ...otherProps }: Omit<ProductShelfProps, 'inView'>) {
+function ProductShelfSection({
+  ...otherProps
+}: Omit<ProductShelfProps, 'inView'>) {
   const { ref, inView } = useInView()
 
   return (
@@ -14,9 +14,9 @@ function ProductShelf({ ...otherProps }: Omit<ProductShelfProps, 'inView'>) {
       className={`${styles.section} section-product-shelf layout__section`}
       ref={ref}
     >
-      <UIProductShelf inView={inView} {...otherProps} />
+      <ProductShelf inView={inView} {...otherProps} />
     </Section>
   )
 }
 
-export default ProductShelf
+export default ProductShelfSection

--- a/packages/core/src/components/sections/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/sections/ProductShelf/ProductShelf.tsx
@@ -1,89 +1,20 @@
-import { useEffect, useId, useRef } from 'react'
 import { useInView } from 'react-intersection-observer'
-
-import { ProductShelf as UIProductShelf } from '@faststore/ui'
-
-import type { ProductsQueryQueryVariables } from '@generated/graphql'
-import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
-import { useViewItemListEvent } from 'src/sdk/analytics/hooks/useViewItemListEvent'
-import { useProductsQuery } from 'src/sdk/product/useProductsQuery'
-import { textToKebabCase } from 'src/utils/utilities'
-
-import Carousel from '../../ui/Carousel'
 import Section from '../Section'
-import { Components } from './Overrides'
-const { ProductCard } = Components
 
 import styles from './section.module.scss'
+import UIProductShelf, {
+  ProductShelfProps,
+} from 'src/components/ui/ProductShelf'
 
-interface ProductShelfProps extends Partial<ProductsQueryQueryVariables> {
-  title: string
-  withDivisor?: boolean
-}
-
-function ProductShelf({
-  title,
-  withDivisor = false,
-  ...variables
-}: ProductShelfProps) {
-  const titleId = textToKebabCase(title)
-  const id = useId()
-  const viewedOnce = useRef(false)
+function ProductShelf({ ...otherProps }: Omit<ProductShelfProps, 'inView'>) {
   const { ref, inView } = useInView()
-  const products = useProductsQuery(variables)
-  const productEdges = products?.edges ?? []
-  const aspectRatio = 1
-
-  const { sendViewItemListEvent } = useViewItemListEvent({
-    products: productEdges,
-    title,
-    page: 0,
-    pageSize: 0,
-  })
-
-  useEffect(() => {
-    if (inView && !viewedOnce.current && productEdges.length) {
-      sendViewItemListEvent()
-
-      viewedOnce.current = true
-    }
-  }, [inView, productEdges.length, sendViewItemListEvent])
-
-  if (products?.edges.length === 0) {
-    return null
-  }
 
   return (
     <Section
-      className={`${styles.section} section-product-shelf layout__section ${
-        withDivisor ? 'section__divisor' : ''
-      }`}
+      className={`${styles.section} section-product-shelf layout__section`}
       ref={ref}
     >
-      <h2 className="text__title-section layout__content">{title}</h2>
-      <ProductShelfSkeleton
-        aspectRatio={aspectRatio}
-        loading={products === undefined}
-      >
-        <UIProductShelf>
-          <Carousel id={titleId || id}>
-            {productEdges.map((product, idx) => (
-              <ProductCard
-                bordered
-                key={`${product.node.id}`}
-                product={product.node}
-                index={idx + 1}
-                aspectRatio={aspectRatio}
-                imgProps={{
-                  width: 216,
-                  height: 216,
-                  sizes: '(max-width: 768px) 42vw, 30vw',
-                }}
-              />
-            ))}
-          </Carousel>
-        </UIProductShelf>
-      </ProductShelfSkeleton>
+      <UIProductShelf inView={inView} {...otherProps} />
     </Section>
   )
 }

--- a/packages/core/src/components/sections/Section/section.scss
+++ b/packages/core/src/components/sections/Section/section.scss
@@ -7,10 +7,3 @@
     margin-bottom: var(--fs-spacing-3);
   }
 }
-
-.section__divisor {
-  padding-top: var(--fs-spacing-5);
-  border-top: var(--fs-border-width) solid var(--fs-border-color-light);
-
-  @include media(">=notebook") { padding-top: var(--fs-spacing-9); }
-}

--- a/packages/core/src/components/ui/ProductShelf/Overrides.tsx
+++ b/packages/core/src/components/ui/ProductShelf/Overrides.tsx
@@ -3,8 +3,8 @@ import ProductCard from 'src/components/product/ProductCard'
 import ProductShelfCustomizations from 'src/customizations/components/overrides/ProductShelf'
 
 const Components = {
-    ProductCard,
-    ...ProductShelfCustomizations.components
+  ProductCard,
+  ...ProductShelfCustomizations.components,
 }
 
 export { Components }

--- a/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
@@ -9,9 +9,9 @@ import { textToKebabCase } from 'src/utils/utilities'
 
 import Carousel from '../../ui/Carousel'
 
-const { ProductCard } = Components
-
 import { Components } from 'src/components/ui/ProductShelf/Overrides'
+
+const { ProductCard } = Components
 
 type Sort =
   | 'discount_desc'

--- a/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
@@ -25,21 +25,27 @@ type Sort =
 
 export type ProductShelfProps = {
   title: string
-  first: number
-  after: string
-  sort: Sort
-  term: string
-  selectedFacets: {
+  first?: number
+  after?: string
+  sort?: Sort
+  term?: string
+  selectedFacets?: {
     key: string
     value: string
   }[]
-  productCardConfiguration: {
+  productCardConfiguration?: {
     showDiscountBadge: boolean
+    bordered: boolean
   }
   inView: boolean
 }
 
-function ProductShelf({ title, inView, ...variables }: ProductShelfProps) {
+function ProductShelf({
+  title,
+  inView,
+  productCardConfiguration,
+  ...variables
+}: ProductShelfProps) {
   const titleId = textToKebabCase(title)
   const id = useId()
   const viewedOnce = useRef(false)
@@ -77,7 +83,8 @@ function ProductShelf({ title, inView, ...variables }: ProductShelfProps) {
           <Carousel id={titleId || id}>
             {productEdges.map((product, idx) => (
               <ProductCard
-                bordered
+                bordered={productCardConfiguration?.bordered}
+                showDiscountBadge={productCardConfiguration?.showDiscountBadge}
                 key={`${product.node.id}`}
                 product={product.node}
                 index={idx + 1}

--- a/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useId, useRef } from 'react'
+
+import { ProductShelf as UIProductShelf } from '@faststore/ui'
+
+import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
+import { useViewItemListEvent } from 'src/sdk/analytics/hooks/useViewItemListEvent'
+import { useProductsQuery } from 'src/sdk/product/useProductsQuery'
+import { textToKebabCase } from 'src/utils/utilities'
+
+import Carousel from '../../ui/Carousel'
+
+const { ProductCard } = Components
+
+import { Components } from 'src/components/ui/ProductShelf/Overrides'
+
+type Sort =
+  | 'discount_desc'
+  | 'name_asc'
+  | 'name_desc'
+  | 'orders_desc'
+  | 'price_asc'
+  | 'price_desc'
+  | 'release_desc'
+  | 'score_desc'
+
+export type ProductShelfProps = {
+  title: string
+  first: number
+  after: string
+  sort: Sort
+  term: string
+  selectedFacets: {
+    key: string
+    value: string
+  }[]
+  productCardConfiguration: {
+    showDiscountBadge: boolean
+  }
+  inView: boolean
+}
+
+function ProductShelf({ title, inView, ...variables }: ProductShelfProps) {
+  const titleId = textToKebabCase(title)
+  const id = useId()
+  const viewedOnce = useRef(false)
+  const products = useProductsQuery(variables)
+  const productEdges = products?.edges ?? []
+  const aspectRatio = 1
+
+  const { sendViewItemListEvent } = useViewItemListEvent({
+    products: productEdges,
+    title,
+    page: 0,
+    pageSize: 0,
+  })
+
+  useEffect(() => {
+    if (inView && !viewedOnce.current && productEdges.length) {
+      sendViewItemListEvent()
+
+      viewedOnce.current = true
+    }
+  }, [inView, productEdges.length, sendViewItemListEvent])
+
+  if (products?.edges.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      <h2 className="text__title-section layout__content">{title}</h2>
+      <ProductShelfSkeleton
+        aspectRatio={aspectRatio}
+        loading={products === undefined}
+      >
+        <UIProductShelf>
+          <Carousel id={titleId || id}>
+            {productEdges.map((product, idx) => (
+              <ProductCard
+                bordered
+                key={`${product.node.id}`}
+                product={product.node}
+                index={idx + 1}
+                aspectRatio={aspectRatio}
+                imgProps={{
+                  width: 216,
+                  height: 216,
+                  sizes: '(max-width: 768px) 42vw, 30vw',
+                }}
+              />
+            ))}
+          </Carousel>
+        </UIProductShelf>
+      </ProductShelfSkeleton>
+    </>
+  )
+}
+
+export default ProductShelf

--- a/packages/core/src/components/ui/ProductShelf/index.ts
+++ b/packages/core/src/components/ui/ProductShelf/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ProductShelf'
+export type { ProductShelfProps } from './ProductShelf'

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -147,7 +147,6 @@ function Page({
           first={ITEMS_PER_SECTION}
           sort="score_desc"
           title="You might also like"
-          withDivisor
         />
 
         <ScrollToTopButton />

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -49,6 +49,7 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
   Breadcrumb,
   Hero,
   ProductGallery,
+  ProductShelf,
   ...CUSTOM_COMPONENTS,
 }
 
@@ -141,12 +142,6 @@ function Page({
           context={collection}
           sections={sections}
           components={COMPONENTS}
-        />
-
-        <ProductShelf
-          first={ITEMS_PER_SECTION}
-          sort="score_desc"
-          title="You might also like"
         />
 
         <ScrollToTopButton />

--- a/packages/ui/src/components/molecules/Carousel/styles.scss
+++ b/packages/ui/src/components/molecules/Carousel/styles.scss
@@ -5,7 +5,7 @@
 
   // Track
   --fs-carousel-padding-mobile             : 0 var(--fs-grid-padding);
-  --fs-carousel-padding-desktop            : 0 calc((100vw - 1230px)/2);
+  --fs-carousel-padding-desktop            : 0 calc((100vw - 1230px)/2) var(--fs-spacing-0);
 
   // Item
   --fs-carousel-item-width-mobile          : 60%;


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to adjust the `ProductShelf` and the related components to support incoming data from CMS.

### How to test it?

- Build the store locally (`yarn workspace @faststore/core dev`);
- Access http://localhost:3000/api/preview?contentType=page&documentId=bd9e01c6-534e-4e54-aa76-f864dcbad024&versionId=dfa86048-f354-11ed-83ab-122449db511d


CMS: https://arthurspace--storeframework.myvtex.com/admin/new-cms/faststore/page/edit/bd9e01c6-534e-4e54-aa76-f864dcbad024/