### PR TITLE
docs: Fixes payment flags doc page

### DIFF
--- a/apps/site/pages/components/organisms/payment-methods.mdx
+++ b/apps/site/pages/components/organisms/payment-methods.mdx
@@ -79,20 +79,32 @@ import '@faststore/ui/src/components/organisms/PaymentMethods/styles.scss'
   </Tab>
   <Tab>
     ```tsx
+    export const flags = [
+      { icon: { icon: 'Visa' }, alt: 'Visa' },
+      { icon: { icon: 'Diners' }, alt: 'Diners Club' },
+      { icon: { icon: 'Mastercard' }, alt: 'Mastercard' },
+      { icon: { icon: 'EloCard' }, alt: 'Elo Card' },
+      { icon: { icon: 'PayPal' }, alt: 'PayPal' },
+      { icon: { icon: 'Stripe' }, alt: 'Stripe' },
+      { icon: { icon: 'GooglePay' }, alt: 'GooglePay' },
+      { icon: { icon: 'ApplePay' }, alt: 'ApplePay' },
+    ]
+
     <PaymentMethods title={<h3>Payment Methods</h3>} flagList={flags} />
     ```
+
   </Tab>
 </Tabs>
 
 export const flags = [
-  { image: <Icon name="Visa" />, text: 'Visa' },
-  { image: <Icon name="Diners" />, text: 'Diners Club' },
-  { image: <Icon name="Mastercard" />, text: 'Mastercard' },
-  { image: <Icon name="EloCard" />, text: 'Elo Card' },
-  { image: <Icon name="PayPal" />, text: 'PayPal' },
-  { image: <Icon name="Stripe" />, text: 'Stripe' },
-  { image: <Icon name="GooglePay" />, text: 'GooglePay' },
-  { image: <Icon name="ApplePay" />, text: 'ApplePay' },
+  { icon: { icon: 'Visa' }, alt: 'Visa' },
+  { icon: { icon: 'Diners' }, alt: 'Diners Club' },
+  { icon: { icon: 'Mastercard' }, alt: 'Mastercard' },
+  { icon: { icon: 'EloCard' }, alt: 'Elo Card' },
+  { icon: { icon: 'PayPal' }, alt: 'PayPal' },
+  { icon: { icon: 'Stripe' }, alt: 'Stripe' },
+  { icon: { icon: 'GooglePay' }, alt: 'GooglePay' },
+  { icon: { icon: 'ApplePay' }, alt: 'ApplePay' },
 ]
 
 ---
@@ -103,12 +115,12 @@ export const flags = [
 
 export const propsFlag = [
   {
-    name: 'image',
-    type: 'ReactNode',
-    description: 'A React component that will represent the flag image.',
+    name: 'icon',
+    type: '{ icon: string }',
+    description: 'An object with the icon name to display the flag image.',
   },
   {
-    name: 'text',
+    name: 'alt',
     type: 'string',
     description:
       'Description of the flag image to be also used for accessibility purposes.',


### PR DESCRIPTION
## What's the purpose of this pull request?

- Fixes the paymentMethod component [page](https://evergreen.faststore.dev/components/organisms/payment-methods) that is broken.

- Updates examples and types in the page


## How to test it?

You should be able to see the PaymentMethods [doc page](https://faststore-site-git-docs-fix-payment-methods-faststore.vercel.app/) and the props section should be updated.
