### PR TITLE
feat: Expose account and engine in Window variable

### DIFF
--- a/packages/core/src/sdk/analytics/index.tsx
+++ b/packages/core/src/sdk/analytics/index.tsx
@@ -5,6 +5,10 @@ import storeConfig from '../../../faststore.config'
 
 if (typeof window !== 'undefined') {
   window.dataLayer = window.dataLayer ?? []
+  window.VTEX_METADATA = {
+    account: storeConfig.api.storeId,
+    renderer: 'faststore',
+  }
 }
 
 export const AnalyticsHandler = () => {

--- a/packages/core/src/typings/global.d.ts
+++ b/packages/core/src/typings/global.d.ts
@@ -1,6 +1,11 @@
 declare module '*.scss';
 declare module '*.png';
+
 interface Window extends Window {
   dataLayer: any[];
+  VTEX_METADATA: {
+    account: string,
+    renderer: "faststore"
+  };
   sendrc: (eventName: string, eventValues?: any) => void
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

The Analytics team asked us to expose the store account and engine in a global window variable.

## How it works?

<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?
Run the store and check if there's a `window.VTEX_METADATA` defined in the console.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/149

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
