### PR TITLE
Fix: Scroll restoration and pages states on PLP when back from PDP

### DIFF
--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -18,6 +18,7 @@ const nextConfig = {
   sassOptions: {
     additionalData: `@import "src/customizations/styles/custom-mixins.scss";`,
   },
+  // TODO: We won't need to enable this experimental feature when migrating to Next.js 13
   experimental: {
     scrollRestoration: true,
   },

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -18,6 +18,9 @@ const nextConfig = {
   sassOptions: {
     additionalData: `@import "src/customizations/styles/custom-mixins.scss";`,
   },
+  experimental: {
+    scrollRestoration: true,
+  },
   webpack: (config, { isServer, dev }) => {
     // https://github.com/vercel/next.js/discussions/11267#discussioncomment-2479112
     // camel-case style names from css modules

--- a/packages/sdk/src/search/useInfiniteSearchState.ts
+++ b/packages/sdk/src/search/useInfiniteSearchState.ts
@@ -43,7 +43,7 @@ function getPagesFromSessionStorage(): number[] | null {
     const item = sessionStorage.getItem(storageKey)
 
     return item ? JSON.parse(item) : null
-  } catch (error) {
+  } catch (_) {
     return null
   }
 }

--- a/packages/sdk/src/search/useInfiniteSearchState.ts
+++ b/packages/sdk/src/search/useInfiniteSearchState.ts
@@ -35,6 +35,9 @@ function setPagesSessionStorage(pages: number[]) {
 function getPagesFromSessionStorage(): number[] | null {
   try {
     const stateKey = window.history.state?.key
+    if (!stateKey) {
+      return null
+    }
     const storageKey = `__fs_gallery_page_${stateKey}`
 
     const item = sessionStorage.getItem(storageKey)

--- a/packages/sdk/src/search/useInfiniteSearchState.ts
+++ b/packages/sdk/src/search/useInfiniteSearchState.ts
@@ -16,24 +16,40 @@ type Action =
       payload: number
     }
 
+function setPagesSessionStorage(pagesArray: number[]) {
+  try {
+    const stateKey = window.history.state?.key
+
+    sessionStorage.setItem(
+      `__fs_gallery_pages_${stateKey}`,
+      JSON.stringify(pagesArray)
+    )
+  } catch (error) {
+    return
+  }
+}
+
 const reducer = (state: State, action: Action) => {
   switch (action.type) {
     case 'addPrev': {
       const prev = state[0] - 1
-
-      return [prev, ...state]
+      const newState = [prev, ...state]
+      setPagesSessionStorage(newState)
+      return newState
     }
 
     case 'addNext': {
       const next = Number(state[state.length - 1]) + 1
-
-      return [...state, next]
+      const newState = [...state, next]
+      setPagesSessionStorage(newState)
+      return newState
     }
 
     case 'reset': {
       const { payload } = action
-
-      return [payload]
+      const newState = [payload]
+      setPagesSessionStorage(newState)
+      return newState
     }
 
     default:
@@ -41,8 +57,27 @@ const reducer = (state: State, action: Action) => {
   }
 }
 
+function retrievePagesFromSessionStorage(): number[] | null {
+
+  try {
+    const stateKey = window.history.state?.key
+    const item = sessionStorage.getItem(`__fs_gallery_pages_${stateKey}`)
+    if (!item) {
+      return null
+    }
+    console.log(item)
+    return JSON.parse(item)
+  } catch (error) {
+    return null
+  }
+}
+
 export const useSearchInfiniteState = (initialPage: number) => {
-  const [pages, dispatch] = useReducer(reducer, undefined, () => [initialPage])
+  const [pages, dispatch] = useReducer(
+    reducer,
+    undefined,
+    () => retrievePagesFromSessionStorage() ?? [initialPage]
+  )
 
   const actions = useMemo(
     () => ({

--- a/packages/sdk/src/search/useInfiniteSearchState.ts
+++ b/packages/sdk/src/search/useInfiniteSearchState.ts
@@ -32,7 +32,7 @@ function setPagesSessionStorage(pages: number[]) {
   }
 }
 
-function retrievePagesFromSessionStorage(): number[] | null {
+function getPagesFromSessionStorage(): number[] | null {
   try {
     const stateKey = window.history.state?.key
     const storageKey = `__fs_gallery_page_${stateKey}`
@@ -77,7 +77,7 @@ export const useSearchInfiniteState = (initialPage: number) => {
   const [pages, dispatch] = useReducer(
     reducer,
     undefined,
-    () => retrievePagesFromSessionStorage() ?? [initialPage]
+    () => getPagesFromSessionStorage() ?? [initialPage]
   )
 
   const actions = useMemo(

--- a/packages/sdk/src/search/useInfiniteSearchState.ts
+++ b/packages/sdk/src/search/useInfiniteSearchState.ts
@@ -27,7 +27,7 @@ function setPagesSessionStorage(pages: number[]) {
     const storageKey = `__fs_gallery_page_${stateKey}`
 
     sessionStorage.setItem(storageKey, JSON.stringify(pages))
-  } catch (error) {
+  } catch (_) {
     return
   }
 }

--- a/packages/sdk/src/search/useInfiniteSearchState.ts
+++ b/packages/sdk/src/search/useInfiniteSearchState.ts
@@ -16,16 +16,32 @@ type Action =
       payload: number
     }
 
-function setPagesSessionStorage(pagesArray: number[]) {
+// Save the array containing loaded pages before navigating away from the PLP
+function setPagesSessionStorage(pages: number[]) {
   try {
+    // Uses the key to identify a product gallery page
     const stateKey = window.history.state?.key
+    if (!stateKey) {
+      return
+    }
+    const storageKey = `__fs_gallery_page_${stateKey}`
 
-    sessionStorage.setItem(
-      `__fs_gallery_pages_${stateKey}`,
-      JSON.stringify(pagesArray)
-    )
+    sessionStorage.setItem(storageKey, JSON.stringify(pages))
   } catch (error) {
     return
+  }
+}
+
+function retrievePagesFromSessionStorage(): number[] | null {
+  try {
+    const stateKey = window.history.state?.key
+    const storageKey = `__fs_gallery_page_${stateKey}`
+
+    const item = sessionStorage.getItem(storageKey)
+
+    return item ? JSON.parse(item) : null
+  } catch (error) {
+    return null
   }
 }
 
@@ -54,21 +70,6 @@ const reducer = (state: State, action: Action) => {
 
     default:
       throw new SDKError('Unknown action for infinite search')
-  }
-}
-
-function retrievePagesFromSessionStorage(): number[] | null {
-
-  try {
-    const stateKey = window.history.state?.key
-    const item = sessionStorage.getItem(`__fs_gallery_pages_${stateKey}`)
-    if (!item) {
-      return null
-    }
-    console.log(item)
-    return JSON.parse(item)
-  } catch (error) {
-    return null
   }
 }
 

--- a/packages/sdk/src/search/useInfiniteSearchState.ts
+++ b/packages/sdk/src/search/useInfiniteSearchState.ts
@@ -19,7 +19,7 @@ type Action =
 // Save the array containing loaded pages before navigating away from the PLP
 function setPagesSessionStorage(pages: number[]) {
   try {
-    // Uses the key to identify a product gallery page
+    // Uses the key to identify a PLP
     const stateKey = window.history.state?.key
     if (!stateKey) {
       return


### PR DESCRIPTION
## What's the purpose of this pull request?

1. Attempts to fix scroll position when going back from the PDP to PLP 

reported issue: https://github.com/vtex/faststore/issues/1972

_Scenario_: On PLP, click on `Load more products`, select a product, go to product's PLP and go back to PLP using browser's back button.

|Before - PLP drops user at bottom of the page|
|-|
|![plp drops users on the bottom](https://github.com/vtex/faststore/assets/3356699/352c7d87-4437-4cdb-a7a1-53bbb993109c)|

|FIx - PLP saves last state (open pages) and keep previous scroll position|
|-|
|![plp saves last state (open pages) and keep previous scroll position](https://github.com/vtex/faststore/assets/3356699/26d1d98b-ff6b-41f9-93b6-ce5f867f0d52)|


2. Enables scroll restoration on the application

|Before - not using scroll restoration| Enable scroll restoration|
|-|-|
|![before](https://github.com/vtex/faststore/assets/3356699/db70ccb3-f94c-4d8b-a284-4d99d62a22fa)|![restore](https://github.com/vtex/faststore/assets/3356699/88b0c7a5-aaf5-456f-8816-1b609f948e3a)|

The default behavior of the Next.js App Router is to scroll to the top of a new route. We enabled the `scrollRestoration` experimental feature. That is a [default behavior in Next.js 13.](https://nextjs.org/docs/app/building-your-application/routing/linking-and-navigating#disabling-scroll-restoration)

``` file=""
experimental: {
    scrollRestoration: true,
},
```


## How it works?

After studying different approach, we decided to change the previous behaviour.
Previously, given the following scenario:
- Navigating in PLP -> Click on `Load more products` -> Select a product's -> go to product's PLP -> back to PLP

We were displaying only the last viewed 'page' (in this example, 'page=1') with the 'Previous Page' button available, which was causing a mismatch in the scroll position.

Looking for a better UX experience and keeping the scroll position as it should, we're now retrieving the previous state with the once-opened pages. To do so, we are storing the state in the session storage and retrieve it from it when needed.
To map it, we are using the `__fs_gallery_page` prefix along with a unique key - this key is a property from the [window.history.state](https://developer.mozilla.org/en-US/docs/Web/API/History/state) , which allow us to uniquely identifying different history entries.

<img width="476" alt="image" src="https://github.com/vtex/faststore/assets/3356699/0d05f492-4e94-4f38-bbde-cd07e7babe11">

This approach is inspired on how the nextjs scrollRestoration is implemented.


## How to test it?

Using this preview link: https://starter-git-fix-plp-pdp-back-fs-1285-2-faststore.vercel.app/

1. Navigate to PLP 
2. Click on `Load more products`
3. Select a product's -> go to product's PLP
4. Use the browser's back button and go back to PLP

The previously opened pages and scroll position should be restored.


### Starters Deploy Preview

WIP - https://github.com/vtex-sites/starter.store/pull/217

## References

https://nextjs.org/docs/app/building-your-application/routing/linking-and-navigating
https://github.com/vercel/next.js/blob/a44b4f85b56ef1c5cfe9ab931839a24241c10230/packages/next/src/shared/lib/router/router.ts#L950
https://levelup.gitconnected.com/browser-navigation-a-guide-to-window-location-and-window-history-in-javascript-45284c32dabd


Thanks, @icazevedo , for delving into this matter with me and exploring various approaches to address this issue 🌟 

