### PR TITLE
Feat: Adds `CartSidebar` Section

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1422,5 +1422,100 @@
         }
       }
     }
+  },
+  {
+    "name": "CartSidebar",
+    "schema": {
+      "title": "Cart Sidebar",
+      "type": "object",
+      "description": "Cart Sidebar configuration",
+      "properties": {
+        "title": {
+          "title": "Title text",
+          "type": "string",
+          "default": "Your Cart"
+        },
+        "alert": {
+          "title": "Alert",
+          "type": "object",
+          "properties": {
+            "icon": {
+              "title": "Icon",
+              "type": "object",
+              "required": ["icon", "alt"],
+              "properties": {
+                "icon": {
+                  "title": "Icon",
+                  "type": "string",
+                  "enumNames": [
+                    "Bell",
+                    "BellRinging",
+                    "Checked",
+                    "Info",
+                    "Truck",
+                    "User"
+                  ],
+                  "enum": [
+                    "Bell",
+                    "BellRinging",
+                    "Checked",
+                    "Info",
+                    "Truck",
+                    "User"
+                  ],
+                  "default": "Truck"
+                },
+                "alt": {
+                  "title": "Alternative label",
+                  "type": "string",
+                  "default": "Arrow Right icon"
+                }
+              }
+            },
+            "text": {
+              "type": "string",
+              "title": "Text",
+              "default": "Free shipping starts at $300"
+            }
+          }
+        },
+        "checkoutButton": {
+          "title": "Checkout button",
+          "type": "object",
+          "required": ["label", "loadingLabel", "icon"],
+          "properties": {
+            "label": {
+              "title": "Label",
+              "type": "string",
+              "default": "Checkout"
+            },
+            "loadingLabel": {
+              "title": "Loading label",
+              "type": "string",
+              "default": "Loading..."
+            },
+            "icon": {
+              "title": "Icon",
+              "type": "object",
+              "required": ["icon", "alt"],
+              "properties": {
+                "icon": {
+                  "title": "Icon",
+                  "type": "string",
+                  "enumNames": ["ArrowRight"],
+                  "enum": ["ArrowRight"],
+                  "default": "ArrowRight"
+                },
+                "alt": {
+                  "title": "Alternative label",
+                  "type": "string",
+                  "default": "Arrow Right icon"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   }
 ]

--- a/packages/core/src/Layout.tsx
+++ b/packages/core/src/Layout.tsx
@@ -3,21 +3,14 @@ import { lazy, Suspense } from 'react'
 
 import { useUI } from '@faststore/ui'
 
-const CartSidebar = lazy(() => import('src/components/cart/CartSidebar'))
 const RegionModal = lazy(() => import('src/components/region/RegionModal'))
 
 function Layout({ children }: PropsWithChildren) {
-  const { cart: displayCart, modal: displayModal } = useUI()
+  const { modal: displayModal } = useUI()
 
   return (
     <>
       {children}
-
-      {displayCart && (
-        <Suspense fallback={null}>
-          <CartSidebar />
-        </Suspense>
-      )}
 
       {displayModal && (
         <Suspense fallback={null}>

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -1,7 +1,6 @@
-import { PropsWithChildren, useMemo } from 'react'
-
 import { Locator, Section } from '@vtex/client-cms'
 import type { ComponentType } from 'react'
+import { PropsWithChildren, lazy } from 'react'
 import CUSTOM_COMPONENTS from 'src/customizations/components'
 import { PageContentType, getPage } from 'src/server/cms'
 
@@ -10,8 +9,9 @@ import Toast from 'src/components/common/Toast'
 import RenderSections from './RenderSections'
 
 import Alert from 'src/components/sections/Alert'
-import Navbar from 'src/components/sections/Navbar'
 import Footer from 'src/components/sections/Footer'
+import Navbar from 'src/components/sections/Navbar'
+const CartSidebar = lazy(() => import('src/components/cart/CartSidebar'))
 
 export const GLOBAL_SECTIONS_CONTENT_TYPE = 'globalSections'
 
@@ -22,8 +22,9 @@ export type GlobalSectionsData = {
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
   Alert,
-  Footer,
   Navbar,
+  CartSidebar,
+  Footer,
   ...CUSTOM_COMPONENTS,
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Create CMS sections for `CartSidebar` and integrate the data.

## How it works?

- [x] Creates sections in `sections.json` for `CartSidebar` .
- [x] adapt `GlobalSection` to receive CMS props.

After the merge
- [ ] sync in main workspace after merge this PR.
- [ ] publish changes in Global Sections content type in main workspace.

## How to test it?

- Run the core package locally: `yarn dev`
- Use my dev workspace in draft version of `Global Section` page, and add a new `Cart Sidebar` Section: https://formspace--storeframework.myvtex.com/admin/new-cms/faststore/globalSections/edit/a56db112-87a6-40d5-a4d5-f6df686f93d0/
- Check the preview.

### Starters Deploy Preview

TBD after the merge of this PR

