### PR TITLE
Chore: Not Available product

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1374,6 +1374,18 @@
             }
           }
         },
+        "notAvailableButton": {
+          "title": "Not Available Button",
+          "description": "Shown when a SKU is not available",
+          "type": "object",
+          "properties": {
+            "title": {
+              "title": "Title",
+              "type": "string",
+              "default": "Not Available"
+            }
+          }
+        },
         "shippingSimulator": {
           "title": "Shipping Simulation",
           "type": "object",
@@ -1440,18 +1452,6 @@
               "title": "Image Position",
               "enumNames": ["Center", "Top", "Bottom"],
               "enum": ["center", "top", "bottom"]
-            }
-          }
-        },
-        "notAvailableButton": {
-          "title": "Not Available Button",
-          "description": "Shown when a SKU is not available",
-          "type": "object",
-          "properties": {
-            "title": {
-              "title": "Title",
-              "type": "string",
-              "default": "Not Available"
             }
           }
         }

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1442,6 +1442,18 @@
               "enum": ["center", "top", "bottom"]
             }
           }
+        },
+        "notAvailableButton": {
+          "title": "Not Available Button",
+          "description": "Shown when a SKU is not available",
+          "type": "object",
+          "properties": {
+            "title": {
+              "title": "Title",
+              "type": "string",
+              "default": "Not Available"
+            }
+          }
         }
       }
     }

--- a/packages/core/src/components/product/NotAvailableButton/NotAvailableButton.tsx
+++ b/packages/core/src/components/product/NotAvailableButton/NotAvailableButton.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from 'react'
+import { Button } from '@faststore/ui'
+
+// TODO: Remove this component when <OutOfStock /> is ready to use
+function NotAvailableButton({ children }: PropsWithChildren) {
+  return (
+    <Button variant="primary" disabled data-fs-buy-button>
+      {children}
+    </Button>
+  )
+}
+
+export default NotAvailableButton

--- a/packages/core/src/components/product/NotAvailableButton/index.ts
+++ b/packages/core/src/components/product/NotAvailableButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NotAvailableButton'

