### PR TITLE
Feat: adds landing page feature

### DIFF
--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -6,8 +6,8 @@
     "isSingleton": true
   },
   {
-    "id": "page",
-    "name": "Page",
+    "id": "landingPage",
+    "name": "Landing Page",
     "configurationSchemaSets": [
       {
         "name": "Settings",

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -51,9 +51,8 @@ export const getGlobalSectionsData = async (
   previewData: Locator
 ): Promise<GlobalSectionsData> => {
   const { sections } = await getPage<PageContentType>({
-    ...(previewData?.contentType === GLOBAL_SECTIONS_CONTENT_TYPE
-      ? previewData
-      : { filters: { 'settings.seo.slug': '/' } }),
+    ...(previewData?.contentType === GLOBAL_SECTIONS_CONTENT_TYPE &&
+      previewData),
     contentType: GLOBAL_SECTIONS_CONTENT_TYPE,
   })
 

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -1,38 +1,40 @@
 import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
 import type { ComponentType } from 'react'
-import type { GetStaticPaths, GetStaticProps } from 'next'
 import type { Locator } from '@vtex/client-cms'
 
 import RenderSections from 'src/components/cms/RenderSections'
 import Hero from 'src/components/sections/Hero'
-import { mark } from 'src/sdk/tests/mark'
+import Incentives from 'src/components/sections/Incentives'
+import ProductShelf from 'src/components/sections/ProductShelf'
+import ProductTiles from 'src/components/sections/ProductTiles'
+import BannerText from 'src/components/sections/BannerText'
+import Newsletter from 'src/components/sections/Newsletter'
 import { getPage } from 'src/server/cms'
 import type { PageContentType } from 'src/server/cms'
 import CUSTOM_COMPONENTS from 'src/customizations/components'
 
-import storeConfig from '../../../faststore.config'
-import GlobalSections, {
-  GlobalSectionsData,
-  getGlobalSectionsData,
-} from 'src/components/cms/GlobalSections'
+import storeConfig from '../../../../faststore.config'
 
-/**
- * Sections: Components imported from each store's custom components and '../components/sections'.
- * Do not import or render components from any other folder in here.
- */
+/* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
   Hero,
+  Incentives,
+  ProductShelf,
+  ProductTiles,
+  BannerText,
+  Newsletter,
   ...CUSTOM_COMPONENTS,
 }
 
-type Props = {
+export type LandingPageProps = {
   page: PageContentType
-  globalSections: GlobalSectionsData
 }
 
-function Page({ page: { sections, settings }, globalSections }: Props) {
+export default function LandingPage({
+  page: { sections, settings },
+}: LandingPageProps) {
   return (
-    <GlobalSections {...globalSections}>
+    <>
       {/* SEO */}
       <NextSeo
         title={settings?.seo?.title ?? storeConfig.seo.title}
@@ -69,46 +71,27 @@ function Page({ page: { sections, settings }, globalSections }: Props) {
         (not the HTML tag) before rendering it here.
       */}
       <RenderSections sections={sections} components={COMPONENTS} />
-    </GlobalSections>
+    </>
   )
 }
 
-export const getStaticProps: GetStaticProps<
-  Props,
-  Record<string, string>,
-  Locator
-> = async ({ previewData, ...context }) => {
-  const [page, globalSections] = await Promise.all([
-    getPage<PageContentType>({
-      ...(previewData?.contentType === 'page'
+export const getLandingPageBySlug = async (
+  slug: string,
+  previewData: Locator
+) => {
+  try {
+    const landingPageData = await getPage<PageContentType>({
+      ...(previewData?.contentType === 'landingPage'
         ? previewData
         : {
             filters: {
-              filters: { 'settings.seo.slug': `/${context.params?.page}` },
+              filters: { 'settings.seo.slug': `/${slug}` },
             },
           }),
-      contentType: 'page',
-    }),
-    getGlobalSectionsData(previewData),
-  ])
-
-  if (!page) {
-    return {
-      notFound: true,
-    }
-  }
-
-  return {
-    props: { page, globalSections },
+      contentType: 'landingPage',
+    })
+    return landingPageData
+  } catch (error) {
+    return null
   }
 }
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  return {
-    paths: [],
-    fallback: 'blocking',
-  }
-}
-
-Page.displayName = 'Page'
-export default mark(Page)

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -2,6 +2,7 @@ import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
 import type { ComponentType } from 'react'
 import type { Locator } from '@vtex/client-cms'
 
+import MissingContentError from 'src/sdk/error/MissingContentError/MissingContentError'
 import RenderSections from 'src/components/cms/RenderSections'
 import Hero from 'src/components/sections/Hero'
 import Incentives from 'src/components/sections/Incentives'
@@ -92,6 +93,10 @@ export const getLandingPageBySlug = async (
     })
     return landingPageData
   } catch (error) {
-    return null
+    if (error instanceof MissingContentError) {
+      return null
+    }
+
+    throw error
   }
 }

