### PR TITLE
Doc: Add Reference section

### DIFF
--- a/apps/site/pages/docs/_meta.json
+++ b/apps/site/pages/docs/_meta.json
@@ -34,5 +34,6 @@
     "type": "separator",
     "title": "How To Guides"
   },
-  "component-customization": "Component Customization"
+  "component-customization": "Component Customization",
+  "reference-guides": "Reference"
 }

--- a/apps/site/pages/docs/component-customization/override-component.mdx
+++ b/apps/site/pages/docs/component-customization/override-component.mdx
@@ -46,7 +46,7 @@ Also, take in to consideration the following:
 
 ### Step 1 - Choosing a Native Section
 
-1. Choose the native section to be customized from the [list of available native sections](./tbd-link).
+1. Choose the native section to be customized from the [list of available native sections](/docs/reference-guides/list-of-available-native-sections).
 2. In your store repository, navigate to `src/components/overrides` and create a new file named after the native section.
    For example, if you chose the `ProductDetails` section for customization, create a new file named `ProductDetails.tsx` under the `src/components/overrides` directory.
 
@@ -69,7 +69,7 @@ export default overrides
 
 ### Step 2 - Choosing a component to override
 
-1. Choose a component to override from the [list of overridable components for each native section](/tbd-link). In this example, we are overriding the `Price` component.
+1. Choose a component to override from the [list of overridable components for each native section](/docs/reference-guides/list-of-overridable-components-for-each-native-section). In this example, we are overriding the `Price` component.
 
 2. Add an object with the name of the component you wish to override to the `components` property inside the `overrides` object.
 

--- a/apps/site/pages/docs/component-customization/override-component.mdx
+++ b/apps/site/pages/docs/component-customization/override-component.mdx
@@ -20,8 +20,9 @@ For example, you might want to change the behavior of a Price component to meet 
 In this guide, you'll learn how to customize native section components by overriding them or adding extra props.
 
 
-**Overriding a component leads you to miss out on performance updates and bug fixes provided by VTEX for that component.** We highly recommend you to pass additional prop and using our theming tools to achieve the desired behavior
-without missing out on updates and bug fixes from VTEX. Check out the available props for each component on [Components UI](https://evergreen.faststore.dev/components).
+<Callout type="warning" emoji="⚠️">
+  By overriding a component, you lose all the integration developed on [@faststore/core](docs/getting-started/project-structure#faststorecore) for that component. **We strongly recommend that you pass additional props and use our [theming tools](/docs/customizing)** to achieve the desired behavior without compromising the existing integration implemented in @faststore/core. You can find the available props for each component on the [Components UI](https://evergreen.faststore.dev/components).
+</Callout>
 
 
 {/* {Image or gif of the expected behavior after completing the guide} */}

--- a/apps/site/pages/docs/component-customization/override-component.mdx
+++ b/apps/site/pages/docs/component-customization/override-component.mdx
@@ -21,7 +21,7 @@ In this guide, you'll learn how to customize native section components by overri
 
 
 <Callout type="warning" emoji="⚠️">
-  By overriding a component, you lose all the integration developed on [@faststore/core](docs/getting-started/project-structure#faststorecore) for that component. **We strongly recommend that you pass additional props and use our [theming tools](/docs/customizing)** to achieve the desired behavior without compromising the existing integration implemented in @faststore/core. You can find the available props for each component on the [Components UI](https://evergreen.faststore.dev/components).
+  **By overriding a component, you lose all the integration developed on [@faststore/core](docs/getting-started/project-structure#faststorecore) for that component.** *We strongly recommend that you pass additional props and use our [theming tools](/docs/customizing)* to achieve the desired behavior without compromising the existing integration implemented in `@faststore/core`. You can find the available props for each component on the [Components UI](https://evergreen.faststore.dev/components).
 </Callout>
 
 

--- a/apps/site/pages/docs/reference-guides/list-of-available-native-sections.mdx
+++ b/apps/site/pages/docs/reference-guides/list-of-available-native-sections.mdx
@@ -1,0 +1,16 @@
+---
+title: 'List of available native sections'
+sidebar_label: 'Reference'
+---
+
+import { Callout, Tab, Tabs } from 'nextra-theme-docs'
+
+<header>
+
+# List of available native sections
+
+</header>
+
+<Callout type="warning" emoji="⚠️">
+This documentation is currently under development.
+</Callout>

--- a/apps/site/pages/docs/reference-guides/list-of-overridable-components-for-each-native-section.mdx
+++ b/apps/site/pages/docs/reference-guides/list-of-overridable-components-for-each-native-section.mdx
@@ -1,0 +1,16 @@
+---
+title: 'List of overridable components for each native section'
+sidebar_label: 'Reference'
+---
+
+import { Callout, Tab, Tabs } from 'nextra-theme-docs'
+
+<header>
+
+# List of overridable components for each native section
+
+</header>
+
+<Callout type="warning" emoji="⚠️">
+This documentation is currently under development.
+</Callout>


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds the `Reference` section to the documentation

## How it works?

The Reference section will store docs such as:
- List of available natives sections
- List of overridable components for each native section
- Best Practices, like Debugging best practices
- etc

🔗 [Preview](https://faststore-site-git-reference-guides-faststore.vercel.app/docs/reference-guides/list-of-available-native-sections)
