### PR TITLE
Fix: ProductGallery Title style

### DIFF
--- a/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
+++ b/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
@@ -90,7 +90,10 @@ function ProductGallery({
   return (
     <section data-testid="product-gallery" data-fs-product-listing>
       {searchTerm && (
-        <header data-fs-product-listing-search-term>
+        <header
+          data-fs-product-listing-search-term
+          data-fs-content="product-gallery"
+        >
           <h1>
             {searchTermLabel} <span>{searchTerm}</span>
           </h1>


### PR DESCRIPTION
## What's the purpose of this pull request?

- Fixes `Showing results for: ` title style. Added missing `data-fs-content="product-gallery"` to header.

|Before|After|
|-|-|
|<img width="961" alt="image" src="https://github.com/vtex/faststore/assets/3356699/8087b4c4-6556-4f50-8890-1aaea321893d">|<img width="961" alt="image" src="https://github.com/vtex/faststore/assets/3356699/b2106c14-c76f-410b-a559-bae7b9007c02">

## How to test it?

1. Run yarn dev on `faststore/core` application or use the starter preview
2. Search for a term, e.g.: `shirt`. You should see the `Showing results for: shirt` title aligned with the Filters component, as shown in the image above. 

### Starters Deploy Preview

[Starter Preview](https://starter-git-fix-product-gallery-title-faststore.vercel.app)

