### PR TITLE
perf(core): add sideEffects false

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
   "engines": {
     "node": ">=14"
   },
+  "sideEffects": false,
   "dependencies": {
     "@builder.io/partytown": "^0.6.1",
     "@envelop/core": "^1.2.0",


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR enables sideEffects optimization by webpack. This reduces first load bundle size and significantly improves navigation between pages by reducing the bundle downloaded when navigating between pages. 

## How it works?

The sideEffects optimization works by analyzing which parts of side-effect free packages are used by the store and removing the rest. This optimization was already enabled for packages that explicitly define they are side-effect free. By setting `sideEffect` as `false` in the package.json file, we assure anyone using `@faststore/core` it is a side-effect free package & signal to webpack it should analyze every package for side-effect free code & CSS, which allows it to remove unused code from the final bundle.

Usually, this comes at the cost of increased build times. I tested it to see how much this would affect us, and couldn't find any meaningful difference. Build time locally usually sits around 25 seconds, and it remained that way after the change.

This is the bundle before and after (how to read those values: https://nextjs.org/docs/pages/api-reference/next-cli#build)
![Screenshot 2023-09-21 at 18 28 16](https://github.com/vtex/faststore/assets/8127610/a26ca56e-dded-4237-85a9-14bdd5689dc7)
![Screenshot 2023-09-21 at 18 28 54](https://github.com/vtex/faststore/assets/8127610/19578392-5df8-40aa-8e85-61b9a8dd7ee0)

## How to test it?

I'll link the deploy preview below. Please just browse it and make sure everything works like before.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/204

## References

https://webpack.js.org/configuration/optimization/#optimizationsideeffects
https://docs.w3cub.com/webpack/configuration/optimization#optimization-sideeffects
https://github.com/vercel/next.js/issues/12681