### PR TITLE
fix: rollback prettier to 2ˆ to fix publishing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@faststore/eslint-config": "*",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "lerna": "6.4.1",
-    "prettier": "latest",
+    "prettier": "^2",
     "turbo": "latest"
   },
   "version": "0.0.0",

--- a/packages/api/src/platforms/vtex/utils/sanitizeHtml.ts
+++ b/packages/api/src/platforms/vtex/utils/sanitizeHtml.ts
@@ -1,23 +1,21 @@
 import sanitizeHtmlLib from 'sanitize-html'
 
-
 /**
  * For now, we're using sanitize-html's default set
  * of allowed tags and attributes, which don't even include img elements
- * 
+ *
  * It is known many client depends on pontentially vulnerable tags, such as script tags
  * We chose to be restrictive at first, and document those restrictions later.
- * 
+ *
  * When expanding the set of allowed tags and attributes, please consider performance, privacy and security.
- * 
+ *
  * This possibily breaks compatibility with Portal and Store Framework,
  * which both allows an enormous amount of tags and attributes
- * 
+ *
  * This was a thoughtful decision that can be reviewed in the future given
  * research was made to back up those changes.
  */
 export const sanitizeHtml = (
   dirty: Parameters<typeof sanitizeHtmlLib>[0],
   options?: Parameters<typeof sanitizeHtmlLib>[1]
-) =>
-  sanitizeHtmlLib(dirty, options)
+) => sanitizeHtmlLib(dirty, options)

--- a/yarn.lock
+++ b/yarn.lock
@@ -19321,15 +19321,15 @@ prettier@^1.19.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
+prettier@^2:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
 prettier@^2.2.0:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"
   integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==
-
-prettier@latest:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
-  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.6.0:
   version "5.6.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes [this](https://github.com/vtex/faststore/actions/runs/6458890810/job/17533535581) issue that happened while publishing packages due to incompatible `eslint-plugin-prettier` versions with prettier 3.x.

## How it works?

In #2050 I upgraded the prettier version to 3.x. That caused the issue because `tsdx` has a dependency on an old `eslint-plugin-prettier` version, which is incompatible with `prettier@3`. I'm rolling back the upgrade and fixing the prettier version on the major `2` which makes it difficult for others to make the same mistake as me.

In the future, we remove all uses of `tsdx` as it is no longer supported and has gone 3 years without updates. 

## How to test it?

By merging this!

## References

https://github.com/prettier/eslint-plugin-prettier/issues/562
Thanks @hellofanny for noticing the error and investigating it!
