### PR TITLE
Docs: Create fragments session in documentation

### DIFF
--- a/apps/site/components/ExtendableQueryTable/ExtendableQueryTable.tsx
+++ b/apps/site/components/ExtendableQueryTable/ExtendableQueryTable.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from "react"
+
+export type ExtendableQueryTableProps = {
+    children: ReactNode
+}
+
+const ExtendableQueryTable = ({ children }: ExtendableQueryTableProps) => {
+    return (
+        <table className="nx-simple-table">
+            <thead>
+                <tr>
+                    <th>Side</th>
+                    <th>Query operation</th>
+                    <th>Page</th>
+                    <th>Where is used</th>
+                    <th>Return</th>
+                    <th>Parameters</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    {
+                        children
+                    }
+                </tr>
+            </tbody>
+        </table>
+    )
+}
+
+export default ExtendableQueryTable

--- a/apps/site/components/ExtendableQueryTable/index.ts
+++ b/apps/site/components/ExtendableQueryTable/index.ts
@@ -1,0 +1,1 @@
+export { default as ExtendableQueryTable } from "./ExtendableQueryTable"

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -28,7 +28,7 @@ Inside the repository, there is a clear separation about what comes from VTEX AP
 
 ## VTEX APIs schema extensions
 
-FastStore streamline the way of using data from VTEX APIs that the FastStore API does not expose.
+FastStore streamlines the way of using data from VTEX APIs that the FastStore API does not expose.
 
 As FastStore uses GraphQL, it's required to write [type definitions](https://graphql.org/learn/schema/#object-types-and-fields) and [resolvers](https://graphql.org/learn/execution/#root-fields-resolvers) to fetch the data you need. You will learn how to do this using API Extensions by following the steps below.
 

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -219,4 +219,99 @@ query {
 }
 ```
 
+---
+
+## Consume new fields from pages
+
+GraphQL enables clients to precisely define the required data by crafting specific GraphQL queries. The server then returns only the data that matches the query, eliminating the need for multiple requests, client-side filtering, and reducing the amount of data from requests.
+
+Therefore, it is crucial to avoid requesting unnecessary fields in queries and to be mindful of fragments that may call extraneous data in other contexts. By using GraphQL in this manner, we can optimize performance and streamline data transmission between clients and servers.
+
+When rendering a custom page or adding a custom section to an existing page, sometimes it is necessary to add new fields fetched from the previously defined custom or extended schema. We should determine which fields/fragments we need to request for the rendering of each page and avoid over-fetching unused data. 
+
+## Extending Queries Using Fragments
+
+When developers need to include custom fields in existing server queries, they can utilize the src/fragments folder. Within this directory, they can generate files containing GraphQL fragments, which can then be integrated into the desired queries for extension purposes.
+
+To introduce additional fields to an already established query, developers should generate a new .ts file within the src/fragments folder. This file's name should match the corresponding Query that requires extension.
+
+For instance, if a developer aims to retrieve a new query (illustrated here as newField with a data property) within the context of the ClientProductGallery query, the recommended approach involves creating a src/fragments/ClientProductGallery.ts file. This file should embody code similar to the example provided below:
+
+```ts
+// src/fragments/ClientProductGalery.ts
+
+import { gql } from '@faststore/graphql-utils'
+
+export const fragment = gql`
+  fragment ClientProductGallery on Query {
+    newField {
+      data
+    }
+  }
+`
+```
+
+## Queries to be extended
+
+
+### ClientProductGalleryQuery (Client Side)
+
+Query operation: search
+
+Page: PLP
+
+Where is used: In the hook `useGalleryQuery()` from the `ProductGallery` component.
+
+Return: Products totalCount from StorePageInfo, and facets (StoreFacet) from StoreSearchResult.
+Parameters: Frontend data from the `useSearch()` and `useLocalizedVariables()` hooks, the latter uses `useSession()`.
+
+### ServerCollectionPageQuery (Server Side)
+
+Query operation: collection
+
+Page: PLP
+
+Where is used: In the function `getStaticProps()` from `PLP`.
+
+Return: seo, breadcrumbList and meta data from collection (StoreCollection).
+Parameters: Collection `slug` that comes from URL.
+
+### ServerProductPageQuery (Server Side)
+
+Query operation: product
+
+Page: PDP
+
+Where is used: In the function `getStaticProps()` from `PDP`.
+
+Return: General product data from StoreProduct.
+Parameters: The `locator` with `slug` key/value.
+
+### ClientProductQuery (Client Side)
+
+Query operation: product
+
+Page: PDP
+
+Where is used: In the hook `useProduct()` from `ProductDetails`component.
+
+Return: General product data from StoreProduct to update product data inside `PDP` (product coming from `ServerProductPageQuery` as fallback).
+Parameters: Frontend data from the `useSession()` hook in locator array with `id`, `channel`, `locale` as key/values.
+
+### ClientProductsQuery (Client Side)
+
+Query operation: search
+
+Page: PLP + Pages that use `ProductShelf`, and `ProductTiles` components.
+
+Where is used: 
+- In the hook `useProducts()` from `GalleryPage` from `PLP`. 
+- In the hook `useProductsPrefetch()` to prefetch the previous (prev) and next (next) page from the current `PLP` page.
+- In the hook `useProductsQuery()`, in `ProductShelf`, `ProductTiles` components, that can be used on multiple pages.
+
+Return: General products data (StoreProduct)  with the `totalCount` from StorePageInfo.
+
+Parameters: Frontend data from the `useLocalizedVariables()` and `useSession()` hooks.
+
+
 

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -220,7 +220,7 @@ query {
 
 ## Extending Queries Using Fragments
 
-When developers need to include custom fields in existing server queries, they can utilize the src/fragments folder. Within this directory, they can generate files containing GraphQL fragments, which can then be integrated into the desired queries for extension purposes.
+To add custom fields to existing [extendable queries](/docs/api-extensions#extendable-queries), extend them using fragments located in the `src/fragments` folder. Fragments are GraphQL components that can be integrated into queries to extend functionality.
 
 To introduce additional fields to an already established query, developers should generate a new .ts file within the src/fragments folder. This file's name should match the corresponding Query that requires extension.
 

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -251,7 +251,7 @@ export const fragment = gql`
 `
 ```
 
