### PR TITLE
Doc: Update go-live step 5 for Legacy CMS stores

### DIFF
--- a/apps/site/pages/docs/go-live/5-integrating-the-vtex-order-placed-and-my-account.mdx
+++ b/apps/site/pages/docs/go-live/5-integrating-the-vtex-order-placed-and-my-account.mdx
@@ -23,12 +23,14 @@ Before proceeding any further, make sure you already have:
 
 - Integrated your FastStore project with the VTEX Checkout. See [this guide](/how-to-guides/platform-integration/vtex/integrating-vtex-checkout) for more information.
 - The VTEX IO CLI installed on your machine. Please refer to [this documentation](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference) for more information.
-- The `vtex.edition-store 5.x` app version installed on your VTEX account.
+- Check the Editon Store on your VTEX account:
+  - **Stores using Store Framework or FastStore technology:** the `vtex.edition-store 5.x` version should be installed on your VTEX account.
+  - **Stores using Legacy CMS Portal technology:** the `vtex.edition-store 3.x` version should be installed on your VTEX account.
+
 
 <Callout type="info" emoji=" ℹ️ ">
 Run `vtex edition get` to check if the `vtex.edition-store` app is installed on your account. If not, [open a support ticket](https://help.vtex.com/en/support) communicating you need the `vtex.edition-store@5.x` to be installed on your account so you can integrate your FastStore project with the VTEX platform.
 </Callout>
-
 
 ---
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Added in the **Before you start** section the requirement for stores using Legacy CMS Portal technology. The store edition 5.x could not be installed as the documentation suggests, but rather 3.x.

Preview: https://faststore-site-git-review-go-live-faststore.vercel.app/docs/go-live/5-integrating-the-vtex-order-placed-and-my-account#before-you-start