### PR TITLE
Third-Party Script Management Proposal

### DIFF
--- a/packages/core/src/components/ThirdPartyScripts/ThirdPartyScripts.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/ThirdPartyScripts.tsx
@@ -1,5 +1,5 @@
 import { Partytown } from '@builder.io/partytown/react'
-import OverwriteComponents from 'src/customizations/GlobalOverrides'
+import OverrideComponents from 'src/customizations/GlobalOverrides'
 import storeConfig from '../../../faststore.config'
 import GoogleTagManager from './GoogleTagManager'
 import VTEX from './vtex'
@@ -26,7 +26,7 @@ function ThirdPartyScripts() {
     <>
       {includeGTM && <GoogleTagManager containerId={gtmContainerId} />}
       {includeVTEX && <VTEX />}
-      <OverwriteComponents.ThirdPartyScripts />
+      <OverrideComponents.ThirdPartyScripts />
       <Partytown
         key="partytown"
         // Variables to forward to from main to worker

--- a/packages/core/src/components/ThirdPartyScripts/ThirdPartyScripts.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/ThirdPartyScripts.tsx
@@ -1,5 +1,5 @@
 import { Partytown } from '@builder.io/partytown/react'
-
+import OverwriteComponents from 'src/customizations/GlobalOverrides'
 import storeConfig from '../../../faststore.config'
 import GoogleTagManager from './GoogleTagManager'
 import VTEX from './vtex'
@@ -26,6 +26,7 @@ function ThirdPartyScripts() {
     <>
       {includeGTM && <GoogleTagManager containerId={gtmContainerId} />}
       {includeVTEX && <VTEX />}
+      <OverwriteComponents.ThirdPartyScripts />
       <Partytown
         key="partytown"
         // Variables to forward to from main to worker

--- a/packages/core/src/customizations/GlobalOverrides.tsx
+++ b/packages/core/src/customizations/GlobalOverrides.tsx
@@ -1,11 +1,11 @@
 import WebFontsOverrides from 'src/customizations/components/overrides/WebFonts'
 import { default as CoreWebFonts } from 'src/fonts/WebFonts'
-import ThirdPartyScripts from 'src/customizations/components/overrides/ThirdPartyScripts'
+import ThirdPartyScriptsOverrides from 'src/customizations/components/overrides/ThirdPartyScripts'
 
 const Components = {
   WebFonts: CoreWebFonts,
   ...WebFontsOverrides.components,
-  ...ThirdPartyScripts.components,
+  ...ThirdPartyScriptsOverrides.components,
 }
 
 export const WebFonts = Components.WebFonts

--- a/packages/core/src/customizations/GlobalOverrides.tsx
+++ b/packages/core/src/customizations/GlobalOverrides.tsx
@@ -1,9 +1,11 @@
 import WebFontsOverrides from 'src/customizations/components/overrides/WebFonts'
 import { default as CoreWebFonts } from 'src/fonts/WebFonts'
+import ThirdPartyScripts from 'src/customizations/components/overrides/ThirdPartyScripts'
 
 const Components = {
   WebFonts: CoreWebFonts,
   ...WebFontsOverrides.components,
+  ...ThirdPartyScripts.components,
 }
 
 export const WebFonts = Components.WebFonts

--- a/packages/core/src/customizations/components/overrides/ThirdPartyScripts.tsx
+++ b/packages/core/src/customizations/components/overrides/ThirdPartyScripts.tsx
@@ -1,22 +1,30 @@
 import { default as ThirdPartyScripts } from 'src/customizations/scripts/ThirdPartyScripts'
 
-const RenderThirdPartyScripts = (ThirdPartyScripts: () => string) => {
-  const scriptContent = ThirdPartyScripts()
+const RenderThirdPartyScripts = (
+  ThirdPartyScripts: () => string[] | string
+) => {
+  const scriptContent = ThirdPartyScripts() || []
 
-  const scriptInjection = () => {
-    return (
-      <>
-        <script
-          key="thirdpartyscript"
-          type="text/partytown"
-          dangerouslySetInnerHTML={{
-            __html: scriptContent,
-          }}
-        />
-      </>
-    )
+  const buildScript = (script: string, index?: number) => (
+    <script
+      key={`thirdpartyscript-${index}`}
+      type="text/partytown"
+      dangerouslySetInnerHTML={{
+        __html: script,
+      }}
+    />
+  )
+
+  const renderScriptTags = (): JSX.Element => {
+    if (Array.isArray(scriptContent)) {
+      return (
+        <>{scriptContent.map((script, index) => buildScript(script, index))}</>
+      )
+    }
+    return buildScript(scriptContent)
   }
-  return scriptInjection
+
+  return renderScriptTags
 }
 
 const overrides = {

--- a/packages/core/src/customizations/components/overrides/ThirdPartyScripts.tsx
+++ b/packages/core/src/customizations/components/overrides/ThirdPartyScripts.tsx
@@ -1,0 +1,28 @@
+import { default as ThirdPartyScripts } from 'src/customizations/scripts/ThirdPartyScripts'
+
+const RenderThirdPartyScripts = (ThirdPartyScripts: () => string) => {
+  const scriptContent = ThirdPartyScripts()
+
+  const scriptInjection = () => {
+    return (
+      <>
+        <script
+          key="thirdpartyscript"
+          type="text/partytown"
+          dangerouslySetInnerHTML={{
+            __html: scriptContent,
+          }}
+        />
+      </>
+    )
+  }
+  return scriptInjection
+}
+
+const overrides = {
+  components: {
+    ThirdPartyScripts: RenderThirdPartyScripts(ThirdPartyScripts),
+  },
+}
+
+export default overrides

--- a/packages/core/src/customizations/components/overrides/ThirdPartyScripts.tsx
+++ b/packages/core/src/customizations/components/overrides/ThirdPartyScripts.tsx
@@ -1,35 +1,8 @@
 import { default as ThirdPartyScripts } from 'src/customizations/scripts/ThirdPartyScripts'
 
-const RenderThirdPartyScripts = (
-  ThirdPartyScripts: () => string[] | string
-) => {
-  const scriptContent = ThirdPartyScripts() || []
-
-  const buildScript = (script: string, index?: number) => (
-    <script
-      key={`thirdpartyscript-${index}`}
-      type="text/javascript"
-      dangerouslySetInnerHTML={{
-        __html: script,
-      }}
-    />
-  )
-
-  const renderScriptTags = (): JSX.Element => {
-    if (Array.isArray(scriptContent)) {
-      return (
-        <>{scriptContent.map((script, index) => buildScript(script, index))}</>
-      )
-    }
-    return buildScript(scriptContent)
-  }
-
-  return renderScriptTags
-}
-
 const overrides = {
   components: {
-    ThirdPartyScripts: RenderThirdPartyScripts(ThirdPartyScripts),
+    ThirdPartyScripts,
   },
 }
 

--- a/packages/core/src/customizations/components/overrides/ThirdPartyScripts.tsx
+++ b/packages/core/src/customizations/components/overrides/ThirdPartyScripts.tsx
@@ -8,7 +8,7 @@ const RenderThirdPartyScripts = (
   const buildScript = (script: string, index?: number) => (
     <script
       key={`thirdpartyscript-${index}`}
-      type="text/partytown"
+      type="text/javascript"
       dangerouslySetInnerHTML={{
         __html: script,
       }}

--- a/packages/core/src/customizations/scripts/ThirdPartyScripts.ts
+++ b/packages/core/src/customizations/scripts/ThirdPartyScripts.ts
@@ -1,9 +1,0 @@
-/**
- * Place holder function to return JS script
- * @returns string or array of string of JS themplate
- * Example: `console.log("my script is running")` or [`console.log("console1")`, `console.log("console2")`]
- */
-const ThirdPartyScripts = () => {
-  return ``
-}
-export default ThirdPartyScripts

--- a/packages/core/src/customizations/scripts/ThirdPartyScripts.ts
+++ b/packages/core/src/customizations/scripts/ThirdPartyScripts.ts
@@ -1,0 +1,9 @@
+/**
+ * Place holder function to return JS script
+ * @returns string JS themplate
+ * Example: `console.log("my script is running")`
+ */
+const ThirdPartyScripts = () => {
+  return ``
+}
+export default ThirdPartyScripts

--- a/packages/core/src/customizations/scripts/ThirdPartyScripts.ts
+++ b/packages/core/src/customizations/scripts/ThirdPartyScripts.ts
@@ -1,7 +1,7 @@
 /**
  * Place holder function to return JS script
- * @returns string JS themplate
- * Example: `console.log("my script is running")`
+ * @returns string or array of string of JS themplate
+ * Example: `console.log("my script is running")` or [`console.log("console1")`, `console.log("console2")`]
  */
 const ThirdPartyScripts = () => {
   return ``

--- a/packages/core/src/customizations/scripts/ThirdPartyScripts.tsx
+++ b/packages/core/src/customizations/scripts/ThirdPartyScripts.tsx
@@ -1,0 +1,8 @@
+/**
+ * Place holder function to return component to mount it on the header
+ * @returns react component */
+
+const ThirdPartyScripts = () => {
+  return <></>
+}
+export default ThirdPartyScripts


### PR DESCRIPTION
## What's the purpose of this pull request?
Handle third-party scripts

## How it works?
1. In the FastStore client, add a new file name `ThirdPartyScripts.ts` within the `src/scripts` directory.
2. Define a function named ThirdPartyScripts.

```
const Component1 = () => {
   return <script type="text/javascript" dangerouslySetInnerHTML={{__html:"console.log('hello from a third-party script')"}}/>
}

const ThirdPartyScripts = () => { 
    return (<> 
      <Component1/>
      <Component2/>
      <ComponentX/>
    </>)
}
export default ThirdPartyScripts
```
The script is injected using the PartyTown framework dependency to avoid blocking the main tread

