### PR TITLE
Chore: removes unnecessary css imports + enable system fonts

### DIFF
--- a/apps/site/pages/docs/getting-started/2-setting-up-the-project.mdx
+++ b/apps/site/pages/docs/getting-started/2-setting-up-the-project.mdx
@@ -166,9 +166,6 @@ Let's make the first level of customization which is update the store's theme wi
 // Theme Soft Blue
 // ----------------------------------------------------------
 
-@import '@faststore/ui/src/styles/base/utilities.scss';
-@import '@faststore/ui/src/styles/base/typography.scss';
-
 .theme {
   // --------------------------------------------------------
   // Colors (Branding Core)

--- a/apps/site/pages/docs/themes/midnight.mdx
+++ b/apps/site/pages/docs/themes/midnight.mdx
@@ -34,8 +34,6 @@ theme: 'midnight',
 // Theme Midnight
 // ----------------------------------------------------------
 
-@import '@faststore/ui/src/styles/base/utilities.scss';
-
 .theme {
   // --------------------------------------------------------
   // Colors (Branding Core)

--- a/apps/site/pages/docs/themes/soft-blue.mdx
+++ b/apps/site/pages/docs/themes/soft-blue.mdx
@@ -34,8 +34,6 @@ theme: 'soft-blue',
 // Theme Soft Blue
 // ----------------------------------------------------------
 
-@import '@faststore/ui/src/styles/base/utilities.scss';
-
 .theme {
   // --------------------------------------------------------
   // Colors (Branding Core)

--- a/packages/ui/src/styles/base.scss
+++ b/packages/ui/src/styles/base.scss
@@ -1,5 +1,5 @@
+@import "./base/reset";
 @import "./base/utilities";
 @import "./base/typography";
-@import "./base/reset";
 @import "./base/tokens";
 @import "./base/layout";


### PR DESCRIPTION
## What's the purpose of this pull request?

- [x] Removes unnecessary fonts imported in the theme file and its docs.
- [x] Import the reset.css as the first file.

Related PR  
-  https://github.com/vtex/faststore/pull/1792

## How it works?

1. We don't need to import this external files inside the theme file since it's already imported in the global css from `_app.tsx`.
2.  Import the `reset.css` as the first file so that the `font-family` from modern normalize, that is imported from `reset.scss`can be overrided  by the ones from the theme in `starter.store`.

## How to test it?

- Use the midnight theme file from this branch in `starter.store` PR and check if the font family from the HTML is `Raleway` (from midnight) instead of `system-ui, -apple-system` (from modern-normalize).


### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/62

