### PR TITLE
Feat: Adds `Newsletter` Section from CMS

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1033,7 +1033,10 @@
         },
         "privacyPolicy": {
           "title": "Privacy Policy Disclaimer",
-          "type": "string"
+          "type": "string",
+          "widget": {
+            "ui:widget": "draftjs-rich-text"
+          }
         },
         "emailInputLabel": {
           "title": "Email input label",
@@ -1054,6 +1057,66 @@
           "title": "Subscribe button label",
           "type": "string",
           "default": "Subscribe"
+        },
+        "subscribeButtonLoadingLabel": {
+          "title": "Subscribe button loading label",
+          "type": "string",
+          "default": "Loading..."
+        },
+        "card": {
+          "title": "Newsletter should be in card format?",
+          "type": "boolean",
+          "default": false
+        },
+        "toastSubscribe": {
+          "title": "Toast Subscribe",
+          "type": "object",
+          "properties": {
+            "title": {
+              "title": "Title",
+              "description": "Message Title",
+              "type": "string",
+              "default": "Hooray!"
+            },
+            "message": {
+              "title": "Message",
+              "description": "Message",
+              "type": "string",
+              "default": "Thank for your subscription."
+            },
+            "icon": {
+              "title": "Icon",
+              "type": "string",
+              "enumNames": ["CircleWavyCheck"],
+              "enum": ["CircleWavyCheck"],
+              "default": "CircleWavyCheck"
+            }
+          }
+        },
+        "toastSubscribeError": {
+          "title": "Toast Subscribe Error",
+          "type": "object",
+          "properties": {
+            "title": {
+              "title": "Title",
+              "description": "Message Title",
+              "type": "string",
+              "default": "Oops."
+            },
+            "message": {
+              "title": "Message",
+              "description": "Message",
+              "type": "string",
+              "default": "Something went wrong. Please Try again."
+            },
+            "icon": {
+              "title": "Icon",
+              "type": "string",
+              "enumNames": ["CircleWavyWarning"],
+              "enum": ["CircleWavyWarning"],
+              "default": "CircleWavyWarning"
+            }
+          }
         }
       }
     }
@@ -1081,11 +1144,13 @@
           "properties": {
             "title": {
               "title": "Title",
-              "type": "string"
+              "type": "string",
+              "default": "Get to Know Our Next Release"
             },
             "caption": {
               "title": "Caption",
-              "type": "string"
+              "type": "string",
+              "default": "Discover cutting-edge tech, advanced features, and a seamless user experience. Get ready for the future!"
             },
             "link": {
               "title": "Call to Action",
@@ -1094,11 +1159,13 @@
               "properties": {
                 "text": {
                   "title": "Text",
-                  "type": "string"
+                  "type": "string",
+                  "default": "Shop now"
                 },
                 "url": {
                   "title": "URL",
-                  "type": "string"
+                  "type": "string",
+                  "default": "/"
                 }
               }
             },
@@ -1106,13 +1173,15 @@
               "title": "Color variant",
               "type": "string",
               "enumNames": ["Main", "Light", "Accent"],
-              "enum": ["main", "light", "accent"]
+              "enum": ["main", "light", "accent"],
+              "default": "light"
             },
             "variant": {
               "title": "Variant",
               "type": "string",
               "enumNames": ["Primary", "Secondary"],
-              "enum": ["primary", "secondary"]
+              "enum": ["primary", "secondary"],
+              "default": "secondary"
             }
           }
         },