--- a/packages/core/src/components/templates/LandingPage/index.ts
+++ b/packages/core/src/components/templates/LandingPage/index.ts
@@ -1,0 +1,2 @@
+export { default, getLandingPageBySlug } from './LandingPage'
+export type { LandingPageProps } from './LandingPage'

--- a/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
+++ b/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
@@ -1,0 +1,138 @@
+import type { SearchState } from '@faststore/sdk'
+import {
+  formatSearchState,
+  parseSearchState,
+  SearchProvider,
+} from '@faststore/sdk'
+import { BreadcrumbJsonLd, NextSeo } from 'next-seo'
+import { useRouter } from 'next/router'
+import { useMemo } from 'react'
+
+import type { ServerCollectionPageQueryQuery } from '@generated/graphql'
+import Breadcrumb from 'src/components/sections/Breadcrumb'
+import Hero from 'src/components/sections/Hero'
+import ProductGallery from 'src/components/sections/ProductGallery'
+import ProductShelf from 'src/components/sections/ProductShelf'
+import ScrollToTopButton from 'src/components/sections/ScrollToTopButton'
+import { ITEMS_PER_PAGE } from 'src/constants'
+import { useApplySearchState } from 'src/sdk/search/state'
+
+import type { ComponentType } from 'react'
+import RenderSections from 'src/components/cms/RenderSections'
+import CUSTOM_COMPONENTS from 'src/customizations/components'
+import { PLPContentType } from 'src/server/cms'
+
+import storeConfig from '../../../../faststore.config'
+
+export type ProductListingPageProps = ServerCollectionPageQueryQuery & {
+  page: PLPContentType
+}
+
+/**
+ * Sections: Components imported from each store's custom components and '../components/sections' only.
+ * Do not import or render components from any other folder in here.
+ */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  Breadcrumb,
+  Hero,
+  ProductGallery,
+  ProductShelf,
+  ...CUSTOM_COMPONENTS,
+}
+
+type UseSearchParams = ServerCollectionPageQueryQuery & {
+  sort: SearchState['sort']
+}
+const useSearchParams = ({
+  collection,
+  sort,
+}: UseSearchParams): SearchState => {
+  const selectedFacets = collection?.meta.selectedFacets
+  const { asPath } = useRouter()
+
+  const hrefState = useMemo(() => {
+    const url = new URL(asPath, 'http://localhost')
+
+    const shouldUpdateDefaultSort = sort && !url.searchParams.has('sort')
+    if (shouldUpdateDefaultSort) {
+      url.searchParams.set('sort', sort)
+    }
+
+    const newState = parseSearchState(url)
+    // In case we are in an incomplete url
+    if (newState.selectedFacets.length === 0) {
+      newState.selectedFacets = selectedFacets
+    }
+
+    return formatSearchState(newState).href
+  }, [asPath, selectedFacets, sort])
+
+  return useMemo(() => parseSearchState(new URL(hrefState)), [hrefState])
+}
+
+export default function ProductListingPage({
+  page: { sections, settings },
+  ...otherProps
+}: ProductListingPageProps) {
+  const { collection } = otherProps
+  const router = useRouter()
+  const applySearchState = useApplySearchState()
+  const searchParams = useSearchParams({
+    ...otherProps,
+    sort: settings?.productGallery?.sortBySelection as SearchState['sort'],
+  })
+
+  const { page, sort } = searchParams
+  const title = collection?.seo.title ?? storeConfig.seo.title
+  const description = collection?.seo.description ?? storeConfig.seo.title
+  const pageQuery = page !== 0 ? `?page=${page}` : ''
+  const separator = pageQuery !== '' ? '&' : '?'
+  const sortQuery = !!sort ? `${separator}sort=${sort}` : ''
+  const [pathname] = router.asPath.split('?')
+  const canonical = `${storeConfig.storeUrl}${pathname}${pageQuery}${sortQuery}`
+
+  return (
+    <>
+      <SearchProvider
+        onChange={applySearchState}
+        itemsPerPage={settings?.productGallery?.itemsPerPage ?? ITEMS_PER_PAGE}
+        {...searchParams}
+      >
+        {/* SEO */}
+        <NextSeo
+          title={title}
+          description={description}
+          titleTemplate={storeConfig.seo.titleTemplate}
+          canonical={canonical}
+          openGraph={{
+            type: 'website',
+            title,
+            description,
+          }}
+        />
+        <BreadcrumbJsonLd
+          itemListElements={collection?.breadcrumbList.itemListElement ?? []}
+        />
+
+        {/*
+          WARNING: Do not import or render components from any
+          other folder than '../components/sections' in here.
+
+          This is necessary to keep the integration with the CMS
+          easy and consistent, enabling the change and reorder
+          of elements on this page.
+
+          If needed, wrap your component in a <Section /> component
+          (not the HTML tag) before rendering it here.
+        */}
+        <RenderSections
+          context={collection}
+          sections={sections}
+          components={COMPONENTS}
+        />
+
+        <ScrollToTopButton />
+      </SearchProvider>
+    </>
+  )
+}

