### PR TITLE
Fix/geo coordinates for shipping data

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -19,7 +19,11 @@ import { getCookie } from '../../utils/getCookies'
 import type { SalesChannel } from './types/SalesChannel'
 import { MasterDataResponse } from './types/Newsletter'
 import type { Address, AddressInput } from './types/Address'
-import { DeliveryMode, ShippingDataBody } from './types/ShippingData'
+import {
+  DeliveryMode,
+  ShippingDataBody,
+  SelectedAddress,
+} from './types/ShippingData'
 import { IncrementedAddress } from './types/IncrementedAddress'
 
 type ValueOf<T> = T extends Record<string, infer K> ? K : never
@@ -123,44 +127,46 @@ export const VtexCommerce = (
         },
         incrementedAddress?: IncrementedAddress
       ): Promise<OrderForm> => {
-        const selectedAddress = body?.selectedAddresses?.[0]
-
-        const longitude =
-          selectedAddress?.geoCoordinates instanceof Array
-            ? null
-            : selectedAddress?.geoCoordinates?.longitude || null
-
-        const latitude =
-          selectedAddress?.geoCoordinates instanceof Array
-            ? null
-            : selectedAddress?.geoCoordinates?.latitude || null
-
-        const geoCoordinates =
-          longitude && latitude
-            ? [longitude, latitude]
-            : incrementedAddress?.geoCoordinates || []
-
         const mappedBody = {
           logisticsInfo: Array.from({ length: index }, (_, itemIndex) => ({
             itemIndex,
-            selectedDeliveryChannel: deliveryMode?.deliveryChannel,
-            selectedSla: deliveryMode?.deliveryMethod,
+            selectedDeliveryChannel: deliveryMode?.deliveryChannel || null,
+            selectedSla: deliveryMode?.deliveryMethod || null,
           })),
-          selectedAddresses: body?.selectedAddresses?.map((address) => ({
-            addressType: address.addressType || null,
-            receiverName: address.receiverName || null,
-            postalCode:
-              address.postalCode || incrementedAddress?.postalCode || null,
-            city: incrementedAddress?.city || null,
-            state: incrementedAddress?.state || null,
-            country: address.country || incrementedAddress?.country || null,
-            street: incrementedAddress?.street || null,
-            number: incrementedAddress?.number || null,
-            neighborhood: incrementedAddress?.neighborhood || null,
-            complement: incrementedAddress?.complement || null,
-            reference: incrementedAddress?.reference || null,
-            geoCoordinates: geoCoordinates,
-          })),
+          selectedAddresses: body?.selectedAddresses?.map((address) => {
+            const selectedAddress: SelectedAddress = {
+              addressType: address.addressType || null,
+              receiverName: address.receiverName || null,
+              postalCode:
+                address.postalCode || incrementedAddress?.postalCode || null,
+              city: incrementedAddress?.city || null,
+              state: incrementedAddress?.state || null,
+              country: address.country || incrementedAddress?.country || null,
+              street: incrementedAddress?.street || null,
+              number: incrementedAddress?.number || null,
+              neighborhood: incrementedAddress?.neighborhood || null,
+              complement: incrementedAddress?.complement || null,
+              reference: incrementedAddress?.reference || null,
+              geoCoordinates: [], // Initialize with default value
+            }
+
+            const longitude =
+              address?.geoCoordinates instanceof Array
+                ? null
+                : address?.geoCoordinates?.longitude || null
+
+            const latitude =
+              address?.geoCoordinates instanceof Array
+                ? null
+                : address?.geoCoordinates?.latitude || null
+
+            selectedAddress.geoCoordinates =
+              longitude && latitude
+                ? { longitude, latitude }
+                : incrementedAddress?.geoCoordinates || []
+
+            return selectedAddress
+          }),
         }
 
         return fetchAPI(
@@ -195,45 +201,47 @@ export const VtexCommerce = (
             }
           : null
 
-        const selectedAddress = body?.selectedAddresses?.[0]
-
-        const longitude =
-          selectedAddress?.geoCoordinates instanceof Array
-            ? null
-            : selectedAddress?.geoCoordinates?.longitude || null
-
-        const latitude =
-          selectedAddress?.geoCoordinates instanceof Array
-            ? null
-            : selectedAddress?.geoCoordinates?.latitude || null
-
-        const geoCoordinates =
-          longitude && latitude
-            ? [longitude, latitude]
-            : incrementedAddress?.geoCoordinates || []
-
         const mappedBody = {
           logisticsInfo: Array.from({ length: index }, (_, itemIndex) => ({
             itemIndex,
-            selectedDeliveryChannel: deliveryMode?.deliveryChannel,
-            selectedSla: deliveryMode?.deliveryMethod,
+            selectedDeliveryChannel: deliveryMode?.deliveryChannel || null,
+            selectedSla: deliveryMode?.deliveryMethod || null,
             deliveryWindow: deliveryWindow,
           })),
-          selectedAddresses: body?.selectedAddresses?.map((address) => ({
-            addressType: address.addressType || null,
-            receiverName: address.receiverName || null,
-            postalCode:
-              address.postalCode || incrementedAddress?.postalCode || null,
-            city: incrementedAddress?.city || null,
-            state: incrementedAddress?.state || null,
-            country: address.country || incrementedAddress?.country || null,
-            street: incrementedAddress?.street || null,
-            number: incrementedAddress?.number || null,
-            neighborhood: incrementedAddress?.neighborhood || null,
-            complement: incrementedAddress?.complement || null,
-            reference: incrementedAddress?.reference || null,
-            geoCoordinates: geoCoordinates,
-          })),
+          selectedAddresses: body?.selectedAddresses?.map((address) => {
+            const selectedAddress: SelectedAddress = {
+              addressType: address.addressType || null,
+              receiverName: address.receiverName || null,
+              postalCode:
+                address.postalCode || incrementedAddress?.postalCode || null,
+              city: incrementedAddress?.city || null,
+              state: incrementedAddress?.state || null,
+              country: address.country || incrementedAddress?.country || null,
+              street: incrementedAddress?.street || null,
+              number: incrementedAddress?.number || null,
+              neighborhood: incrementedAddress?.neighborhood || null,
+              complement: incrementedAddress?.complement || null,
+              reference: incrementedAddress?.reference || null,
+              geoCoordinates: [], // Initialize with default value
+            }
+
+            const longitude =
+              address?.geoCoordinates instanceof Array
+                ? null
+                : address?.geoCoordinates?.longitude || null
+
+            const latitude =
+              address?.geoCoordinates instanceof Array
+                ? null
+                : address?.geoCoordinates?.latitude || null
+
+            selectedAddress.geoCoordinates =
+              longitude && latitude
+                ? [longitude, latitude]
+                : incrementedAddress?.geoCoordinates || []
+
+            return selectedAddress
+          }),
         }
 
         return fetchAPI(

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -181,6 +181,23 @@ export const VtexCommerce = (
             }
           : null
 
+        const selectedAddress = body?.selectedAddresses?.[0]
+
+        const longitude =
+          selectedAddress?.geoCoordinates instanceof Array
+            ? null
+            : selectedAddress?.geoCoordinates?.longitude || null
+
+        const latitude =
+          selectedAddress?.geoCoordinates instanceof Array
+            ? null
+            : selectedAddress?.geoCoordinates?.latitude || null
+
+        const geoCoordinates =
+          longitude && latitude
+            ? [longitude, latitude]
+            : incrementedAddress?.geoCoordinates || []
+
         const mappedBody = {
           logisticsInfo: Array.from({ length: index }, (_, itemIndex) => ({
             itemIndex,
@@ -201,10 +218,7 @@ export const VtexCommerce = (
             neighborhood: incrementedAddress?.neighborhood || null,
             complement: incrementedAddress?.complement || null,
             reference: incrementedAddress?.reference || null,
-            geoCoordinates:
-              address.geoCoordinates ||
-              incrementedAddress?.geoCoordinates ||
-              [],
+            geoCoordinates: geoCoordinates,
           })),
         }
 

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -123,6 +123,23 @@ export const VtexCommerce = (
         },
         incrementedAddress?: IncrementedAddress
       ): Promise<OrderForm> => {
+        const selectedAddress = body?.selectedAddresses?.[0]
+
+        const longitude =
+          selectedAddress?.geoCoordinates instanceof Array
+            ? null
+            : selectedAddress?.geoCoordinates?.longitude || null
+
+        const latitude =
+          selectedAddress?.geoCoordinates instanceof Array
+            ? null
+            : selectedAddress?.geoCoordinates?.latitude || null
+
+        const geoCoordinates =
+          longitude && latitude
+            ? [longitude, latitude]
+            : incrementedAddress?.geoCoordinates || []
+
         const mappedBody = {
           logisticsInfo: Array.from({ length: index }, (_, itemIndex) => ({
             itemIndex,
@@ -142,10 +159,7 @@ export const VtexCommerce = (
             neighborhood: incrementedAddress?.neighborhood || null,
             complement: incrementedAddress?.complement || null,
             reference: incrementedAddress?.reference || null,
-            geoCoordinates:
-              address.geoCoordinates ||
-              incrementedAddress?.geoCoordinates ||
-              [],
+            geoCoordinates: geoCoordinates,
           })),
         }
 

--- a/packages/api/src/platforms/vtex/clients/commerce/types/ShippingData.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/ShippingData.ts
@@ -1,42 +1,42 @@
 export interface ShippingDataBody {
-    clearAddressIfPostalCodeNotFound?: boolean;
-    selectedAddresses?: SelectedAddress[];
-    logisticsInfo?: LogisticsInfo[];
+  clearAddressIfPostalCodeNotFound?: boolean
+  selectedAddresses?: SelectedAddress[]
+  logisticsInfo?: LogisticsInfo[]
 }
 
 export interface SelectedAddress {
-    addressType?: string | null;
-    receiverName?: string | null;
-    postalCode?: string | null;
-    city?: string | null;
-    state?: string | null;
-    country?: string | null;
-    street?: string | null;
-    number?: string | null;
-    neighborhood?: string | null;
-    complement?: string | null;
-    reference?: string | null;
-    geoCoordinates?: GeoCoordinates | null | [];
+  addressType?: string | null
+  receiverName?: string | null
+  postalCode?: string | null
+  city?: string | null
+  state?: string | null
+  country?: string | null
+  street?: string | null
+  number?: string | null
+  neighborhood?: string | null
+  complement?: string | null
+  reference?: string | null
+  geoCoordinates?: GeoCoordinates | GLfloat[] | null | []
 }
 
 export interface GeoCoordinates {
-    latitude: GLfloat;
-    longitude: GLfloat;
+  latitude: GLfloat
+  longitude: GLfloat
 }
 
 export interface DeliveryWindow {
-    startDate: string;
-    endDate: string;
+  startDate: string
+  endDate: string
 }
 
 export interface LogisticsInfo {
-    itemIndex?: number;
-    selectedDeliveryChannel?: string;
-    selectedSla?: string;
+  itemIndex?: number
+  selectedDeliveryChannel?: string
+  selectedSla?: string
 }
 
 export interface DeliveryMode {
-    deliveryChannel?: string;
-    deliveryMethod?: string;
-    deliveryWindow?: DeliveryWindow | null ;
+  deliveryChannel?: string
+  deliveryMethod?: string
+  deliveryWindow?: DeliveryWindow | null
 }

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -235,6 +235,7 @@ const getOrderForm = async (
   }
 
   const shouldUpdateShippingData =
+    orderForm.items.length > 0 &&
     (typeof session.postalCode === 'string' &&
       orderForm.shippingData?.address?.postalCode !== session.postalCode) ||
     (typeof session.geoCoordinates === 'object' &&
@@ -243,11 +244,11 @@ const getOrderForm = async (
       (orderForm.shippingData?.address?.geoCoordinates[0] !==
         session.geoCoordinates.longitude ||
         orderForm.shippingData?.address?.geoCoordinates[1] !==
-          session.geoCoordinates.latitude))
+          session.geoCoordinates.latitude)) 
 
   if (shouldUpdateShippingData) {
     let incrementedAddress: IncrementedAddress | undefined
-
+    
     if (session.postalCode) {
       incrementedAddress = await commerce.checkout.incrementAddress(
         session.country,
@@ -272,7 +273,7 @@ const getOrderForm = async (
         incrementedAddress
       )
     }
-
+    
     return commerce.checkout.shippingData(
       {
         id: orderForm.orderFormId,


### PR DESCRIPTION
## What's the purpose of this pull request?

Shipping Data was receiving the geoCoordinates in the wrong format breaking the call.

![image](https://github.com/vtex/faststore/assets/67066494/6f8d2920-7962-4f46-9885-38e0470faeeb)


## How it works?

Add only a geoCoordinate at the faststore config

## How to test it?

Before: geoCoordinates: { latitude: 10.5, longitude: 20.34 }
Now: geoCoordinates: [ 20.34, 10.5 ] //checkout receives longitude and after latitude.

Only geoCoord:
<img width="283" alt="image" src="https://github.com/vtex/faststore/assets/67066494/5d3a2345-67ca-42b2-b2fc-ed4d9d7b2015">


With incremented address:
<img width="283" alt="image" src="https://github.com/vtex/faststore/assets/67066494/84c52794-6610-4f92-8889-41ac69291494">

Without geoCoord:

<img width="283" alt="image" src="https://github.com/vtex/faststore/assets/67066494/cf7bf043-7f4a-4e8f-aff2-ff31a85862f4">



