### PR TITLE
feat: support cookies on api v1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.46",
+  "version": "1.12.47",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faststore/api",
-  "version": "1.12.46",
+  "version": "1.12.47",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -19,6 +19,7 @@ import type { SalesChannel } from './types/SalesChannel'
 import { MasterDataResponse } from './types/Newsletter'
 import type { Address, AddressInput } from './types/Address'
 import { ShippingDataBody } from './types/ShippingData'
+import getCookieByName from '../../../../utils/get-cookie-by-name'
 
 type ValueOf<T> = T extends Record<string, infer K> ? K : never
 
@@ -27,6 +28,18 @@ const BASE_INIT = {
   headers: {
     'content-type': 'application/json',
   },
+}
+
+const setCheckoutOrderFormOwnershipCookie = (
+  headers: Headers,
+  ctx: Context
+) => {
+  if (headers) {
+    ctx.storage.cookies = `CheckoutOrderFormOwnership=${getCookieByName(
+      'CheckoutOrderFormOwnership',
+      headers.get('set-cookie') ?? ''
+    )}`
+  }
 }
 
 export const VtexCommerce = (
@@ -108,7 +121,8 @@ export const VtexCommerce = (
           {
             ...BASE_INIT,
             body: JSON.stringify(body),
-          }
+          },
+          (headers) => setCheckoutOrderFormOwnershipCookie(headers, ctx)
         )
       },
       orderForm: ({
@@ -128,7 +142,8 @@ export const VtexCommerce = (
 
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm/${id}?${params.toString()}`,
-          BASE_INIT
+          BASE_INIT,
+          (headers) => setCheckoutOrderFormOwnershipCookie(headers, ctx)
         )
       },
       updateOrderFormItems: ({
@@ -158,7 +173,8 @@ export const VtexCommerce = (
               noSplitItem: !shouldSplitItem,
             }),
             method: 'PATCH',
-          }
+          },
+          (headers) => setCheckoutOrderFormOwnershipCookie(headers, ctx)
         )
       },
       setCustomData: ({
@@ -178,7 +194,8 @@ export const VtexCommerce = (
             ...BASE_INIT,
             body: JSON.stringify({ value }),
             method: 'PUT',
-          }
+          },
+          (headers) => setCheckoutOrderFormOwnershipCookie(headers, ctx)
         )
       },
       region: async ({
@@ -208,14 +225,18 @@ export const VtexCommerce = (
         'items',
         'profile.id,profile.email,profile.firstName,profile.lastName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol'
       )
-      return fetchAPI(`${base}/api/sessions?${params.toString()}`, {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          cookie: ctx.headers.cookie,
+      return fetchAPI(
+        `${base}/api/sessions?${params.toString()}`,
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            cookie: ctx.headers.cookie,
+          },
+          body: '{}',
         },
-        body: '{}',
-      })
+        (headers) => setCheckoutOrderFormOwnershipCookie(headers, ctx)
+      )
     },
     subscribeToNewsletter: (data: {
       name: string

--- a/packages/api/src/platforms/vtex/clients/fetch.ts
+++ b/packages/api/src/platforms/vtex/clients/fetch.ts
@@ -3,7 +3,11 @@ import packageJson from '../../../../package.json'
 
 const USER_AGENT = `${packageJson.name}@${packageJson.version}`
 
-export const fetchAPI = async (info: RequestInfo, init?: RequestInit) => {
+export const fetchAPI = async (
+  info: RequestInfo,
+  init?: RequestInit,
+  getHeaders?: (headers: Headers) => void
+) => {
   const response = await fetch(info, {
     ...init,
     headers: {
@@ -13,6 +17,10 @@ export const fetchAPI = async (info: RequestInfo, init?: RequestInit) => {
   })
 
   if (response.ok) {
+    if (getHeaders) {
+      getHeaders(response.headers)
+    }
+
     return response.status !== 204 ? response.json() : undefined
   }
 

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -56,6 +56,7 @@ export interface Context {
     locale: string
     flags: FeatureFlags
     searchArgs?: Omit<SearchArgs, 'type'>
+    cookies?: string | null
   }
   headers: Record<string, string>
 }

--- a/packages/api/src/utils/get-cookie-by-name.ts
+++ b/packages/api/src/utils/get-cookie-by-name.ts
@@ -1,0 +1,6 @@
+export default function getCookieByName(cookiename: string, source: string) {
+  var cookiestring = RegExp(cookiename + '=[^;]+').exec(source)
+  return decodeURIComponent(
+    !!cookiestring ? cookiestring.toString().replace(/^[^=]+./, '') : ''
+  )
+}

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,9 @@
     },
     "dev": {
       "cache": false
+    },
+    "dev:server": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
Available on `@faststore/api@1.12.47`

In addition to this update, the following modifications need to be added to the v1 store:

```ts
// src/pages/api/graphql.ts

if (extensions.cookies && !hasErrors) {
  response.setHeader('set-cookie', extensions.cookies)
}
```

```ts
// src/server/index.ts

extensions: {
  cookies: contextValue.storage.cookies,
  cacheControl: contextValue.cacheControl,
},
```


You can see these changes in the [v2 PR](https://github.com/vtex/faststore/pull/2035/files), since the core is part of the monorepo.
