### PR TITLE
chore: remove copying faststore config during build

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -21,10 +21,6 @@ export default class Build extends Command {
     }
 
     await copyResource(`${tmpDir}/.next`, `${userDir}/.next`)
-    await copyResource(
-      `${tmpDir}/faststore.config.js`,
-      `${userDir}/faststore.config.js`
-    )
     await copyResource(`${tmpDir}/public`, `${userDir}/public`)
     await copyResource(
       `${tmpDir}/lighthouserc.js`,


### PR DESCRIPTION
## What's the purpose of this pull request?

The faststore.config.js file from the `.faststore` folder was being copied to the starter after the build, which caused it to throw errors because it couldn't find default definitions for the config or the copied starter config present inside `.faststore`.

Lighthouse was not working because of this.

## How it works?

This PR makes the CLI not copy the `.faststore/faststore.config.js` file to the starter after the build.

## How to test it?

Run `yarn build` on the starter. You shouldn't see any changes in the starter's `faststore.config.js` file.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/232

The integration tests are failing due to an unsupported workflow on webops. Lighthouse actually started working after this change!
