### PR TITLE
fix: PLP when navigating through different PLPs w/ additional pages

### DIFF
--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -129,6 +129,7 @@ export const getStaticProps: GetStaticProps<
       page,
       globalSections: await globalSectionsPromise,
       type: 'plp',
+      key: slug,
     },
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

- Fix PLP bug when navigating through different PLPs w/ additional pages. The loaded pages in the PLP are not being reset, and there are no products to show; it displays a list of the Product's card skeleton.

|Bug - Before|
|-|
|![bug-plp-before](https://github.com/vtex/faststore/assets/3356699/04e3fb12-73f3-4e90-890e-fd991678514f)|![bug-plp-fix](https://github.com/vtex/faststore/assets/3356699/306d3920-fe9a-4c95-8d66-9bc9dc1bc1fa)|

|After|
|-|
|![bug-plp-fix](https://github.com/vtex/faststore/assets/3356699/306d3920-fe9a-4c95-8d66-9bc9dc1bc1fa)|


## How it works?

- Adds key prop to identify the different PLP pages and mount it again.

## How to test it?

Use this preview link: https://starter-git-fix-plp-plp-reset-page-fs-1280-faststore.vercel.app
1. Click on the `Office` category in the Navbar
2. Click twice on the `Load more products` button; it should load 3 pages In the PLP
3. Now, click in the `Technology` category in the Navbar

You should see no more product's card skeleton being loaded and just 1 page in the PLP.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/212

## References

https://legacy.reactjs.org/docs/reconciliation.html#keys

