### PR TITLE
Chore: Adds Logo link fields on Navbar and Footer on CMS

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -575,8 +575,19 @@
               "type": "string"
             },
             "link": {
-              "title": "Link URL",
-              "type": "string"
+              "title": "Logo Link",
+              "type": "object",
+              "required": ["url", "title"],
+              "properties": {
+                "url": {
+                  "title": "Link URL",
+                  "type": "string"
+                },
+                "title": {
+                  "title": "Link Title",
+                  "type": "string"
+                }
+              }
             }
           }
         },

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -560,8 +560,12 @@
               }
             },
             "alt": {
-              "type": "string",
-              "title": "Alternative Label"
+              "title": "Alternative Label",
+              "type": "string"
+            },
+            "url": {
+              "title": "Link URL",
+              "type": "string"
             }
           }
         },

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -168,8 +168,19 @@
               "type": "string"
             },
             "link": {
-              "title": "Link URL",
-              "type": "string"
+              "title": "Logo Link",
+              "type": "object",
+              "required": ["url", "title"],
+              "properties": {
+                "url": {
+                  "title": "Link URL",
+                  "type": "string"
+                },
+                "title": {
+                  "title": "Link Title",
+                  "type": "string"
+                }
+              }
             }
           }
         },

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -563,7 +563,7 @@
               "title": "Alternative Label",
               "type": "string"
             },
-            "url": {
+            "link": {
               "title": "Link URL",
               "type": "string"
             }

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -166,6 +166,10 @@
             "alt": {
               "title": "Alternative Label",
               "type": "string"
+            },
+            "link": {
+              "title": "Link URL",
+              "type": "string"
             }
           }
         },

