### PR TITLE
chore: tweaks GH action to publish as patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "turbo run lint",
     "test": "turbo run test --filter=!./packages/core",
     "size": "turbo run size",
-    "release": "lerna publish prepatch --yes --no-verify-access --ignore-scripts --conventional-commits --dist-tag alpha",
+    "release": "lerna publish patch --yes --no-verify-access --ignore-scripts --conventional-commits",
     "generate-ui-component": "yarn plop --plopfile generators/plopfile.ts",
     "clean": "turbo run clean && rm -rf node_modules",
     "format": "prettier --ignore-path .gitignore --write \"**/*.{js,jsx,ts,tsx,md}\""


### PR DESCRIPTION
## What's the purpose of this pull request?

Tweaks Github Action to automatically publish  as patch versions.

⚠️  Only merge after publishing the major.


