### PR TITLE
Docs: Add recommendation for mac users while installing cms plugins

### DIFF
--- a/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
+++ b/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra-theme-docs'
   # Part 1: Configuring your VTEX account with the VTEX Headless CMS
 </header>
 
-Let's set up all the tools you will need to integrate the VTEX Headless CMS with your FastStore project. First, we will install the **VTEX IO CLI**.
+Let's set up all the tools you need to integrate the VTEX Headless CMS with your FastStore project. First, we will install the **VTEX IO CLI**.
 The VTEX IO CLI will help you during your development process by allowing you to perform different actions in the VTEX platform. In the following, we will install and configure the VTEX Headless CMS app in your VTEX account.
 
 ---
@@ -54,10 +54,11 @@ Now, check if the installation of the VTEX Headless CMS plugin was successful by
 ![success-vtex-cms-sync](https://vtexhelp.vtexassets.com/assets/docs/src/faststore-vtex-cms___460365970fb39c94e300b9fbd497e17e.png)
 
 <Callout type="warning" emoji="⚠️">
-  If you use Windows as the operating system and find problems while installing
-  the plugin, please refer to our
+  **Windows user**: if you find problems while installing
+  the plugin, please refer to the
   [Troubleshooting](/docs/headless-cms-troubleshooting/error-installing-headless-cms)
   article.
+  **macOS user**: if you find problems, run `yarn config set ignore-engines true` to ignore the node incompatibility versions while installing, then run `vtex plugins install cms` again.
 </Callout>
 
 ### Step 2 - Installing the Headless CMS dependencies on your VTEX account

--- a/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
+++ b/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
@@ -54,7 +54,7 @@ Now, check if the installation of the VTEX Headless CMS plugin was successful by
 ![success-vtex-cms-sync](https://vtexhelp.vtexassets.com/assets/docs/src/faststore-vtex-cms___460365970fb39c94e300b9fbd497e17e.png)
 
 <Callout type="warning" emoji="⚠️">
-  **Windows user**: if you find problems while installing
+  <li>**Windows user**</li>: if you find problems while installing
   the plugin, please refer to the
   [Troubleshooting](/docs/headless-cms-troubleshooting/error-installing-headless-cms)
   article.

--- a/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
+++ b/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
@@ -60,7 +60,7 @@ Now, check if the installation of the VTEX Headless CMS plugin was successful by
   article.</li> 
   <br></br>
   <li>**macOS user:** if you find problems, run `yarn config set ignore-engines true` to ignore the Node.js incompatibility version, then run `vtex plugins install cms` again. 
-  *Remember, you must have the latest Node.js version or a version higher than `15.0.0`.* </li> 
+  *Remember, we recommend using the latest Node.js version or a version higher than `15.0.0`.* </li> 
 
 </Callout>
 

--- a/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
+++ b/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
@@ -54,11 +54,14 @@ Now, check if the installation of the VTEX Headless CMS plugin was successful by
 ![success-vtex-cms-sync](https://vtexhelp.vtexassets.com/assets/docs/src/faststore-vtex-cms___460365970fb39c94e300b9fbd497e17e.png)
 
 <Callout type="warning" emoji="⚠️">
-  <li>**Windows user**</li>: if you find problems while installing
+  <li>**Windows user:** if you find problems while installing
   the plugin, please refer to the
   [Troubleshooting](/docs/headless-cms-troubleshooting/error-installing-headless-cms)
-  article.
-  <li>**macOS user**</li>: if you find problems, run `yarn config set ignore-engines true` to ignore the node incompatibility versions, then run `vtex plugins install cms` again.
+  article.</li> 
+  <br></br>
+  <li>**macOS user:** if you find problems, run `yarn config set ignore-engines true` to ignore the Node.js incompatibility version, then run `vtex plugins install cms` again. 
+  *Remember, you must have the latest Node.js version or a version higher than `15.0.0`.* </li> 
+
 </Callout>
 
 ### Step 2 - Installing the Headless CMS dependencies on your VTEX account

--- a/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
+++ b/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
@@ -58,7 +58,7 @@ Now, check if the installation of the VTEX Headless CMS plugin was successful by
   the plugin, please refer to the
   [Troubleshooting](/docs/headless-cms-troubleshooting/error-installing-headless-cms)
   article.
-  **macOS user**: if you find problems, run `yarn config set ignore-engines true` to ignore the node incompatibility versions while installing, then run `vtex plugins install cms` again.
+  <li>**macOS user**</li>: if you find problems, run `yarn config set ignore-engines true` to ignore the node incompatibility versions, then run `vtex plugins install cms` again.
 </Callout>
 
 ### Step 2 - Installing the Headless CMS dependencies on your VTEX account


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add a recommendation for macOS users while installing the CMS plugins.

<img width="441" alt="Screenshot_179" src="https://github.com/vtex/faststore/assets/67270558/b954dcf9-df77-41a2-a8a7-44a36e7743ce">

Preview: https://faststore-site-git-docs-improve-recommendations-faststore.vercel.app/docs/headless-cms-integration/1-configuring-the-vtex-account#step-1---setting-up-the-command-line-environment