### PR TITLE
fix: Improves `ProductTitle` Accessibility

### DIFF
--- a/packages/components/src/molecules/ProductTitle/ProductTitle.tsx
+++ b/packages/components/src/molecules/ProductTitle/ProductTitle.tsx
@@ -57,14 +57,14 @@ const ProductTitle = forwardRef<HTMLElement, ProductTitleProps>(
         </div>
 
         {(refNumber || ratingValue) && (
-          <p data-fs-product-title-addendum>
+          <div data-fs-product-title-addendum>
             {ratingValue && <Rating value={ratingValue} />}
             {refNumber && (
               <>
                 {refTag} {refNumber}
               </>
             )}
-          </p>
+          </div>
         )}
       </header>
     )


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to improve `ProductTitle`'s accessibility, as reported on: https://github.com/vtex/faststore/issues/1935

|Product Title Addendum|
|-|
|<img width="397" alt="Screenshot 2023-08-11 at 19 02 47" src="https://github.com/vtex/faststore/assets/11613011/0e2c1baf-8a0f-4b2c-acf6-56d761aa1bad">|

## How it works?
Changing `Product Title Addendum`'s  `<p>` tag to a regular `<div>` fixes the error.

## How to test it?
The store should look the same.

## References

Issue: [Improve ProductTitle Accessibility #1935](https://github.com/vtex/faststore/issues/1935)
