### PR TITLE
Chore: Add Component's Props 

### DIFF
--- a/apps/site/components/OverviewSection/overview-section.module.css
+++ b/apps/site/components/OverviewSection/overview-section.module.css
@@ -3,7 +3,7 @@
   column-gap: 16px;
   align-items: center;
   border-radius: 4px;
-  margin: 0 0 var(--fs-spacing-3);
+  margin: var(--fs-spacing-3) 0;
   padding: var(--fs-spacing-4) var(--fs-spacing-5);
   background-image: radial-gradient(#ededed 1px, transparent 0);
   background-size: 8px 8px;

--- a/apps/site/pages/components/atoms/label.mdx
+++ b/apps/site/pages/components/atoms/label.mdx
@@ -8,6 +8,33 @@ import PropsSection from 'site/components/PropsSection'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { Label } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const labelPath = path.resolve(__filename)
+  const components = ['Label.tsx']
+  const [labelProps] = getComponentPropsFrom(labelPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        labelProps,
+      },
+    },
+  }
+}
+
+export const LabelPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { labelProps } = useSSG()
+  return {
+    Label: <PropsSection propsList={labelProps} />,
+  }[component]
+}
+
 <header>
 
 # Label
@@ -50,7 +77,7 @@ import { Label } from '@faststore/ui'
 
 ## Props
 
-<PropsSection name="Label" />
+<LabelPropsSection component="Label" />
 
 ---
 

--- a/apps/site/pages/components/atoms/link.mdx
+++ b/apps/site/pages/components/atoms/link.mdx
@@ -74,12 +74,45 @@ import '@faststore/ui/src/components/atoms/Link/styles.scss'
 
 ## Props
 
-The `Link` component supports all attributes supported by the tag chosen through the `as` prop.
-For example, if someone wants to use a wrapper for any external link component (i.e., Next.js `Link` or Gatsby `Link`), the FastStore UI `Link` component can be used with the `as="div"` prop.
+The `Link` component supports all attributes supported by the tag `a`.
+If you need to use it as external link component (i.e., Next.js `Link` or Gatsby `Link`), the FastStore UI `Link` component can be used with the `as={NextLink}` prop.
 
 Besides those attributes, the following props are also supported:
 
-<PropsSection name="link" />
+export const propsLink = [
+  {
+    name: 'testId',
+    type: 'string',
+    description:
+      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
+    default: 'fs-link',
+  },
+  {
+    name: 'variant',
+    type: "'default' | 'display' | 'inline'",
+    description: 'Specifies the component variant.',
+    default: 'default',
+  },
+  {
+    name: 'size',
+    type: "'small' | 'regular'",
+    description: 'Specifies the size variant.',
+    default: 'regular',
+  },
+  {
+    name: 'inverse',
+    type: 'boolean',
+    description: 'Defines the use of inverted colors.',
+  },
+  {
+    name: 'as',
+    type: 'string | PolymorphicComponentPropsWithRef',
+    description: 'Defines how this component should behave.',
+    default: 'a',
+  },
+]
+
+<PropsSection propsList={propsLink} />
 
 ---
 

--- a/apps/site/pages/components/atoms/list.mdx
+++ b/apps/site/pages/components/atoms/list.mdx
@@ -10,33 +10,6 @@ import { TokenTable, TokenRow } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { List } from '@faststore/ui'
 
-import path from 'path'
-import { useSSG } from 'nextra/ssg'
-import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
-
-export const getStaticProps = () => {
-  const listPath = path.resolve(__filename)
-  const components = ['List.tsx']
-  const [listProps] = getComponentPropsFrom(listPath, components)
-  return {
-    props: {
-      // We add an `ssg` field to the page props,
-      // which will be provided to the Nextra `useSSG` hook.
-      ssg: {
-        listProps,
-      },
-    },
-  }
-}
-
-export const ListPropsSection = ({ component }) => {
-  // Get the data from SSG, and render it as a component.
-  const { listProps } = useSSG()
-  return {
-    List: <PropsSection propsList={listProps} />,
-  }[component]
-}
-
 <header>
 
 # List

--- a/apps/site/pages/components/atoms/list.mdx
+++ b/apps/site/pages/components/atoms/list.mdx
@@ -10,6 +10,33 @@ import { TokenTable, TokenRow } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { List } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const listPath = path.resolve(__filename)
+  const components = ['List.tsx']
+  const [listProps] = getComponentPropsFrom(listPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        listProps,
+      },
+    },
+  }
+}
+
+export const ListPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { listProps } = useSSG()
+  return {
+    List: <PropsSection propsList={listProps} />,
+  }[component]
+}
+
 <header>
 
 # List
@@ -101,7 +128,22 @@ import '@faststore/ui/src/components/atoms/List/styles.scss'
 
 ## Props
 
-<PropsSection name="List" />
+export const propsList = [
+  {
+    name: 'testId',
+    type: 'string',
+    description:
+      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
+    default: 'fs-list',
+  },
+  {
+    name: 'marker',
+    type: 'boolean',
+    description: "Specify whether or not this component should display the list's markers (bullets or numbers).",
+  }
+]
+
+<PropsSection propsList={propsList} />
 
 ---
 

--- a/apps/site/pages/components/atoms/loader.mdx
+++ b/apps/site/pages/components/atoms/loader.mdx
@@ -11,6 +11,33 @@ import { OverviewSection } from 'site/components/OverviewSection'
 import { SectionItem, SectionList } from 'site/components/SectionItem'
 import { Loader, Button } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const loaderPath = path.resolve(__filename)
+  const components = ['Loader.tsx']
+  const [loaderProps] = getComponentPropsFrom(loaderPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        loaderProps,
+      },
+    },
+  }
+}
+
+export const LoaderPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { loaderProps } = useSSG()
+  return {
+    Loader: <PropsSection propsList={loaderProps} />,
+  }[component]
+}
+
 <header>
 
 # Loader
@@ -73,7 +100,7 @@ import '@faststore/ui/src/components/atoms/Loader/styles.scss'
 
 ## Props
 
-<PropsSection name="Loader" />
+<LoaderPropsSection component="Loader" />
 
 ---
 

--- a/apps/site/pages/components/atoms/overlay.mdx
+++ b/apps/site/pages/components/atoms/overlay.mdx
@@ -10,6 +10,33 @@ import { TokenTable, TokenRow } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { Overlay } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const overlayPath = path.resolve(__filename)
+  const components = ['Overlay.tsx']
+  const [overlayProps] = getComponentPropsFrom(overlayPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        overlayProps,
+      },
+    },
+  }
+}
+
+export const OverlayPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { overlayProps } = useSSG()
+  return {
+    Overlay: <PropsSection propsList={overlayProps} />,
+  }[component]
+}
+
 <header>
 
 # Overlay
