### PR TITLE
add props to component

### DIFF
--- a/apps/site/pages/components/atoms/input.mdx
+++ b/apps/site/pages/components/atoms/input.mdx
@@ -52,14 +52,14 @@ Inputs are fields used to get user inputs.
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
     <OverviewSection>
-      <InputField label="Label" id="inputfield-default" />
-      <InputField label="Input Disabled" id="inputfield-disabled" disabled />
+      <Input placeholder="Label" id="inputfield-default" />
+      <Input placeholder="Input Disabled" id="inputfield-disabled" disabled />
     </OverviewSection>
   </Tab>
   <Tab>
     ```tsx
-    <InputField label="Label" id="inputfield-default" />
-    <InputField label="Input Disabled" id="inputfield-disabled" disabled />
+     <Input placeholder="Label" id="inputfield-default" />
+     <Input placeholder="Input Disabled" id="inputfield-disabled" disabled />
     ```
   </Tab>
 </Tabs>

--- a/apps/site/pages/components/atoms/input.mdx
+++ b/apps/site/pages/components/atoms/input.mdx
@@ -4,12 +4,40 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Input___77d0e7a8079b7d310e8223dd9e1994f6.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { SectionItem, SectionList } from 'site/components/SectionItem'
 import { Input, InputField } from '@faststore/ui'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+
+export const getStaticProps = () => {
+  const inputPath = path.resolve(__filename)
+  const components = ['Input.tsx']
+  const [inputProps] = getComponentPropsFrom(inputPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        inputProps
+      },
+    },
+  }
+}
+
+export const InputPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { inputProps } = useSSG()
+  return {
+    Input: <PropsSection propsList={inputProps} />
+  }[component]
+}
+
 
 <header>
 
@@ -67,7 +95,7 @@ import '@faststore/ui/src/components/atoms/Input/styles.scss'
 
 ## Props
 
-<PropsSection name="Input" />
+<InputPropsSection component="Input" />
 
 ---
 

--- a/apps/site/pages/components/atoms/select.mdx
+++ b/apps/site/pages/components/atoms/select.mdx
@@ -8,12 +8,40 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Select___8842f3b6522c3e8db0a887b3f216a6ab.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { SectionItem, SectionList } from 'site/components/SectionItem'
 import { Select, SelectField } from '@faststore/ui'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+
+export const getStaticProps = () => {
+  const selectPath = path.resolve(__filename)
+  const components = ['Select.tsx']
+  const [selectProps] = getComponentPropsFrom(selectPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        selectProps
+      },
+    },
+  }
+}
+
+export const SelectPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { selectProps } = useSSG()
+  return {
+    Select: <PropsSection propsList={selectProps} />
+  }[component]
+}
+
 
 <header>
 
@@ -113,7 +141,7 @@ import '@faststore/ui/src/components/atoms/Select/styles.scss'
 
 ## Props
 
-<PropsSection name="Select" />
+<SelectPropsSection component="Select" />
 
 ---
 

--- a/apps/site/pages/components/molecules/alert.mdx
+++ b/apps/site/pages/components/molecules/alert.mdx
@@ -4,11 +4,39 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Alert___8853e3dae68a1a6a1c5d6a103b752ede.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
+import { SectionItem, SectionList } from 'site/components/SectionItem'
 import { Alert, Icon } from '@faststore/ui'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+
+export const getStaticProps = () => {
+  const alertPath = path.resolve(__filename)
+  const components = ['Alert.tsx']
+  const [alertProps] = getComponentPropsFrom(alertPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        alertProps
+      },
+    },
+  }
+}
+
+export const AlertPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { alertProps } = useSSG()
+  return {
+    Alert: <PropsSection propsList={alertProps} />
+  }[component]
+}
 
 <header>
 
@@ -112,7 +140,7 @@ import '@faststore/ui/src/components/atoms/Alert/styles.scss'
 
 ## Props
 
-<PropsSection name="BuyButton" />
+<AlertPropsSection component="Alert" />
 
 ---
 

--- a/apps/site/pages/components/molecules/breadcrumb.mdx
+++ b/apps/site/pages/components/molecules/breadcrumb.mdx
@@ -8,13 +8,39 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Breadcrumb___20a8572e919e1262c1405a5e80009e25.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { Breadcrumb } from '@faststore/ui'
-
 import { breadcrumbList } from '../../../mocks/breadcrumbList'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+
