### PR TITLE
fix: Send `cms-webhook-urls` file to the pipeline

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -30,6 +30,10 @@ export default class Build extends Command {
       `${tmpDir}/lighthouserc.js`,
       `${userDir}/lighthouserc.js`
     )
+    await copyResource(
+      `${tmpDir}/cms-webhook-urls.json`,
+      `${userDir}/cms-webhook-urls.json`
+    )
     
     if (existsSync(`.next/standalone`)) {
       await copyResource(


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to make the `cms-webhook-urls` file visible on the CI/CD's pipeline context after the build step.