### PR TITLE
Feat: exports `useProductsQuery` hook

### DIFF
--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -226,7 +226,7 @@ In the `ServerProductPage.ts` file, define the GraphQL fragment corresponding to
 
 ```ts copy filename="src/fragments/ServerProductPage.ts"
 
-import { gql } from '@faststore/graphql-utils'
+import { gql } from '@faststore/core/api'
 
 export const fragment = gql`
   fragment ServerProductPage on Query {

--- a/apps/site/pages/docs/api-extensions.mdx
+++ b/apps/site/pages/docs/api-extensions.mdx
@@ -430,6 +430,12 @@ export default function CallToAction(props: CallToActionProps) {
 }
 ```
 
+You can also import the `useProductsQuery` and use it inside your custom Sections. This hook fetches data from the [Search query](https://v1.faststore.dev/reference/api/queries/search), and uses the `ClientProducts` fragment to extend API extensions.
+
+```ts copy
+import { useProductsQuery } from "@faststore/core"
+```
+
 ### Consuming API Extensions data from custom components in `Section Overrides`
 
 After [Overriding Native Components and Props](/docs/building-sections/overriding-components-and-props#overriding-a-native-component), you can also use the hooks inside custom components.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -13,3 +13,5 @@ export type {
   PLPContext,
   SearchPageContext,
 } from './src/sdk/overrides/PageProvider'
+
+export { useProductsQuery } from './src/sdk/product/useProductsQuery'

--- a/packages/core/src/components/sections/CrossSellingShelf/CrossSellingShelf.tsx
+++ b/packages/core/src/components/sections/CrossSellingShelf/CrossSellingShelf.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 
 import UIProductShelf from 'src/components/ui/ProductShelf'
 import { useInView } from 'react-intersection-observer'
-import { useProductsQuery } from 'src/sdk/product/useProductsQuery'
 import { usePDP } from 'src/sdk/overrides/PageProvider'
 import styles from '../ProductShelf/section.module.scss'
 import Section from '../Section'


### PR DESCRIPTION
## What's the purpose of this pull request?

Exports the `useProductsQuery` from `@faststore/core` package.

Also it implements small quick wins.

