### PR TITLE
Fix/fs person identification 1.x

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -15,7 +15,6 @@ import type {
 } from './types/Simulation'
 import type { Session } from './types/Session'
 import type { Channel } from '../../utils/channel'
-import { getCookie } from '../../utils/getCookies'
 import type { SalesChannel } from './types/SalesChannel'
 import { MasterDataResponse } from './types/Newsletter'
 import type { Address, AddressInput } from './types/Address'

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -100,9 +100,9 @@ export const VtexCommerce = (
         if (body.selectedAddresses) {
           body.selectedAddresses.forEach((address) => {
             if (address.geoCoordinates === null) {
-              address.geoCoordinates = [];
+              address.geoCoordinates = []
             }
-          });
+          })
         }
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm/${id}/attachments/shippingData`,
@@ -188,7 +188,8 @@ export const VtexCommerce = (
         salesChannel,
       }: RegionInput): Promise<Region> => {
         return fetchAPI(
-          `${base}/api/checkout/pub/regions/?postalCode=${postalCode}&country=${country}&sc=${salesChannel ?? ''
+          `${base}/api/checkout/pub/regions/?postalCode=${postalCode}&country=${country}&sc=${
+            salesChannel ?? ''
           }`
         )
       },
@@ -208,34 +209,13 @@ export const VtexCommerce = (
         'items',
         'profile.id,profile.email,profile.firstName,profile.lastName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol'
       )
-      if (getCookie('vtex_session', ctx.headers.cookie)) {
-        // cookie set
-        return fetchAPI(`${base}/api/sessions?${params.toString()}`, {
-          method: 'GET',
-          headers: {
-            'content-type': 'application/json',
-            cookie: ctx.headers.cookie,
-          },
-        })
-      } else {
-        // cookie unset -> create session
-        return fetchAPI(`${base}/api/sessions?${params.toString()}`, {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            cookie: ctx.headers.cookie,
-          },
-          body: '{}',
-        })
-      }
-    },
-    getSessionOrder: (): Promise<Session> => {
-      return fetchAPI(`${base}/api/sessions?items=checkout.orderFormId`, {
-        method: 'GET',
+      return fetchAPI(`${base}/api/sessions?${params.toString()}`, {
+        method: 'POST',
         headers: {
           'content-type': 'application/json',
           cookie: ctx.headers.cookie,
         },
+        body: '{}',
       })
     },
     subscribeToNewsletter: (data: {

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -1,7 +1,6 @@
 import deepEquals from 'fast-deep-equal'
 
 import { mutateChannelContext, mutateLocaleContext } from '../utils/contex'
-import { getCookie } from '../utils/getCookies'
 import { md5 } from '../utils/md5'
 import {
   attachmentToPropertyValue,

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -6,20 +6,22 @@ import { md5 } from '../utils/md5'
 import {
   attachmentToPropertyValue,
   getPropertyId,
-  VALUE_REFERENCES
+  VALUE_REFERENCES,
 } from '../utils/propertyValue'
 
 import type { Context } from '..'
 import type {
   IStoreOffer,
   IStoreOrder,
-  IStorePropertyValue, IStoreSession, Maybe,
-  MutationValidateCartArgs
+  IStorePropertyValue,
+  IStoreSession,
+  Maybe,
+  MutationValidateCartArgs,
 } from '../../../__generated__/schema'
 import type {
   OrderForm,
   OrderFormInputItem,
-  OrderFormItem
+  OrderFormItem,
 } from '../clients/commerce/types/OrderForm'
 
 type Indexed<T> = T & { index?: number }
@@ -199,20 +201,6 @@ const isOrderFormStale = (form: OrderForm) => {
   return newEtag !== oldEtag
 }
 
-async function getOrderNumberFromSession(
-  headers: Record<string, string> = {},
-  commerce: Context['clients']['commerce']
-) {
-
-  const cookieSession = getCookie('vtex_session', headers.cookie)
-
-  if (cookieSession) {
-    const { namespaces } = await commerce.getSessionOrder()
-    return namespaces.checkout?.orderFormId?.value
-  }
-  return ;
-}
-
 // Returns the regionalized orderForm
 const getOrderForm = async (
   id: string,
@@ -266,11 +254,10 @@ export const validateCart = async (
   { cart: { order }, session }: MutationValidateCartArgs,
   ctx: Context
 ) => {
-  const { orderNumber:  orderNumberFromCart, acceptedOffer, shouldSplitItem } = order
+  const { orderNumber, acceptedOffer, shouldSplitItem } = order
   const {
     clients: { commerce },
     loaders: { skuLoader },
-    headers,
   } = ctx
 
   const channel = session?.channel
@@ -284,13 +271,6 @@ export const validateCart = async (
     mutateLocaleContext(ctx, locale)
   }
 
-  const orderNumberFromSession = await getOrderNumberFromSession(
-    headers,
-    commerce
-  )
-
-  const orderNumber = orderNumberFromSession ?? orderNumberFromCart ?? ''
-
   // Step1: Get OrderForm from VTEX Commerce
   const orderForm = await getOrderForm(orderNumber, session, ctx)
 
@@ -298,11 +278,11 @@ export const validateCart = async (
   // If so, this means the user interacted with this cart elsewhere and expects
   // to see this new cart state instead of what's stored on the user's browser.
   const isStale = isOrderFormStale(orderForm)
-  
+
   if (isStale && orderNumber) {
     const newOrderForm = await setOrderFormEtag(orderForm, commerce).then(
       joinItems
-      )
+    )
     return orderFormToCart(newOrderForm, skuLoader)
   }
 
@@ -366,9 +346,7 @@ export const validateCart = async (
       shouldSplitItem,
     })
     // update orderForm etag so we know last time we touched this orderForm
-    .then((form) =>
-      setOrderFormEtag(form, commerce)
-    )
+    .then((form) => setOrderFormEtag(form, commerce))
     .then(joinItems)
 
   // Step5: If no changes detected before/after updating orderForm, the order is validated

--- a/packages/api/src/platforms/vtex/utils/getCookies.ts
+++ b/packages/api/src/platforms/vtex/utils/getCookies.ts
@@ -1,8 +1,0 @@
-export const getCookie = (name: string, cookie: string): string => {
-  const value = `; ${cookie}`
-  const parts = value.split(`; ${name}=`)
-  if (parts.length === 2) {
-    return parts?.pop()?.split(';').shift() ?? ''
-  }
-  return ''
-}


### PR DESCRIPTION
## What's the purpose of this pull request?

The session must update every time so this PR fix the person identification flow at FastStore.

## How it works?

Remove the Session Cookie logic from FS

## How to test it?

Log in and the vtexAuthCookie will exist -> The client will be identified
Log out and the vtexAuthCookie wont exist -> The client wont be identified

