### PR TITLE
Fix/fs person identification 

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -15,7 +15,6 @@ import type {
 } from './types/Simulation'
 import type { Session } from './types/Session'
 import type { Channel } from '../../utils/channel'
-import { getCookie } from '../../utils/getCookies'
 import type { SalesChannel } from './types/SalesChannel'
 import { MasterDataResponse } from './types/Newsletter'
 import type { Address, AddressInput } from './types/Address'
@@ -131,7 +130,7 @@ export const VtexCommerce = (
             headers: {
               'content-type': 'application/json',
               cookie: ctx.headers.cookie,
-            }
+            },
           }
         )
       },
@@ -243,34 +242,13 @@ export const VtexCommerce = (
         'items',
         'profile.id,profile.email,profile.firstName,profile.lastName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol'
       )
-      if (getCookie('vtex_session', ctx.headers.cookie)) {
-        // cookie set
-        return fetchAPI(`${base}/api/sessions?${params.toString()}`, {
-          method: 'GET',
-          headers: {
-            'content-type': 'application/json',
-            cookie: ctx.headers.cookie,
-          },
-        })
-      } else {
-        // cookie unset -> create session
-        return fetchAPI(`${base}/api/sessions?${params.toString()}`, {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            cookie: ctx.headers.cookie,
-          },
-          body: '{}',
-        })
-      }
-    },
-    getSessionOrder: (): Promise<Session> => {
-      return fetchAPI(`${base}/api/sessions?items=public.orderFormId`, {
-        method: 'GET',
+      return fetchAPI(`${base}/api/sessions?${params.toString()}`, {
+        method: 'POST',
         headers: {
           'content-type': 'application/json',
           cookie: ctx.headers.cookie,
         },
+        body: '{}',
       })
     },
     subscribeToNewsletter: (data: {

--- a/packages/api/src/platforms/vtex/utils/getCookies.ts
+++ b/packages/api/src/platforms/vtex/utils/getCookies.ts
@@ -1,8 +1,0 @@
-export const getCookie = (name: string, cookie: string): string => {
-  const value = `; ${cookie}`
-  const parts = value.split(`; ${name}=`)
-  if (parts.length === 2) {
-    return parts?.pop()?.split(';').shift() ?? ''
-  }
-  return ''
-}


### PR DESCRIPTION
## What's the purpose of this pull request?

The session must update every time so this PR fix the person identification flow at FastStore.

## How it works?

Remove the Session Cookie logic from FS

## How to test it?

Log in and the vtexAuthCookie will exist -> The client will be identified
Log out and the vtexAuthCookie wont exist -> The client wont be identified