@@ -104,7 +131,7 @@ import '@faststore/ui/src/components/atoms/Overlay/styles.scss'
 
 ## Props
 
-<PropsSection name="Overlay" />
+<OverlayPropsSection component="Overlay" />
 
 ---
 

--- a/apps/site/pages/components/atoms/radio.mdx
+++ b/apps/site/pages/components/atoms/radio.mdx
@@ -11,6 +11,33 @@ import { OverviewSection } from 'site/components/OverviewSection'
 import { SectionItem, SectionList } from 'site/components/SectionItem'
 import { Radio, RadioField } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const radioPath = path.resolve(__filename)
+  const components = ['Radio.tsx']
+  const [radioProps] = getComponentPropsFrom(radioPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        radioProps,
+      },
+    },
+  }
+}
+
+export const RadioPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { radioProps } = useSSG()
+  return {
+    Radio: <PropsSection propsList={radioProps} />,
+  }[component]
+}
+
 <header>
 
 # Radio
@@ -70,7 +97,7 @@ import '@faststore/ui/src/components/atoms/Radio/styles.scss'
 
 ## Props
 
-<PropsSection name="Radio" />
+<RadioPropsSection component="Radio" />
 
 ---
 

--- a/apps/site/pages/components/atoms/slider.mdx
+++ b/apps/site/pages/components/atoms/slider.mdx
@@ -13,6 +13,33 @@ import { Slider, Price, PriceRange } from '@faststore/ui'
 import PriceRangeUsage from 'site/components/PriceRange/PriceRangeUsage'
 import { useFormattedPrice } from 'site/components/utilities/usePriceFormatter'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const sliderPath = path.resolve(__filename)
+  const components = ['Slider.tsx']
+  const [sliderProps] = getComponentPropsFrom(sliderPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        sliderProps,
+      },
+    },
+  }
+}
+
+export const SliderPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { sliderProps } = useSSG()
+  return {
+    Slider: <PropsSection propsList={sliderProps} />,
+  }[component]
+}
+
 <header>
 
 # Slider
@@ -124,7 +151,43 @@ import '@faststore/ui/src/components/atoms/Slider/styles.scss'
 
 ## Props
 
-<PropsSection name="Slider" />
+<SliderPropsSection component="Slider" />
+
+### Range
+
+export const propsRange = [
+  {
+    name: 'absolute',
+    type: 'number',
+    description: 'The absolute value of the slider.',
+  },
+  {
+    name: 'selected',
+    type: 'number',
+    description:
+      'The selected value of the slider.',
+  }
+]
+
+<PropsSection propsList={propsRange} />
+
+### RangeLabel
+
+export const propsRangeLabel = [
+  {
+    name: 'min',
+    type: 'string | ReactNode',
+    description: 'Label for minimum range value.',
+  },
+  {
+    name: 'max',
+    type: 'string | ReactNode',
+    description:
+      'Label for maximum range value.',
+  }
+]
+
+<PropsSection propsList={propsRangeLabel} />
 
 ---
 

--- a/apps/site/pages/components/atoms/sr-only.mdx
+++ b/apps/site/pages/components/atoms/sr-only.mdx
@@ -12,6 +12,33 @@ import PropsSection from 'site/components/PropsSection'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { SROnly } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const sROnlyPath = path.resolve(__filename)
+  const components = ['SROnly.tsx']
+  const [sROnlyProps] = getComponentPropsFrom(sROnlyPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        sROnlyProps,
+      },
+    },
+  }
+}
+
+export const SROnlyPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { sROnlyProps } = useSSG()
+  return {
+    SROnly: <PropsSection propsList={sROnlyProps} />,
+  }[component]
+}
+
 <header>
 
 # SROnly
@@ -51,7 +78,7 @@ import '@faststore/ui/src/components/atoms/SROnly/styles.scss'
 
 ## Props
 
-<PropsSection name="SROnly" />
+<SROnlyPropsSection component="SROnly" />
 
 ---
 

--- a/apps/site/pages/components/atoms/sr-only.mdx
+++ b/apps/site/pages/components/atoms/sr-only.mdx
@@ -11,21 +11,20 @@ sidebar_custom_props:
 import PropsSection from 'site/components/PropsSection'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { SROnly } from '@faststore/ui'