-## Queries to be extended
+## Extendable Queries
 
 
 ### ClientProductGalleryQuery (Client Side)

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -5,6 +5,7 @@ import { Steps, Step } from 'nextra-theme-docs'
 # API Extensions
 
 In this guide you will learn how to extend the FastStore API schema.
+
 </header>
 
 Although the [FastStore API](https://v1.faststore.dev/reference/api/faststore-api) provides a [GraphQL schema for ecommerce](https://v1.faststore.dev/reference/api/queries) that suits a general use case, some stores may need to access other, more specific, information.
@@ -28,7 +29,7 @@ Inside the repository, there is a clear separation about what comes from VTEX AP
 
 FastStore streamline the way of using data from VTEX APIs that the FastStore API does not expose.
 
-As FastStore uses GraphQL, it's required to write [type definitions](https://graphql.org/learn/schema/#object-types-and-fields) and [resolvers](https://graphql.org/learn/execution/#root-fields-resolvers) to fetch the data you need.  You will learn how to do this using API Extensions by following the steps below.
+As FastStore uses GraphQL, it's required to write [type definitions](https://graphql.org/learn/schema/#object-types-and-fields) and [resolvers](https://graphql.org/learn/execution/#root-fields-resolvers) to fetch the data you need. You will learn how to do this using API Extensions by following the steps below.
 
 ### Folder Structure
 
@@ -95,7 +96,6 @@ const productResolver = {
 }
 
 export default productResolver
-
 ```
 
 As you see, you can leverage the use of TypeScript by typing the root param as [StoreProductRoot](https://v1.faststore.dev/reference/api/root-object-fields#root-product):
@@ -114,7 +114,6 @@ const resolvers = {
 }
 
 export default resolvers
-
 ```
 
 That's it, you only need to define these files within the vtex folder for the sake of exposing the new fields. The entire GraphQL creation process must be transparent and done in the background by the FastStore.
@@ -122,6 +121,7 @@ That's it, you only need to define these files within the vtex folder for the sa
 ### How to use
 
 **TBD - After the Consume new fields from pages features be done. Here we can be inspired by these steps:**
+
 1. add the `customData` field in the `Fragment X` from the `Y file`.
 2. run `yarn dev` in the core package.
 3. run `yarn generate` in the core package (with `yarn dev` running).
@@ -151,9 +151,8 @@ starter.store/
 
 Following this structure, you can use the same pattern mentioned above regarding the VTEX API Schema extensions but using the `thirdParty` folder, with resolvers and typeDefs inside their respective folders and resolvers being imported into the `index.ts` file.
 
-One crucial aspect to consider when developing a third-party extension is the creation of a Query or Mutation schema. This schema plays a vital role in generating new query entry points to access data. 
+One crucial aspect to consider when developing a third-party extension is the creation of a Query or Mutation schema. This schema plays a vital role in generating new query entry points to access data.
 Below, you will find an example code the implementation of a third-party extension:
-
 
 ```ts
 //graphql/thirdParty/typeDefs/extra.graphql
@@ -170,7 +169,6 @@ type Query {
   namedExtraData(name: String!): ExtraData
 }
 ```
-
 
 ```ts
 //graphql/thirdParty/resolvers/extra.ts
@@ -189,7 +187,6 @@ const extraDataResolver = {
     },
   },
 }
-
 
 export default extraDataResolver
 ```
@@ -227,7 +224,7 @@ GraphQL enables clients to precisely define the required data by crafting specif
 
 Therefore, it is crucial to avoid requesting unnecessary fields in queries and to be mindful of fragments that may call extraneous data in other contexts. By using GraphQL in this manner, we can optimize performance and streamline data transmission between clients and servers.
 
-When rendering a custom page or adding a custom section to an existing page, sometimes it is necessary to add new fields fetched from the previously defined custom or extended schema. We should determine which fields/fragments we need to request for the rendering of each page and avoid over-fetching unused data. 
+When rendering a custom page or adding a custom section to an existing page, sometimes it is necessary to add new fields fetched from the previously defined custom or extended schema. We should determine which fields/fragments we need to request for the rendering of each page and avoid over-fetching unused data.
 
 ## Extending Queries Using Fragments
 
@@ -253,65 +250,11 @@ export const fragment = gql`
 
 ## Extendable Queries
 
-
-### ClientProductGalleryQuery (Client Side)
-
-Query operation: search
-
-Page: PLP
-
-Where is used: In the hook `useGalleryQuery()` from the `ProductGallery` component.
-
-Return: Products totalCount from StorePageInfo, and facets (StoreFacet) from StoreSearchResult.
-Parameters: Frontend data from the `useSearch()` and `useLocalizedVariables()` hooks, the latter uses `useSession()`.
-
-### ServerCollectionPageQuery (Server Side)
-
-Query operation: collection
-
-Page: PLP
-
-Where is used: In the function `getStaticProps()` from `PLP`.
-
-Return: seo, breadcrumbList and meta data from collection (StoreCollection).
-Parameters: Collection `slug` that comes from URL.
-
-### ServerProductPageQuery (Server Side)
-
-Query operation: product
-
-Page: PDP
-
-Where is used: In the function `getStaticProps()` from `PDP`.
-
-Return: General product data from StoreProduct.
-Parameters: The `locator` with `slug` key/value.
-
-### ClientProductQuery (Client Side)
-
-Query operation: product
-
-Page: PDP
-
-Where is used: In the hook `useProduct()` from `ProductDetails`component.
-
-Return: General product data from StoreProduct to update product data inside `PDP` (product coming from `ServerProductPageQuery` as fallback).
-Parameters: Frontend data from the `useSession()` hook in locator array with `id`, `channel`, `locale` as key/values.
-
-### ClientProductsQuery (Client Side)
-
-Query operation: search
-
-Page: PLP + Pages that use `ProductShelf`, and `ProductTiles` components.
-
-Where is used: 
-- In the hook `useProducts()` from `GalleryPage` from `PLP`. 
-- In the hook `useProductsPrefetch()` to prefetch the previous (prev) and next (next) page from the current `PLP` page.
-- In the hook `useProductsQuery()`, in `ProductShelf`, `ProductTiles` components, that can be used on multiple pages.
-
-Return: General products data (StoreProduct)  with the `totalCount` from StorePageInfo.
-
-Parameters: Frontend data from the `useLocalizedVariables()` and `useSession()` hooks.
-
-
+| **Query Name** | **Side** | **Query operation** | **Page** | **Where is used** | **Return** | **Parameters** |
+|---|---|---|---|---|---|---|
+| ClientProductGalleryQuery | Client | search | PLP | In the hook `useGalleryQuery()` from the `ProductGallery` component. | Products totalCount from StorePageInfo, and facets (StoreFacet) from StoreSearchResult. | Frontend data from the `useSearch()` and `useLocalizedVariables()` hooks, the latter uses `useSession()`. |
+| ServerCollectionPageQuery | Server | collection | PLP | In the function `getStaticProps()` from `PLP`. | seo, breadcrumbList and meta data from collection (StoreCollection). | Collection `slug` that comes from URL. |
+| ServerProductPageQuery | Server | product | PDP | In the function `getStaticProps()` from `PDP`. | General product data from StoreProduct. | The `locator` with `slug` key/value. |
+| ClientProductQuery | Client | product | PDP | In the hook `useProduct()` from `ProductDetails`component. | General product data from StoreProduct to update product data inside `PDP` (product coming from `ServerProductPageQuery` as fallback). | Frontend data from the `useSession()` hook in locator array with `id`, `channel`, `locale` as key/values. |
+| ClientProductsQuery | Client | search | PLP + Pages that use `ProductShelf`, and `ProductTiles` components. | In the hook `useProducts()` from `GalleryPage` from `PLP`.<br />In the hook `useProductsPrefetch()` to prefetch the previous (prev) and next (next) page from the current `PLP` page.<br />In the hook `useProductsQuery()`, in `ProductShelf`, `ProductTiles` components, that can be used on multiple pages. | General products data (StoreProduct)  with the `totalCount` from StorePageInfo. | Frontend data from the `useLocalizedVariables()` and `useSession()` hooks. |
 

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -1,4 +1,4 @@
-import { Steps, Step } from 'nextra-theme-docs'
+import { Steps, Step, Callout } from 'nextra-theme-docs'
 
 <header className="hero">
 
@@ -241,6 +241,38 @@ export const fragment = gql`
 ```
 
 ## Extendable Queries
+
+<ul class="nx-section-checklist">
+  <li>
+    <details>
+      <summary>Query: `ClientProductGalleryQuery`</summary>
+
+        <table class="nx-simple-table">
+            <thead>
+                <tr>
+                    <th>Side</th>
+                    <th>Query operation</th>
+                    <th>Page</th>
+                    <th>Where is used</th>
+                    <th>Return</th>
+                    <th>Parameters</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Client</td>
+                    <td><a href="">Search</a></td>
+                    <td>PLP</td>
+                    <td>In the hook `useGalleryQuery()` from the `ProductGallery` component.</td>
+                    <td>Products totalCount from StorePageInfo, and facets (StoreFacet) from StoreSearchResult.</td>
+                    <td>Frontend data from the useSearch() and useLocalizedVariables() hooks, the latter uses useSession().</td>
+                </tr>
+            </tbody>
+        </table>
+
+    </details>
+  </li>
+</ul>
 
 | **Query Name** | **Side** | **Query operation** | **Page** | **Where is used** | **Return** | **Parameters** |
 |---|---|---|---|---|---|---|

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -3,7 +3,7 @@ import { ExtendableQueryTable } from './../../components/ExtendableQueryTable'
 
 <header className="hero">
 
-# API Extensions
+# API extensions
 
 In this guide you will learn how to extend the FastStore API schema.
 
@@ -15,7 +15,7 @@ You will not be able to add other APIs endpoints to your storefront since this m
 
 ---
 
-## Before starting
+## Before you start
 
 Note that even though you can add information to the FastStore API schema, you must be careful not to over-fetch data on your pages. See the [best practices for fetching data on your storefront](https://v1.faststore.dev/how-to-guides/faststore-api/fetching-api-data#best-practices-for-fetching-data).
 
@@ -26,7 +26,7 @@ Inside the repository, there is a clear separation about what comes from VTEX AP
 
 ---
 
-## VTEX APIs Schema Extensions
+## VTEX APIs schema extensions
 
 FastStore streamline the way of using data from VTEX APIs that the FastStore API does not expose.
 
@@ -127,7 +127,7 @@ That's it, you only need to define these files within the vtex folder for the sa
 
 ---
 
-## Third-party APIs Schema Extensions
+## Third-party APIs schema extensions
 
 Also, as stores tend to grow, so does the possibility of consuming new data that is **not provided by default in the FastStore API or other VTEX APIs**. As such, FastStore must consume new data from third-party APIs.
 
@@ -213,21 +213,19 @@ query {
 
 ---
 
-## Extending Queries Using Fragments
+## Extending queries using fragments
 
 To add custom fields to existing [extendable queries](/docs/api-extensions#extendable-queries), extend them using fragments located in the `src/fragments` folder. Fragments are GraphQL components that can be integrated into queries to extend functionality.
 
-To add additional fields to an existing query, follow the steps below. We will use the `ServerProductPage` query as an example to demonstrate how to extend a query.
+To add additional fields to an existing query, follow the steps below. We will use the `ServerProductPage` query as an example to illustrate how to extend a query.
 
-<Callout type="info" emoji="ℹ️">
-  We will use the `ServerProductPage` query to illustrate.
-</Callout>
-
-Step 1: Create a New File
+### Step 1: Create a new file
 Create a new `.ts` file in the `src/fragments` folder named `ServerProductPage.ts`. _The name of the file should match the name of the query you want to extend._
 
-Step 2: Define the GraphQL Fragment
+### Step 2: Define the GraphQL fragment
 In the `ServerProductPage.ts` file, define the GraphQL fragment corresponding to the new fields you want. In this example, the new field is represented by `customData` property to retrieve. Use the following syntax as a guideline:
+
+{/*TO DO: ADD THE EXPECTED RESULT FROM THIS CODE SAMPLE*/}
 
 ```ts copy filename="src/fragments/ServerProductPage.ts"
 
@@ -241,6 +239,8 @@ export const fragment = gql`
   }
 `
 ```
+
+{/*TO DO: ADD THE EXPECTED RESULT FROM THIS CODE SAMPLE*/}
 
 ## Extendable Queries
 
@@ -323,12 +323,12 @@ export const fragment = gql`
           PLP + Pages that use `ProductShelf`, and `ProductTiles` components.
         </td>
         <td>
-          In the hook `useProducts()` from `GalleryPage` from `PLP`.
+          - In the hook `useProducts()` from `GalleryPage` from `PLP`.
           <br />
-          In the hook `useProductsPrefetch()` to prefetch the previous (prev)
+          - In the hook `useProductsPrefetch()` to prefetch the previous (prev)
           and next (next) page from the current `PLP` page.
           <br />
-          In the hook `useProductsQuery()`, in `ProductShelf`, `ProductTiles`
+          - In the hook `useProductsQuery()`, in `ProductShelf`, `ProductTiles`
           components, that can be used on multiple pages.
           <br />
         </td>

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -1,4 +1,5 @@
 import { Steps, Step, Callout } from 'nextra-theme-docs'
+import { ExtendableQueryTable } from './../../components/ExtendableQueryTable'
 
 <header className="hero">
 
@@ -229,10 +230,10 @@ To add additional fields to an existing query, follow the steps below. We will u
 </Callout>
 
 Step 1: Create a New File
-Create a new `.ts` file in the `src/fragments` folder named `ServerProductPage.ts`. *The name of the file should match the name of the query you want to extend.*
+Create a new `.ts` file in the `src/fragments` folder named `ServerProductPage.ts`. _The name of the file should match the name of the query you want to extend._
 
 Step 2: Define the GraphQL Fragment
-In the `ServerProductPage.ts` file, define the GraphQL fragment corresponding to the new fields you want. In this example, the new field is represented by `customData` property to retrieve. Use the following syntax as a guideline: 
+In the `ServerProductPage.ts` file, define the GraphQL fragment corresponding to the new fields you want. In this example, the new field is represented by `customData` property to retrieve. Use the following syntax as a guideline:
 
 ```ts
 // src/fragments/ServerProductPage.ts
@@ -250,43 +251,103 @@ export const fragment = gql`
 
 ## Extendable Queries
 
-<ul class="nx-section-checklist">
+<ul>
   <li>
     <details>
       <summary>Query: `ClientProductGalleryQuery`</summary>
-
-        <table class="nx-simple-table">
-            <thead>
-                <tr>
-                    <th>Side</th>
-                    <th>Query operation</th>
-                    <th>Page</th>
-                    <th>Where is used</th>
-                    <th>Return</th>
-                    <th>Parameters</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Client</td>
-                    <td><a href="">Search</a></td>
-                    <td>PLP</td>
-                    <td>In the hook `useGalleryQuery()` from the `ProductGallery` component.</td>
-                    <td>Products totalCount from StorePageInfo, and facets (StoreFacet) from StoreSearchResult.</td>
-                    <td>Frontend data from the useSearch() and useLocalizedVariables() hooks, the latter uses useSession().</td>
-                </tr>
-            </tbody>
-        </table>
-
+      <ExtendableQueryTable>
+        <td>Client</td>
+        <td>search</td>
+        <td>PLP</td>
+        <td>
+          In the hook `useGalleryQuery()` from the `ProductGallery` component.
+        </td>
+        <td>
+          Products totalCount from StorePageInfo, and facets (StoreFacet) from
+          StoreSearchResult.
+        </td>
+        <td>
+          Frontend data from the `useSearch()` and `useLocalizedVariables()`
+          hooks, the latter uses `useSession()`.
+        </td>
+      </ExtendableQueryTable>
+    </details>
+  </li>
+  <li>
+    <details>
+      <summary>Query: `ServerCollectionPageQuery`</summary>
+      <ExtendableQueryTable>
+        <td>Server</td>
+        <td>collection</td>
+        <td>PLP</td>
+        <td>In the function `getStaticProps()` from `PLP`.</td>
+        <td>
+          seo, breadcrumbList and meta data from collection (StoreCollection).
+        </td>
+        <td>Collection `slug` that comes from URL.</td>
+      </ExtendableQueryTable>
+    </details>
+  </li>
+  <li>
+    <details>
+      <summary>Query: `ServerProductPageQuery`</summary>
+      <ExtendableQueryTable>
+        <td>Server</td>
+        <td>product</td>
+        <td>PDP</td>
+        <td>In the function `getStaticProps()` from `PDP`.</td>
+        <td>General product data from StoreProduct.</td>
+        <td>The `locator` with `slug` key/value.</td>
+      </ExtendableQueryTable>
+    </details>
+  </li>
+  <li>
+    <details>
+      <summary>Query: `ClientProductQuery`</summary>
+      <ExtendableQueryTable>
+        <td>Client</td>
+        <td>product</td>
+        <td>PDP</td>
+        <td>In the hook `useProduct()` from `ProductDetails`component.</td>
+        <td>
+          General product data from StoreProduct to update product data inside
+          `PDP` (product coming from `ServerProductPageQuery` as fallback).
+        </td>
+        <td>
+          >Frontend data from the `useSession()` hook in locator array with
+          `id`, `channel`, `locale` as key/values.
+        </td>
+      </ExtendableQueryTable>
+    </details>
+  </li>
+  <li>
+    <details>
+      <summary>Query: `ClientProductsQuery`</summary>
+      <ExtendableQueryTable>
+        <td>Client</td>
+        <td>search</td>
+        <td>
+          PLP + Pages that use `ProductShelf`, and `ProductTiles` components.
+        </td>
+        <td>
+          In the hook `useProducts()` from `GalleryPage` from `PLP`.
+          <br />
+          In the hook `useProductsPrefetch()` to prefetch the previous (prev)
+          and next (next) page from the current `PLP` page.
+          <br />
+          In the hook `useProductsQuery()`, in `ProductShelf`, `ProductTiles`
+          components, that can be used on multiple pages.
+          <br />
+        </td>
+        <td>
+          General products data (StoreProduct) with the `totalCount` from
+          StorePageInfo.
+        </td>
+        <td>
+          Frontend data from the `useLocalizedVariables()` and `useSession()`
+          hooks.
+        </td>
+      </ExtendableQueryTable>
     </details>
   </li>
 </ul>
-
-| **Query Name** | **Side** | **Query operation** | **Page** | **Where is used** | **Return** | **Parameters** |
-|---|---|---|---|---|---|---|
-| ClientProductGalleryQuery | Client | search | PLP | In the hook `useGalleryQuery()` from the `ProductGallery` component. | Products totalCount from StorePageInfo, and facets (StoreFacet) from StoreSearchResult. | Frontend data from the `useSearch()` and `useLocalizedVariables()` hooks, the latter uses `useSession()`. |
-| ServerCollectionPageQuery | Server | collection | PLP | In the function `getStaticProps()` from `PLP`. | seo, breadcrumbList and meta data from collection (StoreCollection). | Collection `slug` that comes from URL. |
-| ServerProductPageQuery | Server | product | PDP | In the function `getStaticProps()` from `PDP`. | General product data from StoreProduct. | The `locator` with `slug` key/value. |
-| ClientProductQuery | Client | product | PDP | In the hook `useProduct()` from `ProductDetails`component. | General product data from StoreProduct to update product data inside `PDP` (product coming from `ServerProductPageQuery` as fallback). | Frontend data from the `useSession()` hook in locator array with `id`, `channel`, `locale` as key/values. |
-| ClientProductsQuery | Client | search | PLP + Pages that use `ProductShelf`, and `ProductTiles` components. | In the hook `useProducts()` from `GalleryPage` from `PLP`.<br />In the hook `useProductsPrefetch()` to prefetch the previous (prev) and next (next) page from the current `PLP` page.<br />In the hook `useProductsQuery()`, in `ProductShelf`, `ProductTiles` components, that can be used on multiple pages. | General products data (StoreProduct)  with the `totalCount` from StorePageInfo. | Frontend data from the `useLocalizedVariables()` and `useSession()` hooks. |
-

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -36,7 +36,7 @@ As FastStore uses GraphQL, it's required to write [type definitions](https://gra
 
 The store's repository provides the following folder structure for the VTEX APIs Schema Extensions that is held in the `src/graphql/vtex` folder.
 
-```ts
+```ts copy
 starter.store/
 └─ src/
     └─ graphql/
@@ -58,8 +58,7 @@ You can create a new `<typeName>.graphql` files inside the `vtex/typeDefs` folde
 
 See the following code example that creates a `product.graphql` file, that extends the [StoreProduct](https://v1.faststore.dev/reference/api/objects#storeproduct) type from FastStore API and exposes a new `customData` field:
 
-```graphql
-// graphql/vtex/typeDefs/product.graphql
+```graphql filename="graphql/vtex/typeDefs/product.graphql"
 
 extend type StoreProduct {
   """
@@ -83,8 +82,7 @@ The way that it will be organized inside this folder is flexible, it's possible 
 
 See the following code example that creates a `product.ts` resolver file and resolves the `customData` field from `StoreProduct`:
 
-```ts
-// graphql/vtex/resolvers/product.ts
+```ts copy filename="graphql/vtex/resolvers/product.ts"
 
 import type { StoreProductRoot } from '@faststore/api'
 
@@ -105,8 +103,7 @@ As you see, you can leverage the use of TypeScript by typing the root param as [
 
 Then, it's important to import the resolvers inside the `index.ts` file, spread them in the resolver object and re-export the final resolver object.
 
-```ts
-// graphql/vtex/resolvers/index.ts
+```ts copy filename="graphql/vtex/resolvers/index.ts"
 
 import { default as StoreProductResolver } from './product'
 
@@ -136,7 +133,7 @@ Also, as stores tend to grow, so does the possibility of consuming new data that
 
 Intending to separate what comes from VTEX and what comes from third-party APIs. The store's repository provides the following folder structure for third-party APIs Schema Extensions that is held in the `src/graphql/thirdParty` folder:
 
-```ts
+```ts copy
 starter.store/
 └── src/
     └── graphql/
@@ -155,8 +152,7 @@ Following this structure, you can use the same pattern mentioned above regarding
 One crucial aspect to consider when developing a third-party extension is the creation of a Query or Mutation schema. This schema plays a vital role in generating new query entry points to access data.
 Below, you will find an example code the implementation of a third-party extension:
 
-```ts
-//graphql/thirdParty/typeDefs/extra.graphql
+```ts copy filename="graphql/thirdParty/typeDefs/extra.graphql"
 
 type ExtraData {
   """
@@ -171,8 +167,7 @@ type Query {
 }
 ```
 
-```ts
-//graphql/thirdParty/resolvers/extra.ts
+```ts copy filename="graphql/thirdParty/resolvers/extra.ts"
 
 const extraDataResolver = {
   Query: {
@@ -192,8 +187,7 @@ const extraDataResolver = {
 export default extraDataResolver
 ```
 
-```ts
-//graphql/thirdParty/resolvers/index.ts
+```ts copy filename="graphql/thirdParty/resolvers/index.ts"
 
 import { default as StoreExtraResolver } from './extra'
 
@@ -206,7 +200,7 @@ export default resolvers
 
 In this example, the extra data is accessible by this query:
 
-```ts
+```ts copy
 query {
 	extraData {
 		data
@@ -235,8 +229,7 @@ Create a new `.ts` file in the `src/fragments` folder named `ServerProductPage.t
 Step 2: Define the GraphQL Fragment
 In the `ServerProductPage.ts` file, define the GraphQL fragment corresponding to the new fields you want. In this example, the new field is represented by `customData` property to retrieve. Use the following syntax as a guideline:
 
-```ts
-// src/fragments/ServerProductPage.ts
+```ts copy filename="src/fragments/ServerProductPage.ts"
 
 import { gql } from '@faststore/graphql-utils'
 

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -222,12 +222,20 @@ query {
 
 To add custom fields to existing [extendable queries](/docs/api-extensions#extendable-queries), extend them using fragments located in the `src/fragments` folder. Fragments are GraphQL components that can be integrated into queries to extend functionality.
 
-To introduce additional fields to an already established query, developers should generate a new .ts file within the src/fragments folder. This file's name should match the corresponding Query that requires extension.
+To add additional fields to an existing query, follow the steps below. We will use the `ServerProductPage` query as an example to demonstrate how to extend a query.
 
-For instance, if a developer aims to retrieve a new query (illustrated here as customData property) within the context of the ServerProductPage query, the recommended approach involves creating a src/fragments/ServerProductPage.ts file. This file should embody code similar to the example provided below:
+<Callout type="info" emoji="ℹ️">
+  We will use the `ServerProductPage` query to illustrate.
+</Callout>
+
+Step 1: Create a New File
+Create a new `.ts` file in the `src/fragments` folder named `ServerProductPage.ts`. *The name of the file should match the name of the query you want to extend.*
+
+Step 2: Define the GraphQL Fragment
+In the `ServerProductPage.ts` file, define the GraphQL fragment corresponding to the new fields you want. In this example, the new field is represented by `customData` property to retrieve. Use the following syntax as a guideline: 
 
 ```ts
-// src/fragments/ClientProductGalery.ts
+// src/fragments/ServerProductPage.ts
 
 import { gql } from '@faststore/graphql-utils'
 

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -218,21 +218,13 @@ query {
 
 ---
 
-## Consume new fields from pages
-
-GraphQL enables clients to precisely define the required data by crafting specific GraphQL queries. The server then returns only the data that matches the query, eliminating the need for multiple requests, client-side filtering, and reducing the amount of data from requests.
-
-Therefore, it is crucial to avoid requesting unnecessary fields in queries and to be mindful of fragments that may call extraneous data in other contexts. By using GraphQL in this manner, we can optimize performance and streamline data transmission between clients and servers.
-
-When rendering a custom page or adding a custom section to an existing page, sometimes it is necessary to add new fields fetched from the previously defined custom or extended schema. We should determine which fields/fragments we need to request for the rendering of each page and avoid over-fetching unused data.
-
 ## Extending Queries Using Fragments
 
 When developers need to include custom fields in existing server queries, they can utilize the src/fragments folder. Within this directory, they can generate files containing GraphQL fragments, which can then be integrated into the desired queries for extension purposes.
 
 To introduce additional fields to an already established query, developers should generate a new .ts file within the src/fragments folder. This file's name should match the corresponding Query that requires extension.
 
-For instance, if a developer aims to retrieve a new query (illustrated here as newField with a data property) within the context of the ClientProductGallery query, the recommended approach involves creating a src/fragments/ClientProductGallery.ts file. This file should embody code similar to the example provided below:
+For instance, if a developer aims to retrieve a new query (illustrated here as customData property) within the context of the ServerProductPage query, the recommended approach involves creating a src/fragments/ServerProductPage.ts file. This file should embody code similar to the example provided below:
 
 ```ts
 // src/fragments/ClientProductGalery.ts
@@ -240,9 +232,9 @@ For instance, if a developer aims to retrieve a new query (illustrated here as n
 import { gql } from '@faststore/graphql-utils'
 
 export const fragment = gql`
-  fragment ClientProductGallery on Query {
-    newField {
-      data
+  fragment ServerProductPage on Query {
+    product(locator: $locator) {
+      customData
     }
   }
 `


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR creates the "Consume new fields from pages" session in api extension documentation

[Link to Documentation](https://faststore-site-git-docs-documents-extension-ap-f66250-faststore.vercel.app/docs/api-extensions#consume-new-fields-from-pages)

[Task](https://vtex-dev.atlassian.net/browse/FS-1268)