+export const getStaticProps = () => {
+  const breadcrumbPath = path.resolve(__filename)
+  const components = ['Breadcrumb.tsx']
+  const [breadcrumbProps] = getComponentPropsFrom(breadcrumbPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        breadcrumbProps
+      },
+    },
+  }
+}
+
+export const BreadcrumbPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { breadcrumbProps } = useSSG()
+  return {
+    Breadcrumb: <PropsSection propsList={breadcrumbProps} />
+  }[component]
+}
 
 <header>
 
@@ -104,7 +130,7 @@ import '@faststore/ui/src/components/molecules/Breadcrumb/styles.scss'
 
 ## Props
 
-<PropsSection name="Breadcrumb" />
+<BreadcrumbPropsSection component="Breadcrumb" />
 
 ---
 

--- a/apps/site/pages/components/molecules/breadcrumb.mdx
+++ b/apps/site/pages/components/molecules/breadcrumb.mdx
@@ -8,13 +8,39 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Breadcrumb___20a8572e919e1262c1405a5e80009e25.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { Breadcrumb } from '@faststore/ui'
-
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
 import { breadcrumbList } from '../../../mocks/breadcrumbList'
+
+export const getStaticProps = () => {
+  const breadcrumbPath = path.resolve(__filename)
+  const components = ['Breadcrumb.tsx']
+  const [breadcrumbProps] = getComponentPropsFrom(breadcrumbPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        breadcrumbProps
+      },
+    },
+  }
+}
+
+export const BreadcrumbPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { breadcrumbProps } = useSSG()
+  return {
+    Breadcrumb: <PropsSection propsList={breadcrumbProps} />
+  }[component]
+}
+
 
 <header>
 
@@ -104,7 +130,7 @@ import '@faststore/ui/src/components/molecules/Breadcrumb/styles.scss'
 
 ## Props
 
-<PropsSection name="Breadcrumb" />
+<BreadcrumbPropsSection component="Breadcrumb" />
 
 ---
 

--- a/apps/site/pages/components/molecules/breadcrumb.mdx
+++ b/apps/site/pages/components/molecules/breadcrumb.mdx
@@ -8,39 +8,13 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Breadcrumb___20a8572e919e1262c1405a5e80009e25.png
 ---
 
-import path from 'path'
-import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { Breadcrumb } from '@faststore/ui'
+
 import { breadcrumbList } from '../../../mocks/breadcrumbList'
-import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
-
-export const getStaticProps = () => {
-  const breadcrumbPath = path.resolve(__filename)
-  const components = ['Breadcrumb.tsx']
-  const [breadcrumbProps] = getComponentPropsFrom(breadcrumbPath, components)
-  return {
-    props: {
-      // We add an `ssg` field to the page props,
-      // which will be provided to the Nextra `useSSG` hook.
-      ssg: {
-        breadcrumbProps
-      },
-    },
-  }
-}
-
-export const BreadcrumbPropsSection = ({ component }) => {
-  // Get the data from SSG, and render it as a component.
-  const { breadcrumbProps } = useSSG()
-  return {
-    Breadcrumb: <PropsSection propsList={breadcrumbProps} />
-  }[component]
-}
-
 
 <header>
 
@@ -130,7 +104,7 @@ import '@faststore/ui/src/components/molecules/Breadcrumb/styles.scss'
 
 ## Props
 
-<BreadcrumbPropsSection component="Breadcrumb" />
+<PropsSection name="Breadcrumb" />
 
 ---
 

--- a/apps/site/pages/components/molecules/breadcrumb.mdx
+++ b/apps/site/pages/components/molecules/breadcrumb.mdx
@@ -15,8 +15,8 @@ import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { Breadcrumb } from '@faststore/ui'
-import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
 import { breadcrumbList } from '../../../mocks/breadcrumbList'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
 
 export const getStaticProps = () => {
   const breadcrumbPath = path.resolve(__filename)

--- a/apps/site/pages/components/molecules/buy-button.mdx
+++ b/apps/site/pages/components/molecules/buy-button.mdx
@@ -8,10 +8,39 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/Button___6d6b16886d5d7e2a05dba8c45c075796.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
 import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { BuyButton } from '@faststore/ui'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+
+export const getStaticProps = () => {
+  const buyButtonPath = path.resolve(__filename)
+  const components = ['BuyButton.tsx']
+  const [buyButtonProps] = getComponentPropsFrom(buyButtonPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        buyButtonProps
+      },
+    },
+  }
+}
+
+export const BuyButtonPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { buyButtonProps } = useSSG()
+  return {
+    BuyButton: <PropsSection propsList={buyButtonProps} />
+  }[component]
+}
+
 
 <header>
 