-
 import path from 'path'
 import { useSSG } from 'nextra/ssg'
 import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
 
 export const getStaticProps = () => {
-  const sROnlyPath = path.resolve(__filename)
+  const srOnlyPath = path.resolve(__filename)
   const components = ['SROnly.tsx']
-  const [sROnlyProps] = getComponentPropsFrom(sROnlyPath, components)
+  const [srOnlyProps] = getComponentPropsFrom(srOnlyPath, components)
   return {
     props: {
       // We add an `ssg` field to the page props,
       // which will be provided to the Nextra `useSSG` hook.
       ssg: {
-        sROnlyProps,
+        srOnlyProps,
       },
     },
   }
@@ -33,9 +32,9 @@ export const getStaticProps = () => {
 
 export const SROnlyPropsSection = ({ component }) => {
   // Get the data from SSG, and render it as a component.
-  const { sROnlyProps } = useSSG()
+  const { srOnlyProps } = useSSG()
   return {
-    SROnly: <PropsSection propsList={sROnlyProps} />,
+    SROnly: <PropsSection propsList={srOnlyProps} />,
   }[component]
 }
 

--- a/apps/site/pages/components/atoms/sr-only.mdx
+++ b/apps/site/pages/components/atoms/sr-only.mdx
@@ -41,7 +41,7 @@ export const SROnlyPropsSection = ({ component }) => {
 
 <header>
 
-# SROnly
+# SR Only
 
 Hides an element visually. Improve accessibility by providing text to
 screen readers when applied.

--- a/apps/site/pages/components/atoms/sr-only.mdx
+++ b/apps/site/pages/components/atoms/sr-only.mdx
@@ -11,32 +11,6 @@ sidebar_custom_props:
 import PropsSection from 'site/components/PropsSection'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { SROnly } from '@faststore/ui'
-import path from 'path'
-import { useSSG } from 'nextra/ssg'
-import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
-
-export const getStaticProps = () => {
-  const srOnlyPath = path.resolve(__filename)
-  const components = ['SROnly.tsx']
-  const [srOnlyProps] = getComponentPropsFrom(srOnlyPath, components)
-  return {
-    props: {
-      // We add an `ssg` field to the page props,
-      // which will be provided to the Nextra `useSSG` hook.
-      ssg: {
-        srOnlyProps,
-      },
-    },
-  }
-}
-
-export const SROnlyPropsSection = ({ component }) => {
-  // Get the data from SSG, and render it as a component.
-  const { srOnlyProps } = useSSG()
-  return {
-    SROnly: <PropsSection propsList={srOnlyProps} />,
-  }[component]
-}
 
 <header>
 
@@ -77,7 +51,23 @@ import '@faststore/ui/src/components/atoms/SROnly/styles.scss'
 
 ## Props
 
-<SROnlyPropsSection component="SROnly" />
+export const propsSROnly = [
+  {
+    name: 'text',
+    type: 'string',
+    description:
+      'Defines component element type (e.g.: span).',
+    required: true,
+  },
+  {
+    name: 'as',
+    type: "ElementType",
+    description: 'Defines component element type (e.g.: span, div, h1).',
+    default: 'span',
+  }
+]
+
+<PropsSection propsList={propsSROnly} />
 
 ---
 

--- a/apps/site/pages/components/molecules/cart-item.mdx
+++ b/apps/site/pages/components/molecules/cart-item.mdx
@@ -244,10 +244,6 @@ import '@faststore/ui/src/components/atoms/CartItem/styles.scss'
 
 <CartItemPropsSection component="CartItem" />
 
-#### Price Definition
-
-<PropsSection propsList={propsPriceDefinition} />
-
 ### Cart Item Image
 
 <CartItemPropsSection component="CartItemImage" />
@@ -255,6 +251,10 @@ import '@faststore/ui/src/components/atoms/CartItem/styles.scss'
 ### Cart Item Summary
 
 <CartItemPropsSection component="CartItemSummary" />
+
+#### Price Definition
+
+<PropsSection propsList={propsPriceDefinition} />
 
 ---
 

--- a/apps/site/pages/components/molecules/cart-item.mdx
+++ b/apps/site/pages/components/molecules/cart-item.mdx
@@ -240,7 +240,7 @@ import '@faststore/ui/src/components/atoms/CartItem/styles.scss'
 
 ## Props
 
-### CartItem
+### Cart Item
 
 <CartItemPropsSection component="CartItem" />
 
@@ -248,11 +248,11 @@ import '@faststore/ui/src/components/atoms/CartItem/styles.scss'
 
 <PropsSection propsList={propsPriceDefinition} />
 
-### CartItemImage
+### Cart Item Image
 
 <CartItemPropsSection component="CartItemImage" />
 
-### CartItemSummary
+### Cart Item Summary
 
 <CartItemPropsSection component="CartItemSummary" />
 

--- a/apps/site/pages/components/molecules/cart-item.mdx
+++ b/apps/site/pages/components/molecules/cart-item.mdx
@@ -252,7 +252,9 @@ import '@faststore/ui/src/components/atoms/CartItem/styles.scss'
 
 <CartItemPropsSection component="CartItemSummary" />
 
-#### Price Definition
+### Other Resources
+
+#### PriceDefinition
 
 <PropsSection propsList={propsPriceDefinition} />
 

--- a/apps/site/pages/components/molecules/checkbox-field.mdx
+++ b/apps/site/pages/components/molecules/checkbox-field.mdx
@@ -113,8 +113,6 @@ import '@faststore/ui/src/components/molecules/CheckboxField/styles.scss'
 
 ## Props
 
-### Checkbox Field
-
 <CheckboxFieldPropsSection component="CheckboxField" />
 
 ---

--- a/apps/site/pages/components/molecules/dropdown.mdx
+++ b/apps/site/pages/components/molecules/dropdown.mdx
@@ -217,11 +217,11 @@ import '@faststore/ui/src/components/molecules/Dropdown/styles.scss'
 
 <DropdownPropsSection component="DropdownItem" />
 
-### DropdownMenu
+### Dropdown Menu
 
 <DropdownPropsSection component="DropdownMenu" />
 
-### DropdownButton
+### Dropdown Button
 
 <DropdownPropsSection component="DropdownButton" />
 
@@ -231,7 +231,7 @@ import '@faststore/ui/src/components/molecules/Dropdown/styles.scss'
 
 ### Compound Components
 
-#### DropdownItem
+#### Dropdown Item
 
 <TokenTable>
   <TokenRow token="--fs-dropdown-item-min-height" value="2.375rem" />
@@ -281,7 +281,7 @@ import '@faststore/ui/src/components/molecules/Dropdown/styles.scss'
   />
 </TokenTable>
 
-#### DropdownMenu
+#### Dropdown Menu
 
 <TokenTable>
   <TokenRow
@@ -321,11 +321,11 @@ import '@faststore/ui/src/components/molecules/Dropdown/styles.scss'
 
 For further customization, you can use the following data attributes:
 
-#### DropdownItem
+#### Dropdown Item
 
 `data-fs-dropdown-item`
 
-#### DropdownMenu
+#### Dropdown Menu
 
 `data-fs-dropdown-menu`
 
@@ -335,7 +335,7 @@ For further customization, you can use the following data attributes:
 
 `data-fs-dropdown-menu-size="small | regular"`
 
-#### DropdownButton
+#### Dropdown Button
 
 `data-fs-dropdown-button`
 

--- a/apps/site/pages/components/molecules/dropdown.mdx
+++ b/apps/site/pages/components/molecules/dropdown.mdx
@@ -213,7 +213,7 @@ import '@faststore/ui/src/components/molecules/Dropdown/styles.scss'
 
 <DropdownPropsSection component="Dropdown" />
 
-### DropdownItem
+### Dropdown Item
 
 <DropdownPropsSection component="DropdownItem" />
 

--- a/apps/site/pages/components/molecules/dropdown.mdx
+++ b/apps/site/pages/components/molecules/dropdown.mdx
@@ -26,6 +26,42 @@ import {
 } from '@faststore/ui'
 import { OverviewSection } from 'site/components/OverviewSection'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const dropdownPath = path.resolve(__filename)
+  const components = ['Dropdown.tsx', 'DropdownItem.tsx', 'DropdownMenu.tsx', 'DropdownButton.tsx']
+  const [dropdownProps, dropdownItemProps, dropdownMenuProps, dropdownButtonProps ] = getComponentPropsFrom(
+    dropdownPath,
+    components
+  )
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        dropdownProps,
+        dropdownItemProps,
+        dropdownMenuProps,
+        dropdownButtonProps,
+      },
+    },
+  }
+}
+
+export const DropdownPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { dropdownProps, dropdownItemProps, dropdownMenuProps, dropdownButtonProps } = useSSG()
+  return {
+    Dropdown: <PropsSection propsList={dropdownProps} />,
+    DropdownItem: <PropsSection propsList={dropdownItemProps} />,
+    DropdownMenu: <PropsSection propsList={dropdownMenuProps} />,
+    DropdownButton: <PropsSection propsList={dropdownButtonProps} />,
+  }[component]
+}
+
 <header>
 
 # Dropdown
@@ -175,19 +211,19 @@ import '@faststore/ui/src/components/molecules/Dropdown/styles.scss'
 
 ### Dropdown
 
-<PropsSection name="Dropdown" />
+<DropdownPropsSection component="Dropdown" />
 
 ### DropdownItem
 