--- a/packages/core/src/components/sections/ProductDetails/Overrides.tsx
+++ b/packages/core/src/components/sections/ProductDetails/Overrides.tsx
@@ -14,6 +14,7 @@ import {
 import LocalImageGallery from 'src/components/ui/ImageGallery'
 import LocalShippingSimulation from 'src/components/ui/ShippingSimulation/ShippingSimulation'
 import { Image } from 'src/components/ui/Image'
+import LocalNotAvailableButton from 'src/components/product/NotAvailableButton'
 
 import { getSectionOverrides } from 'src/utils/overrides'
 import { override } from 'src/customizations/components/overrides/ProductDetails'
@@ -33,6 +34,7 @@ const {
   __experimentalImageGalleryImage,
   __experimentalImageGallery,
   __experimentalShippingSimulation,
+  __experimentalNotAvailableButton,
 } = getSectionOverrides(
   {
     ProductTitle: UIProductTitle,
@@ -48,6 +50,7 @@ const {
     __experimentalImageGalleryImage: Image,
     __experimentalImageGallery: LocalImageGallery,
     __experimentalShippingSimulation: LocalShippingSimulation,
+    __experimentalNotAvailableButton: LocalNotAvailableButton,
   },
   override as ProductDetailsOverrideDefinition
 )
@@ -66,4 +69,5 @@ export {
   __experimentalImageGalleryImage,
   __experimentalImageGallery,
   __experimentalShippingSimulation,
+  __experimentalNotAvailableButton,
 }

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 
 import { gql } from '@faststore/graphql-utils'
 import { sendAnalyticsEvent } from '@faststore/sdk'
@@ -162,7 +162,10 @@ function ProductDetails({
     gtin,
   ])
 
-  const outOfStock = availability === 'https://schema.org/OutOfStock'
+  const outOfStock = useMemo(
+    () => availability === 'https://schema.org/OutOfStock',
+    [availability]
+  )
 
   return (
     <Section className={`${styles.section} section-product-details`}>

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -155,7 +155,7 @@ function ProductDetails({
     gtin,
   ])
 
-  const outOfStock = availability == 'https://schema.org/OutOfStock'
+  const outOfStock = availability === 'https://schema.org/OutOfStock'
 
   return (
     <Section className={`${styles.section} section-product-details`}>

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -194,19 +194,14 @@ function ProductDetails({
               data-fs-product-details-settings
               data-fs-product-details-section
             >
-              {!outOfStock ? (
-                <ProductDetailsSettings
-                  product={data.product}
-                  isValidating={isValidating}
-                  buyButtonTitle={buyButtonTitle}
-                  quantity={quantity}
-                  setQuantity={setQuantity}
-                  buyButtonIcon={buyButtonIcon}
-                />
-              ) : (
-                // TODO: Adds <OutOfStock /> when component is ready to use
-                <p>Not Available</p>
-              )}
+              <ProductDetailsSettings
+                product={data.product}
+                isValidating={isValidating}
+                buyButtonTitle={buyButtonTitle}
+                quantity={quantity}
+                setQuantity={setQuantity}
+                buyButtonIcon={buyButtonIcon}
+              />
             </section>
 
             {!outOfStock && (

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -21,6 +21,7 @@ import {
   DiscountBadge,
   __experimentalImageGallery as ImageGallery,
   __experimentalShippingSimulation as ShippingSimulation,
+  __experimentalNotAvailableButton as NotAvailableButton,
 } from 'src/components/sections/ProductDetails/Overrides'
 
 interface ProductDetailsContextProps {
@@ -59,6 +60,9 @@ export interface ProductDetailsProps {
   imageGallery: {
     imagePosition: 'top' | 'center' | 'bottom'
   }
+  notAvailableButton: {
+    title: string
+  }
 }
 
 function ProductDetails({
@@ -91,6 +95,9 @@ function ProductDetails({
     displayDescription: shouldDisplayProductDescription,
   },
   imageGallery: { imagePosition = ImageGallery.props.imagePosition },
+  notAvailableButton: {
+    title: notAvailableButtonTitle = NotAvailableButton.props.title,
+  },
 }: ProductDetailsProps & ProductDetailsContextProps) {
   const { currency } = useSession()
   const [quantity, setQuantity] = useState(1)
@@ -201,6 +208,7 @@ function ProductDetails({
                 quantity={quantity}
                 setQuantity={setQuantity}
                 buyButtonIcon={buyButtonIcon}
+                notAvailableButtonTitle={notAvailableButtonTitle}
               />
             </section>
 

--- a/packages/core/src/components/ui/ProductDetails/ProductDetailsSettings.tsx
+++ b/packages/core/src/components/ui/ProductDetails/ProductDetailsSettings.tsx
@@ -7,6 +7,7 @@ import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 
 import Selectors from 'src/components/ui/SkuSelector'
 import AddToCartLoadingSkeleton from './AddToCartLoadingSkeleton'
+import NotAvailableButton from 'src/components/product/NotAvailableButton'
 
 import {
   BuyButton,
@@ -54,7 +55,7 @@ function ProductDetailsSettings({
     },
   } = product
 
-  const buyDisabled = availability !== 'https://schema.org/InStock'
+  const outOfStock = availability === 'https://schema.org/OutOfStock'
 
   const buyProps = useBuyButton({
     id,
@@ -77,58 +78,60 @@ function ProductDetailsSettings({
 
   return (
     <>
-      <section data-fs-product-details-values>
-        <div data-fs-product-details-prices>
-          {shouldShowDiscountedPrice ? (
-            <>
+      {!outOfStock && (
+        <section data-fs-product-details-values>
+          <div data-fs-product-details-prices>
+            {shouldShowDiscountedPrice ? (
+              <>
+                <Price.Component
+                  formatter={useFormattedPrice}
+                  testId="list-price"
+                  variant="listing"
+                  SRText="Original price:"
+                  {...Price.props}
+                  // Dynamic props shouldn't be overridable
+                  // This decision can be reviewed later if needed
+                  value={listPrice}
+                  data-value={listPrice}
+                />
+                <Price.Component
+                  formatter={useFormattedPrice}
+                  testId="price"
+                  variant="spot"
+                  className="text__lead"
+                  SRText="Sale Price:"
+                  {...Price.props}
+                  // Dynamic props shouldn't be overridable
+                  // This decision can be reviewed later if needed
+                  value={lowPrice}
+                  data-value={lowPrice}
+                />
+              </>
+            ) : (
               <Price.Component
                 formatter={useFormattedPrice}
                 testId="list-price"
-                variant="listing"
-                SRText="Original price:"
-                {...Price.props}
-                // Dynamic props shouldn't be overridable
-                // This decision can be reviewed later if needed
-                value={listPrice}
-                data-value={listPrice}
-              />
-              <Price.Component
-                formatter={useFormattedPrice}
-                testId="price"
                 variant="spot"
                 className="text__lead"
-                SRText="Sale Price:"
+                SRText="Original price:"
                 {...Price.props}
                 // Dynamic props shouldn't be overridable
                 // This decision can be reviewed later if needed
                 value={lowPrice}
                 data-value={lowPrice}
               />
-            </>
-          ) : (
-            <Price.Component
-              formatter={useFormattedPrice}
-              testId="list-price"
-              variant="spot"
-              className="text__lead"
-              SRText="Original price:"
-              {...Price.props}
-              // Dynamic props shouldn't be overridable
-              // This decision can be reviewed later if needed
-              value={lowPrice}
-              data-value={lowPrice}
-            />
-          )}
-        </div>
-        <QuantitySelector.Component
-          min={1}
-          max={10}
-          {...QuantitySelector.props}
-          // Dynamic props shouldn't be overridable
-          // This decision can be reviewed later if needed
-          onChange={setQuantity}
-        />
-      </section>
+            )}
+          </div>
+          <QuantitySelector.Component
+            min={1}
+            max={10}
+            {...QuantitySelector.props}
+            // Dynamic props shouldn't be overridable
+            // This decision can be reviewed later if needed
+            onChange={setQuantity}
+          />
+        </section>
+      )}
       {skuVariants && (
         <Selectors
           slugsMap={skuVariants.slugsMap}
@@ -137,30 +140,31 @@ function ProductDetailsSettings({
           data-fs-product-details-selectors
         />
       )}
-      {
+      {outOfStock ? (
+        // TODO: Adds <OutOfStock /> when component is ready to use
+        <NotAvailableButton>Not Available</NotAvailableButton>
+      ) : isValidating ? (
         /* NOTE: A loading skeleton had to be used to avoid a Lighthouse's
-                  non-composited animation violation due to the button transitioning its
-                  background color when changing from its initial disabled to active state.
-                  See full explanation on commit https://git.io/JyXV5. */
-        isValidating ? (
-          <AddToCartLoadingSkeleton />
-        ) : (
-          <BuyButton.Component
-            {...BuyButton.props}
-            icon={
-              <Icon.Component
-                {...Icon.props}
-                aria-label={buyButtonIconAlt}
-                name={buyButtonIconName}
-              />
-            }
-            disabled={buyDisabled}
-            {...buyProps}
-          >
-            {buyButtonTitle || 'Add to Cart'}
-          </BuyButton.Component>
-        )
-      }
+                    non-composited animation violation due to the button transitioning its
+                    background color when changing from its initial disabled to active state.
+                    See full explanation on commit https://git.io/JyXV5. */
+        <AddToCartLoadingSkeleton />
+      ) : (
+        <BuyButton.Component
+          {...BuyButton.props}
+          icon={
+            <Icon.Component
+              {...Icon.props}
+              aria-label={buyButtonIconAlt}
+              name={buyButtonIconName}
+            />
+          }
+          disabled={outOfStock}
+          {...buyProps}
+        >
+          {buyButtonTitle || 'Add to Cart'}
+        </BuyButton.Component>
+      )}
     </>
   )
 }

--- a/packages/core/src/typings/overrides.ts
+++ b/packages/core/src/typings/overrides.ts
@@ -204,6 +204,7 @@ export type ProductDetailsOverrideDefinition = SectionOverrideDefinition<
     __experimentalImageGalleryImage: ComponentOverrideDefinition<any, any>
     __experimentalImageGallery: ComponentOverrideDefinition<any, any>
     __experimentalShippingSimulation: ComponentOverrideDefinition<any, any>
+    __experimentalNotAvailableButton: ComponentOverrideDefinition<any, any>
   }
 >
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Previously on FastStore

- https://github.com/vtex/faststore/pull/1962
> Although our lib has the [OutOfStock](https://www.faststore.dev/components/organisms/out-of-stock) component, it's not fully integrated into our application, so we will temporarily remove it until implemented.

Then after it, we decided on use a `Not Available` product option.

Also, this PR aims to deal with this issue
- https://github.com/vtex/faststore/issues/1977

|Before|After|
|-|-|
|<img width="416" alt="Screenshot 2023-09-19 at 13 04 20" src="https://github.com/vtex/faststore/assets/11325562/9573b7bf-4f0d-48f6-a367-732b491141eb">|<img width="412" alt="Screenshot 2023-09-19 at 13 03 16" src="https://github.com/vtex/faststore/assets/11325562/e83d5cca-adc4-49a0-b1fb-7b7c94a2538f">|



## How it works?

It shows the Selector even when the product is outOfStock so that the user can change to another product sku.

## How to test it?

You can use one product with one sku available and another outOfStock option and test it.
(reach me out if you need example)

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/200

