### PR TITLE
Fix/session logic 1.x

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -100,9 +100,9 @@ export const VtexCommerce = (
         if (body.selectedAddresses) {
           body.selectedAddresses.forEach((address) => {
             if (address.geoCoordinates === null) {
-              address.geoCoordinates = [];
+              address.geoCoordinates = []
             }
-          });
+          })
         }
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm/${id}/attachments/shippingData`,
@@ -188,7 +188,8 @@ export const VtexCommerce = (
         salesChannel,
       }: RegionInput): Promise<Region> => {
         return fetchAPI(
-          `${base}/api/checkout/pub/regions/?postalCode=${postalCode}&country=${country}&sc=${salesChannel ?? ''
+          `${base}/api/checkout/pub/regions/?postalCode=${postalCode}&country=${country}&sc=${
+            salesChannel ?? ''
           }`
         )
       },
@@ -203,31 +204,27 @@ export const VtexCommerce = (
     },
     session: (search: string): Promise<Session> => {
       const params = new URLSearchParams(search)
+      const authCookie = {
+        name: `VtexIdclientAutCookie_${account}`,
+        value: getCookie(
+          `VtexIdclientAutCookie_${account}` ?? null,
+          ctx.headers.cookie
+        ),
+      }
 
       params.set(
         'items',
         'profile.id,profile.email,profile.firstName,profile.lastName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol'
       )
-      if (getCookie('vtex_session', ctx.headers.cookie)) {
-        // cookie set
-        return fetchAPI(`${base}/api/sessions?${params.toString()}`, {
-          method: 'GET',
-          headers: {
-            'content-type': 'application/json',
-            cookie: ctx.headers.cookie,
-          },
-        })
-      } else {
-        // cookie unset -> create session
-        return fetchAPI(`${base}/api/sessions?${params.toString()}`, {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            cookie: ctx.headers.cookie,
-          },
-          body: '{}',
-        })
-      }
+
+      return fetchAPI(`${base}/api/sessions?${params.toString()}`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: `${authCookie.name}=${authCookie.value}`,
+        },
+        body: '{}',
+      })
     },
     getSessionOrder: (): Promise<Session> => {
       return fetchAPI(`${base}/api/sessions?items=checkout.orderFormId`, {

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -206,10 +206,9 @@ export const VtexCommerce = (
       const params = new URLSearchParams(search)
       const authCookie = {
         name: `VtexIdclientAutCookie_${account}`,
-        value: getCookie(
-          `VtexIdclientAutCookie_${account}` ?? null,
-          ctx.headers.cookie
-        ),
+        value:
+          getCookie(`VtexIdclientAutCookie_${account}`, ctx.headers.cookie) ??
+          null,
       }
 
       params.set(


### PR DESCRIPTION
## What's the purpose of this pull request?

The login (field person) is unstable when you have the vtex_session in FastStore.

## How it works?

The vtex_session cookie now is only used at the getSessionOrder and the session will only use the authCookie with a POST to maintain the session always updated without loosing the checkout object in order to sync the cart.

## How to test it?

Create a vtex_session and the authCookie at the local env with valid values and check the expected behaviour.


https://github.com/vtex/faststore/assets/67066494/f11b52ca-4692-4a66-8498-3efefaa1bbbf

Same as: https://github.com/vtex/faststore/pull/1987