### PR TITLE
adding section context

### DIFF
--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -11,6 +11,7 @@ import Alert from 'src/components/sections/Alert'
 import Footer from 'src/components/sections/Footer'
 import Navbar from 'src/components/sections/Navbar'
 import RegionBar from 'src/components/sections/RegionBar'
+import { SectionProvider } from 'src/sdk/ui/SectionContex'
 
 const RegionModal = lazy(() => import('src/components/region/RegionModal'))
 const CartSidebar = lazy(() => import('src/components/cart/CartSidebar'))
@@ -37,11 +38,12 @@ function GlobalSections({
   ...otherProps
 }: PropsWithChildren<GlobalSectionsData>) {
   return (
-    <RenderSections components={COMPONENTS} {...otherProps}>
-      <Toast />
-
-      <main>{children}</main>
-    </RenderSections>
+    <SectionProvider sections={otherProps.sections}>
+      <RenderSections components={COMPONENTS} {...otherProps}>
+        <Toast />
+        <main>{children}</main>
+      </RenderSections>
+    </SectionProvider>
   )
 }
 

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -11,7 +11,6 @@ import Alert from 'src/components/sections/Alert'
 import Footer from 'src/components/sections/Footer'
 import Navbar from 'src/components/sections/Navbar'
 import RegionBar from 'src/components/sections/RegionBar'
-import { SectionProvider } from 'src/sdk/ui/SectionContex'
 
 const RegionModal = lazy(() => import('src/components/region/RegionModal'))
 const CartSidebar = lazy(() => import('src/components/cart/CartSidebar'))