@@ -61,7 +90,7 @@ import '@faststore/ui/src/components/atoms/BuyButton/styles.scss'
 
 ## Props
 
-<PropsSection name="BuyButton" />
+<BuyButtonPropsSection component="BuyButton" />
 
 ---
 

--- a/apps/site/pages/components/molecules/icon-button.mdx
+++ b/apps/site/pages/components/molecules/icon-button.mdx
@@ -4,10 +4,37 @@ sidebar_custom_props:
   image: https://vtexhelp.vtexassets.com/assets/docs/src/IconButton___a815b0a38dda52d079b3f73784c92c6b.png
 ---
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
 import { Tab, Tabs } from 'nextra-theme-docs'
 import PropsSection from 'site/components/PropsSection'
+import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { IconButton, Icon } from '@faststore/ui'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const iconButtonPath = path.resolve(__filename)
+  const components = ['IconButton.tsx']
+  const [iconButtonProps] = getComponentPropsFrom(iconButtonPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        iconButtonProps
+      },
+    },
+  }
+}
+
+export const IconButtonPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { iconButtonProps } = useSSG()
+  return {
+    IconButton: <PropsSection propsList={iconButtonProps} />
+  }[component]
+}
 
 <header>
 
@@ -69,7 +96,7 @@ import '@faststore/ui/src/components/atoms/Button/styles.scss'
 
 ## Props
 
-<PropsSection name="IconButton" />
+<IconButtonPropsSection component="IconButton" />
 
 ---
 

--- a/packages/components/src/molecules/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/molecules/Breadcrumb/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import BreadcrumbBase, { BreadcrumbBaseProps } from './BreadcrumbBase'
 
