### PR TITLE
fix: search for the entire slug intead of just the first one

### DIFF
--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -79,8 +79,10 @@ export const getStaticProps: GetStaticProps<
   { slug: string[] },
   Locator
 > = async ({ params, previewData }) => {
+  const slug = params?.slug.join('/') ?? ''
+
   const [landingPagePromise, globalSectionsPromise] = [
-    getLandingPageBySlug(params?.slug[0], previewData),
+    getLandingPageBySlug(slug, previewData),
     getGlobalSectionsData(previewData),
   ]
 
@@ -99,7 +101,7 @@ export const getStaticProps: GetStaticProps<
       ServerCollectionPageQueryQueryVariables,
       ServerCollectionPageQueryQuery
     >({
-      variables: { slug: params?.slug.join('/') ?? '' },
+      variables: { slug },
       operationName: query,
     }),
     getPage<PLPContentType>({


### PR DESCRIPTION
## What's the purpose of this pull request?

fix the problem, when a page is created in headless cms with more than one path parameter, '/first/second'

## How it works?

in the getStaticProps function it was changed so that the slug is built both for the page search in the cms and for the plp

## How to test it?

Just create a new landing page in the cms with more than one parameter in the path.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
