### PR TITLE
fix: upgrade protobufjs to avoid vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19464,9 +19464,9 @@ proto-list@~1.2.1:
   integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
 protobufjs@^7.0.0, protobufjs@^7.2.2:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.3.tgz#01af019e40d9c6133c49acbb3ff9e30f4f0f70b2"
-  integrity sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.5.tgz#45d5c57387a6d29a17aab6846dcc283f9b8e7f2d"
+  integrity sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR upgrades protobufjs sub-dependency to incorporate the fix introduced in https://github.com/protobufjs/protobuf.js/releases/tag/protobufjs-v7.2.4, which was a vulnerability in the package.

## How it works?

Updated the version `yarn.lock` uses to resolve the package.

## How to test it?

Check yarn.lock. Alternatively, install the packages and see the installed version in node_modules.
## References

https://github.com/protobufjs/protobuf.js/releases/tag/protobufjs-v7.2.4
https://github.com/yarnpkg/yarn/issues/4986#issuecomment-395036563
https://github.com/advisories/GHSA-h755-8qp9-cq85
