### PR TITLE
feat: new command to cms sync

### DIFF
--- a/apps/site/pages/docs/component-customization/creating-a-new-section.mdx
+++ b/apps/site/pages/docs/component-customization/creating-a-new-section.mdx
@@ -114,7 +114,7 @@ export default { CallToAction }
 
 ### Step 3: Synchronizing the new section with the Headless CMS
 
-1. In the terminal, navigate to the `.faststore` folder and run `vtex cms sync faststore`. This command will synchronize the new section you created with the @faststore/core.
+1. In the terminal, run `yarn cms-sync`. This command will synchronize the new section you created with the @faststore/core.
 2. Go to the VTEX Admin and access **Storefront > Headless CMS**.
 3. Click on the `Home` content type.
 4. In the `Sections` tab, click the `+`, search for the new `Call to Action` section, and add it to your page.

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -1,0 +1,20 @@
+import { Command } from '@oclif/core'
+import { spawn } from 'child_process'
+import { existsSync } from 'fs-extra'
+import { tmpDir } from '../utils/directory'
+
+export default class CmsSync extends Command {
+  async run() {
+    if (!existsSync(tmpDir)) {
+      throw Error(
+        'The ".faststore" directory could not be found. If you are trying to serve your store, run "faststore build" first.'
+      )
+    }
+
+    return spawn(`vtex cms sync faststore`, {
+      shell: true,
+      cwd: tmpDir,
+      stdio: 'inherit',
+    })
+  }
+}

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -2,13 +2,12 @@ import { Command } from '@oclif/core'
 import { spawn } from 'child_process'
 import { existsSync } from 'fs-extra'
 import { tmpDir } from '../utils/directory'
+import { generate } from '../utils/generate'
 
 export default class CmsSync extends Command {
   async run() {
     if (!existsSync(tmpDir)) {
-      throw Error(
-        'The ".faststore" directory could not be found. If you are trying to serve your store, run "faststore build" first.'
-      )
+      await generate({ setup: true })
     }
 
     return spawn(`vtex cms sync faststore`, {


### PR DESCRIPTION
## What's the purpose of this pull request?

Create a new command on Faststore CLI called `cms-sync` in order to prevent the user from entering the temporary folder so that the script can run.

## How it works?

```cmd
faststore cms-sync
```
## How to test it?

running the script above

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
