### PR TITLE
add checkout namespace

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -261,7 +261,7 @@ export const VtexCommerce = (
       }
     },
     getSessionOrder: (): Promise<Session> => {
-      return fetchAPI(`${base}/api/sessions?items=checkout.orderFormId`, {
+      return fetchAPI(`${base}/api/sessions?items=public.orderFormId`, {
         method: 'GET',
         headers: {
           'content-type': 'application/json',

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -261,7 +261,7 @@ export const VtexCommerce = (
       }
     },
     getSessionOrder: (): Promise<Session> => {
-      return fetchAPI(`${base}/api/sessions?items=checkout.orderFormId,public.orderFormId`, {
+      return fetchAPI(`${base}/api/sessions?items=checkout.orderFormId`, {
         method: 'GET',
         headers: {
           'content-type': 'application/json',

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -261,7 +261,7 @@ export const VtexCommerce = (
       }
     },
     getSessionOrder: (): Promise<Session> => {
-      return fetchAPI(`${base}/api/sessions?items=checkout.orderFormId&public.orderFormId`, {
+      return fetchAPI(`${base}/api/sessions?items=checkout.orderFormId,public.orderFormId`, {
         method: 'GET',
         headers: {
           'content-type': 'application/json',

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -261,7 +261,7 @@ export const VtexCommerce = (
       }
     },
     getSessionOrder: (): Promise<Session> => {
-      return fetchAPI(`${base}/api/sessions?items=public.orderFormId`, {
+      return fetchAPI(`${base}/api/sessions?items=checkout.orderFormId&public.orderFormId`, {
         method: 'GET',
         headers: {
           'content-type': 'application/json',

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
@@ -7,6 +7,7 @@ export interface Namespaces {
   profile?: Profile
   store?: Store
   checkout?: Checkout
+  public?: Checkout
 }
 
 export interface Value {

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
@@ -7,7 +7,7 @@ export interface Namespaces {
   profile?: Profile
   store?: Store
   checkout?: Checkout
-  public?: Checkout
+  public?: Public
 }
 
 export interface Value {
@@ -31,4 +31,9 @@ export interface Profile {
 
 export interface Checkout {
   orderFormId?: Value
+}
+
+export interface Public {
+  orderFormId?: Value
+  items?: Value
 }

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -213,7 +213,7 @@ async function getOrderNumberFromSession(
 
   if (cookieSession) {
     const { namespaces } = await commerce.getSessionOrder()
-    return namespaces.checkout?.orderFormId?.value ?? undefined
+    return namespaces.public?.orderFormId?.value ?? undefined
   }
   return
 }

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -213,7 +213,9 @@ async function getOrderNumberFromSession(
 
   if (cookieSession) {
     const { namespaces } = await commerce.getSessionOrder()
-    return namespaces.checkout?.orderFormId?.value
+    //remove before merge
+    console.log("bibi", namespaces)
+    return namespaces.checkout?.orderFormId?.value ?? namespaces.public?.orderFormId?.value
   }
   return
 }

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -213,9 +213,10 @@ async function getOrderNumberFromSession(
 
   if (cookieSession) {
     const { namespaces } = await commerce.getSessionOrder()
-    //remove before merge
-    console.log("bibi", namespaces)
-    return namespaces.checkout?.orderFormId?.value ?? namespaces.public?.orderFormId?.value
+    return (
+      namespaces.checkout?.orderFormId?.value ??
+      namespaces.public?.orderFormId?.value
+    )
   }
   return
 }

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -213,10 +213,7 @@ async function getOrderNumberFromSession(
 
   if (cookieSession) {
     const { namespaces } = await commerce.getSessionOrder()
-    return (
-      namespaces.checkout?.orderFormId?.value ??
-      namespaces.public?.orderFormId?.value
-    )
+    return namespaces.checkout?.orderFormId?.value ?? undefined
   }
   return
 }
@@ -328,7 +325,6 @@ export const validateCart = async (
     headers,
     commerce
   )
-
   const orderNumber = orderNumberFromSession ?? orderNumberFromCart ?? ''
 
   // Step1: Get OrderForm from VTEX Commerce


### PR DESCRIPTION
## What's the purpose of this pull request?

Change to fix bug created by the PR 1871
https://github.com/vtex/faststore/pull/1871

## How it works?

Fix the value returned by the getOrderNumberFromSession so it should return:

```
{
  public: { orderFormId: { value: '4d93b6f616604ec58bd016eb266a2eb2' } }
}
```

And we should use the namespaces.public?.orderFormId?.value if its available otherwise it should return undefined and the orderNumber will be the one from the local Storage.

Before this function was not returning the namespace needed for the sync to happen.

## How to test it?

Create the vtex_session cookie at the localhost and test doing changes at the cart (deleting the checkout cookie / adding items etc)


https://github.com/vtex/faststore/assets/67066494/891efeac-7ec1-473a-8000-6af869fe9544


