### PR TITLE
Chore: uses `graphql-codegen` from core

### DIFF
--- a/packages/cli/src/commands/generate-graphql.ts
+++ b/packages/cli/src/commands/generate-graphql.ts
@@ -37,7 +37,7 @@ export default class GenerateGraphql extends Command {
     })
 
     runCommandSync({
-      cmd: 'yarn run graphql-codegen',
+      cmd: 'yarn generate:codegen',
       errorMessage:
         'GraphQL was not optimized and TS files were not updated. Changes in the GraphQL layer did not take effect',
       throws: 'error',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "generate:schema": "tsx src/server/generator/generateGraphQLSchemaFile.ts",
+    "generate:codegen": "graphql-codegen",
     "generate": "faststore generate-graphql -c",
     "build": "yarn partytown & yarn generate && next build",
     "dev": "yarn partytown & yarn generate && next dev",

--- a/packages/core/src/server/generator/schema.ts
+++ b/packages/core/src/server/generator/schema.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import { writeFileSync } from 'fs-extra'
 import { getSchema, getTypeDefs } from '@faststore/api'
 import { printSchemaWithDirectives } from '@graphql-tools/utils'
@@ -69,7 +70,7 @@ export const getMergedSchema = (): GraphQLSchema =>
 export function writeGraphqlSchemaFile(apiSchema: GraphQLSchema) {
   try {
     writeFileSync(
-      [process.cwd(), '@generated', 'graphql', 'schema.graphql'].join('/'),
+      path.join(process.cwd(), '@generated', 'graphql', 'schema.graphql'),
       printSchemaWithDirectives(apiSchema)
     )
 


### PR DESCRIPTION
## What's the purpose of this pull request?

- [x] uses `graphql-codegen` from core.
- [x] uses `path.join` instead of `[...].join('/')` in `writeGraphqlSchemaFile`.