--- a/packages/core/src/components/templates/ProductListingPage/index.ts
+++ b/packages/core/src/components/templates/ProductListingPage/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ProductListingPage'
+export type { ProductListingPageProps } from './ProductListingPage'

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -1,152 +1,51 @@
 import { isNotFoundError } from '@faststore/api'
 import { gql } from '@faststore/graphql-utils'
-import type { SearchState } from '@faststore/sdk'
-import {
-  formatSearchState,
-  parseSearchState,
-  SearchProvider,
-} from '@faststore/sdk'
 import type { GetStaticPaths, GetStaticProps } from 'next'
-import { BreadcrumbJsonLd, NextSeo } from 'next-seo'
-import { useRouter } from 'next/router'
-import { useMemo } from 'react'
 
 import type {
   ServerCollectionPageQueryQuery,
   ServerCollectionPageQueryQueryVariables,
 } from '@generated/graphql'
-import Breadcrumb from 'src/components/sections/Breadcrumb'
-import Hero from 'src/components/sections/Hero'
-import ProductGallery from 'src/components/sections/ProductGallery'
-import ProductShelf from 'src/components/sections/ProductShelf'
-import ScrollToTopButton from 'src/components/sections/ScrollToTopButton'
-import { ITEMS_PER_PAGE, ITEMS_PER_SECTION } from 'src/constants'
-import { useApplySearchState } from 'src/sdk/search/state'
 import { mark } from 'src/sdk/tests/mark'
 import { execute } from 'src/server'
 
 import { Locator } from '@vtex/client-cms'
-import type { ComponentType } from 'react'
 import GlobalSections, {
   getGlobalSectionsData,
   GlobalSectionsData,
 } from 'src/components/cms/GlobalSections'
-import RenderSections from 'src/components/cms/RenderSections'
-import CUSTOM_COMPONENTS from 'src/customizations/components'
-import { getPage, PLPContentType } from 'src/server/cms'
-import storeConfig from '../../faststore.config'
+import { getPage, PageContentType, PLPContentType } from 'src/server/cms'
+import ProductListingPage, {
+  ProductListingPageProps,
+} from 'src/components/templates/ProductListingPage'
+import LandingPage, {
+  getLandingPageBySlug,
+  LandingPageProps,
+} from 'src/components/templates/LandingPage'
 
