### PR TITLE
Fix: Content bleed on tablet views

### DIFF
--- a/packages/ui/src/styles/base/layout.scss
+++ b/packages/ui/src/styles/base/layout.scss
@@ -13,6 +13,7 @@
   main {
     display: flex;
     flex-direction: column;
+    overflow: hidden;
   }
 
   .layout__section {


### PR DESCRIPTION
## What's the purpose of this pull request?
The current tablet version has a content bleed and adds an extra space on the right.

## How it works?
|Before|After|
|-|-|
|<img width="574" alt="image" src="https://github.com/vtex/faststore/assets/11613011/3888db0d-bab6-4922-81ce-7533f67460bd">|<img width="574" alt="image" src="https://github.com/vtex/faststore/assets/11613011/c7cd49e2-a7cf-4c2d-9177-709849eefef9">|

## How to test it?

`faststore/core` application:
1. Run `yarn dev`
2. Check `Homepage` on table view

## Starters Deploy Preview
`WIP`