### PR TITLE
Docs: adding recommendation for Windows user

### DIFF
--- a/apps/site/pages/docs/getting-started/2-setting-up-the-project.mdx
+++ b/apps/site/pages/docs/getting-started/2-setting-up-the-project.mdx
@@ -3,7 +3,7 @@ title: '2. Setting Up the Project'
 sidebar_label: 'Getting Started'
 ---
 
-import { Callout, Tab, Tabs } from 'nextra-theme-docs'
+import { Callout, Tab, Tabs, Steps } from 'nextra-theme-docs'
 
 <header>
 
@@ -22,6 +22,10 @@ In this guide, you will:
 ---
 
 ## Before you start
+
+<Steps>
+
+### Required tooling
 Before cloning your store's repository, ensure that you have the following tools on your machine:
 
 <details>
@@ -89,6 +93,13 @@ Before cloning your store's repository, ensure that you have the following tools
   since our documentation may include screenshots from VS Code.
 </Callout>
 
+### Enabling Developer Mode (Windows users)
+We strongly recommend enabling Developer Mode when using the terminal for FastStore projects. 
+Since FastStore projects rely on creating symlinks, this mode grants the necessary permissions and privileges, reducing the chance of errors during development. 
+To activate Developer Mode, refer to Microsoft's official guide on [Enabling your device for development](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development#accessing-settings-for-developers).
+
+</Steps>
+
 ---
 
 ## Step 1: Cloning the Store's Repository
@@ -96,7 +107,7 @@ Before cloning your store's repository, ensure that you have the following tools
 1. Open the terminal and navigate to the directory where you want to store your project.
 
 <Callout type="info" emoji="ℹ️">
-  For Windowns users we highly recommend to run the terminal in administrator mode. To run in this mode, right-click on the terminal icon and select `Run as administrator`.
+  For Windowns users we highly recommend to enable the [Developer mode](/docs/getting-started/2-setting-up-the-project#developer-mode-for-windows-users) to run the terminal. 
 </Callout>
 
 2. Clone the repository created during the [FastStore Onboarding](/docs/getting-started/1-faststore-onboarding/onboarding#repository-and-live-store-created) by running the following command in the terminal:

--- a/apps/site/pages/docs/getting-started/2-setting-up-the-project.mdx
+++ b/apps/site/pages/docs/getting-started/2-setting-up-the-project.mdx
@@ -98,6 +98,11 @@ We strongly recommend enabling Developer Mode when using the terminal for FastSt
 Since FastStore projects rely on creating symlinks, this mode grants the necessary permissions and privileges, reducing the chance of errors during development. 
 To activate Developer Mode, refer to Microsoft's official guide on [Enabling your device for development](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development#accessing-settings-for-developers).
 
+<Callout type="warning" emoji="⚠️">
+  Running the FastStore project as an Administrator is not recommended.
+</Callout>
+
+
 </Steps>
 
 ---

--- a/apps/site/pages/docs/headless-cms-troubleshooting/error-installing-headless-cms.mdx
+++ b/apps/site/pages/docs/headless-cms-troubleshooting/error-installing-headless-cms.mdx
@@ -24,6 +24,10 @@ Installing plugin @vtex/cli-plugin-cms... failed
 To solve this issue, enable the [Developer Mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development#accessing-settings-for-developers) in your machine.
 Since FastStore projects rely on creating symbolic links (symlinks), this mode grants the necessary permissions and privileges, reducing the chance of errors during development. 
 
+<Callout type="warning" emoji="⚠️">
+  Running the FastStore project as an Administrator is not recommended.
+</Callout>
+
 1. To enable Developer Mode, refer to Microsoft's official guide on [Enabling your device for development](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development#accessing-settings-for-developers).
 
 2. After enabling the mode, launch the Windows Terminal and then, run `vtex cms`.

--- a/apps/site/pages/docs/headless-cms-troubleshooting/error-installing-headless-cms.mdx
+++ b/apps/site/pages/docs/headless-cms-troubleshooting/error-installing-headless-cms.mdx
@@ -21,8 +21,12 @@ Installing plugin @vtex/cli-plugin-cms... failed
     Code: EPERM
 ```
 
-To solve this issue, please launch the Windows Terminal as administrator. Then, run `vtex cms`.
+To solve this issue, enable the [Developer Mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development#accessing-settings-for-developers) in your machine.
+Since FastStore projects rely on creating symbolic links (symlinks), this mode grants the necessary permissions and privileges, reducing the chance of errors during development. 
 
-![administrator-view](https://vtexhelp.vtexassets.com/assets/docs/src/TroubleshootingCMS___fd0e1b6bd9843af1cca2991104370a1a.jpg)
+1. To enable Developer Mode, refer to Microsoft's official guide on [Enabling your device for development](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development#accessing-settings-for-developers).
 
-This will allow the system to create the [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) necessary for running commands from the Headless CMS plugin.
+2. After enabling the mode, launch the Windows Terminal and then, run `vtex cms`.
+
+
+This will allow the system to create the symlinks necessary for running commands from the Headless CMS plugin.


### PR DESCRIPTION
## What's the purpose of this pull request?

To recommend that Windows users enable Developer Mode when running FastStore projects. 

Preview:

- [Setting Up the Project](https://faststore-site-git-docs-windows-requirement-faststore.vercel.app/docs/getting-started/2-setting-up-the-project#enabling-developer-mode-windows-users)
- [Error installing the Headless CMS plugin of VTEX IO CLI](https://faststore-site-git-docs-windows-requirement-faststore.vercel.app/docs/headless-cms-troubleshooting/error-installing-headless-cms)

## Reference
This suggestion is based on @icazevedo's experience with another tool ([Volta](https://docs.volta.sh/guide/getting-started)), which, like FastStore, relies on symlinks during development. Enabling Developer Mode helps prevent errors during development and provides the necessary permissions and privileges, as recommended for Windows users.