### PR TITLE
Docs: Fixes utilities import path

### DIFF
--- a/apps/site/pages/docs/customizing/mixins-breakpoints.mdx
+++ b/apps/site/pages/docs/customizing/mixins-breakpoints.mdx
@@ -69,7 +69,7 @@ Follow the steps below to override the pre-defined sizing system for the screen 
 3. Add the following code snippet into the file:
 
 ```scss {10} filename="src/styles/custom-mixins.scss" copy
-@import "@faststore/ui/utilities"
+@import "@faststore/ui/src/styles/base/utilities";
 
 // Overwrites Breakpoints & Mixins ////////////////////
 
@@ -239,7 +239,7 @@ Overriding the predefined mixins follows a process similar to the [customizing b
 3. Choose the [mixin](#mixins) you want to override and add it to the file:
 
 ```scss {8} filename="src/styles/custom-mixins.scss" copy
-@import "@faststore/ui/utilities"
+@import "@faststore/ui/src/styles/base/utilities";
 
 // Overwrites Breakpoints & Mixins ////////////////////
 


### PR DESCRIPTION
## What's the purpose of this pull request?

The import path for `utilities` is wrong.

<img width="1101" alt="image" src="https://github.com/vtex/faststore/assets/3356699/189128b9-ef78-40a6-9d92-6cb194fdc6ae">

The correct path should be: `@import "@faststore/ui/src/styles/base/utilities";`

## How to test it?

- Following the [guide](https://faststore-site-git-docs-fix-utilities-import-path-faststore.vercel.app/docs/customizing/mixins-breakpoints#customizing-breakpoints). You should be able to override the Breakpoints and Mixins as expected.

## References

https://github.com/vtex/faststore/pull/1917

