### PR TITLE
Feat: Support URL params on config login route

### DIFF
--- a/packages/core/src/pages/login.tsx
+++ b/packages/core/src/pages/login.tsx
@@ -18,7 +18,14 @@ type Props = {
 
 function Page({ globalSections }: Props) {
   useEffect(() => {
-    window.location.href = `${storeConfig.loginUrl}${window.location.search}`
+    const loginUrl = new URL(storeConfig.loginUrl)
+    const incomingParams = new URLSearchParams(window.location.search)
+
+    for (const [key, value] of Array.from(incomingParams)) {
+      loginUrl.searchParams.append(key, value)
+    }
+
+    window.location.href = loginUrl.toString()
   }, [])
 
   return (


### PR DESCRIPTION
## What's the purpose of this pull request?

prevent URL params on the `loginUrl` in `faststore.config.js` from breaking when the user is redirected with additional params. more context in the issue:
https://github.com/vtex/faststore/issues/2073

## How it works?

use URLSearchParams constructor to combine two sets of params

## How to test it?

1. configure store with a `loginUrl` that includes a URL param (e.g. `?oAuthRedirect=XXX`)
2. navigate to a route that already has a URL param (e.g. `?orderForm=XXX`)
3. click the "Sign In" nav button
4. notice that the URL params are now combined instead of appended with two separate `?` query strings