### PR TITLE
chore: Specifies a unique `key` for each PDP

### DIFF
--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -233,6 +233,7 @@ export const getStaticProps: GetStaticProps<
       meta,
       offers,
       globalSections,
+      key: slug,
     },
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to set a unique `key` prop for each PDP to reset the entire component tree’s state.

As an example of wrong state behavior we have the `QuantitySelector` quantity counter that's not resetting when navigating between PDPs. Currently, if the user increase the product's quantity then clicks on any product inside the "People also bought" section (on the current PDP) the counter isn't reset.

## How to test it?

- Go to any PDP;
- Increase the product's quantity;
- Click on any product inside the "People also bought" section".

The product's quantity should be 1.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/209