### PR TITLE
fix: set getTypeDefs as default os getCustomSchema prop

### DIFF
--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -129,18 +129,11 @@ export const execute = async <V extends Maybe<{ [key: string]: unknown }>, D>(
 
 type resolversType = Parameters<typeof makeExecutableSchema>[0]['resolvers']
 
-export function getCustomSchema(
-  customPath: string,
-  resolvers: resolversType,
-  mergedTypes: string[] = getTypeDefs()
-) {
+export function getCustomSchema(customPath: string, resolvers: resolversType) {
   const customTypeDefs = getTypeDefsFromFolder(customPath)
 
   try {
-    const typeDefs = mergeTypeDefs([
-      ...(Array.isArray(mergedTypes) ? mergedTypes : [mergedTypes]),
-      customTypeDefs,
-    ])
+    const typeDefs = mergeTypeDefs([...getTypeDefs(), customTypeDefs])
 
     const schema = makeExecutableSchema({ typeDefs, resolvers })
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -132,7 +132,7 @@ type resolversType = Parameters<typeof makeExecutableSchema>[0]['resolvers']
 export function getCustomSchema(
   customPath: string,
   resolvers: resolversType,
-  mergedTypes: string[] = []
+  mergedTypes: string[] = getTypeDefs()
 ) {
   const customTypeDefs = getTypeDefsFromFolder(customPath)
 
@@ -174,7 +174,7 @@ export function getTypeDefsFromFolder(customPath: string | string[]) {
 }
 
 export function getVTEXExtensionsSchema() {
-  return getCustomSchema('vtex', vtexExtensionsResolvers, getTypeDefs())
+  return getCustomSchema('vtex', vtexExtensionsResolvers)
 }
 
 export function getThirdPartyExtensionsSchema() {


### PR DESCRIPTION
## What's the purpose of this pull request?

Set getTypeDefs as default on getCustomSchema prop