### PR TITLE
Feat: extend Session for Profile V2

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -32,7 +32,7 @@ const BASE_INIT = {
 }
 
 export const VtexCommerce = (
-  { account, environment, incrementAddress }: Options,
+  { account, environment, incrementAddress, profileVersion  }: Options,
   ctx: Context
 ) => {
   const base = `https://${account}.${environment}.com.br`
@@ -271,16 +271,19 @@ export const VtexCommerce = (
       })
     },
     getProfile: (email: string): Promise<Profile> => {
-      return fetchAPI(
-        `${base}/api/storage/profile-system/profiles/${email}/unmask?alternativeKey=email&reason=getProfile-FastStore`,
-        {
-          method: 'GET',
-          headers: {
-            'content-type': 'application/json',
-            cookie: ctx.headers.cookie,
-          },
-        }
-      )
+      if(profileVersion.toLowerCase()==="v2"){
+        return fetchAPI(
+          `${base}/api/storage/profile-system/profiles/${email}/unmask?alternativeKey=email&reason=getProfile-FastStore`,
+          {
+            method: 'GET',
+            headers: {
+              'content-type': 'application/json',
+              cookie: ctx.headers.cookie,
+            },
+          }
+        )
+      }
+      return null
     },
     subscribeToNewsletter: (data: {
       name: string

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -20,6 +20,7 @@ import type { SalesChannel } from './types/SalesChannel'
 import { MasterDataResponse } from './types/Newsletter'
 import type { Address, AddressInput } from './types/Address'
 import { DeliveryMode, SelectedAddress } from './types/ShippingData'
+import { Profile } from './types/Profile'
 
 type ValueOf<T> = T extends Record<string, infer K> ? K : never
 
@@ -268,6 +269,18 @@ export const VtexCommerce = (
           cookie: ctx.headers.cookie,
         },
       })
+    },
+    getProfile: (email: string): Promise<Profile> => {
+      return fetchAPI(
+        `${base}/api/storage/profile-system/profiles/${email}/unmask?alternativeKey=email&reason=getProfile-FastStore`,
+        {
+          method: 'GET',
+          headers: {
+            'content-type': 'application/json',
+            cookie: ctx.headers.cookie,
+          },
+        }
+      )
     },
     subscribeToNewsletter: (data: {
       name: string

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -270,7 +270,7 @@ export const VtexCommerce = (
         },
       })
     },
