### PR TITLE
display correct missing route in 404 page

### DIFF
--- a/packages/core/src/pages/404.tsx
+++ b/packages/core/src/pages/404.tsx
@@ -12,11 +12,10 @@ import EmptyState from 'src/components/sections/EmptyState'
 
 const useErrorState = () => {
   const router = useRouter()
-  const { from } = router.query
-  const { pathname } = router
+  const { pathname, asPath } = router
 
   return {
-    fromUrl: from ?? pathname,
+    fromUrl: asPath ?? pathname,
   }
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

display the correct missing URL when hitting a 404 page
https://github.com/vtex/faststore/issues/2064

## How it works?

use `asPath` which Next provides as the alias for that particular 404 response

## How to test it?

1. visit path which doesn't exist
2. see that the URL is displayed in the body of the page

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
