### PR TITLE
Fix: Improves `PriceRange` accessibility

### DIFF
--- a/packages/components/src/atoms/Slider/Slider.tsx
+++ b/packages/components/src/atoms/Slider/Slider.tsx
@@ -19,7 +19,8 @@ interface RangeLabel {
   max: string | ReactNode
 }
 
-export interface SliderProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+export interface SliderProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    *
@@ -128,7 +129,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
     }))
 
     return (
-      <div data-fs-slider data-testid={testId}>
+      <div data-fs-slider data-testid={testId} {...otherProps}>
         <div data-fs-slider-absolute-values>
           <span>{absoluteValuesLabel.min}</span>
           <span>{absoluteValuesLabel.max}</span>
@@ -162,7 +163,6 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
             aria-valuenow={minVal}
             aria-label={String(minVal)}
             aria-labelledby={getAriaValueText?.(minVal, 'min')}
-            {...otherProps}
           />
           {minValueLabelComponent && (
             <span


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to improve `PriceRange`'s accessibility, as reported on: https://github.com/vtex/faststore/issues/1937

|Slider|
|-|
|<img width="1553" alt="image" src="https://github.com/vtex/faststore/assets/11613011/14f1a755-8d72-4e67-beab-ff6dfa68e038">|

## How it works?
Moving Slider's `otherProps` from `data-fs-slider-thumb="left"` to `data-fs-slider` fixes the error.

## How to test it?
The store should look the same.

## References

Issue: [Improve PriceRange Accessibility #1936](https://github.com/vtex/faststore/issues/1937)
