### PR TITLE
add sellers informations query

### DIFF
--- a/packages/api/mocks/SellersQuery.ts
+++ b/packages/api/mocks/SellersQuery.ts
@@ -1,0 +1,34 @@
+export const SellersQueryResult = `query SellersQuery {
+    sellers(
+      postalCode: "32808"
+      country: "USA"
+    ) {
+        id
+        sellers {
+          id
+          name
+        }
+      }
+    }`
+
+export const regionFetch = {
+    info: 'https://storeframework.vtexcommercestable.com.br/api/checkout/pub/regions/?country=USA&sc=&postalCode=32808',
+    init: undefined,
+    result: [
+        {
+            "id": "v2.4325C29BA00E6470CBA54999680076F9",
+            "sellers": [
+                {
+                    "id": "storeframework01",
+                    "name": "storeframework01",
+                    "logo": ""
+                },
+                {
+                    "id": "storeframework02",
+                    "name": "storeframework02",
+                    "logo": ""
+                }
+            ]
+        }
+    ]
+}

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -1,5 +1,4 @@
 export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
@@ -128,6 +127,13 @@ export type DeliveryIds = {
   warehouseId?: Maybe<Scalars['String']>;
 };
 
+export type IGeoCoordinates = {
+  /** The latitude of the geographic coordinates. */
+  latitude: Scalars['Float'];
+  /** The longitude of the geographic coordinates. */
+  longitude: Scalars['Float'];
+};
+
 /** Person data input to the newsletter. */
 export type IPersonNewsletter = {
   /** Person's email. */
@@ -212,7 +218,7 @@ export type IStoreOrder = {
   /** ID of the order in [VTEX order management](https://help.vtex.com/en/tutorial/license-manager-resources-oms--60QcBsvWeum02cFi3GjBzg#). */
   orderNumber: Scalars['String'];
   /** Indicates whether or not items with attachments should be split. */
-  shouldSplitItem?: InputMaybe<Scalars['Boolean']>;
+  shouldSplitItem?: Maybe<Scalars['Boolean']>;
 };
 
 /** Organization input. */
@@ -236,7 +242,7 @@ export type IStorePerson = {
 /** Product input. Products are variants within product groups, equivalent to VTEX [SKUs](https://help.vtex.com/en/tutorial/what-is-an-sku--1K75s4RXAQyOuGUYKMM68u#). For example, you may have a **Shirt** product group with associated products such as **Blue shirt size L**, **Green shirt size XL** and so on. */
 export type IStoreProduct = {
   /** Custom Product Additional Properties. */
-  additionalProperty?: InputMaybe<Array<IStorePropertyValue>>;
+  additionalProperty?: Maybe<Array<IStorePropertyValue>>;
   /** Array of product images. */
   image: Array<IStoreImage>;
   /** Product name. */
@@ -249,7 +255,7 @@ export type IStorePropertyValue = {
   /** Property name. */
   name: Scalars['String'];
   /** Property id. This propert changes according to the content of the object. */
-  propertyID?: InputMaybe<Scalars['String']>;
+  propertyID?: Maybe<Scalars['String']>;
   /** Property value. May hold a string or the string representation of an object. */
   value: Scalars['ObjectOrString'];
   /** Specifies the nature of the value */
@@ -269,7 +275,7 @@ export type IStoreSession = {
   /** Session input address type. */
   addressType?: Maybe<Scalars['String']>;
   /** Session input channel. */
-  channel?: InputMaybe<Scalars['String']>;
+  channel?: Maybe<Scalars['String']>;
   /** Session input country. */
   country: Scalars['String'];
   /** Session input currency. */
@@ -277,13 +283,13 @@ export type IStoreSession = {
   /** Session input delivery mode. */
   deliveryMode?: Maybe<IStoreDeliveryMode>;
   /** Session input geoCoordinates. */
-  geoCoordinates?: InputMaybe<IStoreGeoCoordinates>;
+  geoCoordinates?: Maybe<IStoreGeoCoordinates>;
   /** Session input locale. */
   locale: Scalars['String'];
   /** Session input person. */
-  person?: InputMaybe<IStorePerson>;
+  person?: Maybe<IStorePerson>;
   /** Session input postal code. */
-  postalCode?: InputMaybe<Scalars['String']>;
+  postalCode?: Maybe<Scalars['String']>;
 };
 
 export type LogisticsInfo = {
@@ -368,7 +374,7 @@ export type MutationSubscribeToNewsletterArgs = {
 
 export type MutationValidateCartArgs = {
   cart: IStoreCart;
-  session?: InputMaybe<IStoreSession>;
+  session?: Maybe<IStoreSession>;
 };
 
 
@@ -440,19 +446,21 @@ export type Query = {
   product: StoreProduct;
   /** Returns the result of a product, facet, or suggestion search. */
   search: StoreSearchResult;
+  /** Returns a list of sellers available for a specific localization. */
+  sellers?: Maybe<SellersData>;
   /** Returns information about shipping simulation. */
   shipping?: Maybe<ShippingData>;
 };
 
 
 export type QueryAllCollectionsArgs = {
-  after?: InputMaybe<Scalars['String']>;
+  after?: Maybe<Scalars['String']>;
   first: Scalars['Int'];
 };
 
 
 export type QueryAllProductsArgs = {
-  after?: InputMaybe<Scalars['String']>;
+  after?: Maybe<Scalars['String']>;
   first: Scalars['Int'];
 };
 
@@ -468,11 +476,19 @@ export type QueryProductArgs = {
 
 
 export type QuerySearchArgs = {
-  after?: InputMaybe<Scalars['String']>;
+  after?: Maybe<Scalars['String']>;
   first: Scalars['Int'];
-  selectedFacets?: InputMaybe<Array<IStoreSelectedFacet>>;
-  sort?: InputMaybe<StoreSort>;
-  term?: InputMaybe<Scalars['String']>;
+  selectedFacets?: Maybe<Array<IStoreSelectedFacet>>;
+  sort?: Maybe<StoreSort>;
+  term?: Maybe<Scalars['String']>;
+};
+
+
+export type QuerySellersArgs = {
+  country: Scalars['String'];
+  geoCoordinates?: Maybe<IGeoCoordinates>;
+  postalCode?: Maybe<Scalars['String']>;
+  salesChannel?: Maybe<Scalars['String']>;
 };
 
 
@@ -489,6 +505,26 @@ export type SearchMetadata = {
   isTermMisspelled: Scalars['Boolean'];
   /** Logical operator used to run the search. */
   logicalOperator: Scalars['String'];
+};
+
+/** Information of sellers. */
+export type SellerInfo = {
+  __typename?: 'SellerInfo';
+  /** Identification of the seller */
+  id?: Maybe<Scalars['String']>;
+  /** Logo of the seller */
+  logo?: Maybe<Scalars['String']>;
+  /** Name of the seller */
+  name?: Maybe<Scalars['String']>;
+};
+
+/** Regionalization with sellers information. */
+export type SellersData = {
+  __typename?: 'SellersData';
+  /** Identification of region. */
+  id?: Maybe<Scalars['String']>;
+  /** List of sellers. */
+  sellers?: Maybe<Array<Maybe<SellerInfo>>>;
 };
 
 /** Shipping Simulation information. */
@@ -566,12 +602,12 @@ export type SkuVariants = {
 
 
 export type SkuVariantsAvailableVariationsArgs = {
-  dominantVariantName?: InputMaybe<Scalars['String']>;
+  dominantVariantName?: Maybe<Scalars['String']>;
 };
 
 
 export type SkuVariantsSlugsMapArgs = {
-  dominantVariantName?: InputMaybe<Scalars['String']>;
+  dominantVariantName?: Maybe<Scalars['String']>;
 };
 
 /** Aggregate offer information, for a given SKU that is available to be fulfilled by multiple sellers. */

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Region.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Region.ts
@@ -1,6 +1,6 @@
 export interface RegionInput {
-  postalCode: string
-  geoCoordinates: GeoCoordinates | null
+  postalCode?: string | null
+  geoCoordinates?: GeoCoordinates | null
   country: string
   salesChannel?: string | null
 }

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -18,6 +18,7 @@ import type {
   QueryCollectionArgs,
   QueryProductArgs,
   QuerySearchArgs,
+  QuerySellersArgs,
   QueryShippingArgs,
 } from "../../../__generated__/schema"
 import type { CategoryTree } from "../clients/commerce/types/CategoryTree"
@@ -142,9 +143,8 @@ export const Query = {
         productId: crossSelling.value,
       })
 
-      query = `product:${
-        products.map((x) => x.productId).slice(0, first).join(";")
-      }`
+      query = `product:${products.map((x) => x.productId).slice(0, first).join(";")
+        }`
     }
 
     const after = maybeAfter ? Number(maybeAfter) : 0
@@ -271,6 +271,25 @@ export const Query = {
     return {
       ...simulation,
       address,
+    }
+  },
+
+  sellers: async (
+    _: unknown,
+    { postalCode, geoCoordinates, country, salesChannel }: QuerySellersArgs,
+    ctx: Context
+  ) => {
+    const {
+      clients: { commerce },
+    } = ctx
+
+    const regionData = await commerce.checkout.region({ postalCode, geoCoordinates, country, salesChannel })
+    const region = regionData?.[0]
+    const { id, sellers } = region
+
+    return {
+      id,
+      sellers
     }
   },
 }

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -184,6 +184,17 @@ type StoreSearchResult {
   metadata: SearchMetadata
 }
 
+input IGeoCoordinates {
+  """
+  The latitude of the geographic coordinates.
+  """
+  latitude: Float!
+  """
+  The longitude of the geographic coordinates.
+  """
+  longitude: Float!
+}
+
 type Query {
   """
   Returns the details of a product based on the specified locator.
@@ -282,4 +293,59 @@ type Query {
     country: String!
   ): ShippingData
     @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
+
+  """
+  Returns a list of sellers available for a specific localization.
+  """
+  sellers(
+    """
+    Postal code input to calculate sellers
+    """
+    postalCode: String
+    """
+    Geocoordinates input to calculate sellers
+    """
+    geoCoordinates: IGeoCoordinates
+    """
+    Country of localization
+    """
+    country: String!
+    """
+    Sales channel of the navigation
+    """
+    salesChannel: String
+  ): SellersData
+    @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
+}
+
+"""
+Regionalization with sellers information.
+"""
+type SellersData {
+  """
+  Identification of region.
+  """
+  id: String
+  """
+  List of sellers.
+  """
+  sellers: [SellerInfo]
+}
+
+"""
+Information of sellers.
+"""
+type SellerInfo {
+  """
+  Identification of the seller
+  """
+  id: String
+  """
+  Name of the seller
+  """
+  name: String
+  """
+  Logo of the seller
+  """
+  logo: String
 }

--- a/packages/api/test/__snapshots__/queries.test.ts.snap
+++ b/packages/api/test/__snapshots__/queries.test.ts.snap
@@ -1091,6 +1091,26 @@ Object {
 }
 `;
 
+exports[`\`sellers\` query 1`] = `
+Object {
+  "data": Object {
+    "sellers": Object {
+      "id": "v2.4325C29BA00E6470CBA54999680076F9",
+      "sellers": Array [
+        Object {
+          "id": "storeframework01",
+          "name": "storeframework01",
+        },
+        Object {
+          "id": "storeframework02",
+          "name": "storeframework02",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`\`shipping\` query 1`] = `
 Object {
   "data": Object {

--- a/packages/api/test/queries.test.ts
+++ b/packages/api/test/queries.test.ts
@@ -34,6 +34,7 @@ import {
   addressFetch,
   ShippingSimulationQueryResult,
 } from '../mocks/ShippingQuery'
+import { SellersQueryResult, regionFetch } from '../mocks/SellersQuery'
 
 const apiOptions = {
   platform: 'vtex',
@@ -227,6 +228,27 @@ test('`shipping` query', async () => {
   const response = await run(ShippingSimulationQueryResult)
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
+
+  fetchAPICalls.forEach((fetchAPICall) => {
+    expect(mockedFetch).toHaveBeenCalledWith(
+      fetchAPICall.info,
+      fetchAPICall.init
+    )
+  })
+
+  expect(response).toMatchSnapshot()
+})
+
+test('`sellers` query', async () => {
+  const fetchAPICalls = [regionFetch]
+
+  mockedFetch.mockImplementation((info, init) =>
+    pickFetchAPICallResult(info, init, fetchAPICalls)
+  )
+
+  const response = await run(SellersQueryResult)
+
+  expect(mockedFetch).toHaveBeenCalledTimes(1)
 
   fetchAPICalls.forEach((fetchAPICall) => {
     expect(mockedFetch).toHaveBeenCalledWith(

--- a/packages/api/test/schema.test.ts
+++ b/packages/api/test/schema.test.ts
@@ -65,6 +65,7 @@ const QUERIES = [
   'allProducts',
   'allCollections',
   'shipping',
+  'sellers',
 ]
 
 const MUTATIONS = ['validateCart', 'validateSession', 'subscribeToNewsletter']


### PR DESCRIPTION
## What's the purpose of this pull request?

For some segments (such as grocery) the customer can choose the store he wants to receive the order when entering the site. For this, it is necessary to provide the region API information for consultation and as this route was already implemented in the client to generate the regionId for validateCart I built a query just to query the regionId as the list of sellers for when necessary to display this list in store.

This PR will enable the first stage of Casino's modal logistics selection.

## How it works?

It is just a query so pass a postalCode or a geoCoordinates with a country of your choise!

## How to test it?

yarn dev at the package API:

```
query {
  sellers(postalCode:"35004",country:"USA", salesChannel:"1") {
    id
    sellers {
      id
      name
    }
  }
}
```

<img width="1512" alt="image" src="https://github.com/vtex/faststore/assets/67066494/7cf9922e-41e6-4841-a58e-4aa4c158cf46">


The return should be the id that identifies that region (regionId) and a list of sellers selected for that region
  