-export interface BreadcrumbProps = Omit<BreadcrumbBaseProps, "isDesktop">
+export type BreadcrumbProps = Omit<BreadcrumbBaseProps, "isDesktop">
 
 
 const Breadcrumb = ({

--- a/packages/components/src/molecules/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/molecules/Breadcrumb/Breadcrumb.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
 import BreadcrumbBase, { BreadcrumbBaseProps } from './BreadcrumbBase'
 
-export interface BreadcrumbBaseProps extends Omit< BreadcrumbBaseProps, 'isDesktop'> { }
+export interface BreadcrumbProps
+  extends Omit<BreadcrumbBaseProps, 'isDesktop'> {}
 
-
-const Breadcrumb = ({
-  breadcrumbList,
-  ...otherProps
-}: BreadcrumbProps) => (
+const Breadcrumb = ({ breadcrumbList, ...otherProps }: BreadcrumbProps) => (
   <>
     <BreadcrumbBase breadcrumbList={breadcrumbList} {...otherProps} />
     <BreadcrumbBase breadcrumbList={breadcrumbList} isDesktop {...otherProps} />

--- a/packages/components/src/molecules/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/molecules/Breadcrumb/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import BreadcrumbBase, { BreadcrumbBaseProps } from './BreadcrumbBase'
 
-export interface BreadcrumbProps = Omit<BreadcrumbBaseProps, "isDesktop">
+export interface BreadcrumbBaseProps extends Omit< BreadcrumbBaseProps, 'isDesktop'> { }
 
 
 const Breadcrumb = ({

--- a/packages/components/src/molecules/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/molecules/Breadcrumb/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import BreadcrumbBase, { BreadcrumbBaseProps } from './BreadcrumbBase'
 
-export type BreadcrumbProps = Omit<BreadcrumbBaseProps, "isDesktop">
+export interface BreadcrumbProps = Omit<BreadcrumbBaseProps, "isDesktop">
 
 
 const Breadcrumb = ({

--- a/packages/components/src/molecules/Breadcrumb/BreadcrumbBase.tsx
+++ b/packages/components/src/molecules/Breadcrumb/BreadcrumbBase.tsx
@@ -31,7 +31,7 @@ type RenderLinkProps = {
   collapsed: boolean
 }
 
-export type BreadcrumbBaseProps = {
+export interface BreadcrumbBaseProps extends BreadcrumbPureProps {
   /**
    * Array of ItemElement that represents each breadcrumb item.
    */
@@ -58,7 +58,7 @@ export type BreadcrumbBaseProps = {
    * @returns Link to be rendered.
    */
   renderLink?: (renderLinkProps: RenderLinkProps) => ReactElement
-} & BreadcrumbPureProps
+}
 
 const BreadcrumbBase = forwardRef<HTMLDivElement, BreadcrumbBaseProps>(
   function BreadcrumbBase(

--- a/packages/components/src/molecules/Breadcrumb/BreadcrumbPure.tsx
+++ b/packages/components/src/molecules/Breadcrumb/BreadcrumbPure.tsx
@@ -1,59 +1,59 @@
-import React, { forwardRef } from "react"
-import List from "../../atoms/List"
 import type { HTMLAttributes, ReactNode } from 'react'
-import ListItem from "./ListItem"
+import React, { forwardRef } from 'react'
+import List from '../../atoms/List'
+import ListItem from './ListItem'
 
-export type BreadcrumbPureProps = {
-    /**
-     * A ReactNode that will be rendered as the Divider icon.
-     */
-    divider?: ReactNode
-    /**
-     * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
-     */
-    testId?: string
-} & HTMLAttributes<HTMLDivElement> 
+export interface BreadcrumbPureProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * A ReactNode that will be rendered as the Divider icon.
+   */
+  divider?: ReactNode
+  /**
+   * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
+   */
+  testId?: string
+}
 
 const BreadcrumbPure = forwardRef<HTMLDivElement, BreadcrumbPureProps>(
-    function BreadcrumbPure(
-      {
-        children,
-        divider: rawDivider = '',
-        testId = 'fs-breadcrumb',
-        ...otherProps
-      },
-      ref
-    ) {
-      return (
-        <nav
-          aria-label="Breadcrumb"
-          role="navigation"
-          ref={ref}
-          data-fs-breadcrumb
-          data-testid={testId}
-          {...otherProps}
-        >
-          <List as="ol" data-fs-breadcrumb-list>
-            {React.Children.toArray(children).map(
-              (child, index, childrenArray) => {
-                const isLastItem = index === childrenArray.length - 1
-  
-                return (
-                  <ListItem
-                    isLastItem={isLastItem}
-                    divider={rawDivider}
-                    key={`breadcrumb-${index}`}
-                    testId={testId}
-                  >
-                    {child}
-                  </ListItem>
-                )
-              }
-            )}
-          </List>
-        </nav>
-      )
-    }
-  )
+  function BreadcrumbPure(
+    {
+      children,
+      divider: rawDivider = '',
+      testId = 'fs-breadcrumb',
+      ...otherProps
+    },
+    ref
+  ) {
+    return (
+      <nav
+        aria-label="Breadcrumb"
+        role="navigation"
+        ref={ref}
+        data-fs-breadcrumb
+        data-testid={testId}
+        {...otherProps}
+      >
+        <List as="ol" data-fs-breadcrumb-list>
+          {React.Children.toArray(children).map(
+            (child, index, childrenArray) => {
+              const isLastItem = index === childrenArray.length - 1
+
+              return (
+                <ListItem
+                  isLastItem={isLastItem}
+                  divider={rawDivider}
+                  key={`breadcrumb-${index}`}
+                  testId={testId}
+                >
+                  {child}
+                </ListItem>
+              )
+            }
+          )}
+        </List>
+      </nav>
+    )
+  }
+)
 
 export default BreadcrumbPure


### PR DESCRIPTION
## What's the purpose of this pull request?

- Adds props to the following components:
- [x] Input
- [x] Select
- [x] Alert
- [x] Breadcrumb
- [x] Buy Button
- [x] Icon Button

## How to test it?

- Check if the props list is appearing according. You can check through the following links:
🔗 [Input](https://faststore-site-git-docs-props-update-faststore.vercel.app/components/atoms/input)
🔗 [Select](https://faststore-site-git-docs-props-update-faststore.vercel.app/components/atoms/select)
🔗 [Alert](https://faststore-site-git-docs-props-update-faststore.vercel.app/components/molecules/alert)
🔗 [Breadcrumb](https://faststore-site-git-docs-props-update-faststore.vercel.app/components/molecules/breadcrumb)
🔗 [Buy Button](https://faststore-site-git-docs-props-update-faststore.vercel.app/components/molecules/buy-button)
🔗 [Icon Button](https://faststore-site-git-docs-props-update-faststore.vercel.app/components/molecules/icon-button)