### PR TITLE
Chore: Sets `hideUnavailableItem` to false as default 

### DIFF
--- a/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
+++ b/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
@@ -90,24 +90,26 @@ const ProductCardContent = forwardRef<HTMLElement, ProductCardContentProps>(
               <span>{title}</span>
             </Link>
           </h3>
-          <div data-fs-product-card-prices>
-            <Price
-              value={price?.listPrice ? price.listPrice : 0}
-              formatter={price?.formatter}
-              testId="list-price"
-              data-value={price?.listPrice}
-              variant="listing"
-              SRText="Original price:"
-            />
-            <Price
-              value={price?.value ? price.value : 0}
-              formatter={price?.formatter}
-              testId="price"
-              data-value={price?.value}
-              variant="spot"
-              SRText="Sale Price:"
-            />
-          </div>
+          {!outOfStock && (
+            <div data-fs-product-card-prices>
+              <Price
+                value={price?.listPrice ? price.listPrice : 0}
+                formatter={price?.formatter}
+                testId="list-price"
+                data-value={price?.listPrice}
+                variant="listing"
+                SRText="Original price:"
+              />
+              <Price
+                value={price?.value ? price.value : 0}
+                formatter={price?.formatter}
+                testId="price"
+                data-value={price?.value}
+                variant="spot"
+                SRText="Sale Price:"
+              />
+            </div>
+          )}
           {ratingValue && (
             <Rating value={ratingValue} icon={<Icon name="Star" />} />
           )}

--- a/packages/core/faststore.config.js
+++ b/packages/core/faststore.config.js
@@ -17,7 +17,7 @@ module.exports = {
     storeId: 'storeframework',
     workspace: 'master',
     environment: 'vtexcommercestable',
-    hideUnavailableItems: true,
+    hideUnavailableItems: false,
     incrementAddress: true,
   },
 

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -11,7 +11,6 @@ import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import type { AnalyticsItem } from 'src/sdk/analytics/types'
 
 import Section from '../Section'
-import OutOfStock from 'src/components/product/OutOfStock'
 import ProductDescription from 'src/components/ui/ProductDescription'
 import { ProductDetailsSettings } from 'src/components/ui/ProductDetails'
 
@@ -152,6 +151,8 @@ function ProductDetails({
     gtin,
   ])
 
+  const outOfStock = availability == 'https://schema.org/OutOfStock'
+
   return (
     <Section className={`${styles.section} section-product-details`}>
       <section data-fs-product-details>
@@ -188,7 +189,7 @@ function ProductDetails({
               data-fs-product-details-settings
               data-fs-product-details-section
             >
-              {availability ? (
+              {!outOfStock ? (
                 <ProductDetailsSettings
                   product={data.product}
                   isValidating={isValidating}
@@ -198,11 +199,12 @@ function ProductDetails({
                   buyButtonIcon={buyButtonIcon}
                 />
               ) : (
-                <OutOfStock />
+                // TODO: Adds <OutOfStock /> when component is ready to use
+                <p>Not Available</p>
               )}
             </section>
 
-            {availability && (
+            {!outOfStock && (
               <ShippingSimulation.Component
                 data-fs-product-details-section
                 data-fs-product-details-shipping


### PR DESCRIPTION
## What's the purpose of this pull request?

The default value for the `hideUnavailableItem` is `false` in the [Intelligent Search](https://developers.vtex.com/docs/api-reference/intelligent-search-api#get-/product_search/-facets-) but in our [faststore.config.js](https://github.com/vtex-sites/starter.store/blob/b92dd359f1fb5245257e03d7f3634fd28459d112/faststore.config.js#L14) we are setting it as `true`.This wasn't clear for some users who weren't finding products they added. 

We decided keeping this value default as `false` would be better. In doing so, we need to adjust our current interface, showing unavailable/out-of-stock products.

|PLP|PDP|
|-|-|
![image](https://github.com/vtex/faststore/assets/3356699/0dd9d012-2b00-4ec8-b139-6afbcd41c7e8)|![image](https://github.com/vtex/faststore/assets/3356699/f4c61fc0-23a9-4192-a3be-048e4f7c4a1b)

To have consistency in our interface, we made some adjusts:
- Hide product's price in `ProductCart` when the product is unavailable
- Although our lib has the [OutOfStock](https://www.faststore.dev/components/organisms/out-of-stock) component, it's not fully integrated into our application, so we will temporarily remove it until implemented.

### Preview

<img width="1373" alt="image" src="https://github.com/vtex/faststore/assets/3356699/a01c19b3-efae-4834-a613-2f8021a16cec">

<img width="1471" alt="image" src="https://github.com/vtex/faststore/assets/3356699/a39505ca-404c-4485-a167-cf4857388180">


## How to test it?

You can run the project locally or use this [preview link](https://starter-git-chore-update-hideunavailableitem-faststore.vercel.app)
1. Go to `Technology` category 
2. You should see unavailable product card with `Out of Stock` badge
3. When clicking in a unavailable product, you should see in the PDP, the product's image and the label `Not Available`

https://github.com/vtex-sites/starter.store/assets/3356699/c080e0b3-d531-458d-ae47-440f33d0b3d3

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/153
