### PR TITLE
Fix: `ShippingSimulation` when exists zip code from session

### DIFF
--- a/packages/core/src/components/ui/ShippingSimulation/useShippingSimulation.ts
+++ b/packages/core/src/components/ui/ShippingSimulation/useShippingSimulation.ts
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from 'react'
-import { useCallback, useEffect, useReducer } from 'react'
+import { useCallback, useEffect, useReducer, useRef } from 'react'
 import { ShippingSimulationProps as UIShippingSimulationProps } from '@faststore/components'
 
 export interface ProductShippingInfo {
@@ -123,9 +123,11 @@ export const useShippingSimulation = (
   )
 
   const { postalCode: shippingPostalCode } = input
+  const shippingPostalCodeRef = useRef(shippingPostalCode)
 
   useEffect(() => {
-    if (!sessionPostalCode || shippingPostalCode) {
+    const shouldFetch = sessionPostalCode && !shippingPostalCodeRef.current
+    if (!shouldFetch) {
       return
     }
 
@@ -154,13 +156,7 @@ export const useShippingSimulation = (
     }
 
     fetchShipping()
-  }, [
-    country,
-    fetchShippingSimulationFn,
-    sessionPostalCode,
-    shippingItem,
-    shippingPostalCode,
-  ])
+  }, [country, fetchShippingSimulationFn, sessionPostalCode, shippingItem])
 
   const handleSubmit = useCallback(async () => {
     try {


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix `ShippingSimulation` when has zip code from session and clear the shipping simulation.

Before

https://github.com/vtex/faststore/assets/11325562/b3c526f5-d4b5-4294-bf88-ec6e15665483

After

https://github.com/vtex/faststore/assets/11325562/c5b4fb94-12c4-418e-884a-a0464f99b897


