### PR TITLE
Chore: Sets import rule to work with `@layer`

### DIFF
--- a/packages/core/stylelint.config.js
+++ b/packages/core/stylelint.config.js
@@ -29,7 +29,7 @@ module.exports = {
     'selector-pseudo-element-no-unknown': true,
     'comment-no-empty': true,
     'no-descending-specificity': null,
-    'no-invalid-position-at-import-rule': null,
+    'no-invalid-position-at-import-rule': true,
     'no-duplicate-at-import-rules': true,
     'no-extra-semicolons': true,
     'no-invalid-double-slash-comments': true,

--- a/packages/core/stylelint.config.js
+++ b/packages/core/stylelint.config.js
@@ -29,7 +29,7 @@ module.exports = {
     'selector-pseudo-element-no-unknown': true,
     'comment-no-empty': true,
     'no-descending-specificity': null,
-    'no-invalid-position-at-import-rule': true,
+    'no-invalid-position-at-import-rule': null,
     'no-duplicate-at-import-rules': true,
     'no-extra-semicolons': true,
     'no-invalid-double-slash-comments': true,
@@ -73,7 +73,12 @@ module.exports = {
     'scss/operator-no-newline-before': true,
     'scss/operator-no-unspaced': true,
     'scss/selector-no-redundant-nesting-selector': true,
-    'scss/at-rule-no-unknown': true,
+    'scss/at-rule-no-unknown': [
+      'true',
+      {
+        ignoreAtRules: ['layer'],
+      },
+    ],
     'scss/at-import-partial-extension': null,
     'scss/no-global-function-names': null,
     'selector-class-pattern':


### PR DESCRIPTION
## What's the purpose of this pull request?

We've introduced css layers feature in the previous PR. I'm trying to configure stylelint `at-rule-no-unknown`, so `@layer` should not be flagged by this rule.

## References

https://stylelint.io/user-guide/rules/no-invalid-position-at-import-rule/
https://stylelint.io/user-guide/rules/at-rule-no-unknown/
https://stylelint.io/changelog/