-type Props = ServerCollectionPageQueryQuery & {
-  page: PLPContentType
+type BaseProps = {
   globalSections: GlobalSectionsData
 }
 
-/**
- * Sections: Components imported from each store's custom components and '../components/sections' only.
- * Do not import or render components from any other folder in here.
- */
-const COMPONENTS: Record<string, ComponentType<any>> = {
-  Breadcrumb,
-  Hero,
-  ProductGallery,
-  ProductShelf,
-  ...CUSTOM_COMPONENTS,
-}
+type Props = BaseProps &
+  (
+    | ({
+        type: 'plp'
+        page: PLPContentType
+      } & ServerCollectionPageQueryQuery)
+    | {
+        type: 'page'
+        page: PageContentType
+      }
+  )
 
-type UseSearchParams = ServerCollectionPageQueryQuery & {
-  sort: SearchState['sort']
-}
-const useSearchParams = ({
-  collection,
-  sort,
-}: UseSearchParams): SearchState => {
-  const selectedFacets = collection?.meta.selectedFacets
-  const { asPath } = useRouter()
-
-  const hrefState = useMemo(() => {
-    const url = new URL(asPath, 'http://localhost')
-
-    const shouldUpdateDefaultSort = sort && !url.searchParams.has('sort')
-    if (shouldUpdateDefaultSort) {
-      url.searchParams.set('sort', sort)
-    }
-
-    const newState = parseSearchState(url)
-    // In case we are in an incomplete url
-    if (newState.selectedFacets.length === 0) {
-      newState.selectedFacets = selectedFacets
-    }
-
-    return formatSearchState(newState).href
-  }, [asPath, selectedFacets, sort])
-
-  return useMemo(() => parseSearchState(new URL(hrefState)), [hrefState])
-}
-
-function Page({
-  page: { sections, settings },
-  globalSections,
-  ...otherProps
-}: Props) {
-  const { collection } = otherProps
-  const router = useRouter()
-  const applySearchState = useApplySearchState()
-  const searchParams = useSearchParams({
-    ...otherProps,
-    sort: settings?.productGallery?.sortBySelection as SearchState['sort'],
-  })
-
-  const { page, sort } = searchParams
-  const title = collection?.seo.title ?? storeConfig.seo.title
-  const description = collection?.seo.description ?? storeConfig.seo.title
-  const pageQuery = page !== 0 ? `?page=${page}` : ''
-  const separator = pageQuery !== '' ? '&' : '?'
-  const sortQuery = !!sort ? `${separator}sort=${sort}` : ''
-  const [pathname] = router.asPath.split('?')
-  const canonical = `${storeConfig.storeUrl}${pathname}${pageQuery}${sortQuery}`
-
+function Page({ globalSections, type, ...otherProps }: Props) {
   return (
     <GlobalSections {...globalSections}>
-      <SearchProvider
-        onChange={applySearchState}
-        itemsPerPage={settings?.productGallery?.itemsPerPage ?? ITEMS_PER_PAGE}
-        {...searchParams}
-      >
-        {/* SEO */}
-        <NextSeo
-          title={title}
-          description={description}
-          titleTemplate={storeConfig.seo.titleTemplate}
-          canonical={canonical}
-          openGraph={{
-            type: 'website',
-            title,
-            description,
-          }}
-        />
-        <BreadcrumbJsonLd
-          itemListElements={collection?.breadcrumbList.itemListElement ?? []}
-        />
-
-        {/*
-          WARNING: Do not import or render components from any
-          other folder than '../components/sections' in here.
-
-          This is necessary to keep the integration with the CMS
-          easy and consistent, enabling the change and reorder
-          of elements on this page.
-
-          If needed, wrap your component in a <Section /> component
-          (not the HTML tag) before rendering it here.
-        */}
-        <RenderSections
-          context={collection}
-          sections={sections}
-          components={COMPONENTS}
-        />
-
-        <ScrollToTopButton />
-      </SearchProvider>
+      {type === 'plp' && (
+        <ProductListingPage {...(otherProps as ProductListingPageProps)} />
+      )}
+      {type === 'page' && <LandingPage {...(otherProps as LandingPageProps)} />}
     </GlobalSections>
   )
 }
@@ -180,7 +79,22 @@ export const getStaticProps: GetStaticProps<
   { slug: string[] },
   Locator
 > = async ({ params, previewData }) => {
-  const [{ data, errors = [] }, page, globalSections] = await Promise.all([
+  const [landingPagePromise, globalSectionsPromise] = [
+    getLandingPageBySlug(params?.slug[0], previewData),
+    getGlobalSectionsData(previewData),
+  ]
+
+  if (await landingPagePromise) {
+    return {
+      props: {
+        page: await landingPagePromise,
+        globalSections: await globalSectionsPromise,
+        type: 'page',
+      },
+    }
+  }
+
+  const [{ data, errors = [] }, page] = await Promise.all([
     execute<
       ServerCollectionPageQueryQueryVariables,
       ServerCollectionPageQueryQuery
@@ -192,7 +106,6 @@ export const getStaticProps: GetStaticProps<
       ...(previewData?.contentType === 'plp' ? previewData : null),
       contentType: 'plp',
     }),
-    getGlobalSectionsData(previewData),
   ])
 
   const notFound = errors.find(isNotFoundError)
@@ -204,6 +117,7 @@ export const getStaticProps: GetStaticProps<
   }
 
   if (errors.length > 0) {
+    console.error(...errors)
     throw errors[0]
   }
 
@@ -211,7 +125,8 @@ export const getStaticProps: GetStaticProps<
     props: {
       ...data,
       page,
-      globalSections,
+      globalSections: await globalSectionsPromise,
+      type: 'plp',
     },
   }
 }

