### PR TITLE
fix: adds empty array as default top term value

### DIFF
--- a/packages/core/src/components/search/SearchTop/SearchTop.tsx
+++ b/packages/core/src/components/search/SearchTop/SearchTop.tsx
@@ -23,7 +23,7 @@ export interface SearchTopProps extends HTMLAttributes<HTMLDivElement> {
   sort?: string
 }
 
-function SearchTop({ topTerms, sort, ...otherProps }: SearchTopProps) {
+function SearchTop({ topTerms = [], sort, ...otherProps }: SearchTopProps) {
   const {
     values: { onSearchSelection },
   } = useSearch()


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix this problem when there is no top terms.

<img width="404" alt="Screenshot 2023-10-16 at 15 21 40" src="https://github.com/vtex/faststore/assets/11325562/221ba140-25c5-4109-8698-1cd39022a448">