-<PropsSection name="DropdownItem" />
+<DropdownPropsSection component="DropdownItem" />
 
 ### DropdownMenu
 
-<PropsSection name="DropdownMenu" />
+<DropdownPropsSection component="DropdownMenu" />
 
 ### DropdownButton
 
-<PropsSection name="DropdownButton" />
+<DropdownPropsSection component="DropdownButton" />
 
 ---
 

--- a/apps/site/pages/components/molecules/gift.mdx
+++ b/apps/site/pages/components/molecules/gift.mdx
@@ -268,7 +268,7 @@ Besides those attributes, the following props are also supported:
 
 <GiftPropsSection component="Gift" />
 
-### GiftContent
+### Gift Content
 
 <GiftPropsSection component="GiftContent" />
 
@@ -276,7 +276,7 @@ Besides those attributes, the following props are also supported:
 
 <PropsSection propsList={propsPriceDefinition} />
 
-### GiftImage
+### Gift Image
 
 <GiftPropsSection component="GiftImage" />
 

--- a/apps/site/pages/components/molecules/gift.mdx
+++ b/apps/site/pages/components/molecules/gift.mdx
@@ -276,7 +276,9 @@ Besides those attributes, the following props are also supported:
 
 <GiftPropsSection component="GiftImage" />
 
-#### Price Definition
+### Other Resources
+
+#### PriceDefinition
 
 <PropsSection propsList={propsPriceDefinition} />
 

--- a/apps/site/pages/components/molecules/gift.mdx
+++ b/apps/site/pages/components/molecules/gift.mdx
@@ -272,13 +272,13 @@ Besides those attributes, the following props are also supported:
 
 <GiftPropsSection component="GiftContent" />
 
-#### Price Definition
-
-<PropsSection propsList={propsPriceDefinition} />
-
 ### Gift Image
 
 <GiftPropsSection component="GiftImage" />
+
+#### Price Definition
+
+<PropsSection propsList={propsPriceDefinition} />
 
 ---
 

--- a/apps/site/pages/components/molecules/input-field.mdx
+++ b/apps/site/pages/components/molecules/input-field.mdx
@@ -91,7 +91,70 @@ import '@faststore/ui/src/components/molecules/InputField/styles.scss'
 
 ## Props
 
-<PropsSection name="InputField" />
+export const propsInputField = [
+  {
+    name: 'testId',
+    type: 'string',
+    description:
+      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
+    default: 'fs-input-field'
+  },
+  {
+    name: 'id',
+    type: 'string',
+    description: 'ID to identify input and corresponding label.',
+    required: true
+  },
+  {
+    name: 'label',
+    type: 'string',
+    description: 'The text displayed to identify input text.',
+    required: true
+  },
+  {
+    name: 'error',
+    type: 'string',
+    description: 'The error message is displayed when an error occurs.'
+  },
+  {
+    name: 'inputRef',
+    type: 'MutableRefObject<HTMLInputElement | null>',
+    description: "Component's ref."
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    description: 'Specifies that the whole input component should be disabled.'
+  },
+  {
+    name: 'actionable',
+    type: "boolean",
+    description: 'Adds a Button to the component.'
+  },
+  {
+    name: 'onSubmit',
+    type: "() => void",
+    description: 'Callback function when button is clicked. Required for actionable input.*'
+  },
+  {
+    name: 'onClear',
+    type: "() => void",
+    description: 'Callback function when clear button is clicked. Required for actionable input.*'
+  },
+  {
+    name: 'buttonActionText',
+    type: "string",
+    description: 'The text displayed on the Button. Suggestion: maximum 9 characters.',
+    default: 'Apply'
+  },
+  {
+    name: 'displayClearButton',
+    type: "boolean",
+    description: 'Boolean that controls the clear button.'
+  },
+]
+
+<PropsSection propsList={propsInputField} />
 
 ---
 

--- a/apps/site/pages/components/molecules/link-button.mdx
+++ b/apps/site/pages/components/molecules/link-button.mdx
@@ -60,7 +60,53 @@ import '@faststore/ui/src/components/molecules/LinkButton/styles.scss'
 
 ## Props
 
-<PropsSection name="LinkButton" />
+The `LinkButton` component supports all attributes supported by the tag `a`.
+
+Besides those attributes, the following props are also supported [Button Props](/components/atoms/button#props):
+
+export const propsLinkButton = [
+  {
+    name: 'testId',
+    type: 'string',
+    description:
+      'ID to find this component in testing tools (e.g.: cypress, testing library, and jest).',
+    default: 'fs-link-button'
+  },
+  {
+    name: 'variant',
+    type: "'primary' | 'secondary' | 'tertiary'",
+    description: 'Specifies the component color variant.',
+    default: 'primary'
+  },
+  {
+    name: 'size',
+    type: "'small' | 'regular'",
+    description: 'Specifies the size variant.',
+    default: 'regular'
+  },
+  {
+    name: 'inverse',
+    type: 'boolean',
+    description: 'Defines the use of inverted colors.'
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    description: 'Specifies that this button should be disabled.'
+  },
+  {
+    name: 'icon',
+    type: 'ReactNode',
+    description: 'A React component that will be rendered as an icon.'
+  },
+   {
+    name: 'iconPosition',
+    type: "'left' | 'right'",
+    description: 'Specifies where the icon should be positioned.'
+  },
+]
+
+<PropsSection propsList={propsLinkButton} />
 
 ---
 

--- a/apps/site/pages/components/molecules/modal.mdx
+++ b/apps/site/pages/components/molecules/modal.mdx
@@ -17,6 +17,40 @@ import {
   Button,
 } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const modalPath = path.resolve(__filename)
+  const components = ['Modal.tsx', 'ModalHeader.tsx','ModalBody.tsx' ]
+  const [modalProps, modalHeaderProp, modalBodyProps ] = getComponentPropsFrom(
+    modalPath,
+    components
+  )
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        modalProps,
+        modalHeaderProp,
+        modalBodyProps,
+      },
+    },
+  }
+}
+
+export const ModalPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { modalProps, modalHeaderProp, modalBodyProps  } = useSSG()
+  return {
+    Modal: <PropsSection propsList={modalProps} />,
+    ModalHeader: <PropsSection propsList={modalHeaderProp} />,
+    ModalBody: <PropsSection propsList={modalBodyProps} />,
+  }[component]
+}
+
 <header>
 
 # Modal
@@ -129,15 +163,15 @@ Besides those attributes, the following props are also supported:
 
 ### Modal
 
-<PropsSection name="Modal" />
+<ModalPropsSection component="Modal" />
 
 ### ModalHeader
 
-<PropsSection name="ModalHeader" />
+<ModalPropsSection component="ModalHeader" />
 
 ### ModalBody
 
-<PropsSection name="ModalBody" />
+<ModalPropsSection component="ModalBody" />
 
 ---
 

