### PR TITLE
Fix: Search input is not being displayed on safari

### DIFF
--- a/apps/site/pages/components/molecules/search-dropdown.mdx
+++ b/apps/site/pages/components/molecules/search-dropdown.mdx
@@ -203,7 +203,7 @@ import '@faststore/ui/src/components/molecules/SearchDropdown/styles.scss'
   />
   <TokenRow
     token="--fs-search-dropdown-position-top-tablet"
-    value="calc(var(--fs-control-tap-size) + var(--fs-spacing-2) + var(--fs-border-width))"
+    value="calc(var(--fs-control-tap-size) + var(--fs-border-width))"
   />
   <TokenRow
     token="--fs-search-dropdown-position-top-desktop"

--- a/apps/site/pages/components/organisms/navbar.mdx
+++ b/apps/site/pages/components/organisms/navbar.mdx
@@ -211,15 +211,6 @@ The [NavbarLinks](/components/molecules/navbar-links) and [NavbarSlider](/compon
 
 <TokenTable>
   <TokenRow
-    token="--fs-navbar-search-expanded-input-wrapper-margin-right"
-    value="0.625rem"
-  />
-  <TokenRow
-    token="--fs-navbar-search-expanded-input-wrapper-margin-left"
-    value="var(--fs-spacing-9)"
-  />
-  <TokenDivider />
-  <TokenRow
     token="--fs-navbar-search-expanded-input-width"
     value="calc(100% - var(--fs-spacing-7))"
   />

--- a/packages/ui/src/components/molecules/SearchDropdown/styles.scss
+++ b/packages/ui/src/components/molecules/SearchDropdown/styles.scss
@@ -18,7 +18,7 @@
   --fs-search-dropdown-position-left-mobile : calc(-1 * var(--fs-control-tap-size));
   --fs-search-dropdown-position-left-tablet : calc(var(--fs-search-dropdown-position-left-mobile) - var(--fs-spacing-1));
   --fs-search-dropdown-position-top-mobile  : calc(var(--fs-search-dropdown-position-top-tablet) + 1px);
-  --fs-search-dropdown-position-top-tablet  : calc(var(--fs-control-tap-size) + var(--fs-spacing-2) + var(--fs-border-width));
+  --fs-search-dropdown-position-top-tablet  : calc(var(--fs-control-tap-size) + var(--fs-border-width));
   --fs-search-dropdown-position-top-desktop : var(--fs-search-input-height-desktop);
 
   --fs-search-dropdown-section-border-color : var(--fs-border-color-light);

--- a/packages/ui/src/components/organisms/Navbar/styles.scss
+++ b/packages/ui/src/components/organisms/Navbar/styles.scss
@@ -175,8 +175,14 @@
       }
 
       [data-fs-icon-button="true"] {
+        right: 0;
         margin-right: var(--fs-navbar-search-expanded-button-icon-margin-right);
         transition: margin var(--fs-navbar-transition-timing) var(--fs-navbar-transition-function);
+      }
+
+      [data-fs-cart-toggle] {
+        display: none;
+        right: 0;
       }
     }
   }
@@ -184,7 +190,6 @@
   [data-fs-navbar-header] {
     z-index: var(--fs-z-index-top);
     padding: var(--fs-navbar-header-padding);
-    overflow-x: clip;
     background-color: var(--fs-navbar-bkg-color);
     backdrop-filter: blur(10px);
     height: 100%;

--- a/packages/ui/src/components/organisms/Navbar/styles.scss
+++ b/packages/ui/src/components/organisms/Navbar/styles.scss
@@ -25,9 +25,6 @@
   --fs-navbar-search-button-icon-height-mobile           : var(--fs-navbar-search-button-icon-width-mobile);
 
   // Search Expanded
-  --fs-navbar-search-expanded-input-wrapper-margin-right : 0.625rem;
-  --fs-navbar-search-expanded-input-wrapper-margin-left  : var(--fs-spacing-9);
-
   --fs-navbar-search-expanded-input-width                : calc(100% - var(--fs-spacing-7));
 
   --fs-navbar-search-expanded-button-icon-margin-right   : -4.063rem;
@@ -161,8 +158,6 @@
 
       [data-fs-search-input] {
         flex: 1 1;
-        margin-right: var(--fs-navbar-search-expanded-input-wrapper-margin-right);
-        margin-left: var(--fs-navbar-search-expanded-input-wrapper-margin-left);
 
         [data-fs-search-input-field] [data-fs-search-input-field-input] {
           width: var(--fs-navbar-search-expanded-input-width);
@@ -176,7 +171,6 @@
 
       [data-fs-icon-button="true"] {
         right: 0;
-        margin-right: var(--fs-navbar-search-expanded-button-icon-margin-right);
         transition: margin var(--fs-navbar-transition-timing) var(--fs-navbar-transition-function);
       }
 
@@ -189,7 +183,6 @@
 
   [data-fs-navbar-header] {
     z-index: var(--fs-z-index-top);
-    padding: var(--fs-navbar-header-padding);
     background-color: var(--fs-navbar-bkg-color);
     backdrop-filter: blur(10px);
     height: 100%;


### PR DESCRIPTION
## What's the purpose of this pull request?

Currently, using https://starter.vtex.app in the safari browser, the search input is not being displayed and the user cannot use it.

**Currently**
|Desktop|Mobile|
|-|-|
![desktop](http://g.recordit.co/TcF6FGyzY9.gif)|![mobile](https://github.com/vtex/faststore/assets/3356699/2e0babc6-b43b-46be-8d36-231c4128de70)

## How it works?

We have introduced the `overflow-x: clip` property, but it works as expected in Safari. We need to change our approach to have the search input inside the [Navbar](packages/ui/src/components/organisms/Navbar/styles.scss). 

For now, I'm just hiding the Cart Toggle button to avoid this issue.




## How to test it?

Open the [preview](https://starter-git-fix-search-input-safari-faststore.vercel.app) in `Safari` browser and try to use the search input, you should see the dropdown working as expected.

**Fixed**
|Desktop|Mobile|
|-|-|
![desktop-after](http://g.recordit.co/mzICoMntFq.gif)|![mobile-fixed](https://github.com/vtex/faststore/assets/3356699/9d8e889b-50ba-46c3-b0ce-a07e5f338e3e)


### Starters Deploy Preview

Starter: https://github.com/vtex-sites/starter.store/pull/120

## References

- https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x
- https://caniuse.com/?search=overflow-clip-margin