--- a/packages/core/src/pages/api/preview.ts
+++ b/packages/core/src/pages/api/preview.ts
@@ -41,8 +41,6 @@ const handler: NextApiHandler = async (req, res) => {
     // Fetch CMS to check if the provided `locator` exists
     const page = await clientCMS.getCMSPage(locator)
 
-    console.log(page)
-
     // If the content doesn't exist prevent preview mode from being enabled
     if (!page) {
       throw new StatusError(
@@ -60,8 +58,8 @@ const handler: NextApiHandler = async (req, res) => {
       return
     }
 
-    if (locator.contentType === 'page') {
-      res.redirect(`/l/${(page.settings as Settings)?.seo.slug}`)
+    if (locator.contentType === 'landingPage') {
+      res.redirect(`${(page.settings as Settings)?.seo.slug}`)
       return
     }
 

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -87,9 +87,7 @@ export const getStaticProps: GetStaticProps<
 > = async ({ previewData }) => {
   const [page, globalSections] = await Promise.all([
     getPage<PageContentType>({
-      ...(previewData?.contentType === 'home'
-        ? previewData
-        : { filters: { 'settings.seo.slug': '/' } }),
+      ...(previewData?.contentType === 'home' && previewData),
       contentType: 'home',
     }),
     getGlobalSectionsData(previewData),

--- a/packages/core/src/pages/l/[page].tsx
+++ b/packages/core/src/pages/l/[page].tsx
@@ -1,0 +1,116 @@
+import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
+import type { ComponentType } from 'react'
+import type { GetStaticPaths, GetStaticProps } from 'next'
+import type { Locator } from '@vtex/client-cms'
+
+import RenderSections from 'src/components/cms/RenderSections'
+import Hero from 'src/components/sections/Hero'
+import { mark } from 'src/sdk/tests/mark'
+import { getPage } from 'src/server/cms'
+import type { PageContentType } from 'src/server/cms'
+import CUSTOM_COMPONENTS from 'src/customizations/components'
+
+import storeConfig from '../../../faststore.config'
+import GlobalSections, {
+  GlobalSectionsData,
+  getGlobalSectionsData,
+} from 'src/components/cms/GlobalSections'
+
+/**
+ * Sections: Components imported from each store's custom components and '../components/sections'.
+ * Do not import or render components from any other folder in here.
+ */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  Hero,
+  ...CUSTOM_COMPONENTS,
+}
+
+type Props = {
+  page: PageContentType
+  globalSections: GlobalSectionsData
+}
+
+function Page({ page: { sections, settings }, globalSections }: Props) {
+  return (
+    <GlobalSections {...globalSections}>
+      {/* SEO */}
+      <NextSeo
+        title={settings?.seo?.title ?? storeConfig.seo.title}
+        description={settings?.seo?.description ?? storeConfig.seo?.description}
+        titleTemplate={storeConfig.seo?.titleTemplate ?? storeConfig.seo?.title}
+        canonical={settings?.seo?.canonical ?? storeConfig.storeUrl}
+        openGraph={{
+          type: 'website',
+          url: storeConfig.storeUrl,
+          title: settings?.seo?.title ?? storeConfig.seo.title,
+          description:
+            settings?.seo?.description ?? storeConfig.seo.description,
+        }}
+      />
+      <SiteLinksSearchBoxJsonLd
+        url={storeConfig.storeUrl}
+        potentialActions={[
+          {
+            target: `${storeConfig.storeUrl}/s/?q`,
+            queryInput: 'search_term_string',
+          },
+        ]}
+      />
+
+      {/*
+        WARNING: Do not import or render components from any
+        other folder than '../components/sections' in here.
+
+        This is necessary to keep the integration with the CMS
+        easy and consistent, enabling the change and reorder
+        of elements on this page.
+
+        If needed, wrap your component in a <Section /> component
+        (not the HTML tag) before rendering it here.
+      */}
+      <RenderSections sections={sections} components={COMPONENTS} />
+    </GlobalSections>
+  )
+}
+
+export const getStaticProps: GetStaticProps<
+  Props,
+  Record<string, string>,
+  Locator
+> = async ({ previewData, ...context }) => {
+  const [page, globalSections] = await Promise.all([
+    getPage<PageContentType>({
+      ...(previewData?.contentType === 'page'
+        ? previewData
+        : {
+            filters: {
+              filters: { 'settings.seo.slug': `/${context.params?.page}` },
+            },
+          }),
+      contentType: 'page',
+    }),
+    getGlobalSectionsData(previewData),
+  ])
+
+  console.log(page.settings.seo)
+
+  if (!page) {
+    return {
+      notFound: true,
+    }
+  }
+
+  return {
+    props: { page, globalSections },
+  }
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}
+
+Page.displayName = 'Page'
+export default mark(Page)

--- a/packages/core/src/pages/l/[page].tsx
+++ b/packages/core/src/pages/l/[page].tsx
@@ -92,8 +92,6 @@ export const getStaticProps: GetStaticProps<
     getGlobalSectionsData(previewData),
   ])
 
-  console.log(page.settings.seo)
-
   if (!page) {
     return {
       notFound: true,

--- a/packages/core/src/sdk/error/MissingContentError/MissingContentError.ts
+++ b/packages/core/src/sdk/error/MissingContentError/MissingContentError.ts
@@ -1,0 +1,15 @@
+import { Options } from 'src/server/cms'
+
+export default class MissingContentError extends Error {
+  constructor(options: Options) {
+    super(
+      `Missing content on the CMS for content type ${
+        options.contentType
+      }. Add content before proceeding. Context: ${JSON.stringify(
+        options,
+        null,
+        2
+      )}`
+    )
+  }
+}

--- a/packages/core/src/sdk/error/MissingContentError/index.ts
+++ b/packages/core/src/sdk/error/MissingContentError/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MissingContentError'

--- a/packages/core/src/sdk/error/MultipleContentError/MultipleContentError.ts
+++ b/packages/core/src/sdk/error/MultipleContentError/MultipleContentError.ts
@@ -1,0 +1,15 @@
+import { Options } from 'src/server/cms'
+
+export default class MultipleContentError extends Error {
+  constructor(options: Options) {
+    super(
+      `Multiple content defined on the CMS for content type ${
+        options.contentType
+      }. Remove duplicated content before proceeding. Context: ${JSON.stringify(
+        options,
+        null,
+        2
+      )}`
+    )
+  }
+}

--- a/packages/core/src/sdk/error/MultipleContentError/index.ts
+++ b/packages/core/src/sdk/error/MultipleContentError/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MultipleContentError'

--- a/packages/core/src/server/cms.ts
+++ b/packages/core/src/server/cms.ts
@@ -2,13 +2,15 @@ import type { ContentData, ContentTypeOptions, Locator } from '@vtex/client-cms'
 import ClientCMS from '@vtex/client-cms'
 
 import config from '../../faststore.config'
+import MultipleContentError from 'src/sdk/error/MultipleContentError'
+import MissingContentError from 'src/sdk/error/MissingContentError'
 
 export const clientCMS = new ClientCMS({
   workspace: config.api.workspace,
   tenant: config.api.storeId,
 })
 
-type Options =
+export type Options =
   | Locator
   | {
       contentType: string
@@ -27,27 +29,11 @@ export const getPage = async <T extends ContentData>(options: Options) => {
   const pages = result.data
 
   if (!pages[0]) {
-    throw new Error(
-      `Missing content on the CMS for content type ${
-        options.contentType
-      }. Add content before proceeding. Context: ${JSON.stringify(
-        options,
-        null,
-        2
-      )}`
-    )
+    throw new MissingContentError(options)
   }
 
   if (pages.length !== 1) {
-    throw new Error(
-      `Multiple content defined on the CMS for content type ${
-        options.contentType
-      }. Remove duplicated content before proceeding. Context: ${JSON.stringify(
-        options,
-        null,
-        2
-      )}`
-    )
+    throw new MultipleContentError(options)
   }
 
   return pages[0] as T

--- a/packages/core/src/server/cms.ts
+++ b/packages/core/src/server/cms.ts
@@ -1,4 +1,4 @@
-import type { ContentData, Locator } from '@vtex/client-cms'
+import type { ContentData, ContentTypeOptions, Locator } from '@vtex/client-cms'
 import ClientCMS from '@vtex/client-cms'
 
 import config from '../../faststore.config'
@@ -12,7 +12,7 @@ type Options =
   | Locator
   | {
       contentType: string
-      filters?: Record<string, string>
+      filters?: Partial<ContentTypeOptions>
     }
 
 const isLocator = (x: any): x is Locator =>


### PR DESCRIPTION
## What's the purpose of this pull request?

This Pull Request adds the Landing Page creation feature to faststore

## How it works?

Now the developer can create a new LandingPage in Admin CMS, and this page will be available in _/slug_ path, based in configs.

## How to test it?

You can to add a new Landing Page in https://storeframework.myvtex.com/admin/new-cms/faststore/
![Screenshot 2023-06-20 at 18 44 13](https://github.com/vtex/faststore/assets/51174217/b76fd4d7-1d48-4590-9b6e-96f27859e504)

To add sections
![Screenshot 2023-06-20 at 18 47 06](https://github.com/vtex/faststore/assets/51174217/25050d2d-0b3d-4f7a-8500-accd85ccb8c0)

To config the path of this Landing Page

![Screenshot 2023-06-20 at 18 48 19](https://github.com/vtex/faststore/assets/51174217/62785d90-c1a4-4312-b37b-b1e4222a034c)

After publish the new page you will can access this landing page by path

![Screenshot 2023-06-20 at 18 51 58](https://github.com/vtex/faststore/assets/51174217/86a1338b-0c6d-4b66-9def-6e321c2c07ec)

### Alert

he landing pages, PLPs (Product Listing Pages), and Category pages currently share the same path structure. As a result, when a Landing Page is created with a path that matches a PLP, the Landing Page takes priority and the PLP will not be displayed.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
