### PR TITLE
fix: SKU overflow in PDP

### DIFF
--- a/packages/ui/src/components/molecules/SkuSelector/styles.scss
+++ b/packages/ui/src/components/molecules/SkuSelector/styles.scss
@@ -79,7 +79,9 @@
 
   [data-fs-sku-selector-list] {
     display: flex;
+    flex-wrap: wrap;
     column-gap: var(--fs-spacing-1);
+    row-gap: var(--fs-spacing-1);
   }
 
   [data-fs-sku-selector-option] {


### PR DESCRIPTION
## What's the purpose of this pull request?

Before: 
<img width="1792" alt="Screenshot 2023-08-10 at 5 09 33 PM" src="https://github.com/vtex/faststore/assets/42946693/95eae5b5-9c7c-4b7c-9214-6e62525a4b87">
After:
<img width="1792" alt="Screenshot 2023-08-10 at 5 09 10 PM" src="https://github.com/vtex/faststore/assets/42946693/405d988d-528d-4d5e-bf96-932b23580b94">


## How to test it?

Run the Store and check a product that has SKUs. You can copy/paste to multiply the HTML elements, so you can see the overflow behavior when we have a lot of SKUs.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/150

## References

Fixes https://github.com/vtex/faststore/issues/1910.
