### PR TITLE
fix: script name

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,8 +14,8 @@
     "node": ">=12"
   },
   "scripts": {
-    "dev": "tsdx watch --entry ./local/server.ts --target node --onSuccess \"node ./dist\"",
-    "dev:no-server": "concurrently \"yarn generate -w\" \"tsdx watch\"",
+    "dev": "concurrently \"yarn generate -w\" \"tsdx watch\"",
+    "dev:server": "tsdx watch --entry ./local/server.ts --target node --onSuccess \"node ./dist\"",
     "build": "graphql-codegen --config codegen.yml && tsdx build",
     "lint": "eslint src/**/*.ts",
     "test": "tsdx test",


### PR DESCRIPTION
When we run the `yarn dev` script on the root, the turbo will run all `dev` package scripts. But the dev script from the `api` package modifies the bundle, so he fails when the `core` package tries to run.

So I rename the script in order to avoid modifying the bundle.