@@ -40,6 +39,7 @@ function GlobalSections({
   return (
     <RenderSections components={COMPONENTS} {...otherProps}>
       <Toast />
+
       <main>{children}</main>
     </RenderSections>
   )

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -38,12 +38,10 @@ function GlobalSections({
   ...otherProps
 }: PropsWithChildren<GlobalSectionsData>) {
   return (
-    <SectionProvider sections={otherProps.sections}>
-      <RenderSections components={COMPONENTS} {...otherProps}>
-        <Toast />
-        <main>{children}</main>
-      </RenderSections>
-    </SectionProvider>
+    <RenderSections components={COMPONENTS} {...otherProps}>
+      <Toast />
+      <main>{children}</main>
+    </RenderSections>
   )
 }
 

--- a/packages/core/src/pages/404.tsx
+++ b/packages/core/src/pages/404.tsx
@@ -9,6 +9,7 @@ import { Locator } from '@vtex/client-cms'
 
 import { Icon as UIIcon } from '@faststore/ui'
 import EmptyState from 'src/components/sections/EmptyState'
+import { SectionProvider } from 'src/sdk/ui/SectionContex'
 
 const useErrorState = () => {
   const router = useRouter()
@@ -29,21 +30,23 @@ function Page({ globalSections }: Props) {
 
   return (
     <GlobalSections {...globalSections}>
-      <NextSeo noindex nofollow />
+      <SectionProvider globalSections={globalSections.sections}>
+        <NextSeo noindex nofollow />
 
-      <EmptyState
-        title="Not Found: 404"
-        titleIcon={
-          <UIIcon
-            name="CircleWavyWarning"
-            width={56}
-            height={56}
-            weight="thin"
-          />
-        }
-      >
-        <p>This app could not find url {fromUrl}</p>
-      </EmptyState>
+        <EmptyState
+          title="Not Found: 404"
+          titleIcon={
+            <UIIcon
+              name="CircleWavyWarning"
+              width={56}
+              height={56}
+              weight="thin"
+            />
+          }
+        >
+          <p>This app could not find url {fromUrl}</p>
+        </EmptyState>
+      </SectionProvider>
     </GlobalSections>
   )
 }

--- a/packages/core/src/pages/500.tsx
+++ b/packages/core/src/pages/500.tsx
@@ -9,6 +9,7 @@ import GlobalSections, {
 
 import { Icon as UIIcon } from '@faststore/ui'
 import EmptyState from 'src/components/sections/EmptyState'
+import { SectionProvider } from 'src/sdk/ui/SectionContex'
 
 type Props = {
   globalSections: GlobalSectionsData
@@ -29,25 +30,27 @@ function Page({ globalSections }: Props) {
 
   return (
     <GlobalSections {...globalSections}>
-      <NextSeo noindex nofollow />
+      <SectionProvider globalSections={globalSections.sections}>
+        <NextSeo noindex nofollow />
 
-      <EmptyState
-        title="500"
-        titleIcon={
-          <UIIcon
-            name="CircleWavyWarning"
-            width={56}
-            height={56}
-            weight="thin"
-          />
-        }
-      >
-        <h2>Internal Server Error</h2>
+        <EmptyState
+          title="500"
+          titleIcon={
+            <UIIcon
+              name="CircleWavyWarning"
+              width={56}
+              height={56}
+              weight="thin"
+            />
+          }
+        >
+          <h2>Internal Server Error</h2>
 
-        <div>
-          The server errored with id {errorId} when visiting page {fromUrl}
-        </div>
-      </EmptyState>
+          <div>
+            The server errored with id {errorId} when visiting page {fromUrl}
+          </div>
+        </EmptyState>
+      </SectionProvider>
     </GlobalSections>
   )
 }

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -22,6 +22,7 @@ import LandingPage, {
   getLandingPageBySlug,
   LandingPageProps,
 } from 'src/components/templates/LandingPage'
+import { SectionProvider } from 'src/sdk/ui/SectionContex'
 
 type BaseProps = {
   globalSections: GlobalSectionsData
@@ -42,10 +43,17 @@ type Props = BaseProps &
 function Page({ globalSections, type, ...otherProps }: Props) {
   return (
     <GlobalSections {...globalSections}>
-      {type === 'plp' && (
-        <ProductListingPage {...(otherProps as ProductListingPageProps)} />
-      )}
-      {type === 'page' && <LandingPage {...(otherProps as LandingPageProps)} />}
+      <SectionProvider
+        globalSections={globalSections.sections}
+        pageSections={otherProps.page.sections}
+      >
+        {type === 'plp' && (
+          <ProductListingPage {...(otherProps as ProductListingPageProps)} />
+        )}
+        {type === 'page' && (
+          <LandingPage {...(otherProps as LandingPageProps)} />
+        )}
+      </SectionProvider>
     </GlobalSections>
   )
 }

--- a/packages/core/src/pages/account.tsx
+++ b/packages/core/src/pages/account.tsx
@@ -8,6 +8,7 @@ import GlobalSections, {
 } from 'src/components/cms/GlobalSections'
 import { GetStaticProps } from 'next'
 import { Locator } from '@vtex/client-cms'
+import { SectionProvider } from 'src/sdk/ui/SectionContex'
 
 type Props = {
   globalSections: GlobalSectionsData
@@ -20,9 +21,11 @@ function Page({ globalSections }: Props) {
 
   return (
     <GlobalSections {...globalSections}>
-      <NextSeo noindex nofollow />
+      <SectionProvider globalSections={globalSections.sections}>
+        <NextSeo noindex nofollow />
 
-      <div>loading...</div>
+        <div>loading...</div>
+      </SectionProvider>
     </GlobalSections>
   )
 }

--- a/packages/core/src/pages/checkout.tsx
+++ b/packages/core/src/pages/checkout.tsx
@@ -8,6 +8,7 @@ import GlobalSections, {
 } from 'src/components/cms/GlobalSections'
 import { GetStaticProps } from 'next'
 import { Locator } from '@vtex/client-cms'
+import { SectionProvider } from 'src/sdk/ui/SectionContex'
 
 type Props = {
   globalSections: GlobalSectionsData
@@ -20,9 +21,11 @@ function Page({ globalSections }: Props) {
 
   return (
     <GlobalSections {...globalSections}>
-      <NextSeo noindex nofollow />
+      <SectionProvider globalSections={globalSections.sections}>
+        <NextSeo noindex nofollow />
 
-      <div>loading...</div>
+        <div>loading...</div>
+      </SectionProvider>
     </GlobalSections>
   )
 }

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -20,6 +20,7 @@ import GlobalSections, {
   getGlobalSectionsData,
 } from 'src/components/cms/GlobalSections'
 import storeConfig from '../../faststore.config'
+import { SectionProvider } from 'src/sdk/ui/SectionContex'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -40,31 +41,39 @@ type Props = {
 function Page({ page: { sections, settings }, globalSections }: Props) {
   return (
     <GlobalSections {...globalSections}>
-      {/* SEO */}
-      <NextSeo
-        title={settings?.seo?.title ?? storeConfig.seo.title}
-        description={settings?.seo?.description ?? storeConfig.seo?.description}
-        titleTemplate={storeConfig.seo?.titleTemplate ?? storeConfig.seo?.title}
-        canonical={settings?.seo?.canonical ?? storeConfig.storeUrl}
-        openGraph={{
-          type: 'website',
-          url: storeConfig.storeUrl,
-          title: settings?.seo?.title ?? storeConfig.seo.title,
-          description:
-            settings?.seo?.description ?? storeConfig.seo.description,
-        }}
-      />
-      <SiteLinksSearchBoxJsonLd
-        url={storeConfig.storeUrl}
-        potentialActions={[
-          {
-            target: `${storeConfig.storeUrl}/s/?q`,
-            queryInput: 'search_term_string',
-          },
-        ]}
-      />
+      <SectionProvider
+        pageSections={sections}
+        globalSections={globalSections.sections}
+      >
+        {/* SEO */}
+        <NextSeo
+          title={settings?.seo?.title ?? storeConfig.seo.title}
+          description={
+            settings?.seo?.description ?? storeConfig.seo?.description
+          }
+          titleTemplate={
+            storeConfig.seo?.titleTemplate ?? storeConfig.seo?.title
+          }
+          canonical={settings?.seo?.canonical ?? storeConfig.storeUrl}
+          openGraph={{
+            type: 'website',
+            url: storeConfig.storeUrl,
+            title: settings?.seo?.title ?? storeConfig.seo.title,
+            description:
+              settings?.seo?.description ?? storeConfig.seo.description,
+          }}
+        />
+        <SiteLinksSearchBoxJsonLd
+          url={storeConfig.storeUrl}
+          potentialActions={[
+            {
+              target: `${storeConfig.storeUrl}/s/?q`,
+              queryInput: 'search_term_string',
+            },
+          ]}
+        />
 
-      {/*
+        {/*
         WARNING: Do not import or render components from any
         other folder than '../components/sections' in here.
 
@@ -75,7 +84,8 @@ function Page({ page: { sections, settings }, globalSections }: Props) {
         If needed, wrap your component in a <Section /> component
         (not the HTML tag) before rendering it here.
       */}
-      <RenderSections sections={sections} components={COMPONENTS} />
+        <RenderSections sections={sections} components={COMPONENTS} />
+      </SectionProvider>
     </GlobalSections>
   )
 }

--- a/packages/core/src/pages/login.tsx
+++ b/packages/core/src/pages/login.tsx
@@ -11,6 +11,7 @@ import { Locator } from '@vtex/client-cms'
 
 import { Loader as UILoader } from '@faststore/ui'
 import EmptyState from 'src/components/sections/EmptyState'
+import { SectionProvider } from 'src/sdk/ui/SectionContex'
 
 type Props = {
   globalSections: GlobalSectionsData
@@ -23,11 +24,13 @@ function Page({ globalSections }: Props) {
 
   return (
     <GlobalSections {...globalSections}>
-      <NextSeo noindex nofollow />
+      <SectionProvider globalSections={globalSections.sections}>
+        <NextSeo noindex nofollow />
 
-      <EmptyState title="Loading">
-        <UILoader />
-      </EmptyState>
+        <EmptyState title="Loading">
+          <UILoader />
+        </EmptyState>
+      </SectionProvider>
     </GlobalSections>
   )
 }

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -22,6 +22,7 @@ import GlobalSections, {
 import RenderSections from 'src/components/cms/RenderSections'
 import { getPage, SearchContentType } from 'src/server/cms'
 import storeConfig from '../../faststore.config'
+import { SectionProvider } from 'src/sdk/ui/SectionContex'
 
 /**
  * Sections: Components imported from each store's custom components and '../components/sections' only.
@@ -79,27 +80,33 @@ function Page({ page: { sections, settings }, globalSections }: Props) {
 
   return (
     <GlobalSections {...globalSections}>
-      <SearchProvider
-        onChange={applySearchState}
-        itemsPerPage={settings?.productGallery?.itemsPerPage ?? ITEMS_PER_PAGE}
-        {...searchParams}
+      <SectionProvider
+        globalSections={globalSections.sections}
+        pageSections={sections}
       >
-        {/* SEO */}
-        <NextSeo
-          noindex
-          title={title}
-          description={description}
-          titleTemplate={titleTemplate}
-          openGraph={{
-            type: 'website',
-            title,
-            description,
-          }}
-        />
+        <SearchProvider
+          onChange={applySearchState}
+          itemsPerPage={
+            settings?.productGallery?.itemsPerPage ?? ITEMS_PER_PAGE
+          }
+          {...searchParams}
+        >
+          {/* SEO */}
+          <NextSeo
+            noindex
+            title={title}
+            description={description}
+            titleTemplate={titleTemplate}
+            openGraph={{
+              type: 'website',
+              title,
+              description,
+            }}
+          />
 
-        <UISROnly as="h1" text={title} />
+          <UISROnly as="h1" text={title} />
 
-        {/*
+          {/*
           WARNING: Do not import or render components from any
           other folder than '../components/sections' in here.
 
@@ -110,17 +117,18 @@ function Page({ page: { sections, settings }, globalSections }: Props) {
           If needed, wrap your component in a <Section /> component
           (not the HTML tag) before rendering it here.
         */}
-        <RenderSections
-          sections={sections}
-          components={COMPONENTS}
-          context={
-            {
-              title,
-              searchTerm: searchParams.term ?? undefined,
-            } as SearchPageContextType
-          }
-        />
-      </SearchProvider>
+          <RenderSections
+            sections={sections}
+            components={COMPONENTS}
+            context={
+              {
+                title,
+                searchTerm: searchParams.term ?? undefined,
+              } as SearchPageContextType
+            }
+          />
+        </SearchProvider>
+      </SectionProvider>
     </GlobalSections>
   )
 }

--- a/packages/core/src/sdk/ui/SectionContex.tsx
+++ b/packages/core/src/sdk/ui/SectionContex.tsx
@@ -1,33 +1,47 @@
-import { createContext, useContext } from 'react'
+import { createContext, useContext, useMemo } from 'react'
 import { Section } from '@vtex/client-cms'
 
-export const SectionContext = createContext<Section[]>([])
+export interface AllSections {
+  globalSections?: Section[]
+  pageSections?: Section[]
+}
+export const SectionContext = createContext<AllSections>({})
 
-export interface SectionContexProps {
+export interface SectionContexProps extends AllSections {
   children?: React.ReactNode
-  sections?: Section[]
 }
 
 SectionContext.displayName = 'Section Context'
 
+/**
+ * Return all the sections global and page sections.
+ * @param sectionName if pressent it will filter the section if not will return all the sections global and page
+ * @returns
+ */
 export const useSection = (
   sectionName?: string
 ): Section | Section[] | undefined => {
-  const sections = useContext(SectionContext) ?? []
-
-  if (sectionName) {
-    return sections?.find((f) => f.name === sectionName)
+  const sections = useContext(SectionContext) ?? {
+    globalSections: [],
+    pageSections: [],
   }
+  const allSections = [...sections.globalSections, ...sections.pageSections]
 
-  return sections
+  return useMemo(() => {
+    if (sectionName) {
+      return allSections.find((section) => section.name === sectionName)
+    }
+    return allSections
+  }, [sectionName])
 }
 
 export const SectionProvider: React.FC<SectionContexProps> = ({
   children,
-  sections,
+  globalSections = [],
+  pageSections = [],
 }) => {
   return (
-    <SectionContext.Provider value={sections}>
+    <SectionContext.Provider value={{ globalSections, pageSections }}>
       {children}
     </SectionContext.Provider>
   )

--- a/packages/core/src/sdk/ui/SectionContex.tsx
+++ b/packages/core/src/sdk/ui/SectionContex.tsx
@@ -21,18 +21,18 @@ SectionContext.displayName = 'Section Context'
 export const useSection = (
   sectionName?: string
 ): Section | Section[] | undefined => {
-  const sections = useContext(SectionContext) ?? {
+  const { globalSections, pageSections } = useContext(SectionContext) ?? {
     globalSections: [],
     pageSections: [],
   }
-  const allSections = [...sections.globalSections, ...sections.pageSections]
 
   return useMemo(() => {
+    const convinedSections = [...globalSections, ...pageSections]
     if (sectionName) {
-      return allSections.find((section) => section.name === sectionName)
+      return convinedSections.find((section) => section.name === sectionName)
     }
-    return allSections
-  }, [sectionName])
+    return convinedSections
+  }, [globalSections, pageSections, sectionName])
 }
 
 export const SectionProvider: React.FC<SectionContexProps> = ({

--- a/packages/core/src/sdk/ui/SectionContex.tsx
+++ b/packages/core/src/sdk/ui/SectionContex.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext } from 'react'
+import { Section } from '@vtex/client-cms'
+
+export const SectionContext = createContext<Section[]>([])
+
+export interface SectionContexProps {
+  children?: React.ReactNode
+  sections?: Section[]
+}
+
+SectionContext.displayName = 'Section Context'
+
+export const useSection = (
+  sectionName?: string
+): Section | Section[] | undefined => {
+  const sections = useContext(SectionContext) ?? []
+
+  if (sectionName) {
+    return sections?.find((f) => f.name === sectionName)
+  }
+
+  return sections
+}
+
+export const SectionProvider: React.FC<SectionContexProps> = ({
+  children,
+  sections,
+}) => {
+  return (
+    <SectionContext.Provider value={sections}>
+      {children}
+    </SectionContext.Provider>
+  )
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

Ability to select the sections props from any overwrite components

## How it works?

use the hook 
```
const section = useSection('section-name ') //will return only the section available
```

```
const section = useSection() //will return all the sections
```

## How to test it?

Create a overwrite component and import the hook `useSection`

 
## References

 Issue [1944](https://github.com/vtex/faststore/issues/1944)

PS: Not sure if that's the right location, feel free to yell at me!!
