### PR TITLE
Docs: Adds Skeleton, ProductTitle and SelectField props

### DIFF
--- a/apps/site/pages/components/atoms/skeleton.mdx
+++ b/apps/site/pages/components/atoms/skeleton.mdx
@@ -10,6 +10,33 @@ import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { Skeleton } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const skeletonPath = path.resolve(__filename)
+  const components = ['Skeleton.tsx']
+  const [skeletonProps] = getComponentPropsFrom(skeletonPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        skeletonProps,
+      },
+    },
+  }
+}
+
+export const SkeletonPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { skeletonProps } = useSSG()
+  return {
+    Skeleton: <PropsSection propsList={skeletonProps} />,
+  }[component]
+}
+
 <header>
 
 # Skeleton
@@ -91,7 +118,7 @@ import '@faststore/ui/src/components/atoms/Skeleton/styles.scss'
 
 ## Props
 
-<PropsSection name="Skeleton" />
+<SkeletonPropsSection component="Skeleton" />
 
 ---
 

--- a/apps/site/pages/components/molecules/product-title.mdx
+++ b/apps/site/pages/components/molecules/product-title.mdx
@@ -10,6 +10,36 @@ import { TokenTable, TokenRow } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { ProductTitle, DiscountBadge } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const productTitlePath = path.resolve(__filename)
+  const components = ['ProductTitle.tsx']
+  const [productTitleProps] = getComponentPropsFrom(
+    productTitlePath,
+    components
+  )
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        productTitleProps,
+      },
+    },
+  }
+}
+
+export const ProductTitlePropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { productTitleProps } = useSSG()
+  return {
+    ProductTitle: <PropsSection propsList={productTitleProps} />,
+  }[component]
+}
+
 <header>
 # Product Title
 
@@ -120,7 +150,7 @@ import '@faststore/ui/src/components/molecules/ProductTitle/styles.scss'
 
 ## Props
 
-<PropsSection name="ProductTitle" />
+<ProductTitlePropsSection component="ProductTitle" />
 
 ---
 

--- a/apps/site/pages/components/molecules/select-field.mdx
+++ b/apps/site/pages/components/molecules/select-field.mdx
@@ -10,6 +10,33 @@ import { TokenTable, TokenRow } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { SelectField } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const selectFieldPath = path.resolve(__filename)
+  const components = ['SelectField.tsx']
+  const [selectFieldProps] = getComponentPropsFrom(selectFieldPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        selectFieldProps,
+      },
+    },
+  }
+}
+
+export const SelectFieldPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { selectFieldProps } = useSSG()
+  return {
+    SelectField: <PropsSection propsList={selectFieldProps} />,
+  }[component]
+}
+
 <header>
 
 # Select Field
@@ -117,7 +144,7 @@ import '@faststore/ui/src/components/molecules/SelectField/styles.scss'
 
 ## Props
 
-<PropsSection name="SelectField" />
+<SelectFieldPropsSection component="SelectField" />
 
 ---
 

--- a/packages/components/src/molecules/ProductTitle/ProductTitle.tsx
+++ b/packages/components/src/molecules/ProductTitle/ProductTitle.tsx
@@ -2,9 +2,8 @@ import React, { forwardRef, HTMLAttributes } from 'react'
 import type { ReactNode } from 'react'
 
 import { Rating } from '../../'
-import type { RatingProps } from '../../'
 
-export type ProductTitleProps = Omit<HTMLAttributes<HTMLElement>, 'title'> & {
+interface ProductTitleProps extends Omit<HTMLAttributes<HTMLElement>, 'title'> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
@@ -29,7 +28,7 @@ export type ProductTitleProps = Omit<HTMLAttributes<HTMLElement>, 'title'> & {
    * The current value of the rating, a number from 0 to 5.
    */
   ratingValue?: number
-} & Omit<RatingProps, 'testId' | 'onChange' | 'value' | 'title'>
+}
 
 const ProductTitle = forwardRef<HTMLElement, ProductTitleProps>(
   function ProductTitle(

--- a/packages/components/src/molecules/ProductTitle/ProductTitle.tsx
+++ b/packages/components/src/molecules/ProductTitle/ProductTitle.tsx
@@ -3,7 +3,8 @@ import type { ReactNode } from 'react'
 
 import { Rating } from '../../'
 
-interface ProductTitleProps extends Omit<HTMLAttributes<HTMLElement>, 'title'> {
+export interface ProductTitleProps
+  extends Omit<HTMLAttributes<HTMLElement>, 'title'> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds Skeleton, ProductTitle and SelectField component's props

## How to test it?

You should be able to see the:

- Skeleton [doc page](https://faststore-site-git-docs-fs-937-adds-props-faststore.vercel.app/components/atoms/skeleton) props section updated.
- ProductTitle [doc page](https://faststore-site-git-docs-fs-937-adds-props-faststore.vercel.app/components/molecules/product-title) props section updated.
- SelectField [doc page](https://faststore-site-git-docs-fs-937-adds-props-faststore.vercel.app/components/molecules/select-field) props section updated.
