### PR TITLE
fix: search result must remove products out of stock

### DIFF
--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -42,7 +42,7 @@ interface FeatureFlags {
   enableOrderFormSync?: boolean
 }
 
-export interface Context {
+export interface Context extends Pick<Options, 'hideUnavailableItems'> {
   clients: Clients
   loaders: Loaders
   /**
@@ -99,6 +99,7 @@ export const getContextFactory =
     }
     ctx.clients = getClients(options, ctx)
     ctx.loaders = getLoaders(options, ctx)
+    ctx.hideUnavailableItems = options.hideUnavailableItems
 
     return ctx
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

unavailable products should not display in the search query

## How it works?

Only skus that have sellers with an item available are returned in the search result. Then a check is added to see if the product is in stock.

### Result

If you look, the product with the slug `polo-ralph-lauren-casaco-de-moletom-com-logo-2952809-130634` is no longer displayed, because both of its offers are `https://schema.org/OutOfStock`.

Before
<img width="1512" alt="Screenshot 2023-05-25 at 17 04 39" src="https://github.com/vtex/faststore/assets/10627086/89d705a9-5c16-4efa-9d51-597a61550f1d">

After
<img width="1512" alt="Screenshot 2023-05-25 at 17 14 02" src="https://github.com/vtex/faststore/assets/10627086/bc4e2cda-60b3-403d-9702-236dce543192">


## References

Rules for picking the best SKU for the product used in FastStore:

1. Checks if it has stock (AvailableQuantity > 0)
2. It takes the SKU of the seller that has the lowest price (spotPrice) that is not sera, but if the price is different from number it is converted to zero to help with the mathematical calculation.
3. Offers are ordered by availability, so those that have stock are always in first place, but if all offers are not available, this order is irrelevant.
