### PR TITLE
chore: Sets FS session cookies

### DIFF
--- a/apps/site/pages/docs/faststore-config-options.mdx
+++ b/apps/site/pages/docs/faststore-config-options.mdx
@@ -28,7 +28,7 @@ It allows you, for example, to set SEO settings, define the store ID, select a t
 
   module.exports = {
     seo: {
-    "title": "NextJSStore",
+    "title": "FastStore Starter",
     "description": "FastStore demo store",
     "titleTemplate": "%s | FastStore",
     "author": "FastStore"

--- a/packages/core/faststore.config.js
+++ b/packages/core/faststore.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   seo: {
-    title: 'NextJSStore',
+    title: 'FastStore Starter',
     description: 'Fast Demo Store',
     titleTemplate: '%s | FastStore',
     author: 'Store Framework',

--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -2,9 +2,10 @@
  * More info at: https://www.notion.so/vtexhandbook/Event-API-Documentation-48eee26730cf4d7f80f8fd7262231f84
  */
 import type { AnalyticsEvent } from '@faststore/sdk'
+import type { SearchSelectItemEvent } from '../../types'
 
 import config from '../../../../../faststore.config'
-import type { SearchSelectItemEvent } from '../../types'
+import { getCookie } from '../../../../utils/getCookie'
 
 const THIRTY_MINUTES_S = 30 * 60
 const ONE_YEAR_S = 365 * 24 * 3600
@@ -14,27 +15,27 @@ const randomUUID = () =>
     ? crypto.randomUUID()
     : (Math.random() * 1e6).toFixed(0)
 
-const createStorage = (key: string, expiresSecond: number) => {
-  const timelapsed = (past: number) => (Date.now() - past) / 1e3
+const createCookie = (key: string, expiresSecond: number) => {
+  const urlDomain = `.${new URL(config.storeUrl).hostname}`
 
   return () => {
-    const item = JSON.parse(localStorage.getItem(key) ?? 'null')
-    const isExpired = !item || timelapsed(item.createdAt) > expiresSecond
-    const payload: string = isExpired ? randomUUID() : item.payload
+    const isExpired = getCookie(key) === undefined
 
     if (isExpired) {
-      const data = { payload, createdAt: Date.now() }
+      const value = randomUUID()
 
-      localStorage.setItem(key, JSON.stringify(data))
+      document.cookie = `${key}=${value}; max-age=${expiresSecond}; domain=${urlDomain}; path=/;`
+
+      return value
     }
 
-    return payload
+    return getCookie(key)
   }
 }
 
 const user = {
-  anonymous: createStorage('vtex.search.anonymous', ONE_YEAR_S),
-  session: createStorage('vtex.search.session', THIRTY_MINUTES_S),
+  anonymous: createCookie('vtex-faststore-anonymous', ONE_YEAR_S),
+  session: createCookie('vtex-faststore-session', THIRTY_MINUTES_S),
 }
 
 type SearchEvent =

--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -16,6 +16,8 @@ const randomUUID = () =>
     : (Math.random() * 1e6).toFixed(0)
 
 const createCookie = (key: string, expiresSecond: number) => {
+  // Setting the domain attribute specifies which host can receive it; we need it to make the cookies available on the `secure` subdomain.
+  // Although https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie mentioned leading dot (.) is not needed and ignored. I couldn't set the cookies without it.
   const urlDomain = `.${new URL(config.storeUrl).hostname}`
 
   return () => {
@@ -25,6 +27,7 @@ const createCookie = (key: string, expiresSecond: number) => {
       const value = randomUUID()
 
       document.cookie = `${key}=${value}; max-age=${expiresSecond}; domain=${urlDomain}; path=/;`
+      // Setting the `path=/` makes the cookie accessible on any path of the domain/subdomain
 
       return value
     }

--- a/packages/core/src/utils/getCookie.ts
+++ b/packages/core/src/utils/getCookie.ts
@@ -1,0 +1,14 @@
+export function getCookie(name: string): string | undefined {
+  const cookieString = decodeURIComponent(document.cookie)
+  const cookies = cookieString.split(';')
+
+  for (const cookie of cookies) {
+    const [cookieName, cookieValue] = cookie.trim().split('=')
+
+    if (cookieName === name) {
+      return cookieValue
+    }
+  }
+
+  return undefined // Cookie not found
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

- Sets FS session identifiers cookies under store domain.
- We aim to use these cookies for sending events to the IS platform.

## How it works?

Sets `vtex-faststore-anonymous` and `vtex-faststore-session` under `https://vtexfaststore.com` domain, so we can retrieve these identifiers on `secure.vtexfaststore.com`.

## How to test it?

- We can simulate it locally (using localhost), make the following change on `src/sdk/analytics/platform/vtex/search.ts` file: 

1. Change 
```js
document.cookie = `${key}=${value}; max-age=${expiresSecond}; domain=${urlDomain.hostname}; path=/;`
```
to 

```js
document.cookie = `${key}=${value}; max-age=${expiresSecond}; path=/`</code>
```

2. Run `yarn develop`
3. Type `apple` in the search 
4. Open `Storage -> Cookies`. You should be able to see the FS cookies.

<img width="791" alt="image" src="https://github.com/vtex/faststore/assets/3356699/185c4f1f-57cf-4fd2-9243-7353aa3ba802">


5. Go to `Network` tab and filter for `event`. Check if `session.ping` event are being send with the correct session identifiers (anonymous and session) cookie's values.

<img width="627" alt="image" src="https://github.com/vtex/faststore/assets/3356699/8269cd1d-04c1-4653-9984-80efb999597e">


### Starters Deploy Preview

____

- After merging this PR, we need to update starter version and make  https://www.vtexfaststore.com/ point to https://starter.vtex.app, then we will should be able to see `vtex-faststore-anonymous` and `vtex-faststore-session` cookies in https://www.vtexfaststore.com/


## References

https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
https://www.bennadel.com/blog/4345-leading-dots-on-http-cookie-domains-ignored.htm