@@ -1121,6 +1190,24 @@
           "type": "object",
           "required": ["title", "description"],
           "properties": {
+            "icon": {
+              "title": "Icon",
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "title": "Icon",
+                  "type": "string",
+                  "enumNames": ["Envelop"],
+                  "enum": ["Envelop"],
+                  "default": "Envelop"
+                },
+                "alt": {
+                  "type": "string",
+                  "title": "Alternative Label",
+                  "default": "Envelop"
+                }
+              }
+            },
             "title": {
               "title": "Title",
               "type": "string",
@@ -1130,6 +1217,43 @@
               "title": "Description",
               "type": "string",
               "default": "Receive our news and promotions in advance"
+            },
+            "privacyPolicy": {
+              "title": "Privacy Policy Disclaimer",
+              "type": "string",
+              "widget": {
+                "ui:widget": "draftjs-rich-text"
+              }
+            },
+            "emailInputLabel": {
+              "title": "Email input label",
+              "type": "string",
+              "default": "Your Email"
+            },
+            "displayNameInput": {
+              "title": "Request name?",
+              "type": "boolean",
+              "default": true
+            },
+            "nameInputLabel": {
+              "title": "Name input label",
+              "type": "string",
+              "default": "Your Name"
+            },
+            "subscribeButtonLabel": {
+              "title": "Subscribe button label",
+              "type": "string",
+              "default": "Subscribe"
+            },
+            "subscribeButtonLoadingLabel": {
+              "title": "Subscribe button loading label",
+              "type": "string",
+              "default": "Loading..."
+            },
+            "card": {
+              "title": "Newsletter should be in card format?",
+              "type": "boolean",
+              "default": true
             }
           }
         }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,8 @@
     "autoprefixer": "^10.4.0",
     "chalk": "^5.2.0",
     "css-loader": "^6.7.1",
+    "draft-js": "^0.11.7",
+    "draft-js-export-html": "^1.4.1",
     "graphql": "^15.0.0",
     "include-media": "^1.4.10",
     "msw": "^0.43.1",

--- a/packages/core/src/components/sections/BannerNewsletter/BannerNewsletter.tsx
+++ b/packages/core/src/components/sections/BannerNewsletter/BannerNewsletter.tsx
@@ -1,31 +1,39 @@
-import {
-  Banner as UIBanner,
-  BannerContent as UIBannerContent,
-} from '@faststore/ui'
-import Newsletter from '../Newsletter'
+import BannerText, { BannerTextProps } from 'src/components/sections/BannerText'
+import Newsletter, { NewsletterProps } from 'src/components/sections/Newsletter'
 import Section from '../Section'
 import styles from './section.module.scss'
 
