### PR TITLE
Fix: Separates `Navbar` and `NavbarSlider` css module imports

### DIFF
--- a/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
+++ b/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
@@ -9,7 +9,7 @@ import { mark } from 'src/sdk/tests/mark'
 
 import type { NavbarProps } from '../Navbar'
 
-import styles from '../../sections/Navbar/section.module.scss'
+import styles from './section.module.scss'
 
 import {
   NavbarSlider as NavbarSliderWrapper,

--- a/packages/core/src/components/navigation/NavbarSlider/section.module.scss
+++ b/packages/core/src/components/navigation/NavbarSlider/section.module.scss
@@ -1,0 +1,12 @@
+.section {
+  @import "@faststore/ui/src/components/atoms/Button/styles.scss";
+  @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
+  @import "@faststore/ui/src/components/atoms/Link/styles.scss";
+  @import "@faststore/ui/src/components/atoms/List/styles.scss";
+  @import "@faststore/ui/src/components/atoms/Logo/styles.scss";
+  @import "@faststore/ui/src/components/molecules/LinkButton/styles.scss";
+  @import "@faststore/ui/src/components/molecules/Modal/styles.scss";
+  @import "@faststore/ui/src/components/molecules/NavbarLinks/styles.scss";
+  @import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
+  @import "@faststore/ui/src/components/organisms/NavbarSlider/styles.scss";
+}

--- a/packages/core/src/components/sections/Navbar/section.module.scss
+++ b/packages/core/src/components/sections/Navbar/section.module.scss
@@ -12,7 +12,6 @@
   @import "@faststore/ui/src/components/atoms/Logo/styles.scss";
   @import "@faststore/ui/src/components/atoms/Price/styles.scss";
   @import "@faststore/ui/src/components/molecules/LinkButton/styles.scss";
-  @import "@faststore/ui/src/components/molecules/Modal/styles.scss";
   @import "@faststore/ui/src/components/molecules/NavbarLinks/styles.scss";
   @import "@faststore/ui/src/components/molecules/SearchAutoComplete/styles.scss";
   @import "@faststore/ui/src/components/molecules/SearchDropdown/styles.scss";
@@ -22,6 +21,4 @@
   @import "@faststore/ui/src/components/molecules/SearchTop/styles.scss";
   @import "@faststore/ui/src/components/organisms/SearchInput/styles.scss";
   @import "@faststore/ui/src/components/organisms/Navbar/styles.scss";
-  @import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
-  @import "@faststore/ui/src/components/organisms/NavbarSlider/styles.scss";
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
The `NavbarSlider` is not opening on mobile because it was inheriting `Navbar`'s css module file. 

## How it works?

<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview


