### PR TITLE
Docs: review CLI guide 

### DIFF
--- a/apps/site/pages/docs/getting-started/4-faststore-cli.mdx
+++ b/apps/site/pages/docs/getting-started/4-faststore-cli.mdx
@@ -47,6 +47,14 @@ Executes a Next.js project in the root directory and usally servers it at `http:
   yarn start
 ```
 
+#### `cms-sync`
+
+Sync changes in the cms folder with the VTEX Headless CMS app.
+
+```bash
+  yarn cms-sync
+```
+
 ---
 
 ## Installing FastStore CLI globally using `npm`
@@ -75,6 +83,12 @@ Installing the CLI via `npm` allows you to use its commands in you machine. To i
 
 ```bash
   yarn faststore start
+```
+
+#### `cms-sync`
+
+```bash
+  yarn faststore cms-sync
 ```
 
 #### `help`

--- a/apps/site/pages/docs/getting-started/4-faststore-cli.mdx
+++ b/apps/site/pages/docs/getting-started/4-faststore-cli.mdx
@@ -17,7 +17,7 @@ Also the CLI is the responsible on keeping the stores up-to-date with the [`@fas
 
 ---
 
-/* ## Runnig FastStore CLI on the project
+## Runnig FastStore CLI on the project
 
 The CLI is a dependency in the `package.json` file of the FastStore project, so once you run `yarn install` during the [set up of the project](/docs/getting-started/2-setting-up-the-project) you can start using it on the project.
 
@@ -47,6 +47,7 @@ Executes a Next.js project in the root directory and usally servers it at `http:
   yarn start
 ```
 
+{/* 
 ---
 
 ## Installing FastStore CLI globally using `npm`
@@ -82,4 +83,4 @@ Installing the CLI via `npm` allows you to use its commands in you machine. To i
 ```bash
   faststore help [COMMAND] [-n]
 ```
-*/
+*/}

--- a/apps/site/pages/docs/getting-started/4-faststore-cli.mdx
+++ b/apps/site/pages/docs/getting-started/4-faststore-cli.mdx
@@ -47,7 +47,6 @@ Executes a Next.js project in the root directory and usally servers it at `http:
   yarn start
 ```
 
-{/* 
 ---
 
 ## Installing FastStore CLI globally using `npm`
@@ -63,24 +62,23 @@ Installing the CLI via `npm` allows you to use its commands in you machine. To i
 #### `dev`
 
 ```bash
-  faststore dev
+  yarn faststore dev
 ```
 
 #### `build`
 
 ```bash
-  faststore build
+  yarn faststore build
 ```
 
 #### `start`
 
 ```bash
-  faststore start
+  yarn faststore start
 ```
 
 #### `help`
 
 ```bash
-  faststore help [COMMAND] [-n]
+  yarn faststore help [COMMAND] [-n]
 ```
-*/}

--- a/apps/site/pages/docs/getting-started/4-faststore-cli.mdx
+++ b/apps/site/pages/docs/getting-started/4-faststore-cli.mdx
@@ -17,7 +17,7 @@ Also the CLI is the responsible on keeping the stores up-to-date with the [`@fas
 
 ---
 
-## Runnig FastStore CLI on the project
+/* ## Runnig FastStore CLI on the project
 
 The CLI is a dependency in the `package.json` file of the FastStore project, so once you run `yarn install` during the [set up of the project](/docs/getting-started/2-setting-up-the-project) you can start using it on the project.
 
@@ -82,3 +82,4 @@ Installing the CLI via `npm` allows you to use its commands in you machine. To i
 ```bash
   faststore help [COMMAND] [-n]
 ```
+*/

--- a/apps/site/pages/docs/getting-started/4-faststore-cli.mdx
+++ b/apps/site/pages/docs/getting-started/4-faststore-cli.mdx
@@ -51,7 +51,7 @@ Executes a Next.js project in the root directory and usally servers it at `http:
 
 ## Installing FastStore CLI globally using `npm`
 
-Installing the CLI via `npm` allows you to use its commands in you machine. To install FastStore CLI, run the following in the terminal:
+Installing the CLI via `npm` allows you to use its commands in you machine. To install [`@faststore/cli`](https://www.npmjs.com/package/@faststore/cli) package, run the following in the terminal:
 
 ```bash
   npm install -g @faststore/cli


### PR DESCRIPTION
## What's the purpose of this pull request?

The PR is to address the issue with the FastStore commands installed via `npm`. They are not functioning correctly in the root directory. Updates the commands to work in the root.

🔗 [Preview](https://faststore-site-git-fix-cli-commands-faststore.vercel.app/docs/getting-started/4-faststore-cli)