### PR TITLE
Fix: Improves `Breadcrumb` accessibility

### DIFF
--- a/packages/components/src/molecules/Breadcrumb/BreadcrumbBase.tsx
+++ b/packages/components/src/molecules/Breadcrumb/BreadcrumbBase.tsx
@@ -138,7 +138,11 @@ const BreadcrumbBase = forwardRef<HTMLDivElement, BreadcrumbBaseProps>(
 
         {collapseBreadcrumb && (
           <Dropdown>
-            <DropdownButton data-fs-breadcrumb-dropdown-button size="small">
+            <DropdownButton
+              aria-label="View More"
+              data-fs-breadcrumb-dropdown-button
+              size="small"
+            >
               {dropdownButtonIcon}
             </DropdownButton>
             <DropdownMenu data-fs-breadcrumb-dropdown-menu>

--- a/packages/components/src/molecules/Dropdown/DropdownButton.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownButton.tsx
@@ -18,9 +18,9 @@ export interface DropdownButtonProps
 const DropdownButton = forwardRef<HTMLButtonElement, DropdownButtonProps>(
   function DropdownButton(
     {
-      children,
       testId = 'fs-dropdown-button',
       'aria-label': ariaLabel,
+       children,
       ...otherProps
     },
     ref

--- a/packages/components/src/molecules/Dropdown/DropdownButton.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownButton.tsx
@@ -1,19 +1,28 @@
-import React, { forwardRef, useImperativeHandle } from 'react'
+import React, { forwardRef, useImperativeHandle, AriaAttributes } from 'react'
 import Button, { ButtonProps } from '../../atoms/Button'
 
 import { useDropdown } from './hooks/useDropdown'
 
 export interface DropdownButtonProps
-  extends Omit<ButtonProps, "variant" | "inverse" >{
+  extends Omit<ButtonProps, 'variant' | 'inverse'> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
   testId?: string
+  /**
+   * For accessibility purposes, add an ARIA label to the element when it doesn't have a label.
+   */
+  'aria-label'?: AriaAttributes['aria-label']
 }
 
 const DropdownButton = forwardRef<HTMLButtonElement, DropdownButtonProps>(
   function DropdownButton(
-    { children, testId = 'fs-dropdown-button', ...otherProps },
+    {
+      children,
+      testId = 'fs-dropdown-button',
+      'aria-label': ariaLabel,
+      ...otherProps
+    },
     ref
   ) {
     const { toggle, dropdownButtonRef, isOpen, id } = useDropdown()
@@ -28,10 +37,11 @@ const DropdownButton = forwardRef<HTMLButtonElement, DropdownButtonProps>(
         onClick={toggle}
         data-testid={testId}
         ref={dropdownButtonRef}
+        aria-label={ariaLabel}
         aria-expanded={isOpen}
         aria-haspopup="menu"
         aria-controls={id}
-        variant='tertiary'
+        variant="tertiary"
         {...otherProps}
       >
         {children}

--- a/packages/ui/src/components/molecules/Breadcrumb/styles.scss
+++ b/packages/ui/src/components/molecules/Breadcrumb/styles.scss
@@ -132,10 +132,6 @@
     border-width: 0;
     border-radius: var(--fs-breadcrumb-dropdown-button-border-radius);
     transition: var(--fs-breadcrumb-dropdown-button-transition-property) var(--fs-breadcrumb-dropdown-button-transition-timing) var(--fs-breadcrumb-dropdown-button-transition-function);
-
-    &:focus, &:focus-visible {
-      @include focus-ring;
-    }
   }
 
   &[data-fs-breadcrumb-is-desktop="true"] {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to improve `Breadcrumb`'s accessibility, as reported on: https://github.com/vtex/faststore/issues/1936

|DropdownButton|
|-|
|<img width="241" alt="image" src="https://github.com/vtex/faststore/assets/11613011/f31512b7-e889-4e49-a7b2-97f40f6299bc">|

## How it works?
Adding a aria-label to `DropdownButton` fixes the error.

## How to test it?
The store should look the same.

## References

Issue: [Improve Breadcrumb Accessibility #1936](https://github.com/vtex/faststore/issues/1936)
