### PR TITLE
chore: removes required button props

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -661,7 +661,6 @@
         "link": {
           "title": "Call to Action",
           "type": "object",
-          "required": ["text", "url"],
           "properties": {
             "text": {
               "type": "string",


### PR DESCRIPTION
## What's the purpose of this pull request?

Removes required props from the Call to Action inside the Hero. Is not required for PLP pages.