-    getProfile: (email: string): Promise<Profile> => {
+    getProfile: (email: string): Promise<Profile> | null => {
       if(profileVersion.toLowerCase()==="v2"){
         return fetchAPI(
           `${base}/api/storage/profile-system/profiles/${email}/unmask?alternativeKey=email&reason=getProfile-FastStore`,

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Profile.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Profile.ts
@@ -1,29 +1,29 @@
 export interface Profile {
-    id: string
-    document: Document
-    meta: Meta
+  id: string
+  document: Document
+  meta: Meta
 }
 
 export interface Document {
-    email?: string | null
-    firstName?: string | null
-    lastName?: string | null
-    documentType?: string | null
-    homePhone?: string | null
-    isPJ?: string | null
-    userId?: string | null
-    id?: string | null
-    name?: string | null
-    document?: string | null
-    title?: string | null
-    phoneNumber?: string | null
-    birthDate?: string | null
+  email?: string | null
+  firstName?: string | null
+  lastName?: string | null
+  documentType?: string | null
+  homePhone?: string | null
+  isPJ?: string | null
+  userId?: string | null
+  id?: string | null
+  name?: string | null
+  document?: string | null
+  title?: string | null
+  phoneNumber?: string | null
+  birthDate?: string | null
 }
 
 export interface Meta {
-    version: string | null
-    author: string | null
-    creationDate: string | null
-    lastUpdateDate: string | null
-    expirationDate: string | null
+  version: string | null
+  author: string | null
+  creationDate: string | null
+  lastUpdateDate: string | null
+  expirationDate: string | null
 }

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Profile.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Profile.ts
@@ -1,0 +1,29 @@
+export interface Profile {
+    id: string
+    document: Document
+    meta: Meta
+}
+
+export interface Document {
+    email?: string | null
+    firstName?: string | null
+    lastName?: string | null
+    documentType?: string | null
+    homePhone?: string | null
+    isPJ?: string | null
+    userId?: string | null
+    id?: string | null
+    name?: string | null
+    document?: string | null
+    title?: string | null
+    phoneNumber?: string | null
+    birthDate?: string | null
+}
+
+export interface Meta {
+    version: string | null
+    author: string | null
+    creationDate: string | null
+    lastUpdateDate: string | null
+    expirationDate: string | null
+}

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -36,6 +36,7 @@ export interface Options {
   locale: string
   hideUnavailableItems: boolean
   incrementAddress: boolean,
+  profileVersion: string,  
   flags?: FeatureFlags
 }
 

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -36,7 +36,7 @@ export interface Options {
   locale: string
   hideUnavailableItems: boolean
   incrementAddress: boolean,
-  profileVersion: string,  
+  profileVersion: string,
   flags?: FeatureFlags
 }
 

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -1,7 +1,7 @@
 import deepEquals from 'fast-deep-equal'
 
 import ChannelMarshal from '../utils/channel'
-import type { Context, Options } from '..'
+import type { Context } from '..'
 import type {
   MutationValidateSessionArgs,
   StoreSession,
@@ -41,7 +41,7 @@ export const validateSession = async (
   // Set seller only if it's inside a region
   const seller = region?.sellers.find((seller) => channel.seller === seller.id)
 
-  const profilev2 = await clients.commerce.getProfile(profile.email.value)
+  const profilev2 = profile?.email?.value ? await clients.commerce.getProfile(profile?.email?.value) : null
 
   console.log("Profile V2 Information", profilev2)
   const newSession = {
@@ -61,11 +61,11 @@ export const validateSession = async (
           id: profile.id?.value ?? '',
           email: profile.email?.value ?? '',
           givenName:
-            profilev2
+            !profilev2
               ? profile.firstName?.value ?? ''
               : profilev2.document?.firstName ?? '',
           familyName:
-            profilev2
+            !profilev2
               ? profile.lastName?.value ?? ''
               : profilev2.document?.lastName ?? '',
         }

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -46,7 +46,7 @@ export const validateSession = async (
     profileVersion.toLowerCase() === 'v2' && profile?.email
       ? await clients.commerce.getProfile(profile.email.value)
       : ''
-
+  console.log("Profile V2 Information", profilev2)
   const newSession = {
     ...oldSession,
     currency: {

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -10,8 +10,7 @@ import type {
 export const validateSession = async (
   _: any,
   { session: oldSession, search }: MutationValidateSessionArgs,
-  { clients }: Context,
-  { profileVersion }: Options
+  { clients }: Context
 ): Promise<StoreSession | null> => {
   const channel = ChannelMarshal.parse(oldSession.channel ?? '')
   const postalCode = String(oldSession.postalCode ?? '').replace(/\D/g, '')
@@ -42,10 +41,8 @@ export const validateSession = async (
   // Set seller only if it's inside a region
   const seller = region?.sellers.find((seller) => channel.seller === seller.id)
 
-  const profilev2 =
-    profileVersion.toLowerCase() === 'v2' && profile?.email
-      ? await clients.commerce.getProfile(profile.email.value)
-      : ''
+  const profilev2 = await clients.commerce.getProfile(profile.email.value)
+
   console.log("Profile V2 Information", profilev2)
   const newSession = {
     ...oldSession,
@@ -64,11 +61,11 @@ export const validateSession = async (
           id: profile.id?.value ?? '',
           email: profile.email?.value ?? '',
           givenName:
-            profilev2 === ''
+            profilev2
               ? profile.firstName?.value ?? ''
               : profilev2.document?.firstName ?? '',
           familyName:
-            profilev2 === ''
+            profilev2
               ? profile.lastName?.value ?? ''
               : profilev2.document?.lastName ?? '',
         }

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -1,7 +1,7 @@
 import deepEquals from 'fast-deep-equal'
 
 import ChannelMarshal from '../utils/channel'
-import type { Context } from '..'
+import type { Context, Options } from '..'
 import type {
   MutationValidateSessionArgs,
   StoreSession,
@@ -10,7 +10,8 @@ import type {
 export const validateSession = async (
   _: any,
   { session: oldSession, search }: MutationValidateSessionArgs,
-  { clients }: Context
+  { clients }: Context,
+  { profileVersion }: Options
 ): Promise<StoreSession | null> => {
   const channel = ChannelMarshal.parse(oldSession.channel ?? '')
   const postalCode = String(oldSession.postalCode ?? '').replace(/\D/g, '')
@@ -41,6 +42,8 @@ export const validateSession = async (
   // Set seller only if it's inside a region
   const seller = region?.sellers.find((seller) => channel.seller === seller.id)
 
+  const profilev2 = profileVersion.toLowerCase() === "v2" && profile?.email ?  await clients.commerce.getProfile(profile.email.value) : ''
+
   const newSession = {
     ...oldSession,
     currency: {
@@ -57,7 +60,7 @@ export const validateSession = async (
       ? {
           id: profile.id?.value ?? '',
           email: profile.email?.value ?? '',
-          givenName: profile.firstName?.value ?? '',
+          givenName: (profilev2 === '' ? (profile.firstName?.value ?? '') : (profilev2.document?.firstName ?? '')),
           familyName: profile.lastName?.value ?? '',
         }
       : null,

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -42,7 +42,10 @@ export const validateSession = async (
   // Set seller only if it's inside a region
   const seller = region?.sellers.find((seller) => channel.seller === seller.id)
 
-  const profilev2 = profileVersion.toLowerCase() === "v2" && profile?.email ?  await clients.commerce.getProfile(profile.email.value) : ''
+  const profilev2 =
+    profileVersion.toLowerCase() === 'v2' && profile?.email
+      ? await clients.commerce.getProfile(profile.email.value)
+      : ''
 
   const newSession = {
     ...oldSession,
@@ -60,8 +63,14 @@ export const validateSession = async (
       ? {
           id: profile.id?.value ?? '',
           email: profile.email?.value ?? '',
-          givenName: (profilev2 === '' ? (profile.firstName?.value ?? '') : (profilev2.document?.firstName ?? '')),
-          familyName: profile.lastName?.value ?? '',
+          givenName:
+            profilev2 === ''
+              ? profile.firstName?.value ?? ''
+              : profilev2.document?.firstName ?? '',
+          familyName:
+            profilev2 === ''
+              ? profile.lastName?.value ?? ''
+              : profilev2.document?.lastName ?? '',
         }
       : null,
   }

--- a/packages/api/test/mutations.test.ts
+++ b/packages/api/test/mutations.test.ts
@@ -26,6 +26,7 @@ const apiOptions = {
   locale: 'en-US',
   hideUnavailableItems: false,
   incrementAddress: false,
+  profileVersion: 'v1',
   flags: {
     enableOrderFormSync: true,
   },

--- a/packages/api/test/queries.test.ts
+++ b/packages/api/test/queries.test.ts
@@ -48,6 +48,7 @@ const apiOptions = {
   locale: 'en-US',
   hideUnavailableItems: false,
   incrementAddress: false,
+  profileVersion: 'v1',
   flags: {
     enableOrderFormSync: true,
   },

--- a/packages/api/test/schema.test.ts
+++ b/packages/api/test/schema.test.ts
@@ -82,6 +82,7 @@ beforeAll(async () => {
     locale: 'en-US',
     hideUnavailableItems: false,
     incrementAddress: false,
+    profileVersion: 'v1',
     flags: {
       enableOrderFormSync: true,
     },

--- a/packages/core/faststore.config.js
+++ b/packages/core/faststore.config.js
@@ -19,6 +19,7 @@ module.exports = {
     environment: 'vtexcommercestable',
     hideUnavailableItems: true,
     incrementAddress: true,
+    profileVersion: 'v2',
   },
 
   // Default session

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -30,6 +30,7 @@ const apiOptions: APIOptions = {
   environment: storeConfig.api.environment as APIOptions['environment'],
   hideUnavailableItems: storeConfig.api.hideUnavailableItems,
   incrementAddress: storeConfig.api.incrementAddress,
+  profileVersion: storeConfig.api.profileVersion,
   channel: storeConfig.session.channel,
   locale: storeConfig.session.locale,
   flags: {


### PR DESCRIPTION
## What's the purpose of this pull request?

Currently the session for stores in profile V2 does not return user information such as first name and last name. The purpose of this PR is to make the profile version configurable and return this information directly from the backend to be used in store components. (ex: Header for logged in client)

## How it works?

The store configures the profile type and validateSession makes an additional call to the profile system API if the store owner uses Profile V2.

## How to test it?

Testing in stores using Profile V2 that givenName and familyName information are not returned by default, but with this change the information is filled in correctly.

