### PR TITLE
chore: fix package json exports

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@faststore/components",
   "version": "2.1.76",
-  "type": "module",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
   "exports": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,13 +1,23 @@
 {
   "name": "@faststore/components",
   "version": "2.1.76",
-  "module": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "type": "module",
+  "main": "dist/esm/index.js",
+  "module": "dist/esm/index.js",
+  "typings": "dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/esm/index.d.ts",
+      "default": "./dist/esm/index.js"
+    }
+  },
   "author": "Emerson Laurentino @emersonlaurentino",
   "license": "MIT",
   "scripts": {
     "dev": "tsc --watch",
-    "build": "tsc",
+    "build": "tsc --module commonjs --outDir dist/cjs & tsc --module esnext --outDir dist/esm",
     "lint": "eslint src/**/*.{ts,tsx}"
   },
   "repository": {
@@ -20,6 +30,10 @@
     "dist",
     "src"
   ],
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
   "devDependencies": {
     "@faststore/eslint-config": "^2.1.53",
     "@faststore/shared": "^2.1.53",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,7 +39,11 @@
   },
   "size-limit": [
     {
-      "path": "dist/index.js",
+      "path": "dist/cjs/index.js",
+      "limit": "40 KB"
+    },
+    {
+      "path": "dist/esm/index.js",
       "limit": "40 KB"
     }
   ],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,8 +10,7 @@
     "directory": "packages/ui"
   },
   "browserslist": "supports es6-module and not dead and last 2 version",
-  "type": "module",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,8 +10,19 @@
     "directory": "packages/ui"
   },
   "browserslist": "supports es6-module and not dead and last 2 version",
-  "module": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "type": "module",
+  "main": "dist/esm/index.js",
+  "module": "dist/esm/index.js",
+  "typings": "dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/esm/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "./src/*": "./src/*"
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=10"
@@ -22,7 +33,7 @@
   ],
   "scripts": {
     "dev": "tsc --watch",
-    "build": "tsc",
+    "build": "tsc --module commonjs --outDir dist/cjs & tsc --module esnext --outDir dist/esm",
     "lint": "eslint src/**/*.{ts,tsx}",
     "size": "size-limit",
     "analyze": "size-limit --why"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR has the same purpose as #1924 which was reverted by #1931. Read it's description to learn more about it.

## How it works?

The difference between this PR and #1924 is that we're now exporting CommonJS and ESM definitions for the `ui` and components `packages`. This allows us to define the `main` property on `package.json` pointing to the CommonJS version, which allows jest to correctly recognize this dependency without needing to transform it.

If any user of this package uses this through modern js, it is imported as an ESM package (because of the `module` and `exports` definitions). The two packages are bundled and tree-shaken by webpack anyway, so it doesn't affect performance.

I've also experimented using `tsup` to bundle the package, but ended up facing tree-shaking problems and other configuration errors.  I went back to tsc because of this and for the sake of simplicity.

## How to test it?

See the Starter PR below. If you want to test it in your package or store, just use the new versions of `core`, `ui` and `components` as dependency.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/155

## References

https://cmdcolin.github.io/posts/2022-05-27-youmaynotneedabundler

And all other dependencies of #1924 