### PR TITLE
chore(ui): add exports to package json

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,8 +1,6 @@
 {
   "name": "@faststore/components",
   "version": "2.1.53",
-  "module": "dist/index.js",
-  "typings": "dist/index.d.ts",
   "author": "Emerson Laurentino @emersonlaurentino",
   "license": "MIT",
   "scripts": {
@@ -15,6 +13,18 @@
     "url": "https://github.com/vtex/faststore",
     "directory": "packages/components"
   },
+  "type": "module",
+  "exports": {
+    ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "require": "./dist/index.js",
+        "default": "./dist/index.js"
+      }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "files": [
     "dist",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,16 @@
     "directory": "packages/ui"
   },
   "browserslist": "supports es6-module and not dead and last 2 version",
+  "type": "module",
+  "exports": {
+    ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "require": "./dist/index.js",
+        "default": "./dist/index.js"
+      }
+  },
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,8 +18,7 @@
         "require": "./dist/index.js",
         "default": "./dist/index.js"
     },
-    "./src/styles/*": "./src/styles/*",
-    "./src/**/*.scss": "./src/**/*.scss"
+    "./src/*": "./src/*"
   },
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,8 @@
         "require": "./dist/index.js",
         "default": "./dist/index.js"
     },
-    "./src/styles/*": "./src/styles/*"
+    "./src/styles/*": "./src/styles/*",
+    "./src/*.scss": "./src/*.scss"
   },
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
         "default": "./dist/index.js"
     },
     "./src/styles/*": "./src/styles/*",
-    "./src/*.scss": "./src/*.scss"
+    "./src/**/*.scss": "./src/**/*.scss"
   },
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,7 +17,8 @@
         "import": "./dist/index.js",
         "require": "./dist/index.js",
         "default": "./dist/index.js"
-      }
+    },
+    "./src/styles/*": "./src/styles/*"
   },
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds exports definitions to `package.json`. This allows for the `@faststore/ui` and `@faststore/components` packages to be imported from Jest tests and be transpiled to CommonJS.

We only included the definition for the ESM files, which were not sufficient for users importing from CommonJS files. We still export ESM files as the `main` and `require` exports, which means they'll have to transpile it to CommonJS, but it will be usable.

I investigated the possibility of exporting these packages as CommonJS natively as well, but I don't think it's worth it. We'd have to support it and all kinds of errors could come from this, especially the [dual package harzard](https://nodejs.org/api/packages.html#dual-package-hazard).

For using Jest for these packages, enable transpilation by removing them from the ignored paths (inside your Jest config file):

`transformIgnorePatterns: ["/node_modules/(?!(@faststore/ui|@faststore/components)/)"]`

## How it works?

It now exports definitions of those packages for when they're imported from CommonJS files.

## References

https://nodejs.org/api/packages.html
https://www.typescriptlang.org/docs/handbook/esm-node.html
https://thesametech.com/how-to-build-typescript-project/

