### PR TITLE
chore: relax bf-cache rule to use warn instead of error

### DIFF
--- a/packages/lighthouse/src/index.ts
+++ b/packages/lighthouse/src/index.ts
@@ -84,6 +84,7 @@ const lhConfig = ({ urls, server, assertions = {} }: Params) => {
 
           // Extra Lighthouse Assertion rules
           'unused-javascript': ['error', { maxLength: 10 }],
+          'bf-cache': ['warn', {}],
 
           ...assertions,
         },


### PR DESCRIPTION
## What's the purpose of this pull request?

relaxing this rule, but we need to revisit afterward (rollback and investigate).

