### PR TITLE
Fix: Misplaced "bordered" and "showDiscountBadge" props in ProductGrid

### DIFF
--- a/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
@@ -53,8 +53,8 @@ function ProductGrid({
                 sizes: '30vw',
               }}
               {...ProductCard.props}
-              bordered={showDiscountBadge}
-              showDiscountBadge={bordered}
+              bordered={bordered}
+              showDiscountBadge={showDiscountBadge}
               product={product}
               index={pageSize * page + idx + 1}
             />


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix misplaced "bordered" and "showDiscountBadge" props in `ProductGrid`.
<img width="509" alt="image" src="https://github.com/vtex/faststore/assets/3356699/a36538da-9ffc-40b4-9b8f-315079ffc2b6">


## How it works?

<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?

Changes made through hCMS should work as expected.
<img width="590" alt="image" src="https://github.com/vtex/faststore/assets/3356699/160b2565-bf19-4574-8c1f-576b59719605">

- `Show discount badge?` should toggle `showDiscountBadge` prop
- `Cards should be bordered?` should toggle `bordered ` prop


### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

Issue reported: https://github.com/vtex/faststore/issues/2061
