### PR TITLE
fix: don't run ci cd on release commit - it already runs on the PR merge commit

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   "useWorkspaces": true,
   "command": {
     "publish": {
-      "message": "Release: %v"
+      "message": "[no ci] Release: %v"
     }
   },
   "changelogPreset": {


### PR DESCRIPTION
## What's the purpose of this pull request?

Fixes failed CI/CD runs on release commits.

## How it works?
It is not necessary to run CI/CD on those commits, since they are only a version bump that is already incorporated by the PR merge commit.

## How to test it?

Merge this PR :confia:

## References
https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs