### PR TITLE
Feat: Hero from CMS in PLP

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -607,7 +607,7 @@
       "title": "Hero",
       "description": "Add a quick promotion with an image/action pair",
       "type": "object",
-      "required": ["title", "link"],
+      "required": ["title"],
       "properties": {
         "title": {
           "title": "Title",

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -46,6 +46,7 @@ type Props = ServerCollectionPageQueryQuery &
  * Do not import or render components from any other folder in here.
  */
 const COMPONENTS: Record<string, ComponentType<any>> = {
+  Hero,
   Breadcrumb,
   ...CUSTOM_COMPONENTS,
 }
@@ -121,16 +122,6 @@ function Page({ sections, globalSections, ...otherProps }: Props) {
           context={collection}
           sections={sections}
           components={COMPONENTS}
-        />
-
-        <Hero
-          variant="secondary"
-          title={title}
-          subtitle={`All the amazing ${title} from the brands we partner with.`}
-          image={{
-            src: 'https://storeframework.vtexassets.com/arquivos/ids/190897/Photo.jpg',
-            alt: 'Quest 2 Controller on a table',
-          }}
         />
 
         <ProductGallery title={title} />


### PR DESCRIPTION
## What's the purpose of this pull request?

- [x] Remove static Hero from PLP and Render Hero from CMS.
- [x] Remove link as required from the Hero session in `sections.json ` 
- [ ] TODO: publish in main workspace after this got merged.

## How to test it?

1. You can test it running core package locally: `yarn dev`.
2. Add the Hero as a draft in PLP page some workspace (https://formspace--storeframework.myvtex.com/admin/new-cms/faststore/plp/edit/568e09a3-03cf-48ce-9a0c-363008ad8681/).
3. Click in the preview link (use the same content-type and versionId etc for localhost).
4. browse to a new PLP and see the changes without publish.

### Starters Deploy Preview
PR: https://github.com/vtex-sites/starter.store/pull/58
