### PR TITLE
Show list price only when discounted

### DIFF
--- a/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
+++ b/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
@@ -1,7 +1,7 @@
-import type { HTMLAttributes } from 'react'
-import React, { forwardRef } from 'react'
+import type { HTMLAttributes } from "react";
+import React, { forwardRef } from "react";
 
-import type { PriceDefinition } from '../../typings/PriceDefinition'
+import type { PriceDefinition } from "../../typings/PriceDefinition";
 
 import {
   Badge,
@@ -13,69 +13,72 @@ import {
   LinkProps,
   Price,
   Rating,
-} from '../../'
+} from "../../";
 
 export interface ProductCardContentProps extends HTMLAttributes<HTMLElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
-  testId?: string
+  testId?: string;
   /**
    * Specifies the product's title.
    */
-  title: string
+  title: string;
   /**
    * Props for the link from ProductCard component.
    */
-  linkProps?: Partial<LinkProps<LinkElementType>>
+  linkProps?: Partial<LinkProps<LinkElementType>>;
   /**
    * Specifies product's prices.
    */
-  price?: PriceDefinition
+  price?: PriceDefinition;
   /**
    * Enables a outOfStock status.
    */
-  outOfStock?: boolean
+  outOfStock?: boolean;
   /**
    * Specifies the OutOfStock badge's label.
    */
-  outOfStockLabel?: string
+  outOfStockLabel?: string;
   /**
    * Specifies Rating Value of the product.
    */
-  ratingValue?: number
+  ratingValue?: number;
   /**
    * Specifies the button's label.
    */
-  buttonLabel?: string
+  buttonLabel?: string;
   /**
    * Enables a DiscountBadge to the component.
    */
-  showDiscountBadge?: boolean
+  showDiscountBadge?: boolean;
   /**
    * Callback function when button is clicked.
    */
-  onButtonClick?: () => void
+  onButtonClick?: () => void;
 }
 
 const ProductCardContent = forwardRef<HTMLElement, ProductCardContentProps>(
   function CardContent(
     {
-      testId = 'fs-product-card-content',
+      testId = "fs-product-card-content",
       title,
       linkProps,
       price,
       outOfStock,
-      outOfStockLabel = 'Out of stock',
+      outOfStockLabel = "Out of stock",
       ratingValue,
       showDiscountBadge,
-      buttonLabel = 'Add',
+      buttonLabel = "Add",
       onButtonClick,
       children,
       ...otherProps
     },
-    ref
+    ref,
   ) {
+    const listPrice = price?.listPrice ?? 0;
+    const sellingPrice = price?.value ?? 0;
+
     return (
       <section
         ref={ref}
@@ -92,22 +95,32 @@ const ProductCardContent = forwardRef<HTMLElement, ProductCardContentProps>(
           </h3>
           {!outOfStock && (
             <div data-fs-product-card-prices>
+              sellingPrice !== listPrice ? (<>
+                <Price
+                  value={listPrice}
+                  formatter={price?.formatter}
+                  testId="list-price"
+                  data-value={listPrice}
+                  variant="listing"
+                  SRText="Original price:"
+                />
+                <Price
+                  value={sellingPrice}
+                  formatter={price?.formatter}
+                  testId="price"
+                  data-value={sellingPrice}
+                  variant="spot"
+                  SRText="Sale Price:"
+                />
+              </>) : (
               <Price
-                value={price?.listPrice ? price.listPrice : 0}
-                formatter={price?.formatter}
-                testId="list-price"
-                data-value={price?.listPrice}
-                variant="listing"
-                SRText="Original price:"
-              />
-              <Price
-                value={price?.value ? price.value : 0}
+                value={sellingPrice}
                 formatter={price?.formatter}
                 testId="price"
-                data-value={price?.value}
+                data-value={sellingPrice}
                 variant="spot"
                 SRText="Sale Price:"
-              />
+              />)
             </div>
           )}
           {ratingValue && (
@@ -135,8 +148,8 @@ const ProductCardContent = forwardRef<HTMLElement, ProductCardContentProps>(
           </div>
         )}
       </section>
-    )
-  }
-)
+    );
+  },
+);
 
-export default ProductCardContent
+export default ProductCardContent;

--- a/packages/core/src/components/ui/ProductDetails/ProductDetailsSettings.tsx
+++ b/packages/core/src/components/ui/ProductDetails/ProductDetailsSettings.tsx
@@ -73,33 +73,52 @@ function ProductDetailsSettings({
     },
   })
 
+  const shouldShowDiscountedPrice = lowPrice !== listPrice
+
   return (
     <>
       <section data-fs-product-details-values>
         <div data-fs-product-details-prices>
-          <Price.Component
-            formatter={useFormattedPrice}
-            testId="list-price"
-            variant="listing"
-            SRText="Original price:"
-            {...Price.props}
-            // Dynamic props shouldn't be overridable
-            // This decision can be reviewed later if needed
-            value={listPrice}
-            data-value={listPrice}
-          />
-          <Price.Component
-            formatter={useFormattedPrice}
-            testId="price"
-            variant="spot"
-            className="text__lead"
-            SRText="Sale Price:"
-            {...Price.props}
-            // Dynamic props shouldn't be overridable
-            // This decision can be reviewed later if needed
-            value={lowPrice}
-            data-value={lowPrice}
-          />
+          {shouldShowDiscountedPrice ? (
+            <>
+              <Price.Component
+                formatter={useFormattedPrice}
+                testId="list-price"
+                variant="listing"
+                SRText="Original price:"
+                {...Price.props}
+                // Dynamic props shouldn't be overridable
+                // This decision can be reviewed later if needed
+                value={listPrice}
+                data-value={listPrice}
+              />
+              <Price.Component
+                formatter={useFormattedPrice}
+                testId="price"
+                variant="spot"
+                className="text__lead"
+                SRText="Sale Price:"
+                {...Price.props}
+                // Dynamic props shouldn't be overridable
+                // This decision can be reviewed later if needed
+                value={lowPrice}
+                data-value={lowPrice}
+              />
+            </>
+          ) : (
+            <Price.Component
+              formatter={useFormattedPrice}
+              testId="list-price"
+              variant="spot"
+              className="text__lead"
+              SRText="Original price:"
+              {...Price.props}
+              // Dynamic props shouldn't be overridable
+              // This decision can be reviewed later if needed
+              value={lowPrice}
+              data-value={lowPrice}
+            />
+          )}
         </div>
         <QuantitySelector.Component
           min={1}


### PR DESCRIPTION
## What's the purpose of this pull request?

Show a single price instead of the same price with a strikethrough and 

## How it works?

Added check to see if the prices are equal, if they are we only show the non-striked price.

| Before | After |
|-|-|
| <img width="407" alt="image" src="https://github.com/vtex/faststore/assets/77246/8b9e8132-1f74-4069-8522-7e887a00fd37">
 |  <img width="408" alt="image" src="https://github.com/vtex/faststore/assets/77246/c3b5e223-33b6-4390-a123-ad0ca18be798"> | 

## How to test it?

Locally you should check the product "Apple Magic Mouse" where you'll see that there's no list price striked.

### Starters Deploy Preview

Starter PR in progress.

## References

Fixes #1965 