--- a/apps/site/pages/components/molecules/modal.mdx
+++ b/apps/site/pages/components/molecules/modal.mdx
@@ -165,7 +165,7 @@ Besides those attributes, the following props are also supported:
 
 <ModalPropsSection component="Modal" />
 
-### ModalHeader
+### Modal Header
 
 <ModalPropsSection component="ModalHeader" />
 

--- a/apps/site/pages/components/molecules/modal.mdx
+++ b/apps/site/pages/components/molecules/modal.mdx
@@ -169,7 +169,7 @@ Besides those attributes, the following props are also supported:
 
 <ModalPropsSection component="ModalHeader" />
 
-### ModalBody
+### Modal Body
 
 <ModalPropsSection component="ModalBody" />
 

--- a/apps/site/pages/components/molecules/product-card.mdx
+++ b/apps/site/pages/components/molecules/product-card.mdx
@@ -306,7 +306,9 @@ All product card related components support all attributes also supported by the
 
 <ProductCardPropsSection component="ProductCardContent" />
 
-#### Price Definition
+### Other Resources
+
+#### PriceDefinition
 
 <PropsSection propsList={propsPriceDefinition} />
 

--- a/apps/site/pages/components/molecules/radio-field.mdx
+++ b/apps/site/pages/components/molecules/radio-field.mdx
@@ -10,6 +10,33 @@ import { TokenTable, TokenRow } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { RadioField } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const radioFieldPath = path.resolve(__filename)
+  const components = ['RadioField.tsx']
+  const [radioFieldProps] = getComponentPropsFrom(radioFieldPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        radioFieldProps,
+      },
+    },
+  }
+}
+
+export const RadioFieldPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { radioFieldProps } = useSSG()
+  return {
+    RadioField: <PropsSection propsList={radioFieldProps} />,
+  }[component]
+}
+
 <header>
 
 # Radio Field
@@ -63,6 +90,10 @@ import { RadioField } from '@faststore/ui'
 Import Styles
 
 ```tsx
+import '@faststore/ui/src/components/atoms/Radio/styles.scss'
+```
+
+```tsx
 import '@faststore/ui/src/components/molecules/RadioField/styles.scss'
 ```
 
@@ -82,7 +113,7 @@ import '@faststore/ui/src/components/molecules/RadioField/styles.scss'
 
 ## Props
 
-<PropsSection name="RadioField" />
+<RadioFieldPropsSection component="RadioField" />
 
 ---
 

--- a/apps/site/pages/components/molecules/radio-group.mdx
+++ b/apps/site/pages/components/molecules/radio-group.mdx
@@ -123,7 +123,28 @@ import { RadioGroup } from '@faststore/ui'
 
 ## Props
 
-<PropsSection name="RadioGroup" />
+export const propsRadioGroup = [
+  {
+    name: 'name',
+    type: 'string',
+    description:
+      'Name to link children by context.',
+    required: true
+  },
+  {
+    name: 'selectedValue',
+    type: 'string | number',
+    description: 'Value of checked child.',
+  },
+  {
+    name: 'onChange',
+    type: 'ChangeEventHandler<HTMLInputElement>',
+    description:
+      "Function that is triggered when any children is checked.",
+  },
+]
+
+<PropsSection propsList={propsRadioGroup} />
 
 ---
 

--- a/apps/site/pages/components/molecules/radio-group.mdx
+++ b/apps/site/pages/components/molecules/radio-group.mdx
@@ -72,7 +72,17 @@ Radio Group allows users to select a single option from a list of two or more mu
 Import the component from [@faststore/ui](/../components)
 
 ```tsx
-import { RadioGroup } from '@faststore/ui'
+import { RadioGroup, RadioField } from '@faststore/ui'
+```
+
+Import Styles
+
+```tsx
+import '@faststore/ui/src/components/atoms/Radio/styles.scss'
+```
+
+```tsx
+import '@faststore/ui/src/components/molecules/RadioField/styles.scss'
 ```
 
 ---

--- a/apps/site/pages/components/molecules/rating.mdx
+++ b/apps/site/pages/components/molecules/rating.mdx
@@ -11,6 +11,33 @@ import { OverviewSection } from 'site/components/OverviewSection'
 import { Rating, Icon } from '@faststore/ui'
 import RatingActionable from 'site/components/Rating/RatingActionable'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const ratingPath = path.resolve(__filename)
+  const components = ['Rating.tsx']
+  const [ratingProps] = getComponentPropsFrom(ratingPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        ratingProps,
+      },
+    },
+  }
+}
+
+export const RatingPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { ratingProps } = useSSG()
+  return {
+    Rating: <PropsSection propsList={ratingProps} />,
+  }[component]
+}
+
 <header>
 
 # Rating
@@ -77,7 +104,7 @@ import '@faststore/ui/src/components/molecules/Rating/styles.scss'
 
 ## Props
 
-<PropsSection name="Rating" />
+<RatingPropsSection component="Rating" />
 
 ---
 

--- a/apps/site/pages/components/molecules/search-products.mdx
+++ b/apps/site/pages/components/molecules/search-products.mdx
@@ -207,7 +207,9 @@ All search product related components support all attributes also supported by t
 
 <SearchProductsPropsSection component="SearchProductItemContent" />
 
-#### Price Definition
+### Other Resources
+
+#### PriceDefinition
 
 <PropsSection propsList={propsPriceDefinition} />
 

--- a/apps/site/pages/components/molecules/table.mdx
+++ b/apps/site/pages/components/molecules/table.mdx
@@ -446,23 +446,23 @@ All table-related components support all attributes also supported by their resp
 
 <TablePropsSection component="Table" />
 
-### TableBody
+### Table Body
 
 <TablePropsSection component="TableBody" />
 
-### TableHead
+### Table Head
 
 <TablePropsSection component="TableHead" />
 
-### TableRow
+### Table Row
 
 <TablePropsSection component="TableRow" />
 
-### TableFooter
+### Table Footer
 
 <TablePropsSection component="TableFooter" />
 
-### TableCell
+### Table Cell
 
 <TablePropsSection component="TableCell" />
 

--- a/apps/site/pages/components/molecules/table.mdx
+++ b/apps/site/pages/components/molecules/table.mdx
@@ -20,6 +20,46 @@ import {
 } from '@faststore/ui'
 import { useFormattedPrice } from 'site/components/utilities/usePriceFormatter'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const tablePath = path.resolve(__filename)