-function BannerNewsletter() {
+function BannerNewsletter({
+  banner,
+  newsletter,
+}: {
+  banner: BannerTextProps
+  newsletter: NewsletterProps
+}) {
   return (
     <Section
       className={`${styles.section} section-banner-newsletter layout__content`}
     >
       <div data-fs-banner-newsletter>
-        <UIBanner variant="secondary" colorVariant="light">
-          <UIBannerContent
-            title="Get to Know Our Next Release"
-            caption="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam elit nisi, vehicula in turpis sit amet, posuere aliquam nisl. "
-            link="/"
-            linkText="Shop Now"
-          />
-        </UIBanner>
-
+        <BannerText
+          title={banner.title}
+          caption={banner.caption}
+          link={banner?.link}
+          variant={banner.variant}
+          colorVariant={banner.colorVariant}
+        />
         <Newsletter
-          title="Get News and Special Offers!"
-          description="Receive our news and promotions in advance. Enjoy and get 10% off your first purchase. For more information click here."
-          card
-          lite
+          title={newsletter.title}
+          description={newsletter.description}
+          icon={newsletter.icon}
+          privacyPolicy={newsletter.privacyPolicy}
+          emailInputLabel={newsletter.emailInputLabel}
+          displayNameInput={newsletter.displayNameInput}
+          nameInputLabel={newsletter.nameInputLabel}
+          subscribeButtonLabel={newsletter.subscribeButtonLabel}
+          toastSubscribe={newsletter.toastSubscribe}
+          toastSubscribeError={newsletter.toastSubscribeError}
+          card={newsletter.card}
         />
       </div>
     </Section>

--- a/packages/core/src/components/sections/Newsletter/Newsletter.tsx
+++ b/packages/core/src/components/sections/Newsletter/Newsletter.tsx
@@ -1,10 +1,6 @@
-import { Button as UIButton, InputField as UIInputField } from '@faststore/ui'
-import type { ComponentPropsWithRef, FormEvent, ReactNode } from 'react'
-import { forwardRef, useRef } from 'react'
-
-import { Icon, useUI } from '@faststore/ui'
-import Link from 'src/components/ui/Link'
-import { useNewsletter } from 'src/sdk/newsletter/useNewsletter'
+import { ComponentPropsWithRef } from 'react'
+import UINewsletter from 'src/components/ui/Newsletter'
+import { SubscribeMessage } from 'src/components/ui/Newsletter/Newsletter'
 
 import Section from '../Section'
 import styles from './section.module.scss'
@@ -12,132 +8,82 @@ import styles from './section.module.scss'
 export interface NewsletterProps
   extends Omit<ComponentPropsWithRef<'form'>, 'title' | 'onSubmit'> {
   /**
+   * Icon for the section.
+   */
+  icon: {
+    icon: string
+    alt: string
+  }
+  /**
    * Title for the section.
    */
-  title: ReactNode
+  title: string
   /**
    * A description for the section.
    */
-  description?: ReactNode
+  description?: string
+  /**
+   * The Privacy Policy disclaimer.
+   */
+  privacyPolicy?: string
+  /**
+   * The email input label.
+   */
+  emailInputLabel?: string
+  /**
+   * The name input visibility.
+   */
+  displayNameInput?: boolean
+  /**
+   * The name input label.
+   */
+  nameInputLabel?: string
+  /**
+   * The subscribe button label.
+   */
+  subscribeButtonLabel?: string
   /**
    * The card Variant
    */
-  card?: boolean
-  /**
-   * The compact version of the Newsletter component
-   */
-  lite?: boolean
+  card: Boolean
+
+  toastSubscribe: SubscribeMessage
+
+  toastSubscribeError: SubscribeMessage
 }
 
-const Newsletter = forwardRef<HTMLFormElement, NewsletterProps>(
-  function Newsletter({ title, description, card = false, lite = false }, ref) {
-    const { subscribeUser, loading, data } = useNewsletter()
-    const nameInputRef = useRef<HTMLInputElement>(null)
-    const emailInputRef = useRef<HTMLInputElement>(null)
-
-    const { pushToast } = useUI()
-
-    const handleSubmit = (event: FormEvent) => {
-      event.preventDefault()
-      subscribeUser({
-        data: {
-          name: nameInputRef.current?.value ?? '',
-          email: emailInputRef.current?.value ?? '',
-        },
-      })
-
-      if (data?.subscribeToNewsletter?.id) {
-        pushToast({
-          title: 'Hooray!',
-          message: 'Thank for your subscription.',
-          status: 'INFO',
-          icon: <Icon name="CircleWavyCheck" width={30} height={30} />,
-        })
-      } else {
-        pushToast({
-          title: 'Oops.',
-          message: 'Something went wrong. Please Try again.',
-          status: 'ERROR',
-          icon: <Icon name="CircleWavyWarning" width={30} height={30} />,
-        })
-      }
-
-      const formElement = event.currentTarget as HTMLFormElement
-
-      formElement.reset()
-    }
-
-    return (
-      <Section className={`${styles.section} section-newsletter`}>
-        <div data-fs-newsletter={card ? 'card' : ''}>
-          <form
-            ref={ref}
-            data-fs-newsletter-form
-            onSubmit={handleSubmit}
-            className="layout__content"
-          >
-            <header data-fs-newsletter-header>
-              <h3>
-                <Icon name="Envelop" width={32} height={32} />
-                {title}
-              </h3>
-              {description && <span> {description}</span>}
-            </header>
-
-            <div data-fs-newsletter-controls>
-              {lite ? (
-                <>
-                  <UIInputField
-                    inputRef={emailInputRef}
-                    id="newsletter-email"
-                    label="Your Email"
-                    type="email"
-                    required
-                    actionable
-                    onSubmit={() => undefined}
-                    onClear={() => undefined}
-                    buttonActionText="Subscribe"
-                    displayClearButton={false}
-                  />
-                  <span data-fs-newsletter-addendum>
-                    By subscribing to our newsletter you agree to to our{' '}
-                    <Link href="/" inverse variant="inline">
-                      Privacy Policy.
-                    </Link>
-                  </span>
-                </>
-              ) : (
-                <>
-                  <UIInputField
-                    inputRef={nameInputRef}
-                    id="newsletter-name"
-                    label="Your Name"
-                    required
-                  />
-                  <UIInputField
-                    inputRef={emailInputRef}
-                    id="newsletter-email"
-                    label="Your Email"
-                    type="email"
-                    required
-                  />
-                  <span data-fs-newsletter-addendum>
-                    By subscribing to our newsletter you agree to to our{' '}
-                    <Link href="/" inverse variant="inline">
-                      Privacy Policy.
-                    </Link>
-                  </span>
-                  <UIButton variant="secondary" inverse type="submit">
-                    {loading ? 'Loading...' : 'Subscribe'}
-                  </UIButton>
-                </>
-              )}
-            </div>
-          </form>
-        </div>
-      </Section>
-    )
-  }
-)
+const Newsletter = function Newsletter({
+  icon,
+  title,
+  description,
+  privacyPolicy,
+  emailInputLabel,
+  displayNameInput,
+  nameInputLabel,
+  subscribeButtonLabel,
+  card,
+  toastSubscribe,
+  toastSubscribeError,
+  ...otherProps
+}: NewsletterProps) {
+  return (
+    <Section className={`${styles.section} section-newsletter`}>
+      <UINewsletter
+        icon={icon}
+        title={title}
+        description={description}
+        privacyPolicy={privacyPolicy}
+        emailInputLabel={emailInputLabel}
+        displayNameInput={displayNameInput}
+        nameInputLabel={nameInputLabel}
+        subscribeButtonLabel={subscribeButtonLabel}
+        toastSubscribe={toastSubscribe}
+        toastSubscribeError={toastSubscribeError}
+        card={card}
+        {...otherProps}
+      />
+    </Section>
+  )
+}
 
 export default Newsletter

--- a/packages/core/src/components/ui/Newsletter/Newsletter.tsx
+++ b/packages/core/src/components/ui/Newsletter/Newsletter.tsx
@@ -1,0 +1,198 @@
+import { Button as UIButton, InputField as UIInputField } from '@faststore/ui'
+import { ComponentPropsWithRef, FormEvent } from 'react'
+import { forwardRef, useRef } from 'react'
+import { convertFromRaw } from 'draft-js'
+import { stateToHTML } from 'draft-js-export-html'
+import { Icon, useUI } from '@faststore/ui'
+import { useNewsletter } from 'src/sdk/newsletter/useNewsletter'
+
+const cmsToHtml = (content) => {
+  if (!content) {
+    return ''
+  }
+  const rawDraftContentState = JSON.parse(content)
+  const html = stateToHTML(convertFromRaw(rawDraftContentState), {
+    entityStyleFn: (entity) => {
+      const entityType = entity.get('type').toLowerCase()
+      if (entityType === 'link') {
+        const data = entity.getData()
+        return {
+          element: 'a',
+          attributes: {
+            'data-fs-link': 'true',
+            'data-fs-link-variant': 'inline',
+            'data-fs-link-inverse': 'true',
+            'data-fs-link-size': 'regular',
+            'data-testid': 'fs-link',
+            href: data.url,
+          },
+        }
+      }
+    },
+  })
+
+  return html
+}
+
+export type SubscribeMessage = {
+  title: string
+  message: string
+  icon: string
+}
+
+export interface NewsletterProps
+  extends Omit<ComponentPropsWithRef<'form'>, 'title' | 'onSubmit'> {
+  /**
+   * Icon for the section.
+   */
+  icon: {
+    icon: string
+    alt: string
+  }
+  /**
+   * Title for the section.
+   */
+  title: string
+  /**
+   * A description for the section.
+   */
+  description?: string
+  /**
+   * The Privacy Policy disclaimer.
+   */
+  privacyPolicy?: string
+  /**
+   * The email input label.
+   */
+  emailInputLabel?: string
+  /**
+   * The name input visibility.
+   */
+  displayNameInput?: boolean
+  /**
+   * The name input label.
+   */
+  nameInputLabel?: string
+  /**
+   * The subscribe button label.
+   */
+  subscribeButtonLabel?: string
+  /**
+   * The subscribe button loading label.
+   */
+  subscribeButtonLoadingLabel?: string
+  /**
+   * The card Variant
+   */
+  card: Boolean
+
+  toastSubscribe: SubscribeMessage
+
+  toastSubscribeError: SubscribeMessage
+}
+
+const Newsletter = forwardRef<HTMLFormElement, NewsletterProps>(
+  function Newsletter(
+    {
+      icon,
+      title,
+      description,
+      privacyPolicy,
+      emailInputLabel,
+      displayNameInput,
+      nameInputLabel,
+      subscribeButtonLabel,
+      subscribeButtonLoadingLabel,
+      card,
+      toastSubscribe,
+      toastSubscribeError,
+      ...otherProps
+    },
+    ref
+  ) {
+    const { subscribeUser, loading, data } = useNewsletter()
+    const nameInputRef = useRef<HTMLInputElement>(null)
+    const emailInputRef = useRef<HTMLInputElement>(null)
+
+    const { pushToast } = useUI()
+
+    const handleSubmit = (event: FormEvent) => {
+      event.preventDefault()
+      subscribeUser({
+        data: {
+          name: nameInputRef.current?.value ?? '',
+          email: emailInputRef.current?.value ?? '',
+        },
+      })
+
+      if (data?.subscribeToNewsletter?.id) {
+        pushToast({
+          ...toastSubscribe,
+          status: 'INFO',
+          icon: <Icon name={toastSubscribe.icon} width={30} height={30} />,
+        })
+      } else {
+        pushToast({
+          ...toastSubscribeError,
+          status: 'ERROR',
+          icon: <Icon name={toastSubscribeError.icon} width={30} height={30} />,
+        })
+      }
+
+      const formElement = event.currentTarget as HTMLFormElement
+
+      formElement.reset()
+    }
+
+    return (
+      <div data-fs-newsletter={card ? 'card' : ''}>
+        <form
+          data-fs-newsletter-form
+          ref={ref}
+          onSubmit={handleSubmit}
+          {...otherProps}
+          className="layout__content"
+        >
+          <header data-fs-newsletter-header>
+            <h3>
+              <Icon name={icon.icon} width={32} height={32} />
+              {title}
+            </h3>
+            {description && <span> {description}</span>}
+          </header>
+
+          <div data-fs-newsletter-controls>
+            <>
+              {displayNameInput ? (
+                <UIInputField
+                  inputRef={nameInputRef}
+                  id="newsletter-name"
+                  label={nameInputLabel}
+                  required
+                />
+              ) : null}
+              <UIInputField
+                inputRef={emailInputRef}
+                id="newsletter-email"
+                label={emailInputLabel}
+                type="email"
+                required
+              />
+              <span
+                data-fs-newsletter-addendum
+                dangerouslySetInnerHTML={{
+                  __html: cmsToHtml(privacyPolicy),
+                }}
+              ></span>
+              <UIButton variant="secondary" inverse type="submit">
+                {loading ? subscribeButtonLoadingLabel : subscribeButtonLabel}
+              </UIButton>
+            </>
+          </div>
+        </form>
+      </div>
+    )
+  }
+)
+
+export default Newsletter

--- a/packages/core/src/components/ui/Newsletter/index.ts
+++ b/packages/core/src/components/ui/Newsletter/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Newsletter'
+export type { NewsletterProps } from './Newsletter'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9303,6 +9303,11 @@ core-js@^3.4:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.27.1.tgz#23cc909b315a6bb4e418bf40a52758af2103ba46"
   integrity sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww==
 
+core-js@^3.6.4:
+  version "3.30.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.30.2.tgz#6528abfda65e5ad728143ea23f7a14f0dcf503fc"
+  integrity sha512-uBJiDmwqsbJCWHAwjrx3cvjbMXP7xD72Dmsn5LOJpiRmE3WbBbN5rCqQ2Qh6Ek6/eOrjlWngEynBWo4VxerQhg==
+
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -9417,6 +9422,13 @@ cross-env@^7.0.2:
   integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
   dependencies:
     cross-spawn "^7.0.1"
+
+cross-fetch@^3.0.4:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
+  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
+  dependencies:
+    node-fetch "^2.6.11"
 
 cross-fetch@^3.1.5:
   version "3.1.5"
@@ -10250,6 +10262,27 @@ dotenv@~10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
+draft-js-export-html@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/draft-js-export-html/-/draft-js-export-html-1.4.1.tgz#7cdad970c6f7f2cdd19ce4c1f5073fdf0f313b4d"
+  integrity sha512-G4VGBSalPowktIE4wp3rFbhjs+Ln9IZ2FhXeHjsZDSw0a2+h+BjKu5Enq+mcsyVb51RW740GBK8Xbf7Iic51tw==
+  dependencies:
+    draft-js-utils "^1.4.0"
+
+draft-js-utils@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/draft-js-utils/-/draft-js-utils-1.4.1.tgz#a59c792ad621f7050292031a237d524708a6d509"
+  integrity sha512-xE81Y+z/muC5D5z9qWmKfxEW1XyXfsBzSbSBk2JRsoD0yzMGGHQm/0MtuqHl/EUDkaBJJLjJ2EACycoDMY/OOg==
+
+draft-js@^0.11.7:
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.11.7.tgz#be293aaa255c46d8a6647f3860aa4c178484a206"
+  integrity sha512-ne7yFfN4sEL82QPQEn80xnADR8/Q6ALVworbC5UOSzOvjffmYfFsr3xSZtxbIirti14R7Y33EZC5rivpLgIbsg==
+  dependencies:
+    fbjs "^2.0.0"
+    immutable "~3.7.4"
+    object-assign "^4.1.1"
 
 dset@3.1.2, dset@^3.1.2:
   version "3.1.2"
@@ -11582,6 +11615,20 @@ fbjs-css-vars@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
   integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-2.0.0.tgz#01fb812138d7e31831ed3e374afe27b9169ef442"
+  integrity sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==
+  dependencies:
+    core-js "^3.6.4"
+    cross-fetch "^3.0.4"
+    fbjs-css-vars "^1.0.0"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 fbjs@^3.0.0:
   version "3.0.4"
@@ -13404,7 +13451,7 @@ immutable@^4.0.0:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.2.2.tgz#2da9ff4384a4330c36d4d1bc88e90f9e0b0ccd16"
   integrity sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og==
 
-immutable@~3.7.6:
+immutable@~3.7.4, immutable@~3.7.6:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
   integrity sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==
@@ -17456,6 +17503,13 @@ node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -22698,6 +22752,11 @@ typeson@^6.0.0, typeson@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/typeson/-/typeson-6.1.0.tgz#5b2a53705a5f58ff4d6f82f965917cabd0d7448b"
   integrity sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==
+
+ua-parser-js@^0.7.18:
+  version "0.7.35"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.35.tgz#8bda4827be4f0b1dda91699a29499575a1f1d307"
+  integrity sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==
 
 ua-parser-js@^0.7.30:
   version "0.7.33"


### PR DESCRIPTION
[⚠️ This PR is a reference to that and was created to avoid the lint error
](https://github.com/vtex/faststore/pull/1773)

## What's the purpose of this pull request?

Adjusts Newsletter and BannerNewsletter section for CMS.

## How it works?

- [x] Adjust sections in sections.json
- [x] Adapt Newsletter and BannerNewsletter to receive CMS props.
- [x] Remove Privacy Policy Disclaimer. (I don't know if it's possible to make it dynamic, since we have a link with the string)
- [x] Remove the `lite` prop, that behavior is controlled by `displayNameInput` now.

## How to test it?

- Publish BannerNewsletter and Newsletter in CMS.
- `yarn dev`.
- Check the CMS preview.