### PR TITLE
fix: Reset `QuantitySelector` counter when navigating between PDPs

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -210,7 +210,10 @@ export type { ToggleProps } from './molecules/Toggle'
 export { default as ToggleField } from './molecules/ToggleField'
 export type { ToggleFieldProps } from './molecules/ToggleField'
 export { default as QuantitySelector } from './molecules/QuantitySelector'
-export type { QuantitySelectorProps } from './molecules/QuantitySelector'
+export type {
+  QuantitySelectorRef,
+  QuantitySelectorProps,
+} from './molecules/QuantitySelector'
 
 // Organisms
 export {

--- a/packages/components/src/molecules/QuantitySelector/QuantitySelector.tsx
+++ b/packages/components/src/molecules/QuantitySelector/QuantitySelector.tsx
@@ -1,6 +1,11 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useImperativeHandle } from 'react'
+import type { MutableRefObject } from 'react'
 
 import { Icon, IconButton, Input } from '../../'
+
+export interface QuantitySelectorRef {
+  reset: () => void
+}
 
 export interface QuantitySelectorProps {
   /**
@@ -29,18 +34,27 @@ export interface QuantitySelectorProps {
    * Event emitted when value is changed
    */
   onChange?: (value: number) => void
+  /**
+   * Current quantity selector's input ref.
+   */
+  inputRef?: MutableRefObject<QuantitySelectorRef | null>
 }
 
 const QuantitySelector = ({
   max,
-  min = 1,
   initial,
-  disabled = false,
   onChange,
+  inputRef,
+  min = 1,
+  disabled = false,
   testId = 'fs-quantity-selector',
   ...otherProps
 }: QuantitySelectorProps) => {
   const [quantity, setQuantity] = useState<number>(initial ?? min)
+
+  useImperativeHandle(inputRef, () => ({
+    reset: () => setQuantity(initial ?? min),
+  }))
 
   const isLeftDisabled = quantity === min
   const isRightDisabled = quantity === max

--- a/packages/components/src/molecules/QuantitySelector/index.ts
+++ b/packages/components/src/molecules/QuantitySelector/index.ts
@@ -1,2 +1,5 @@
 export { default } from './QuantitySelector'
-export type { QuantitySelectorProps } from './QuantitySelector'
+export type {
+  QuantitySelectorRef,
+  QuantitySelectorProps,
+} from './QuantitySelector'

--- a/packages/core/src/components/ui/ProductDetails/ProductDetailsSettings.tsx
+++ b/packages/core/src/components/ui/ProductDetails/ProductDetailsSettings.tsx
@@ -1,6 +1,8 @@
 import type { Dispatch, SetStateAction } from 'react'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
+import { useRouter } from 'next/router'
 
+import type { QuantitySelectorRef } from '@faststore/ui'
 import type { ProductDetailsFragment_ProductFragment } from '@generated/graphql'
 
 import { useBuyButton } from 'src/sdk/cart/useBuyButton'
@@ -42,6 +44,24 @@ function ProductDetailsSettings({
   },
   notAvailableButtonTitle,
 }: ProductDetailsSettingsProps) {
+  const router = useRouter()
+  const quantitySelectorRef = useRef<QuantitySelectorRef | undefined>(null)
+
+  useEffect(() => {
+    function resetQuantitySelector() {
+      if (quantitySelectorRef.current) {
+        quantitySelectorRef.current.reset()
+      }
+    }
+
+    // Reset `QuantitySelector` when navigating between PDPs
+    router.events.on('routeChangeComplete', resetQuantitySelector)
+
+    return () => {
+      router.events.off('routeChangeComplete', resetQuantitySelector)
+    }
+  }, [router.events])
+
   const {
     id,
     sku,
@@ -160,6 +180,7 @@ function ProductDetailsSettings({
             // Dynamic props shouldn't be overridable
             // This decision can be reviewed later if needed
             onChange={setQuantity}
+            inputRef={quantitySelectorRef}
           />
         </section>
       )}

--- a/packages/core/src/typings/overrides.ts
+++ b/packages/core/src/typings/overrides.ts
@@ -186,7 +186,7 @@ export type ProductDetailsOverrideDefinition = SectionOverrideDefinition<
     >
     QuantitySelector: ComponentOverrideDefinition<
       QuantitySelectorProps,
-      Omit<QuantitySelectorProps, 'onChange'>
+      Omit<QuantitySelectorProps, 'onChange' | 'inputRef'>
     >
     SkuSelector: ComponentOverrideDefinition<SkuSelectorProps, SkuSelectorProps>
     ShippingSimulation: ComponentOverrideDefinition<


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix a wrong `QuantitySelector` behavior when navigating between PDPs.

Currently, if the user increase the product's quantity then clicks on any product inside the "People also bought" section (on the current PDP) the counter isn't reset.

https://github.com/vtex/faststore/assets/15722605/d2f4d1ec-5fb7-4fb8-bf10-bd2937bbf687

## How it works?

Adds a handle to reset the `QuantitySelector` to the initial input's state.

## How to test it?

- Go to any PDP;
- Increase the product's quantity;
- Click on any product inside the "People also bought" section"

The product's quantity should be 1.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/209