### PR TITLE
Fix: Update Shipping Data from OrderForm

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -421,11 +421,11 @@ export const validateCart = async (
     .then((form) => setOrderFormEtag(form, commerce))
     .then(joinItems)
   
+  await updateOrderFormShippingData(updatedOrderForm, session, ctx)
   // Step5: If no changes detected before/after updating orderForm, the order is validated
   if (equals(order, updatedOrderForm)) {
     return null
   }
-  await updateOrderFormShippingData(updatedOrderForm, session, ctx)
   // Step6: There were changes, convert orderForm to StoreCart
   return orderFormToCart(updatedOrderForm, skuLoader)
 }

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -223,11 +223,9 @@ const getOrderForm = async (
   id: string,
   { clients: { commerce } }: Context
 ) => {
-  const orderForm = await commerce.checkout.orderForm({
+  return await commerce.checkout.orderForm({
     id,
-  })
-
-  return orderForm
+  }) 
 }
 
 const updateOrderFormShippingData = async (
@@ -242,7 +240,7 @@ const updateOrderFormShippingData = async (
   // because the following code was trying to change the shippingData to an undefined address/session
 
     if (!session) {
-      return orderForm
+      return 
     }
   
     const { updateShipping, addressChanged } = shouldUpdateShippingData(
@@ -285,7 +283,7 @@ const updateOrderFormShippingData = async (
         true
       )
     }
-    return orderForm
+    return 
   }
 
 /**
@@ -409,6 +407,9 @@ export const validateCart = async (
     return null
   }
 
+  // Step5: Update ShippingData from orderForm
+  await updateOrderFormShippingData(orderForm, session, ctx)
+
   // Step4: Apply delta changes to order form
   const updatedOrderForm = await commerce.checkout
     // update orderForm items
@@ -420,9 +421,6 @@ export const validateCart = async (
     // update orderForm etag so we know last time we touched this orderForm
     .then((form) => setOrderFormEtag(form, commerce))
     .then(joinItems)
-  
-  // Step5: Update ShippingData from orderForm
-  await updateOrderFormShippingData(updatedOrderForm, session, ctx)
 
   // Step6: If no changes detected before/after updating orderForm, the order is validated
   if (equals(order, updatedOrderForm)) {

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -167,7 +167,7 @@ const setOrderFormEtag = async (
   commerce: Context['clients']['commerce']
 ) => {
   try {
-    console.log("Updated Order Form", JSON.stringify(form.items), JSON.stringify(form.shippingData.logisticsInfo))
+    console.log("Updated Order Form", JSON.stringify(form.items), JSON.stringify(form.shippingData?.logisticsInfo))
     const orderForm = await commerce.checkout.setCustomData({
       id: form.orderFormId,
       appId: 'faststore',

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -421,7 +421,7 @@ export const validateCart = async (
     .then((form) => setOrderFormEtag(form, commerce))
     .then(joinItems)
   
-  // Step5: Update ShippingData from order form
+  // Step5: Update ShippingData from orderForm
   await updateOrderFormShippingData(updatedOrderForm, session, ctx)
 
   // Step6: If no changes detected before/after updating orderForm, the order is validated

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -285,6 +285,7 @@ const updateOrderFormShippingData = async (
         true
       )
     }
+    return orderForm
   }
 
 /**

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -228,7 +228,7 @@ const getOrderForm = async (
   }) 
 }
 
-const updateOrderFormShippingData = async (
+const updateOrderFormShippingData =  async (
   orderForm: OrderForm,
   session: Maybe<IStoreSession> | undefined,
   { clients: { commerce } }: Context)=>
@@ -407,10 +407,7 @@ export const validateCart = async (
     return null
   }
 
-  // Step5: Update ShippingData from orderForm
-  await updateOrderFormShippingData(orderForm, session, ctx)
-
-  // Step4: Apply delta changes to order form
+  // Step5: Apply delta changes to order form
   const updatedOrderForm = await commerce.checkout
     // update orderForm items
     .updateOrderFormItems({
@@ -418,8 +415,9 @@ export const validateCart = async (
       orderItems: changes,
       shouldSplitItem,
     })
+    .then((form: OrderForm) => updateOrderFormShippingData(form, session, ctx))
     // update orderForm etag so we know last time we touched this orderForm
-    .then((form) => setOrderFormEtag(form, commerce))
+    .then((form: OrderForm) => setOrderFormEtag(form, commerce))
     .then(joinItems)
 
   // Step6: If no changes detected before/after updating orderForm, the order is validated

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -167,6 +167,7 @@ const setOrderFormEtag = async (
   commerce: Context['clients']['commerce']
 ) => {
   try {
+    console.log("Updated Order Form", JSON.stringify(form.items), JSON.stringify(form.shippingData.logisticsInfo))
     const orderForm = await commerce.checkout.setCustomData({
       id: form.orderFormId,
       appId: 'faststore',
@@ -240,7 +241,7 @@ const updateOrderFormShippingData =  async (
   // because the following code was trying to change the shippingData to an undefined address/session
 
     if (!session) {
-      return 
+      return orderForm
     }
   
     const { updateShipping, addressChanged } = shouldUpdateShippingData(
@@ -283,7 +284,7 @@ const updateOrderFormShippingData =  async (
         true
       )
     }
-    return 
+    return orderForm
   }
 
 /**

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -404,7 +404,7 @@ export const validateCart = async (
     return null
   }
 
-  // Step5: Apply delta changes to order form
+  // Step4: Apply delta changes to order form
   const updatedOrderForm = await commerce.checkout
     // update orderForm items
     .updateOrderFormItems({
@@ -412,15 +412,16 @@ export const validateCart = async (
       orderItems: changes,
       shouldSplitItem,
     })
+    // update orderForm shippingData
     .then((form: OrderForm) => updateOrderFormShippingData(form, session, ctx))
     // update orderForm etag so we know last time we touched this orderForm
     .then((form: OrderForm) => setOrderFormEtag(form, commerce))
     .then(joinItems)
 
-  // Step6: If no changes detected before/after updating orderForm, the order is validated
+  // Step5: If no changes detected before/after updating orderForm, the order is validated
   if (equals(order, updatedOrderForm)) {
     return null
   }
-  // Step7: There were changes, convert orderForm to StoreCart
+  // Step6: There were changes, convert orderForm to StoreCart
   return orderFormToCart(updatedOrderForm, skuLoader)
 }

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -421,11 +421,13 @@ export const validateCart = async (
     .then((form) => setOrderFormEtag(form, commerce))
     .then(joinItems)
   
+  // Step5: Update ShippingData from order form
   await updateOrderFormShippingData(updatedOrderForm, session, ctx)
-  // Step5: If no changes detected before/after updating orderForm, the order is validated
+
+  // Step6: If no changes detected before/after updating orderForm, the order is validated
   if (equals(order, updatedOrderForm)) {
     return null
   }
-  // Step6: There were changes, convert orderForm to StoreCart
+  // Step7: There were changes, convert orderForm to StoreCart
   return orderFormToCart(updatedOrderForm, skuLoader)
 }

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -220,7 +220,7 @@ async function getOrderNumberFromSession(
 
 // Returns the regionalized orderForm
 const getOrderForm = async (id: string, { clients: { commerce } }: Context) => {
-  return await commerce.checkout.orderForm({
+  return commerce.checkout.orderForm({
     id,
   })
 }

--- a/packages/api/src/platforms/vtex/utils/shouldUpdateShippingData.ts
+++ b/packages/api/src/platforms/vtex/utils/shouldUpdateShippingData.ts
@@ -13,12 +13,14 @@ export const shouldUpdateShippingData = (
   session: IStoreSession
 ) => {
   if (!hasSessionPostalCodeOrGeoCoordinates(session)) {
+    console.log("hasSessionPostalCodeOrGeoCoordinates")
     return { updateShipping: false, addressChanged: false }
   }
 
   const selectedAddress = orderForm.shippingData?.selectedAddresses[0]
 
   if (checkPostalCode(selectedAddress, session.postalCode)) {
+    console.log("checkPostalCode")
     return { updateShipping: true, addressChanged: true }
   }
 
@@ -29,14 +31,17 @@ export const shouldUpdateShippingData = (
       session.postalCode
     )
   ) {
+    console.log("checkGeoCoordinates")
     return { updateShipping: true, addressChanged: true }
   }
 
   if (checkAddressType(selectedAddress, session.addressType)) {
+    console.log("checkAddressType")
     return { updateShipping: true, addressChanged: true }
   }
 
   if (!hasItems(orderForm)) {
+    console.log("hasItems")
     return { updateShipping: false, addressChanged: false }
   }
 
@@ -44,16 +49,20 @@ export const shouldUpdateShippingData = (
   const { logisticsInfo } = orderForm.shippingData!
 
   if (shouldUpdateDeliveryChannel(logisticsInfo, session)) {
+    console.log("shouldUpdateDeliveryChannel")
     return { updateShipping: true, addressChanged: false }
   }
 
   if (shouldUpdateDeliveryMethod(logisticsInfo, session)) {
+    console.log("shouldUpdateDeliveryMethod")
     return { updateShipping: true, addressChanged: false }
   }
 
   if (shouldUpdateDeliveryWindow(logisticsInfo, session)) {
+    console.log("shouldUpdateDeliveryWindow")
     return { updateShipping: true, addressChanged: false }
   }
+  console.log("noUpdate")
   return { updateShipping: false, addressChanged: false }
 }
 

--- a/packages/api/src/platforms/vtex/utils/shouldUpdateShippingData.ts
+++ b/packages/api/src/platforms/vtex/utils/shouldUpdateShippingData.ts
@@ -12,16 +12,13 @@ export const shouldUpdateShippingData = (
   orderForm: OrderForm,
   session: IStoreSession
 ) => {
-  console.log("orderForm:",JSON.stringify(orderForm.shippingData?.logisticsInfo))
   if (!hasSessionPostalCodeOrGeoCoordinates(session)) {
-    console.log("hasSessionPostalCodeOrGeoCoordinates")
     return { updateShipping: false, addressChanged: false }
   }
 
   const selectedAddress = orderForm.shippingData?.selectedAddresses[0]
 
   if (checkPostalCode(selectedAddress, session.postalCode)) {
-    console.log("checkPostalCode")
     return { updateShipping: true, addressChanged: true }
   }
 
@@ -32,17 +29,14 @@ export const shouldUpdateShippingData = (
       session.postalCode
     )
   ) {
-    console.log("checkGeoCoordinates")
     return { updateShipping: true, addressChanged: true }
   }
 
   if (checkAddressType(selectedAddress, session.addressType)) {
-    console.log("checkAddressType")
     return { updateShipping: true, addressChanged: true }
   }
 
   if (!hasItems(orderForm)) {
-    console.log("hasItems")
     return { updateShipping: false, addressChanged: false }
   }
 
@@ -50,20 +44,16 @@ export const shouldUpdateShippingData = (
   const { logisticsInfo } = orderForm.shippingData!
 
   if (shouldUpdateDeliveryChannel(logisticsInfo, session)) {
-    console.log("shouldUpdateDeliveryChannel")
     return { updateShipping: true, addressChanged: false }
   }
 
   if (shouldUpdateDeliveryMethod(logisticsInfo, session)) {
-    console.log("shouldUpdateDeliveryMethod")
     return { updateShipping: true, addressChanged: false }
   }
 
   if (shouldUpdateDeliveryWindow(logisticsInfo, session)) {
-    console.log("shouldUpdateDeliveryWindow")
     return { updateShipping: true, addressChanged: false }
   }
-  console.log("noUpdate")
   return { updateShipping: false, addressChanged: false }
 }
 

--- a/packages/api/src/platforms/vtex/utils/shouldUpdateShippingData.ts
+++ b/packages/api/src/platforms/vtex/utils/shouldUpdateShippingData.ts
@@ -12,7 +12,7 @@ export const shouldUpdateShippingData = (
   orderForm: OrderForm,
   session: IStoreSession
 ) => {
-  console.log("orderForm:",JSON.stringify(orderForm.shippingData.logisticsInfo))
+  console.log("orderForm:",JSON.stringify(orderForm.shippingData?.logisticsInfo))
   if (!hasSessionPostalCodeOrGeoCoordinates(session)) {
     console.log("hasSessionPostalCodeOrGeoCoordinates")
     return { updateShipping: false, addressChanged: false }

--- a/packages/api/src/platforms/vtex/utils/shouldUpdateShippingData.ts
+++ b/packages/api/src/platforms/vtex/utils/shouldUpdateShippingData.ts
@@ -12,7 +12,7 @@ export const shouldUpdateShippingData = (
   orderForm: OrderForm,
   session: IStoreSession
 ) => {
-  console.log("orderForm:",orderForm)
+  console.log("orderForm:",JSON.stringify(orderForm.shippingData.logisticsInfo))
   if (!hasSessionPostalCodeOrGeoCoordinates(session)) {
     console.log("hasSessionPostalCodeOrGeoCoordinates")
     return { updateShipping: false, addressChanged: false }

--- a/packages/api/src/platforms/vtex/utils/shouldUpdateShippingData.ts
+++ b/packages/api/src/platforms/vtex/utils/shouldUpdateShippingData.ts
@@ -12,6 +12,7 @@ export const shouldUpdateShippingData = (
   orderForm: OrderForm,
   session: IStoreSession
 ) => {
+  console.log("orderForm:",orderForm)
   if (!hasSessionPostalCodeOrGeoCoordinates(session)) {
     console.log("hasSessionPostalCodeOrGeoCoordinates")
     return { updateShipping: false, addressChanged: false }


### PR DESCRIPTION
## What's the purpose of this pull request?

Updating shipping information must occur within the context of the new OrderForm (post adding or removing items)

This PR aims to correct sending the selectedSLA to the OrderForm when the delivery configuration has a mandatory minimum value in its settings.

## How it works?

The logic for updating shipping occurred within getOrderForm with the initial orderForm context. This logic is now separate and is done right after the changes are made in FastStore at the orderForm level.

## How to test it?

Configure a minimum cart value for a shipping method and validate that before the change, when this value was reached in the first request, no SLA was sent and only in the second request was this information entered.
Now, as soon as the minimum value is reached within the new orderForm context, the shipping information is already set in the orderForm.

Before:
https://github.com/vtex/faststore/assets/67066494/8151ddb7-268d-459f-93ec-7528b3810028

After:
https://github.com/vtex/faststore/assets/67066494/67e5e2f3-f269-412d-8a0d-cf43ee4bb218


