### PR TITLE
Feat: Update Accent Colors 

### DIFF
--- a/apps/site/pages/docs/global-tokens/colors.mdx
+++ b/apps/site/pages/docs/global-tokens/colors.mdx
@@ -27,11 +27,11 @@ The store palette with all the tones needed.
 ### Accent
 
 <TokenColors>
-  <TokenColor token="--fs-color-accent-0" value="#e3e6e8" />
-  <TokenColor token="--fs-color-accent-1" value="#e3e6e8" />
-  <TokenColor token="--fs-color-accent-2" value="#74808b" />
-  <TokenColor token="--fs-color-accent-3" value="#5d666f" />
-  <TokenColor token="--fs-color-accent-4" value="#171a1c" />
+  <TokenColor token="--fs-color-accent-0" value="#e8e3ee" />
+  <TokenColor token="--fs-color-accent-1" value="#b4a4d0" />
+  <TokenColor token="--fs-color-accent-2" value="#9d8abf" />
+  <TokenColor token="--fs-color-accent-3" value="#74678c" />
+  <TokenColor token="--fs-color-accent-4" value="#423759" />
 </TokenColors>
 
 ### Neutral

--- a/apps/site/pages/docs/global-tokens/colors.mdx
+++ b/apps/site/pages/docs/global-tokens/colors.mdx
@@ -27,8 +27,8 @@ The store palette with all the tones needed.
 ### Accent
 
 <TokenColors>
-  <TokenColor token="--fs-color-accent-0" value="#e8e3ee" />
-  <TokenColor token="--fs-color-accent-1" value="#b4a4d0" />
+  <TokenColor token="--fs-color-accent-0" value="#efeaf5" />
+  <TokenColor token="--fs-color-accent-1" value="#d3c9de" />
   <TokenColor token="--fs-color-accent-2" value="#9d8abf" />
   <TokenColor token="--fs-color-accent-3" value="#74678c" />
   <TokenColor token="--fs-color-accent-4" value="#423759" />

--- a/packages/ui/src/styles/base/tokens.scss
+++ b/packages/ui/src/styles/base/tokens.scss
@@ -17,11 +17,11 @@ body {
   --fs-color-main-3                    : #002c71;
   --fs-color-main-4                    : #002155;
 
-  --fs-color-accent-0                  : #e3e6e8;
-  --fs-color-accent-1                  : #e3e6e8;
-  --fs-color-accent-2                  : #74808b;
-  --fs-color-accent-3                  : #5d666f;
-  --fs-color-accent-4                  : #171a1c;
+  --fs-color-accent-0                  : #e8e3ee;
+  --fs-color-accent-1                  : #b4a4d0;
+  --fs-color-accent-2                  : #9d8abf;
+  --fs-color-accent-3                  : #74678c;
+  --fs-color-accent-4                  : #423759;
 
   --fs-color-neutral-0                 : #ffffff;
   --fs-color-neutral-1                 : #f1f2f3;

--- a/packages/ui/src/styles/base/tokens.scss
+++ b/packages/ui/src/styles/base/tokens.scss
@@ -17,8 +17,8 @@ body {
   --fs-color-main-3                    : #002c71;
   --fs-color-main-4                    : #002155;
 
-  --fs-color-accent-0                  : #e8e3ee;
-  --fs-color-accent-1                  : #b4a4d0;
+  --fs-color-accent-0                  : #efeaf5;
+  --fs-color-accent-1                  : #d3c9de;
   --fs-color-accent-2                  : #9d8abf;
   --fs-color-accent-3                  : #74678c;
   --fs-color-accent-4                  : #423759;


### PR DESCRIPTION
## What's the purpose of this pull request?
This is a proposal to update our color tokens in order to better differentiates the accent colors from neutral ones.

## How it works?

|Before|After|
|-|-|
|![image](https://github.com/vtex/faststore/assets/11613011/59287426-54a5-4f42-b91d-dfd351198f8d)|![image](https://github.com/vtex/faststore/assets/11613011/7e96f5ac-82dd-4efd-9804-3945d06e5abf)|
|![image](https://github.com/vtex/faststore/assets/11613011/0125b260-5358-48d7-8652-2596d05975a0)|![image](https://github.com/vtex/faststore/assets/11613011/5fd68a88-94da-4787-bdb2-4214cd81e9db)|

## How to test it?

`library` doc:
1. Review doc pages of affect components: Hero, Alert and Banner

`faststore/core` application:
1. Run `yarn dev`
2. Check all pages

