### PR TITLE
Add missing setup on Account Setup

### DIFF
--- a/apps/site/pages/docs/go-live/1-setting-up-vtex-account-for-faststore.mdx
+++ b/apps/site/pages/docs/go-live/1-setting-up-vtex-account-for-faststore.mdx
@@ -50,4 +50,10 @@ vtex login {account}
 vtex plugins install faststore
 ```
 
+3. Set up your VTEX account for FastStore by running the following command:
+
+```bash copy
+vtex faststore setup
+```
+
 Once the command completes, you should see the following message: `Happy coding on FastStore 🎉`.


### PR DESCRIPTION
I noticed that after installnig the `faststore` CLI plugin we weren't instructing our users to run the setup command, as we [did in v1](https://v1.faststore.dev/how-to-guides/platform-integration/vtex/setting-up-an-account). This PR intends to fix this.