### PR TITLE
Feat: add multiple pdp and plp with seo settings

### DIFF
--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -6,51 +6,6 @@
     "isSingleton": true
   },
   {
-    "id": "page",
-    "name": "Page",
-    "configurationSchemaSets": [
-      {
-        "name": "Settings",
-        "configurations": [
-          {
-            "name": "seo",
-            "schema": {
-              "title": "SEO",
-              "description": "Search Engine Optimization options",
-              "type": "object",
-              "widget": {
-                "ui:ObjectFieldTemplate": "GoogleSeoPreview"
-              },
-              "required": ["slug", "title", "description"],
-              "properties": {
-                "slug": {
-                  "title": "Path",
-                  "type": "string",
-                  "default": "/"
-                },
-                "title": {
-                  "title": "Default page title",
-                  "description": "Display this title when no other tile is available",
-                  "type": "string",
-                  "default": "FastStore"
-                },
-                "description": {
-                  "title": "Meta tag description",
-                  "type": "string",
-                  "default": "A beautifuly designed store"
-                },
-                "canonical": {
-                  "title": "Canonical url for the page",
-                  "type": "string"
-                }
-              }
-            }
-          }
-        ]
-      }
-    ]
-  },
-  {
     "id": "home",
     "name": "Home",
     "isSingleton": true,
@@ -83,7 +38,7 @@
                 "description": {
                   "title": "Meta tag description",
                   "type": "string",
-                  "default": "A beautifuly designed store"
+                  "default": "A beautifully designed store"
                 },
                 "canonical": {
                   "title": "Canonical url for the page",
@@ -99,13 +54,51 @@
   {
     "id": "pdp",
     "name": "Product Page",
-    "isSingleton": true,
-    "configurationSchemaSets": []
+    "configurationSchemaSets": [
+      {
+        "name": "Settings",
+        "configurations": [
+          {
+            "name": "seo",
+            "schema": {
+              "title": "SEO",
+              "description": "Search Engine Optimization options",
+              "type": "object",
+              "widget": {
+                "ui:ObjectFieldTemplate": "GoogleSeoPreview"
+              },
+              "required": ["slug", "title", "description"],
+              "properties": {
+                "slug": {
+                  "title": "Path",
+                  "type": "string",
+                  "default": "/"
+                },
+                "title": {
+                  "title": "Default page title",
+                  "description": "Display this title when no other tile is available",
+                  "type": "string",
+                  "default": "FastStore"
+                },
+                "description": {
+                  "title": "Meta tag description",
+                  "type": "string",
+                  "default": "A beautifully designed store"
+                },
+                "canonical": {
+                  "title": "Canonical url for the page",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
   },
   {
     "id": "plp",
     "name": "Product List Page",
-    "isSingleton": true,
     "configurationSchemaSets": [
       {
         "name": "Settings",
@@ -147,6 +140,40 @@
                     "discount_desc",
                     "score_desc"
                   ]
+                }
+              }
+            }
+          },
+          {
+            "name": "seo",
+            "schema": {
+              "title": "SEO",
+              "description": "Search Engine Optimization options",
+              "type": "object",
+              "widget": {
+                "ui:ObjectFieldTemplate": "GoogleSeoPreview"
+              },
+              "required": ["slug", "title", "description"],
+              "properties": {
+                "slug": {
+                  "title": "Path",
+                  "type": "string",
+                  "default": "/"
+                },
+                "title": {
+                  "title": "Default page title",
+                  "description": "Display this title when no other tile is available",
+                  "type": "string",
+                  "default": "FastStore"
+                },
+                "description": {
+                  "title": "Meta tag description",
+                  "type": "string",
+                  "default": "A beautifully designed store"
+                },
+                "canonical": {
+                  "title": "Canonical url for the page",
+                  "type": "string"
                 }
               }
             }


### PR DESCRIPTION
## What's the purpose of this pull request?

We should enable the possibility of creating multiples PDPs and PLPs using the CMS, and map the pages using SEO settings values. Would be good to use the CMS filter by the slug instead of the content type in the getStaticProps methods. So that we can customize each PLP or PDP according to its context (e.g. Hero Image per brand in PLP).

- [x] Enables multiples PDPs and PLPs.
- [ ] Map by slug in getStaticProps
- [ ] Enable redirects CMS preview by slug (?)

## How it works?

<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
