### PR TITLE
Docs: Checkbox Field component props

### DIFF
--- a/apps/site/components/utilities/propsSection.ts
+++ b/apps/site/components/utilities/propsSection.ts
@@ -24,7 +24,7 @@ export function mapComponentFromMdxPath(
   }
 
   const atomicDesignType = dirs[0] // atoms, molecules, organisms
-  const componentNameWithoutExtension = dirs[1].split('.')[0] // e.g. accordion.mdx -> accordion
+  const componentNameWithoutExtension = dirs[1]?.split('.')[0] // e.g. accordion.mdx -> accordion
   const componentFolder = toPascalCase(componentNameWithoutExtension) // e.g. Accordion
 
   // e.g. <user-path>/faststore/node_modules/@faststore/components/src/molecules/Accordion/Accordion.tsx

--- a/apps/site/pages/components/molecules/checkbox-field.mdx
+++ b/apps/site/pages/components/molecules/checkbox-field.mdx
@@ -4,11 +4,39 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Checkbox___5dfb3d931c093ee7ebfac8bc388e68b5.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
-import { TokenTable, TokenRow } from 'site/components/Tokens'
+import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { CheckboxField } from '@faststore/ui'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+
+export const getStaticProps = () => {
+  const checkboxFieldPath = path.resolve(__filename)
+  const components = ['CheckboxField.tsx']
+  const [checkboxFieldProps] = getComponentPropsFrom(checkboxFieldPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        checkboxFieldProps
+      },
+    },
+  }
+}
+
+export const CheckboxFieldPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { checkboxFieldProps } = useSSG()
+  return {
+    CheckboxField: <PropsSection propsList={checkboxFieldProps} />
+  }[component]
+}
+
 
 <header>
 # Checkbox Field
@@ -85,7 +113,9 @@ import '@faststore/ui/src/components/molecules/CheckboxField/styles.scss'
 
 ## Props
 
-<PropsSection name="CheckboxField" />
+### Checkbox Field
+
+<CheckboxFieldPropsSection component="CheckboxField" />
 
 ---
 

--- a/packages/components/src/molecules/CheckboxField/CheckboxField.tsx
+++ b/packages/components/src/molecules/CheckboxField/CheckboxField.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 import Checkbox from '../../atoms/Checkbox'
 import Label from '../../atoms/Label'
 
-export type CheckboxFieldProps = {
+export interface CheckboxFieldProps {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */


### PR DESCRIPTION
## What's the purpose of this pull request?

- Adds Checkbox Field's component props

P.s.: In the `propsSection.ts` file I added `?` to try to prevent the error when `dirs[1]` is undefined. This way, if `dirs[1]` is undefined, `componentNameWithoutExtension` will also be undefined.

## How to test it?

- Check if the props list is appearing according. You can check through [preview](https://faststore-site-git-checkbox-field-docs-update-faststore.vercel.app/components/molecules/checkbox-field).

