### PR TITLE
add isAuthenticated namespace

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -237,7 +237,7 @@ export const VtexCommerce = (
 
       params.set(
         'items',
-        'profile.id,profile.email,profile.firstName,profile.lastName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol'
+        'profile.id,profile.email,profile.firstName,profile.lastName,profile.isAuthenticated,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol'
       )
       if (getCookie('vtex_session', ctx.headers.cookie)) {
         // cookie set

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
@@ -26,6 +26,7 @@ export interface Profile {
   email?: Value
   firstName?: Value
   lastName?: Value
+  isAuthenticated?: Value
 }
 
 export interface Checkout {

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -34,8 +34,10 @@ export const validateSession = async (
       : Promise.resolve(null),
     clients.commerce.session(params.toString()).catch(() => null),
   ])
-
-  const profile = sessionData?.namespaces.profile ?? null
+  
+  const isAuthenticated =
+    sessionData?.namespaces?.profile?.isAuthenticated?.value ?? false
+  const profile = isAuthenticated ? sessionData?.namespaces.profile : null
   const store = sessionData?.namespaces.store ?? null
   const region = regionData?.[0]
   // Set seller only if it's inside a region

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -34,7 +34,7 @@ export const validateSession = async (
       : Promise.resolve(null),
     clients.commerce.session(params.toString()).catch(() => null),
   ])
-  
+
   const isAuthenticated =
     sessionData?.namespaces?.profile?.isAuthenticated?.value ?? false
   const profile = isAuthenticated ? sessionData?.namespaces.profile : null


### PR DESCRIPTION
## What's the purpose of this pull request?

Do not include profile information in the session at the Local Storage when the user is not logged in, reverting to the previous behavior.

## How it works?

The profile information fields in the session are filled in through a request to the session system through the commerce client session.

When the user is logged the system will create the `VtexIdclientAutCookie_account`  and when the client is logged out the `VtexIdclientAutCookie_account` is removed. 
The session cookie have another behaviour so when the client is logged in or logged out the cookie will always exist but the session can be authenticated or not. Differentiating between an identified and authenticated session.

Now we get the information os the namespace isAuthenticated from the session and if the client is not authenticated we remove the profile information.

## How to test it?

- Create the cookie vtex_session with the value from a session at the IO env
- Log in and check the profile info at the Local Storage
- Log out and check the profile info being erased 

https://github.com/vtex/faststore/assets/67066494/a9ef50ae-d343-4df8-a966-c8fc9b84e4a5

![image](https://github.com/vtex/faststore/assets/67066494/35ad9604-bbba-4823-b065-a4b7ca998d06)


