### PR TITLE
fix: cli build error now exits with proper status

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -9,11 +9,16 @@ import { generate } from '../utils/generate'
 export default class Build extends Command {
   async run() {
     await generate({ setup: true })
-    spawnSync(`yarn build`, {
+
+    const yarnBuildResult = spawnSync(`yarn build`, {
       shell: true,
       cwd: tmpDir,
       stdio: 'inherit',
     })
+
+    if(yarnBuildResult.status && yarnBuildResult.status !== 0) {
+      process.exit(yarnBuildResult.status)
+    }
 
     await copyResource(`${tmpDir}/.next`, `${userDir}/.next`)
     await copyResource(


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes an issue where builds that failed (when `yarn build` failed) were interpreted as a success by the build pipeline because the `@faststore/cli` package didn't return the appropriate status.

## How it works?

It now checks for the status of the `yarn build` call and exits the process if it finds it has thrown an error. 

## How to test it?

Follow the instructions on the PR below

### Starters Deploy Preview
https://github.com/vtex-sites/starter.store/pull/77

