### PR TITLE
fix: Nested footer elements

### DIFF
--- a/packages/core/src/components/sections/Footer/Footer.tsx
+++ b/packages/core/src/components/sections/Footer/Footer.tsx
@@ -1,6 +1,7 @@
 import { PaymentMethods as UIPaymentMethods } from '@faststore/ui'
 import type { PaymentMethodsProps as UIPaymentMethodProps } from '@faststore/ui'
 
+import Section from '../Section'
 import UIFooter, {
   FooterLinks,
   FooterSocial,
@@ -48,7 +49,7 @@ const Footer = ({
   },
 }: FooterProps) => {
   return (
-    <footer className={`section ${styles.section} section-footer`}>
+    <Section className={`section ${styles.section} section-footer`}>
       <UIFooter>
         <UIIncentives incentives={incentives} />
         <UIFooterNavigation>
@@ -71,7 +72,7 @@ const Footer = ({
           </div>
         </UIFooterInfo>
       </UIFooter>
-    </footer>
+    </Section>
   )
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

As reported in that issue https://github.com/vtex/faststore/issues/1901, we're rendering nested `<footer>` elements.

## How it works?

Following our defaults, I'm wrapping our section with the Section component, instead of a `<footer>` element.

## How to test it?

Run the store and check if there's a nested footer like the issue exemplifies. 

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/151

## References

https://github.com/vtex/faststore/issues/1901
