### PR TITLE
feat: Generates CMS webhook URLs json file from the store's config

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -26,6 +26,10 @@ export default class Build extends Command {
       `${userDir}/lighthouserc.js`
     )
     await copyResource(`${tmpDir}/cypress`, `${userDir}/cypress`)
+    await copyResource(
+      `${tmpDir}/cms-webhook-urls.json`,
+      `${userDir}/cms-webhook-urls.json`
+    )
     if (existsSync(`.next/standalone`)) {
       await copyResource(
         `${userDir}/node_modules`,

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -26,10 +26,6 @@ export default class Build extends Command {
       `${userDir}/lighthouserc.js`
     )
     await copyResource(`${tmpDir}/cypress`, `${userDir}/cypress`)
-    await copyResource(
-      `${tmpDir}/cms-webhook-urls.json`,
-      `${userDir}/cms-webhook-urls.json`
-    )
     if (existsSync(`.next/standalone`)) {
       await copyResource(
         `${userDir}/node_modules`,

--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -40,5 +40,4 @@ export const userNodeModulesDir = path.join(userDir, 'node_modules')
 export const tmpNodeModulesDir = path.join(tmpDir, 'node_modules')
 
 export const cmsWebhookUrlsFileName = 'cms-webhook-urls.json'
-export const userCmsWebhookUrlsFileDir = path.join(userDir, cmsWebhookUrlsFileName)
 export const tmpCmsWebhookUrlsFileDir = path.join(tmpDir, cmsWebhookUrlsFileName)

--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -38,3 +38,7 @@ export const tmpStoreConfigFileDir = path.join(tmpDir, configFileName)
 
 export const userNodeModulesDir = path.join(userDir, 'node_modules')
 export const tmpNodeModulesDir = path.join(tmpDir, 'node_modules')
+
+export const cmsWebhookUrlsFileName = 'cms-webhook-urls.json'
+export const userCmsWebhookUrlsFileDir = path.join(userDir, cmsWebhookUrlsFileName)
+export const tmpCmsWebhookUrlsFileDir = path.join(tmpDir, cmsWebhookUrlsFileName)

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -89,7 +89,7 @@ function copyUserSrcToCustomizations() {
   }
 }
 
-async function copyUserCmsWebhookUrls() {
+function copyUserCmsWebhookUrls() {
   if (existsSync(userCmsWebhookUrlsFileDir)) {
     try {
       copySync(userCmsWebhookUrlsFileDir, tmpCmsWebhookUrlsFileDir)
@@ -97,9 +97,9 @@ async function copyUserCmsWebhookUrls() {
     } catch (err) {
       console.error(`${chalk.red('error')} - ${err}`)
     }
+  } else {
+    console.info(`${chalk.blue('info')} - No CMS webhook URLs file found`)
   }
-
-  console.info(`${chalk.blue('info')} - No CMS webhook URLs file found`)
 }
 
 async function copyTheme() {

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -97,9 +97,9 @@ function copyUserCmsWebhookUrls() {
     } catch (err) {
       console.error(`${chalk.red('error')} - ${err}`)
     }
-  } else {
-    console.info(`${chalk.blue('info')} - No CMS webhook URLs file found`)
   }
+
+  console.info(`${chalk.blue('info')} - No CMS webhook URLs file found`)
 }
 
 async function copyTheme() {

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -92,8 +92,8 @@ function copyUserSrcToCustomizations() {
 async function createCmsWebhookUrlsJsonFile() {
   const userStoreConfig = await import(userStoreConfigFileDir)
 
-  if (userStoreConfig?.headlessCms && userStoreConfig.headlessCms?.webhookUrls) {
-    const { webhookUrls } = userStoreConfig?.headlessCms
+  if (userStoreConfig?.vtexHeadlessCms && userStoreConfig.vtexHeadlessCms?.webhookUrls) {
+    const { webhookUrls } = userStoreConfig?.vtexHeadlessCms
 
     try {
       writeJsonSync(tmpCmsWebhookUrlsFileDir, { urls: webhookUrls }, { spaces: 2 })

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -32,7 +32,8 @@ import {
   userSrcDir,
   userStoreConfigFileDir,
   userThemesFileDir,
-  userCmsWebhookUrlsFileDir,
+  // TODO: Remove when validate the approach
+  // userCmsWebhookUrlsFileDir,
 } from './directory'
 
 import chalk from 'chalk'

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -32,8 +32,6 @@ import {
   userSrcDir,
   userStoreConfigFileDir,
   userThemesFileDir,
-  // TODO: Remove when validate the approach
-  // userCmsWebhookUrlsFileDir,
 } from './directory'
 
 import chalk from 'chalk'
@@ -91,24 +89,10 @@ function copyUserSrcToCustomizations() {
   }
 }
 
-// TODO: Remove when validate the approach
-// function copyUserCmsWebhookUrls() {
-//   if (existsSync(userCmsWebhookUrlsFileDir)) {
-//     try {
-//       copySync(userCmsWebhookUrlsFileDir, tmpCmsWebhookUrlsFileDir)
-//       console.log(`${chalk.green('success')} - CMS webhook URLs file copied`)
-//     } catch (err) {
-//       console.error(`${chalk.red('error')} - ${err}`)
-//     }
-//   } else {
-//     console.info(`${chalk.blue('info')} - No CMS webhook URLs file found`)
-//   }
-// }
-
 async function createCmsWebhookUrlsJsonFile() {
   const userStoreConfig = await import(userStoreConfigFileDir)
 
-  if (userStoreConfig?.headlessCms) {
+  if (userStoreConfig?.headlessCms && userStoreConfig.headlessCms?.webhookUrls) {
     const { webhookUrls } = userStoreConfig?.headlessCms
 
     try {

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -97,9 +97,9 @@ function copyUserCmsWebhookUrls() {
     } catch (err) {
       console.error(`${chalk.red('error')} - ${err}`)
     }
+  } else {
+    console.info(`${chalk.blue('info')} - No CMS webhook URLs file found`)
   }
-
-  console.info(`${chalk.blue('info')} - No CMS webhook URLs file found`)
 }
 
 async function copyTheme() {

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -109,10 +109,10 @@ async function createCmsWebhookUrlsJsonFile() {
   const userStoreConfig = await import(userStoreConfigFileDir)
 
   if (userStoreConfig?.headlessCms) {
-    const webhookUrls = userStoreConfig?.headlessCms
+    const { webhookUrls } = userStoreConfig?.headlessCms
 
     try {
-      writeJsonSync(tmpCmsWebhookUrlsFileDir, webhookUrls, { spaces: 2 })
+      writeJsonSync(tmpCmsWebhookUrlsFileDir, { urls: webhookUrls }, { spaces: 2 })
       console.log(`${chalk.green('success')} - CMS webhook URLs file created`)
     } catch (err) {
       console.error(`${chalk.red('error')} - ${err}`)

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -33,7 +33,6 @@ import {
   userStoreConfigFileDir,
   userThemesFileDir,
   userCmsWebhookUrlsFileDir,
-  cmsWebhookUrlsFileName,
 } from './directory'
 
 import chalk from 'chalk'
@@ -91,18 +90,19 @@ function copyUserSrcToCustomizations() {
   }
 }
 
-function copyUserCmsWebhookUrls() {
-  if (existsSync(userCmsWebhookUrlsFileDir)) {
-    try {
-      copySync(userCmsWebhookUrlsFileDir, tmpCmsWebhookUrlsFileDir)
-      console.log(`${chalk.green('success')} - CMS webhook URLs file copied`)
-    } catch (err) {
-      console.error(`${chalk.red('error')} - ${err}`)
-    }
-  } else {
-    console.info(`${chalk.blue('info')} - No CMS webhook URLs file found`)
-  }
-}
+// TODO: Remove when validate the approach
+// function copyUserCmsWebhookUrls() {
+//   if (existsSync(userCmsWebhookUrlsFileDir)) {
+//     try {
+//       copySync(userCmsWebhookUrlsFileDir, tmpCmsWebhookUrlsFileDir)
+//       console.log(`${chalk.green('success')} - CMS webhook URLs file copied`)
+//     } catch (err) {
+//       console.error(`${chalk.red('error')} - ${err}`)
+//     }
+//   } else {
+//     console.info(`${chalk.blue('info')} - No CMS webhook URLs file found`)
+//   }
+// }
 
 async function createCmsWebhookUrlsJsonFile() {
   const userStoreConfig = await import(userStoreConfigFileDir)

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -9,6 +9,7 @@ import {
   removeSync,
   symlinkSync,
   writeFileSync,
+  writeJsonSync
 } from 'fs-extra'
 
 import path from 'path'
@@ -32,6 +33,7 @@ import {
   userStoreConfigFileDir,
   userThemesFileDir,
   userCmsWebhookUrlsFileDir,
+  cmsWebhookUrlsFileName,
 } from './directory'
 
 import chalk from 'chalk'
@@ -99,6 +101,23 @@ function copyUserCmsWebhookUrls() {
     }
   } else {
     console.info(`${chalk.blue('info')} - No CMS webhook URLs file found`)
+  }
+}
+
+async function createCmsWebhookUrlsJsonFile() {
+  const userStoreConfig = await import(userStoreConfigFileDir)
+
+  if (userStoreConfig?.headlessCms) {
+    const webhookUrls = userStoreConfig?.headlessCms
+
+    try {
+      writeJsonSync(tmpCmsWebhookUrlsFileDir, webhookUrls, { spaces: 2 })
+      console.log(`${chalk.green('success')} - CMS webhook URLs file created`)
+    } catch (err) {
+      console.error(`${chalk.red('error')} - ${err}`)
+    }
+  } else {
+    console.info(`${chalk.blue('info')} - No CMS webhook URLs were provided`)
   }
 }
 
@@ -250,7 +269,7 @@ export async function generate(options?: GenerateOptions) {
     setupPromise,
     copyUserSrcToCustomizations(),
     copyTheme(),
-    copyUserCmsWebhookUrls(),
+    createCmsWebhookUrlsJsonFile(),
     mergeCMSFiles(),
     copyStoreConfig(),
   ])

--- a/packages/core/cms-webhook-urls.json
+++ b/packages/core/cms-webhook-urls.json
@@ -1,5 +1,0 @@
-{
-  "urls": [
-    "https://master--storeframework.myvtex.com/cms-releases/webhook-releases"
-  ]
-}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to generate the store's CMS webhook URLs JSON file (used by Releases) through the store's config.

## How it works?

Currently, the store needs to create a `cms-webhook-urls.json` containing the webhook URLs to be triggered in the build step. With these changes, this will be done through the store's config (`faststore.config.js` file) by adding the `vtexHeadlessCms` property.

![Screenshot 2023-06-16 at 12 26 25](https://github.com/vtex/faststore/assets/15722605/10e235ac-d2bf-4ebd-8616-8245aa24ceb1)

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/78