### PR TITLE
Add liveness and readiness probes

### DIFF
--- a/packages/core/src/pages/api/health/live.ts
+++ b/packages/core/src/pages/api/health/live.ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).send('Ok')
+}

--- a/packages/core/src/pages/api/health/ready.ts
+++ b/packages/core/src/pages/api/health/ready.ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).send('Ok')
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds back liveness and readiness probes to core

## How it works?

Our CI/CD pipeline needs this endpoint to scale properly.

## How to test it?

Run the local server and hit http://localhost:3000/api/health/ready and http://localhost:3000/api/health/live you should get an 'Ok' message from both of them.

### Starters Deploy Preview

N/A
