### PR TITLE
get orderFormId from from the public field

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -261,7 +261,7 @@ export const VtexCommerce = (
       }
     },
     getSessionOrder: (): Promise<Session> => {
-      return fetchAPI(`${base}/api/sessions?items=checkout.orderFormId`, {
+      return fetchAPI(`${base}/api/sessions?items=public.orderFormId`, {
         method: 'GET',
         headers: {
           'content-type': 'application/json',


### PR DESCRIPTION
## What's the purpose of this pull request?

Adjust the orderForm that is returning to FS so we were getting it from the checkout.

Edge case: When the user has a session already with an orderForm at portal and the checkout is passing the orderFormId param so the field public will be with the correct orderForm but the previous field will be with the cookie value set with an old orderForm.

What happens is that when the user goes back to the FS he will change the cart for an old orderForm making an unexpected behaviour

## How it works?

- Create a cart and go to the checkout:
`https://secure.vtexfaststore.com/checkout?orderFormId=96c7973b68804795acc398bc6352e026#/cart
```
`
You should have smt like this:
https://secure.vtexfaststore.com/api/sessions?items=*
{
"id": "279c0685-9348-47ad-9630-9b7aeb946e34",
"namespaces": {
"account": {
"id": {
"value": "0173a932-06a9-4418-aa14-1426d10d217a",
"keepAlive": true
},
"accountName": {
"value": "storeframework"
}
},
"store": {
"channel": {
"value": "1"
},
"countryCode": {
"value": "USA"
},
"cultureInfo": {
"value": "en-US"
},
"currencyCode": {
"value": "USD"
},
"currencySymbol": {
"value": "$"
},
"channelPrivacy": {
"value": "public"
}
},
"public": {
"orderFormId": {
"value": "96c7973b68804795acc398bc6352e026"
}
}
}
}
```
Now change the orderForm using the param like this:
https://secure.vtexfaststore.com/checkout?orderFormId=86c7973b68804795acc398bc6352e026#/cart

Get the session again and you should have smt like this:
https://secure.vtexfaststore.com/api/sessions?items=*
```
{
"id": "279c0685-9348-47ad-9630-9b7aeb946e34",
"namespaces": {
"account": {
"id": {
"value": "0173a932-06a9-4418-aa14-1426d10d217a",
"keepAlive": true
},
"accountName": {
"value": "storeframework"
}
},
"store": {
"channel": {
"value": "1"
},
"countryCode": {
"value": "USA"
},
"cultureInfo": {
"value": "en-US"
},
"currencyCode": {
"value": "USD"
},
"currencySymbol": {
"value": "$"
},
"channelPrivacy": {
"value": "public"
}
},
"public": {
"orderFormId": {
"value": "86c7973b68804795acc398bc6352e026"
}
},
"cookie": {
"checkout.vtex.com": {
"value": "__ofid=96c7973b68804795acc398bc6352e026"
}
},
"checkout": {
"orderFormId": {
"value": "96c7973b68804795acc398bc6352e026"
}
}
}
}
```

So the public.orderFormId is up to date at runtime but the checkout.orderFormId is not getting the most up to date value causing the problem.

