### PR TITLE
fix: release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "turbo run lint",
     "test": "turbo run test --filter=!./packages/core",
     "size": "turbo run size",
-    "release": "lerna publish prepatch --yes --no-verify-access --ignore-scripts --conventional-commits --dist-tag alpha",
+    "release": "lerna publish patch --yes --no-verify-access --ignore-scripts --conventional-commits",
     "generate-ui-component": "yarn plop --plopfile generators/plopfile.ts",
     "clean": "turbo run clean && rm -rf node_modules",
     "format": "prettier --ignore-path .gitignore --write \"**/*.{js,jsx,ts,tsx,md}\""


### PR DESCRIPTION
Since we officially released version 2.1.0 in latest, now we need to stop releasing prapatch in alpha.