--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -113,8 +113,8 @@ function Navbar({
                 data-fs-navbar-logo
                 href={logo.link ? logo.link : '/'}
                 prefetch={false}
-                title={homeLabel}
-                aria-label={homeLabel}
+                title={logo.link ? null : homeLabel}
+                aria-label={logo.link ? null : homeLabel}
               >
                 <Logo {...logo} />
               </Link>

--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -110,8 +110,8 @@ function Navbar({
                 aria-label={menuIconAlt}
               />
               <Link
-                href="/"
                 data-fs-navbar-logo
+                href={logo.link ? logo.link : '/'}
                 prefetch={false}
                 title={homeLabel}
                 aria-label={homeLabel}

--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -111,12 +111,11 @@ function Navbar({
               />
               <Link
                 data-fs-navbar-logo
-                href={logo.link ? logo.link : '/'}
+                href={logo.link ? logo.link.url : '/'}
+                title={logo.link ? logo.link.title : homeLabel}
                 prefetch={false}
-                title={logo.link ? null : homeLabel}
-                aria-label={logo.link ? null : homeLabel}
               >
-                <Logo {...logo} />
+                <Logo src={logo.src} alt={logo.alt} />
               </Link>
             </>
           )}

--- a/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
+++ b/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
@@ -52,10 +52,9 @@ function NavbarSlider({
       >
         <Link
           data-fs-navbar-slider-logo
-          href={logo.link ? logo.link : '/'}
+          href={logo.link ? logo.link.url : '/'}
+          title={logo.link ? logo.link.title : homeLabel}
           onClick={fadeOut}
-          title={homeLabel}
-          aria-label={homeLabel}
         >
           <Logo alt={logo.alt} src={logo.src} />
         </Link>

--- a/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
+++ b/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
@@ -51,13 +51,13 @@ function NavbarSlider({
         {...NavbarSliderWrapper.props}
       >
         <Link
-          href="/"
+          data-fs-navbar-slider-logo
+          href={logo.link ? logo.link : '/'}
           onClick={fadeOut}
           title={homeLabel}
           aria-label={homeLabel}
-          data-fs-navbar-slider-logo
         >
-          <Logo {...logo} />
+          <Logo alt={logo.alt} src={logo.src} />
         </Link>
       </NavbarSliderHeader.Component>
       <NavbarSliderContent.Component {...NavbarSliderContent.props}>

--- a/packages/core/src/components/sections/Footer/Footer.tsx
+++ b/packages/core/src/components/sections/Footer/Footer.tsx
@@ -50,6 +50,7 @@ const Footer = ({
     paymentMethods,
   },
 }: FooterProps) => {
+  const homeLabel = 'Go to Home'
   return (
     <Section className={`section ${styles.section} section-footer`}>
       <UIFooter>
@@ -62,7 +63,11 @@ const Footer = ({
           />
         </UIFooterNavigation>
         <UIFooterInfo>
-          <Link href={logoLink ? logoLink : '/'}>
+          <Link
+            href={logoLink ? logoLink : '/'}
+            title={logoLink ? null : homeLabel}
+            aria-label={logoLink ? null : homeLabel}
+          >
             <Logo alt={logoAlt} src={logoSrc} />
           </Link>
 

--- a/packages/core/src/components/sections/Footer/Footer.tsx
+++ b/packages/core/src/components/sections/Footer/Footer.tsx
@@ -11,6 +11,7 @@ import UIFooter, {
 import type { FooterLinksProps, FooterSocialProps } from '../../common/Footer'
 
 import Logo from 'src/components/ui/Logo'
+import Link from 'src/components/ui/Link'
 import UIIncentives from '../../ui/Incentives'
 import type { Incentive } from '../../ui/Incentives'
 
@@ -26,6 +27,7 @@ export type FooterProps = {
   logo: {
     src: string
     alt: string
+    link: string
   }
   copyrightInfo: string
   acceptedPaymentMethods: {
@@ -40,7 +42,7 @@ const Footer = ({
   footerLinks,
   footerSocial,
   footerSocial: { title: footerSocialTitle },
-  logo: { src: logoSrc, alt: logoAlt },
+  logo: { src: logoSrc, alt: logoAlt, link: logoLink },
   copyrightInfo,
   acceptedPaymentMethods: {
     showPaymentMethods,
@@ -60,7 +62,10 @@ const Footer = ({
           />
         </UIFooterNavigation>
         <UIFooterInfo>
-          <Logo alt={logoAlt} src={logoSrc} />
+          <Link href={logoLink ? logoLink : '/'}>
+            <Logo alt={logoAlt} src={logoSrc} />
+          </Link>
+
           {showPaymentMethods && (
             <UIPaymentMethods
               flagList={paymentMethods}

--- a/packages/core/src/components/sections/Footer/Footer.tsx
+++ b/packages/core/src/components/sections/Footer/Footer.tsx
@@ -27,7 +27,10 @@ export type FooterProps = {
   logo: {
     src: string
     alt: string
-    link: string
+    link: {
+      url: string
+      title: string
+    }
   }
   copyrightInfo: string
   acceptedPaymentMethods: {
@@ -64,9 +67,8 @@ const Footer = ({
         </UIFooterNavigation>
         <UIFooterInfo>
           <Link
-            href={logoLink ? logoLink : '/'}
-            title={logoLink ? null : homeLabel}
-            aria-label={logoLink ? null : homeLabel}
+            href={logoLink ? logoLink.url : '/'}
+            title={logoLink ? logoLink.title : homeLabel}
           >
             <Logo alt={logoAlt} src={logoSrc} />
           </Link>

--- a/packages/core/src/components/sections/Navbar/Navbar.tsx
+++ b/packages/core/src/components/sections/Navbar/Navbar.tsx
@@ -13,7 +13,10 @@ export interface NavbarProps {
   logo: {
     alt: string
     src: string
-    link: string
+    link: {
+      url: string
+      title: string
+    }
   }
   searchInput: {
     sort: string

--- a/packages/core/src/components/sections/Navbar/Navbar.tsx
+++ b/packages/core/src/components/sections/Navbar/Navbar.tsx
@@ -13,6 +13,7 @@ export interface NavbarProps {
   logo: {
     alt: string
     src: string
+    link: string
   }
   searchInput: {
     sort: string


### PR DESCRIPTION
## What's the purpose of this pull request?

Add Link URL to Footer's and Navbar's Logo image on CMS Mapping

<img width="503" alt="image" src="https://github.com/vtex/faststore/assets/3356699/5e514fdd-4892-40e6-8295-afd61d888d50">


## How it works?

- Enables edit Link URL in the Navbar's logo, the default is `/`.
- Adds Link URL to Footer's logo, the default is `/`.
- Adds Link Title field to Logo Link 

TO-DO:
 - [ ] Sync in main workspace after merge this PR.
 - [ ] Publish changes in Global Sections content type in main workspace.

## How to test it?

1. Run locally on source: `yarn workspace @faststore/core dev`
2. Use this dev workspace in draft version of Global Section page:
   - https://fanny--storeframework.myvtex.com/admin/new-cms/faststore/globalSections/edit/a56db112-87a6-40d5-a4d5-f6df686f93d0/
   - Edit Navbar's logo using `Link URL` and `Link Title` fields
   - Edit Footer's logo using `Link URL` and `Link Title` fields
3. Save and click on `Preview` 
<img width="1649" alt="image" src="https://github.com/vtex/faststore/assets/3356699/21e4b260-2399-4b3d-a117-6a74ea28dff3">
4. You should be able to see your changes in the localhost.

### Starters Deploy Preview

[WIP]
