### PR TITLE
Feat: (Experimental) Copying Cypress folder from store to .faststore

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -3,12 +3,13 @@ import chalk from 'chalk'
 import { spawnSync } from 'child_process'
 import { existsSync } from 'fs'
 import { copySync, removeSync } from 'fs-extra'
-import { tmpDir, userDir } from '../utils/directory'
+import { tmpDir, userDir, userStoreConfigFileDir } from '../utils/directory'
 import { generate } from '../utils/generate'
 
 export default class Build extends Command {
   async run() {
     await generate({ setup: true })
+    const userStoreConfig = await import(userStoreConfigFileDir)
 
     const yarnBuildResult = spawnSync(`yarn build`, {
       shell: true,
@@ -30,7 +31,13 @@ export default class Build extends Command {
       `${tmpDir}/lighthouserc.js`,
       `${userDir}/lighthouserc.js`
     )
-    await copyResource(`${tmpDir}/cypress`, `${userDir}/cypress`)
+    // await copyResource(`${tmpDir}/cypress`, `${userDir}/cypress`)
+
+    if (userStoreConfig.experimental.enableCypressExtension) {
+      // EXPERIMENTAL
+      await copySync(`${userDir}/cypress`, `${tmpDir}/cypress/integration`, {overwrite: true})
+    }
+    
     if (existsSync(`.next/standalone`)) {
       await copyResource(
         `${userDir}/node_modules`,

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -31,10 +31,9 @@ export default class Build extends Command {
       `${tmpDir}/lighthouserc.js`,
       `${userDir}/lighthouserc.js`
     )
-    // await copyResource(`${tmpDir}/cypress`, `${userDir}/cypress`)
 
+    // EXPERIMENTAL
     if (userStoreConfig.experimental.enableCypressExtension) {
-      // EXPERIMENTAL
       await copySync(`${userDir}/cypress`, `${tmpDir}/cypress/integration`, {overwrite: true})
     }
     

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -9,7 +9,6 @@ import { generate } from '../utils/generate'
 export default class Build extends Command {
   async run() {
     await generate({ setup: true })
-    const userStoreConfig = await import(userStoreConfigFileDir)
 
     const yarnBuildResult = spawnSync(`yarn build`, {
       shell: true,
@@ -31,10 +30,6 @@ export default class Build extends Command {
       `${tmpDir}/lighthouserc.js`,
       `${userDir}/lighthouserc.js`
     )
-
-    if (userStoreConfig.experimental.enableCypressExtension) {
-      await copySync(`${userDir}/cypress`, `${tmpDir}/cypress/integration`, {overwrite: true})
-    }
     
     if (existsSync(`.next/standalone`)) {
       await copyResource(

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 import { spawnSync } from 'child_process'
 import { existsSync } from 'fs'
 import { copySync, removeSync } from 'fs-extra'
-import { tmpDir, userDir, userStoreConfigFileDir } from '../utils/directory'
+import { tmpDir, userDir } from '../utils/directory'
 import { generate } from '../utils/generate'
 
 export default class Build extends Command {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -32,7 +32,6 @@ export default class Build extends Command {
       `${userDir}/lighthouserc.js`
     )
 
-    // EXPERIMENTAL
     if (userStoreConfig.experimental.enableCypressExtension) {
       await copySync(`${userDir}/cypress`, `${tmpDir}/cypress/integration`, {overwrite: true})
     }

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -82,10 +82,10 @@ function copyCoreFiles() {
 async function copyCypressFiles() {
   try {
     const userStoreConfig = await import(userStoreConfigFileDir)
-    if (userStoreConfig.experimental.enableCypressExtension) {
+    if (userStoreConfig?.experimental?.enableCypressExtension) {
       copySync(`${userDir}/cypress`, `${tmpDir}/cypress/integration`, {overwrite: true})
+      console.log(`${chalk.green('success')} - Cypress test files copied`)
     }
-    console.log(`${chalk.green('success')} - Cypress test files copied`)
   } catch (e) {
     console.error(e)
   }

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -32,6 +32,7 @@ import {
   userSrcDir,
   userStoreConfigFileDir,
   userThemesFileDir,
+  userDir,
 } from './directory'
 
 import chalk from 'chalk'
@@ -73,6 +74,18 @@ function copyCoreFiles() {
       },
     })
     console.log(`${chalk.green('success')} - Core files copied`)
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+async function copyCypressFiles() {
+  try {
+    const userStoreConfig = await import(userStoreConfigFileDir)
+    if (userStoreConfig.experimental.enableCypressExtension) {
+      copySync(`${userDir}/cypress`, `${tmpDir}/cypress/integration`, {overwrite: true})
+    }
+    console.log(`${chalk.green('success')} - Cypress test files copied`)
   } catch (e) {
     console.error(e)
   }
@@ -251,6 +264,7 @@ export async function generate(options?: GenerateOptions) {
     setupPromise = Promise.all([
       createTmpFolder(),
       copyCoreFiles(),
+      copyCypressFiles(),
       createNodeModulesSymbolicLink(),
     ])
   }

--- a/packages/core/cypress.json
+++ b/packages/core/cypress.json
@@ -4,6 +4,7 @@
   "video": true,
   "trashAssetsBeforeRuns": true,
   "screenshotOnRunFailure": true,
+  "specPattern": ".faststore/cypress/integration/**/*.test.{js,jsx,ts,tsx}",
   "viewportWidth": 1000,
   "viewportHeight": 600
 }

--- a/packages/core/cypress.json
+++ b/packages/core/cypress.json
@@ -4,7 +4,6 @@
   "video": true,
   "trashAssetsBeforeRuns": true,
   "screenshotOnRunFailure": true,
-  "specPattern": ".faststore/cypress/integration/**/*.test.{js,jsx,ts,tsx}",
   "viewportWidth": 1000,
   "viewportHeight": 600
 }

--- a/packages/core/faststore.config.js
+++ b/packages/core/faststore.config.js
@@ -87,4 +87,8 @@ module.exports = {
     // https://developers.google.com/tag-platform/tag-manager/web#standard_web_page_installation,
     gtmContainerId: 'GTM-PGHZ95N',
   },
+
+  experimental: {
+    enableCypressExtension: false,
+  },
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Today, we copy the Cypress folder from `.faststore` to the store root folder, then our CI runs Cypress inside the root Cypress folder.

With this PR, we use the root Cypress folder as custom tests, so we copy them to `.faststore` and run Cypress inside the .faststore folder.

## How to test it?

https://github.com/vtex-sites/starter.store/pull/136

Just check the Integration Tests CI results or edit README to trigger the CI again.
