### PR TITLE
Docs: Fixes props description

### DIFF
--- a/apps/site/pages/components/molecules/sku-selector.mdx
+++ b/apps/site/pages/components/molecules/sku-selector.mdx
@@ -154,21 +154,21 @@ export const propsSkuOptions = [
   {
     name: 'src',
     type: 'string',
-    description:
-      'Label to describe the option when selected. This is mandatory if you want to use the `image` variant.',
+    description: 'Image URL',
     default: '',
   },
   {
     name: 'label',
     type: 'string',
-    description: 'Current value for this option.',
+    description:
+      'Label to describe the option when selected. This is mandatory if you want to use the `image` variant.',
     default: '',
     required: true,
   },
   {
     name: 'value',
     type: 'string',
-    description: 'Specifies that this option should be disabled.',
+    description: 'Current value for this option.',
     required: true,
   },
   {


### PR DESCRIPTION
## What's the purpose of this pull request?

Fixes `SkuOptions` props description.

<img width="1050" alt="image" src="https://github.com/vtex/faststore/assets/3356699/3fe7ff7e-b499-4d3b-a8d5-a2d40a58e61c">

[Preview](https://faststore-site-git-docs-fix-sku-selector-props-faststore.vercel.app/components/molecules/sku-selector#skuoptions)

## References

https://github.com/vtex/faststore/issues/1945