### PR TITLE
fix: minicart price round

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -130,7 +130,7 @@ const joinItems = (form: OrderForm) => {
       const totalPrice = items.reduce(
         (acc, i) =>
           acc +
-          (i?.priceDefinition?.total ?? i?.quantity * i?.sellingPrice ?? 0),
+          (i?.priceDefinition?.total ?? (i?.quantity ?? 0) * (i?.sellingPrice ?? 0)),
         0
       )
 

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -128,7 +128,7 @@ const joinItems = (form: OrderForm) => {
       const [item] = items
       const quantity = items.reduce((acc, i) => acc + i.quantity, 0)
       const totalPrice = items.reduce(
-        (acc, i) => acc + i.quantity * i.sellingPrice,
+        (acc, i) => acc + i.priceDefinition.total,
         0
       )
 

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -128,7 +128,9 @@ const joinItems = (form: OrderForm) => {
       const [item] = items
       const quantity = items.reduce((acc, i) => acc + i.quantity, 0)
       const totalPrice = items.reduce(
-        (acc, i) => acc + i.priceDefinition.total,
+        (acc, i) =>
+          acc +
+          (i?.priceDefinition?.total ?? i?.quantity * i?.sellingPrice ?? 0),
         0
       )
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Currently, the prices of the products are displayed incorrectly, sometimes a cent below, sometimes a cent above

## How it works?

The value already calculated by the server is taken, which is in priceDefinitions to avoid calculating and losing the decimals

Preview with beta package: https://github.com/vtex-sites/casinofr.store/pull/986