+  const components = ['Table.tsx', 'TableBody.tsx', 'TableHead.tsx', 'TableRow.tsx', 'TableCell.tsx', 'TableFooter.tsx']
+  const [tableProps, tableBodyProps, tableHeadProps, tableRowProps, tableCellProps, tableFooterProps ] = getComponentPropsFrom(
+    tablePath,
+    components
+  )
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        tableProps,
+        tableBodyProps,
+        tableHeadProps,
+        tableRowProps,
+        tableCellProps,
+        tableFooterProps
+      },
+    },
+  }
+}
+
+export const TablePropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { tableProps, tableBodyProps, tableHeadProps, tableRowProps, tableCellProps, tableFooterProps } = useSSG()
+  return {
+    Table: <PropsSection propsList={tableProps} />,
+    TableBody: <PropsSection propsList={tableBodyProps} />,
+    TableHead: <PropsSection propsList={tableHeadProps} />,
+    TableRow: <PropsSection propsList={tableRowProps} />,
+    TableCell: <PropsSection propsList={tableCellProps} />,
+    TableFooter: <PropsSection propsList={tableFooterProps} />,
+  }[component]
+}
+
 <header>
 
 # Table
@@ -404,23 +444,27 @@ All table-related components support all attributes also supported by their resp
 
 ### Table
 
-<PropsSection name="Table" />
+<TablePropsSection component="Table" />
 
 ### TableBody
 
-<PropsSection name="TableBody" />
+<TablePropsSection component="TableBody" />
+
+### TableHead
+
+<TablePropsSection component="TableHead" />
 
 ### TableRow
 
-<PropsSection name="TableRow" />
+<TablePropsSection component="TableRow" />
 
 ### TableFooter
 
-<PropsSection name="TableFooter" />
+<TablePropsSection component="TableFooter" />
 
 ### TableCell
 
-<PropsSection name="TableCell" />
+<TablePropsSection component="TableCell" />
 
 ---
 

--- a/apps/site/pages/components/molecules/tag.mdx
+++ b/apps/site/pages/components/molecules/tag.mdx
@@ -14,6 +14,33 @@ import { TokenTable, TokenRow, TokenDivider } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { Tag } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const tagPath = path.resolve(__filename)
+  const components = ['Tag.tsx']
+  const [tagProps] = getComponentPropsFrom(tagPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        tagProps,
+      },
+    },
+  }
+}
+
+export const TagPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { tagProps } = useSSG()
+  return {
+    Tag: <PropsSection propsList={tagProps} />,
+  }[component]
+}
+
 <header>
 
 # Tag
@@ -85,7 +112,7 @@ import '@faststore/ui/src/components/molecules/Tag/styles.scss'
 
 ## Props
 
-<PropsSection name="Tag" />
+<TagPropsSection component="Tag" />
 
 ---
 

--- a/apps/site/pages/components/molecules/toast.mdx
+++ b/apps/site/pages/components/molecules/toast.mdx
@@ -197,8 +197,6 @@ import '@faststore/ui/src/components/molecules/Toast/styles.scss'
 
 ## Props
 
-### Toast
-
 export const propsToast = [
   {
     name: 'title',

--- a/apps/site/pages/components/molecules/toggle-field.mdx
+++ b/apps/site/pages/components/molecules/toggle-field.mdx
@@ -10,6 +10,33 @@ import { TokenTable, TokenRow } from 'site/components/Tokens'
 import { OverviewSection } from 'site/components/OverviewSection'
 import { ToggleField } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const toggleFieldPath = path.resolve(__filename)
+  const components = ['ToggleField.tsx']
+  const [toggleFieldProps] = getComponentPropsFrom(toggleFieldPath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        toggleFieldProps,
+      },
+    },
+  }
+}
+
+export const ToggleFieldPropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { toggleFieldProps } = useSSG()
+  return {
+    ToggleField: <PropsSection propsList={toggleFieldProps} />,
+  }[component]
+}
+
 <header>
 
 # Toggle Field
@@ -77,7 +104,7 @@ import '@faststore/ui/src/components/molecules/ToggleField/styles.scss'
 
 ## Props
 
-<PropsSection name="ToggleField" />
+<ToggleFieldPropsSection component="ToggleField" />
 
 ---
 

--- a/apps/site/pages/components/molecules/toggle.mdx
+++ b/apps/site/pages/components/molecules/toggle.mdx
@@ -11,6 +11,33 @@ import { OverviewSection } from 'site/components/OverviewSection'
 import { SectionItem, SectionList } from 'site/components/SectionItem'
 import { Toggle, ToggleField } from '@faststore/ui'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const togglePath = path.resolve(__filename)
+  const components = ['Toggle.tsx']
+  const [toggleProps] = getComponentPropsFrom(togglePath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        toggleProps,
+      },
+    },
+  }
+}
+
+export const TogglePropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { toggleProps } = useSSG()
+  return {
+    Toggle: <PropsSection propsList={toggleProps} />,
+  }[component]
+}
+
 <header>
 
 # Toggle
@@ -72,7 +99,7 @@ import '@faststore/ui/src/components/molecules/Toggle/styles.scss'
 
 ## Props
 
-<PropsSection name="Toggle" />
+<TogglePropsSection component="Toggle" />
 
 ---
 

--- a/apps/site/pages/components/organisms/banner-text.mdx
+++ b/apps/site/pages/components/organisms/banner-text.mdx
@@ -114,11 +114,11 @@ import '@faststore/ui/src/components/organisms/BannerText/styles.scss'
 All banner text related components support all attributes also supported by the `<div>` tag.
 Besides those attributes, the following props are also supported:
 
-### BannerText
+### Banner Text
 
 <BannerTextPropsSection component="BannerText" />
 
-### BannerTextContent
+### Banner Text Content
 
 <BannerTextPropsSection component="BannerTextContent" />
 

--- a/apps/site/pages/components/organisms/filter-slider.mdx
+++ b/apps/site/pages/components/organisms/filter-slider.mdx
@@ -47,7 +47,7 @@ export const FilterSliderPropsSection = ({ component }) => {
 
 <header>
 
-# FilterSlider
+# Filter Slider
 
 The mobile `Filter` view that is rendered inside a `SlideOver` component.
 
@@ -221,7 +221,7 @@ import '@faststore/ui/src/components/organisms/FilterSlider/styles.scss'
 
 ## Props
 
-### FilterSlider
+### Filter Slider
 
 <FilterSliderPropsSection component="FilterSlider" />
 

--- a/apps/site/pages/components/organisms/filter.mdx
+++ b/apps/site/pages/components/organisms/filter.mdx
@@ -318,15 +318,15 @@ import '@faststore/ui/src/components/organisms/Filter/styles.scss'
 
 <FilterPropsSection component="Filter" />
 
-### FilterFacets
+### Filter Facets
 
 <FilterPropsSection component="FilterFacets" />
 
-### FilterFacetBooleanItem
+### Filter Facet Boolean Item
 
 <FilterPropsSection component="FilterFacetBooleanItem" />
 
-### FilterFacetRange
+### Filter Facet Range
 
 <FilterPropsSection component="FilterFacetRange" />
 

--- a/apps/site/pages/components/organisms/hero.mdx
+++ b/apps/site/pages/components/organisms/hero.mdx
@@ -132,11 +132,11 @@ Besides those attributes, the following props are also supported:
 
 <HeroPropsSection component="Hero" />
 
-### HeroImage
+### Hero Image
 
 <HeroPropsSection component="HeroImage" />
 
-### HeroHeader
+### Hero Header
 
 <HeroPropsSection component="HeroHeader" />
 

--- a/apps/site/pages/components/organisms/out-of-stock.mdx
+++ b/apps/site/pages/components/organisms/out-of-stock.mdx
@@ -94,8 +94,6 @@ import '@faststore/ui/src/components/organisms/OutOfStock/styles.scss'
 
 ## Props
 
-### Out of Stock
-
 <OutOfStockPropsSection component="OutOfStock" />
 
 ---

--- a/apps/site/pages/components/organisms/payment-methods.mdx
+++ b/apps/site/pages/components/organisms/payment-methods.mdx
@@ -47,7 +47,7 @@ export const PaymentMethodsPropsSection = ({ component }) => {
 
 <header>
 
-# PaymentMethods
+# Payment Methods
 
 The PaymentMethods component displays the logos of the available payment options in a store.
 

--- a/apps/site/pages/components/organisms/price-range.mdx
+++ b/apps/site/pages/components/organisms/price-range.mdx
@@ -11,6 +11,33 @@ import { OverviewSection } from 'site/components/OverviewSection'
 import { PriceRange } from '@faststore/ui'
 import PriceRangeUsage from 'site/components/PriceRange/PriceRangeUsage'
 
+import path from 'path'
+import { useSSG } from 'nextra/ssg'
+import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+
+export const getStaticProps = () => {
+  const priceRangePath = path.resolve(__filename)
+  const components = ['PriceRange.tsx']
+  const [priceRangeProps] = getComponentPropsFrom(priceRangePath, components)
+  return {
+    props: {
+      // We add an `ssg` field to the page props,
+      // which will be provided to the Nextra `useSSG` hook.
+      ssg: {
+        priceRangeProps,
+      },
+    },
+  }
+}
+
+export const PriceRangePropsSection = ({ component }) => {
+  // Get the data from SSG, and render it as a component.
+  const { priceRangeProps } = useSSG()
+  return {
+    PriceRange: <PropsSection propsList={priceRangeProps} />,
+  }[component]
+}
+
 <header>
 
 # Price Range
@@ -75,7 +102,7 @@ import '@faststore/ui/src/components/organisms/PriceRange/styles.scss'
 
 ## Props
 
-<PropsSection name="PriceRange" />
+<PriceRangePropsSection component="PriceRange" />
 
 ---
 

--- a/apps/site/pages/components/organisms/product-grid.mdx
+++ b/apps/site/pages/components/organisms/product-grid.mdx
@@ -167,11 +167,11 @@ import '@faststore/ui/src/components/organisms/ProductGrid/styles.scss'
 
 ## Props
 
-### ProductGrid
+### Product Grid
 
 <ProductGridPropsSection component="ProductGrid" />
 
-### ProductGridItem
+### Product Grid Item
 
 <ProductGridPropsSection component="ProductGridItem" />
 

--- a/apps/site/pages/components/organisms/shipping-simulation.mdx
+++ b/apps/site/pages/components/organisms/shipping-simulation.mdx
@@ -159,9 +159,11 @@ export const propsShippingSla = [
   },
 ]
 
+### Shipping Simulation
+
 <ShippingSimulationPropsSection component="ShippingSimulation" />
 
-### ShippingSLA
+### Shipping SLA
 
 <PropsSection propsList={propsShippingSla} />
 

--- a/apps/site/pages/components/organisms/slide-over.mdx
+++ b/apps/site/pages/components/organisms/slide-over.mdx
@@ -59,7 +59,7 @@ export const SlideOverPropsSection = ({ component }) => {
 
 <header>
 
-# SlideOver
+# Slide Over
 
 This component represents an aditional session that complements the screen's information.
 
@@ -235,11 +235,11 @@ export const SlideOverFullLeft = () => {
 
 ## Props
 
-### SlideOver
+### Slide Over
 
 <SlideOverPropsSection component="SlideOver" />
 
-### SlideOverHeader
+### Slide Over Header
 
 <SlideOverPropsSection component="SlideOverHeader" />
 

--- a/packages/components/src/atoms/Badge/Badge.tsx
+++ b/packages/components/src/atoms/Badge/Badge.tsx
@@ -15,7 +15,7 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
    */
   testId?: string
   /**
-   * Sets the component's size.
+   * Specifies the size variant.
    */
   size?: 'small' | 'big'
   /**

--- a/packages/components/src/atoms/Link/Link.tsx
+++ b/packages/components/src/atoms/Link/Link.tsx
@@ -12,13 +12,13 @@ type LinkBaseProps = {
    */
   variant?: 'default' | 'display' | 'inline'
   /**
-   * Defines use of inverted color.
-   */
-  inverse?: boolean
-  /**
-   * Defines size os element
+   * Specifies the size variant.
    */
   size?: 'small' | 'regular'
+  /**
+   * Defines the use of inverted colors.
+   */
+  inverse?: boolean
 }
 
 export type LinkElementType = ElementType

--- a/packages/components/src/atoms/Loader/Loader.tsx
+++ b/packages/components/src/atoms/Loader/Loader.tsx
@@ -1,18 +1,19 @@
+import type { HTMLAttributes } from 'react'
 import React, { forwardRef } from 'react'
 
-export type LoaderProps = {
-  /**
-   * Specifies the component color variant.
-   */
-  variant?: 'light' | 'dark'
+export interface LoaderProps extends HTMLAttributes<HTMLSpanElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
   testId?: string
+   /**
+   * Specifies the component color variant.
+   */
+   variant?: 'light' | 'dark'
 }
 
 const Loader = forwardRef<HTMLDivElement, LoaderProps>(function Loader(
-  { variant = 'dark', testId = 'fs-loader', ...otherProps }: LoaderProps,
+  { testId = 'fs-loader', variant = 'dark', ...otherProps }: LoaderProps,
   ref
 ) {
   return (

--- a/packages/components/src/atoms/SROnly/SROnly.tsx
+++ b/packages/components/src/atoms/SROnly/SROnly.tsx
@@ -2,7 +2,13 @@ import React from 'react'
 import type { ElementType } from 'react'
 
 interface SROnlyProps {
+  /**
+   * Defines component element type (e.g.: span).
+   */
   text: string
+  /**
+   * Defines component element type (e.g.: span).
+   */
   as?: ElementType
 }
 

--- a/packages/components/src/atoms/Slider/Slider.tsx
+++ b/packages/components/src/atoms/Slider/Slider.tsx
@@ -19,7 +19,7 @@ interface RangeLabel {
   max: string | ReactNode
 }
 
-export interface SliderProps extends HTMLDivElement {
+export interface SliderProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    *

--- a/packages/components/src/atoms/Slider/Slider.tsx
+++ b/packages/components/src/atoms/Slider/Slider.tsx
@@ -19,7 +19,7 @@ interface RangeLabel {
   max: string | ReactNode
 }
 
-export interface SliderProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+export interface SliderProps extends HTMLDivElement {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    *

--- a/packages/components/src/atoms/Slider/Slider.tsx
+++ b/packages/components/src/atoms/Slider/Slider.tsx
@@ -7,7 +7,7 @@ import React, {
   useImperativeHandle,
   forwardRef,
 } from 'react'
-import type { ReactNode } from 'react'
+import type { HTMLAttributes, ReactNode } from 'react'
 
 interface Range {
   absolute: number
@@ -19,7 +19,7 @@ interface RangeLabel {
   max: string | ReactNode
 }
 
-export type SliderProps = {
+export interface SliderProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    *

--- a/packages/components/src/molecules/Dropdown/Dropdown.tsx
+++ b/packages/components/src/molecules/Dropdown/Dropdown.tsx
@@ -1,12 +1,20 @@
-import type { ReactNode } from 'react'
+import type { PropsWithChildren } from 'react'
 import React, { useRef, useMemo, useState, useEffect, useCallback } from 'react'
 
 import DropdownContext from '../Dropdown/contexts/DropdownContext'
 
-export type DropdownProps = {
-  children: ReactNode
+export interface DropdownProps {
+  /**
+   * Event emitted when the Dropdown is closed.
+   */
   onDismiss?(): void
+  /**
+   * A boolean value that represents the state of the Dropdown.
+   */
   isOpen?: boolean
+  /**
+   * ID to identify Dropdown.
+   */
   id?: string
 }
 
@@ -15,7 +23,7 @@ const Dropdown = ({
   isOpen: isOpenDefault = false,
   onDismiss,
   id = 'fs-dropdown',
-}: DropdownProps) => {
+}: PropsWithChildren<DropdownProps>) => {
   const [isOpen, setIsOpen] = useState(isOpenDefault)
   const dropdownItemsRef = useRef<HTMLButtonElement[]>([])
   const selectedDropdownItemIndexRef = useRef(0)

--- a/packages/components/src/molecules/Dropdown/DropdownMenu.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownMenu.tsx
@@ -4,22 +4,15 @@ import type {
   PropsWithChildren,
   MouseEvent,
   ReactNode,
-  DetailedHTMLProps,
-  HTMLAttributes
 } from 'react'
 import React from 'react'
 import { createPortal } from 'react-dom'
 
 import { useDropdown } from './hooks/useDropdown'
 import { useDropdownPosition } from './hooks/useDropdownPosition'
+import type { ModalContentProps } from './../Modal/ModalContent'
 
-//TODO: Replace by ModalContentProps when Modal component be brought
-type BaseModalProps = Omit<
-DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
-'ref' | 'onClick'
->
-
-export interface DropdownMenuProps extends BaseModalProps {
+export interface DropdownMenuProps extends ModalContentProps {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */

--- a/packages/components/src/molecules/Dropdown/DropdownMenu.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownMenu.tsx
@@ -29,8 +29,8 @@ export interface DropdownMenuProps extends ModalContentProps {
    */
   onDismiss?: (event: MouseEvent | KeyboardEvent) => void
 
-  /**
-   * Specifies the size variant
+   /**
+   * Specifies the size variant.
    */
   size?: 'small' | 'regular'
 

--- a/packages/components/src/molecules/Modal/ModalBody.tsx
+++ b/packages/components/src/molecules/Modal/ModalBody.tsx
@@ -1,6 +1,9 @@
 import React, { ReactNode, HTMLAttributes } from 'react'
 
 export interface ModalBodyProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Children or function as a children
+   */
   children: ReactNode
 }
 

--- a/packages/components/src/molecules/RadioField/RadioField.tsx
+++ b/packages/components/src/molecules/RadioField/RadioField.tsx
@@ -1,8 +1,10 @@
-import Label from '../../atoms/Label'
-import Radio from '../../atoms/Radio'
+import type { HTMLAttributes } from 'react'
 import React, { forwardRef } from 'react'
 
-export type RadioFieldProps = {
+import Label from '../../atoms/Label'
+import Radio from '../../atoms/Radio'
+
+export interface RadioFieldProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */

--- a/packages/components/src/molecules/Rating/Rating.tsx
+++ b/packages/components/src/molecules/Rating/Rating.tsx
@@ -6,6 +6,10 @@ import List from '../../atoms/List'
 export interface RatingProps
   extends Omit<HTMLAttributes<HTMLUListElement>, 'onChange'> {
   /**
+   * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
+   */
+  testId?: string
+  /**
    * The length of child elements.
    */
   length?: number
@@ -21,10 +25,6 @@ export interface RatingProps
    * Function to be triggered when Rating option change. This should only be used if you and an actionable rating list.
    */
   onChange?: (value: number) => void
-  /**
-   * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
-   */
-  testId?: string
 }
 
 export interface RatingItemProps {

--- a/packages/components/src/molecules/ToggleField/ToggleField.tsx
+++ b/packages/components/src/molecules/ToggleField/ToggleField.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import { Label, SROnly, Toggle } from './../../'
 
-export type ToggleFieldProps = {
+export interface ToggleFieldProps {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */

--- a/packages/components/src/organisms/PriceRange/PriceRange.tsx
+++ b/packages/components/src/organisms/PriceRange/PriceRange.tsx
@@ -4,7 +4,7 @@ import type { AriaAttributes } from 'react'
 import { Price, Slider, InputField } from '../../'
 import type { PriceProps, SliderProps } from '../../'
 
-export type PriceRangeProps = Omit<SliderProps, 'absoluteValuesLabel'> & {
+export interface PriceRangeProps extends Omit<SliderProps, 'absoluteValuesLabel'> {
   /**
    * The current use case variant for prices.
    */


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds missing props list on component's doc page.

- [x] Slider
- [x] RadioGroup *
- [x] RadioField
- [x] Radio
- [x] Overlay
- [x] Loader
- [x] Label
- [x] Link *
- [x] Dropdown
- [x] List * 
- [x] SROnly
- [x] PriceRange
- [x] InputField *
- [x] LinkButton *
- [x] Modal
- [x] Rating
- [x] Table
- [x] Tag
- [x] Toggle
- [x] ToggleField


## How it works?

Updates our components documentation with list of props.
*= Added it manually because the automatization couldn't handle it properly.

## How to test it?

Go through the components' docs above and check if their props are listed as expected in the `Props` section.

[Documentation Preview Link](https://faststore-site-git-chore-add-components-props-fs-937-faststore.vercel.app/components/atoms/link)

