### PR TITLE
Chore: Carousel/ProductShelf components tweaks

### DIFF
--- a/apps/site/components/Carousel/CarouselSimpleUsage.tsx
+++ b/apps/site/components/Carousel/CarouselSimpleUsage.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable @next/next/no-img-element */
+import React, { PropsWithChildren } from 'react'
+import { Carousel } from '@faststore/ui'
+import styles from './carousel-item.module.css'
+
+export type CarouselSimpleProps = {
+  itemsPerPage: number
+}
+
+export const CarouselSimpleUsage = ({
+  itemsPerPage = 5,
+}: PropsWithChildren<CarouselSimpleProps>) => {
+  return (
+    <Carousel itemsPerPage={itemsPerPage} variant="scroll" infiniteMode={false}>
+      {[...Array(10)].map((_, index) => (
+        <div key={index} className={styles.carouselItem}>
+          {index + 1}
+        </div>
+      ))}
+    </Carousel>
+  )
+}
+
+export default CarouselSimpleUsage

--- a/apps/site/components/Carousel/CarouselSimpleUsage.tsx
+++ b/apps/site/components/Carousel/CarouselSimpleUsage.tsx
@@ -5,13 +5,21 @@ import styles from './carousel-item.module.css'
 
 export type CarouselSimpleProps = {
   itemsPerPage: number
+  infiniteMode: boolean
+  variant: 'slide' | 'scroll'
 }
 
 export const CarouselSimpleUsage = ({
   itemsPerPage = 5,
+  infiniteMode = false,
+  variant,
 }: PropsWithChildren<CarouselSimpleProps>) => {
   return (
-    <Carousel itemsPerPage={itemsPerPage} variant="scroll" infiniteMode={false}>
+    <Carousel
+      itemsPerPage={itemsPerPage}
+      variant={variant}
+      infiniteMode={infiniteMode}
+    >
       {[...Array(10)].map((_, index) => (
         <div key={index} className={styles.carouselItem}>
           {index + 1}

--- a/apps/site/components/Carousel/CarouselSimpleUsage.tsx
+++ b/apps/site/components/Carousel/CarouselSimpleUsage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 import React, { PropsWithChildren } from 'react'
 import { Carousel } from '@faststore/ui'
 import styles from './carousel-item.module.css'

--- a/apps/site/components/Carousel/CarouselSimpleUsage.tsx
+++ b/apps/site/components/Carousel/CarouselSimpleUsage.tsx
@@ -14,9 +14,10 @@ export const CarouselSimpleUsage = ({
   infiniteMode = false,
   variant,
 }: PropsWithChildren<CarouselSimpleProps>) => {
+  const isMobile = window.innerWidth <= 768
   return (
     <Carousel
-      itemsPerPage={itemsPerPage}
+      itemsPerPage={isMobile ? 1 : itemsPerPage}
       variant={variant}
       infiniteMode={infiniteMode}
     >

--- a/apps/site/components/Carousel/CarouselUsage.tsx
+++ b/apps/site/components/Carousel/CarouselUsage.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import {
   Carousel,
   ProductCard,
@@ -10,11 +10,17 @@ import {
 import { products } from 'site/mocks/products'
 import { useFormattedPrice } from '../utilities/usePriceFormatter'
 
-export const CarouselUsage = () => {
+export type CarouselUsageProps = {
+  itemsPerPage: number
+}
+
+export const CarouselUsage = ({
+  itemsPerPage = 3,
+}: PropsWithChildren<CarouselUsageProps>) => {
   const isMobile = window.innerWidth <= 768
   return (
     <Carousel
-      itemsPerPage={isMobile ? 1 : 3}
+      itemsPerPage={isMobile ? 1 : itemsPerPage}
       variant="scroll"
       infiniteMode={false}
     >

--- a/apps/site/components/Carousel/carousel-item.module.css
+++ b/apps/site/components/Carousel/carousel-item.module.css
@@ -1,0 +1,10 @@
+.carouselItem {
+  width: 100%;
+  height: 5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--fs-text-size-3);
+  font-weight: var(--fs-text-weight-bold);
+  background: var(--fs-color-accent-1);
+}

--- a/apps/site/components/OverviewSection/overview-section.module.css
+++ b/apps/site/components/OverviewSection/overview-section.module.css
@@ -46,6 +46,7 @@
 
 @media screen and (min-width: 1280px) {
   .overviewSection [data-fs-carousel-track-container] { padding: 0 70px; }
+  .overviewSection [data-fs-carousel-controls] { width: 100%; }
 }
 
 .overviewSection>[data-doc-overview-group] [data-doc-overview-group-title] {

--- a/apps/site/components/ProductShelf/ProductShelfCarouselUsage.tsx
+++ b/apps/site/components/ProductShelf/ProductShelfCarouselUsage.tsx
@@ -22,7 +22,7 @@ const ProductShelfCarouselUsage = () => {
         infiniteMode={false}
       >
         {products.map(({ product }, idx) => (
-          <ProductCard bordered>
+          <ProductCard bordered key={idx}>
             <ProductCardImage>
               <img
                 data-fs-image

--- a/apps/site/components/ProductShelf/ProductShelfUsage.tsx
+++ b/apps/site/components/ProductShelf/ProductShelfUsage.tsx
@@ -17,12 +17,14 @@ export interface ProductShelfUsageProps {
   bordered?: boolean
   aspectRatio?: number
   items?: number
+  id?: string
 }
 
 const ProductShelfUsage = ({
   withButton,
   bordered,
   aspectRatio,
+  id = 'shelf-example-0',
   items = 10,
 }: ProductShelfUsageProps) => {
   const productsArray = items ? products.slice(0, items) : products
@@ -31,7 +33,7 @@ const ProductShelfUsage = ({
     <ProductShelf>
       <ProductShelfItems>
         {productsArray.map(({ product }, idx) => (
-          <ProductShelfItem key={idx}>
+          <ProductShelfItem key={`${id}-${idx}}`}>
             <ProductCard bordered={bordered}>
               <ProductCardImage aspectRatio={aspectRatio}>
                 <img

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -441,7 +441,7 @@ Considering the component structure placed inside the `Carousel`, determine the 
 
 ### ❌ Don'ts
 
-- Avoid using it when display 1 or 2 items (desktop).
+- Avoid using it when displaying 1 or 2 items (desktop).
 - Don't exaggerate the number of items. You can combine it, providing an alternate navigation path like a `See More` button to a collection.
 
 ---

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -58,10 +58,6 @@ Slides through multiple elements using custom controls.
 
 </header>
 
-We recommend using Carousel when displaying at least 10 items.
-
----
-
 ## Import
 
 Import the component from [@faststore/ui](/../components)
@@ -81,8 +77,7 @@ import '@faststore/ui/src/components/molecules/Carousel/styles.scss'
 ## Usage
 
 <Callout type="warning" emoji="⚠️">
-  This component is a work in progress, so it might not work as expected in some
-  cases, we gratefully accept feedback.
+ This component is a work in progress, and in some cases, it may not perform as expected.
 </Callout>
 
 #### Default

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -439,7 +439,7 @@ Considering the component structure placed inside the `Carousel`, determine the 
 
 ### ❌ Don'ts
 
-- Don't exaggerate the number of items. You can combine it, providing an alternate navigation path like a `See More` button to a collection.
+- Don't exaggerate the number of items according to the item's width. You can combine it, providing an alternate navigation path like a `See More` button to a collection. Also, make sure to check how they look in different screens.
 
 ---
 

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -128,8 +128,9 @@ import '@faststore/ui/src/components/molecules/Carousel/styles.scss'
   </Tab>
   <Tab>
     ```tsx
+    const isMobile = window.innerWidth <= 768
     <Carousel
-      itemsPerPage={5}
+      itemsPerPage={isMobile ? 1 : 5}
       variant="scroll"
     >
      {[...Array(10)].map((_, index) => (
@@ -149,7 +150,9 @@ import '@faststore/ui/src/components/molecules/Carousel/styles.scss'
   </Tab>
   <Tab>
     ```tsx
+    const isMobile = window.innerWidth <= 768
     <Carousel
+      itemsPerPage={isMobile ? 1 : 10}
       itemsPerPage={10}
       variant="scroll"
     >

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -348,7 +348,7 @@ For further customization, you can use the following data attributes:
 
 ### Using `ProductCard` component
 
-For the mobile preview, please refresh the browser after resize it.
+For the mobile preview, please refresh the browser after resizing it.
 
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -439,7 +439,7 @@ Considering the component structure placed inside the `Carousel`, determine the 
 ### ✅ Do's
 
 - We recommend using Carousel when the total of items being displayed is at least 10 items.
-- Choose an `itemsPerPage` value that effectively accommodate the items within the slide without compromising the UI. (Consider proposing different values for mobile and desktop)
+- Choose an `itemsPerPage` value that effectively accommodates the items within the slide without compromising the UI. Consider proposing different values for mobile and desktop.
 - Maintain the visibility of the controls (`navigationArrows` & `paginationBullets`) to ensure that users can easily navigate through the slider. On desktop, these controls are displayed on `hover`, allowing for intuitive item selection.
 
 ### ❌ Don'ts

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -154,9 +154,6 @@ For the mobile preview, please refresh the browser after resize it.
 #### Item
 
 <TokenTable>
-  <TokenRow token="--fs-carousel-item-width-mobile" value="60%" />
-  <TokenRow token="--fs-carousel-item-width-tablet" value="14.2rem" />
-  <TokenRow token="--fs-carousel-item-width-desktop" value="14.4rem" />
   <TokenRow
     token="--fs-carousel-item-margin-right"
     value="var(--fs-spacing-3)"

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -435,13 +435,12 @@ Considering the component structure placed inside the `Carousel`, determine the 
 
 ### ✅ Do's
 
-- Always use more than 1 item per page so then the component keeps the proposed navigation behavior for both versions (mobile and desktop).
-- We recommend using Carousel when displaying at least 10 items.
+- We recommend using Carousel when the total of items displaying is least 10 items.
+- Choose an `itemsPerPage` value that effectively accommodate the items within the slide without compromising the UI. (Consider proposing different values for mobile and desktop)
 - Maintain the visibility of the controls (`navigationArrows` & `paginationBullets`) to ensure that users can easily navigate through the slider. On desktop, these controls are displayed on `hover`, allowing for intuitive item selection.
 
 ### ❌ Don'ts
 
-- Avoid using it when displaying 1 or 2 items (desktop).
 - Don't exaggerate the number of items. You can combine it, providing an alternate navigation path like a `See More` button to a collection.
 
 ---

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -438,7 +438,7 @@ Considering the component structure placed inside the `Carousel`, determine the 
 
 ### ✅ Do's
 
-- We recommend using Carousel when the total of items displaying is least 10 items.
+- We recommend using Carousel when the total of items being displayed is at least 10 items.
 - Choose an `itemsPerPage` value that effectively accommodate the items within the slide without compromising the UI. (Consider proposing different values for mobile and desktop)
 - Maintain the visibility of the controls (`navigationArrows` & `paginationBullets`) to ensure that users can easily navigate through the slider. On desktop, these controls are displayed on `hover`, allowing for intuitive item selection.
 

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -89,9 +89,22 @@ import '@faststore/ui/src/components/molecules/Carousel/styles.scss'
 
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
+  `itemsPerPage = 1`
     <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselSimpleUsage itemsPerPage={1}/></OverviewSection>
   </Tab>
   <Tab>
+    ```css
+    .carouselItem {
+      width: 100%;
+      height: 5rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: var(--fs-text-size-3);
+      font-weight: var(--fs-text-weight-bold);
+      background: var(--fs-color-accent-1);
+    }
+    ```
     ```tsx
     <Carousel
       itemsPerPage={1}
@@ -109,6 +122,7 @@ import '@faststore/ui/src/components/molecules/Carousel/styles.scss'
 
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
+  `itemsPerPage = 5`
     <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselSimpleUsage /></OverviewSection>
   </Tab>
   <Tab>
@@ -129,6 +143,7 @@ import '@faststore/ui/src/components/molecules/Carousel/styles.scss'
 
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
+  `itemsPerPage = 10`
     <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselSimpleUsage itemsPerPage={10}/></OverviewSection>
   </Tab>
   <Tab>
@@ -331,10 +346,9 @@ For further customization, you can use the following data attributes:
 
 For the mobile preview, please refresh the browser after resize it.
 
-`itemsPerPage = 3`
-
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
+  `itemsPerPage = 3`
     <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselUsage /></OverviewSection>
   </Tab>
   <Tab>
@@ -372,10 +386,9 @@ For the mobile preview, please refresh the browser after resize it.
   </Tab>
 </Tabs>
 
-`itemsPerPage = 8`
-
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
+  `itemsPerPage = 8`
     <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselUsage itemsPerPage={8}/></OverviewSection>
   </Tab>
   <Tab>
@@ -423,11 +436,11 @@ For the mobile preview, please refresh the browser after resize it.
 
 - Always use more than 1 item per page so then the component keeps the proposed navigation behavior for both versions (mobile and desktop).
 - We recommend using Carousel when displaying at least 10 items.
-- Keep the controls (`navigationArrows` & `paginationBullets`) visible. It's important to let people in slider control to move the items.
+- Maintain the visibility of the controls (`navigationArrows` & `paginationBullets`) to ensure that users can easily navigate through the slider. On desktop, these controls are displayed on `hover`, allowing for intuitive item selection.
 
 ### ❌ Don'ts
 
-- Avoid using it when display 1 or 2 items.
+- Avoid using it when display 1 or 2 items (desktop).
 - Don't exaggerate the number of items. You can combine it, providing an alternate navigation path like a `See More` button to a collection.
 
 ---

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -85,6 +85,8 @@ import '@faststore/ui/src/components/molecules/Carousel/styles.scss'
   cases, we gratefully accept feedback.
 </Callout>
 
+#### Default
+
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
     <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselSimpleUsage itemsPerPage={1}/></OverviewSection>
@@ -134,6 +136,33 @@ import '@faststore/ui/src/components/molecules/Carousel/styles.scss'
     <Carousel
       itemsPerPage={10}
       variant="scroll"
+    >
+     {[...Array(10)].map((_, index) => (
+        <div key={index} className={styles.carouselItem}>
+          {index + 1}
+        </div>
+      ))}
+    </Carousel>
+    ```
+  </Tab>
+</Tabs>
+
+#### Infinite Scroll Mode
+
+<Callout type="warning" emoji="⚠️">
+  This mode is only supported given the following props setup: `itemsPerPage={1}`, `variant="slide"` and `infiniteMode={true}`
+</Callout>
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselSimpleUsage itemsPerPage={1} infiniteMode={true} variant='slide'/></OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Carousel
+      itemsPerPage={1}
+      variant="slide"
+      infiniteMode={true}
     >
      {[...Array(10)].map((_, index) => (
         <div key={index} className={styles.carouselItem}>

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -331,6 +331,8 @@ For further customization, you can use the following data attributes:
 
 For the mobile preview, please refresh the browser after resize it.
 
+`itemsPerPage = 3`
+
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
     <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselUsage /></OverviewSection>
@@ -370,6 +372,8 @@ For the mobile preview, please refresh the browser after resize it.
   </Tab>
 </Tabs>
 
+`itemsPerPage = 8`
+
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
     <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselUsage itemsPerPage={8}/></OverviewSection>
@@ -403,11 +407,13 @@ For the mobile preview, please refresh the browser after resize it.
         </ProductCard>
       ))}
     </Carousel>
-
     ```
-
   </Tab>
 </Tabs>
+
+<Callout type="warning" emoji="⚠️">
+  Considering the component structure placed inside the `Carousel`, consider to determine the ideal `itemsPerPage` number to properly accommodate the items and achieve the desired UI.
+</Callout>
 
 ---
 

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -20,6 +20,8 @@ import {
 } from '@faststore/ui'
 
 import CarouselUsage from 'site/components/Carousel/CarouselUsage'
+import CarouselSimpleUsage from 'site/components/Carousel/CarouselSimpleUsage'
+
 import { products } from 'site/mocks/products'
 import { useFormattedPrice } from 'site/components/utilities/usePriceFormatter'
 
@@ -79,52 +81,69 @@ import '@faststore/ui/src/components/molecules/Carousel/styles.scss'
 ## Usage
 
 <Callout type="warning" emoji="⚠️">
-  This component is a work in progress, so it might work as expected in some
+  This component is a work in progress, so it might not work as expected in some
   cases, we gratefully accept feedback.
 </Callout>
 
-For the mobile preview, please refresh the browser after resize it.
-
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
-    <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselUsage /></OverviewSection>
+    <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselSimpleUsage itemsPerPage={1}/></OverviewSection>
   </Tab>
   <Tab>
     ```tsx
-    const isMobile = window.innerWidth <= 768
-
     <Carousel
-      itemsPerPage={isMobile ? 1 : 3}
+      itemsPerPage={1}
       variant="scroll"
-      infiniteMode={false}
     >
-      {products.map(({ product }, idx) => (
-        <ProductCard key={idx}>
-          <ProductCardImage>
-            <img
-              data-fs-image
-              src={product.image[0].url}
-              alt={product.image[0].alternateName}
-            />
-          </ProductCardImage>
-          <ProductCardContent
-            title={product.isVariantOf.name}
-            price={{
-              value: product.offers.offers[0].price,
-              listPrice: product.offers.offers[0].listPrice,
-              formatter: useFormattedPrice,
-            }}
-          />
-        </ProductCard>
+     {[...Array(10)].map((_, index) => (
+        <div key={index} className={styles.carouselItem}>
+          {index + 1}
+        </div>
       ))}
     </Carousel>
-
     ```
-
   </Tab>
 </Tabs>
 
----
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselSimpleUsage /></OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Carousel
+      itemsPerPage={5}
+      variant="scroll"
+    >
+     {[...Array(10)].map((_, index) => (
+        <div key={index} className={styles.carouselItem}>
+          {index + 1}
+        </div>
+      ))}
+    </Carousel>
+    ```
+  </Tab>
+</Tabs>
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselSimpleUsage itemsPerPage={10}/></OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <Carousel
+      itemsPerPage={10}
+      variant="scroll"
+    >
+     {[...Array(10)].map((_, index) => (
+        <div key={index} className={styles.carouselItem}>
+          {index + 1}
+        </div>
+      ))}
+    </Carousel>
+    ```
+  </Tab>
+</Tabs>
 
 ## Props
 
@@ -277,6 +296,92 @@ For further customization, you can use the following data attributes:
 
 ---
 
+## Examples
+
+### Using `ProductCard` component
+
+For the mobile preview, please refresh the browser after resize it.
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselUsage /></OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    const isMobile = window.innerWidth <= 768
+
+    <Carousel
+      itemsPerPage={isMobile ? 1 : 3}
+      variant="scroll"
+      infiniteMode={false}
+    >
+      {products.map(({ product }, idx) => (
+        <ProductCard key={idx}>
+          <ProductCardImage>
+            <img
+              data-fs-image
+              src={product.image[0].url}
+              alt={product.image[0].alternateName}
+            />
+          </ProductCardImage>
+          <ProductCardContent
+            title={product.isVariantOf.name}
+            price={{
+              value: product.offers.offers[0].price,
+              listPrice: product.offers.offers[0].listPrice,
+              formatter: useFormattedPrice,
+            }}
+          />
+        </ProductCard>
+      ))}
+    </Carousel>
+
+    ```
+
+  </Tab>
+</Tabs>
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection style={{ width: '100%', overflow: 'hidden' }}><CarouselUsage itemsPerPage={8}/></OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    const isMobile = window.innerWidth <= 768
+
+    <Carousel
+      itemsPerPage={isMobile ? 1 : 8}
+      variant="scroll"
+      infiniteMode={false}
+    >
+      {products.map(({ product }, idx) => (
+        <ProductCard key={idx}>
+          <ProductCardImage>
+            <img
+              data-fs-image
+              src={product.image[0].url}
+              alt={product.image[0].alternateName}
+            />
+          </ProductCardImage>
+          <ProductCardContent
+            title={product.isVariantOf.name}
+            price={{
+              value: product.offers.offers[0].price,
+              listPrice: product.offers.offers[0].listPrice,
+              formatter: useFormattedPrice,
+            }}
+          />
+        </ProductCard>
+      ))}
+    </Carousel>
+
+    ```
+
+  </Tab>
+</Tabs>
+
+---
+
 ## Best Practices
 
 ### ✅ Do's
@@ -304,7 +409,7 @@ For further customization, you can use the following data attributes:
     <ProductShelf>
       <ProductShelfItems>
         {products.map(({ product }, idx) => (
-          <ProductShelfItem>
+          <ProductShelfItem key={idx}>
             <ProductCard>
               <ProductCardImage>
                 <img

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -94,6 +94,7 @@ import '@faststore/ui/src/components/molecules/Carousel/styles.scss'
   </Tab>
   <Tab>
     ```css
+    //  Styles of colored items (ignore this if you're replacing it)
     .carouselItem {
       width: 100%;
       height: 5rem;

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -340,7 +340,7 @@ For further customization, you can use the following data attributes:
 
 ---
 
-## Examples
+## Use Cases
 
 ### Using `ProductCard` component
 

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -425,7 +425,7 @@ For the mobile preview, please refresh the browser after resize it.
 </Tabs>
 
 <Callout type="warning" emoji="⚠️">
-  Considering the component structure placed inside the `Carousel`, consider to determine the ideal `itemsPerPage` number to properly accommodate the items and achieve the desired UI.
+Considering the component structure placed inside the `Carousel`, determine the ideal `itemsPerPage` number to accommodate the items and achieve the desired UI properly.
 </Callout>
 
 ---

--- a/apps/site/pages/components/molecules/carousel.mdx
+++ b/apps/site/pages/components/molecules/carousel.mdx
@@ -94,7 +94,7 @@ import '@faststore/ui/src/components/molecules/Carousel/styles.scss'
   </Tab>
   <Tab>
     ```css
-    //  Styles of colored items (ignore this if you're replacing it)
+    //  Styles of colored items example (ignore this if you're replacing it)
     .carouselItem {
       width: 100%;
       height: 5rem;

--- a/apps/site/pages/components/organisms/product-shelf.mdx
+++ b/apps/site/pages/components/organisms/product-shelf.mdx
@@ -104,7 +104,7 @@ import '@faststore/ui/src/components/organisms/ProductShelf/styles.scss'
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
     <OverviewSection containerStyle={{ justifyContent: 'center' }}>
-      <ProductShelfUsage items={6}/>
+      <ProductShelfUsage items={6} id="shelf-example-1"/>
     </OverviewSection>
   </Tab>
   <Tab>
@@ -112,7 +112,7 @@ import '@faststore/ui/src/components/organisms/ProductShelf/styles.scss'
       <ProductShelf>
         <ProductShelfItems>
           {products.map(({ product }, idx) => (
-            <ProductShelfItem>
+            <ProductShelfItem key={idx}>
               <ProductCard>
                 <ProductCardImage>
                   <img
@@ -189,7 +189,7 @@ You can use [ProductCard variants](/components/molecules/product-card#variants) 
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
     <OverviewSection containerStyle={{ justifyContent: 'center' }}>
-      <ProductShelfUsage withButton items={4}/>
+      <ProductShelfUsage withButton items={4} id="shelf-example-2"/>
     </OverviewSection>
 
   </Tab>
@@ -198,7 +198,7 @@ You can use [ProductCard variants](/components/molecules/product-card#variants) 
       <ProductShelf>
         <ProductShelfItems>
           {products.map(({ product }, idx) => (
-            <ProductShelfItem>
+            <ProductShelfItem key={idx}>
               <ProductCard>
                 <ProductCardImage>
                   <img
@@ -231,7 +231,7 @@ You can use [ProductCard variants](/components/molecules/product-card#variants) 
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
     <OverviewSection containerStyle={{ justifyContent: 'center' }}>
-     <ProductShelfUsage bordered items={4}/>
+     <ProductShelfUsage bordered items={4} id="shelf-example-3"/>
     </OverviewSection>
 
   </Tab>
@@ -241,7 +241,7 @@ You can use [ProductCard variants](/components/molecules/product-card#variants) 
         <ProductShelfItems>
           {products.map(({ product }, idx) => (
             <ProductShelfItem>
-              <ProductCard bordered>
+              <ProductCard bordered key={idx}>
                 <ProductCardImage>
                   <img
                     data-fs-image
@@ -272,7 +272,7 @@ You can use [ProductCard variants](/components/molecules/product-card#variants) 
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
     <OverviewSection containerStyle={{ justifyContent: 'center' }}>
-      <ProductShelfUsage aspectRatio={3/4}/>
+      <ProductShelfUsage aspectRatio={3/4} id="shelf-example-4"/>
     </OverviewSection>
 
   </Tab>
@@ -281,7 +281,7 @@ You can use [ProductCard variants](/components/molecules/product-card#variants) 
       <ProductShelf>
         <ProductShelfItems>
           {products.map(({ product }, idx) => (
-            <ProductShelfItem>
+            <ProductShelfItem key={idx}>
               <ProductCard>
                 <ProductCardImage aspectRatio={3 / 4}>
                   <img
@@ -329,7 +329,7 @@ You can use [ProductCard variants](/components/molecules/product-card#variants) 
             infiniteMode={false}
           >
           {products.map(({ product }, idx) => (
-            <ProductCard>
+            <ProductCard key={idx}>
               <ProductCardImage aspectRatio={3 / 4}>
                 <img
                   data-fs-image

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -101,6 +101,10 @@ function Carousel({
   navigationIcons = undefined,
   ...swipeableConfigOverrides
 }: PropsWithChildren<CarouselProps>) {
+  if (itemsPerPage < 1) {
+    throw new Error('itemsPerPage must be greater than or equal to 1')
+  }
+
   const carouselTrackRef = useRef<HTMLUListElement>(null)
   const isSlideCarousel = variant === 'slide'
   const isScrollCarousel = variant === 'scroll'

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -133,11 +133,12 @@ function Carousel({
 
     if (item) {
       setMarginRight(getComputedStyle(item).getPropertyValue('margin-right'))
+
       setCarouselItemsWidth(
         Number(item.clientWidth) + parseInt(marginRight, 10) + 1
       )
     }
-  }, [marginRight])
+  }, [carouselItemsWidth])
 
   const showNavigationArrows =
     pagesCount !== 1 &&

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -347,6 +347,7 @@ function Carousel({
           <IconButton
             data-fs-carousel-control="left"
             aria-controls={id}
+            disabled={sliderState.currentPage == 0}
             aria-label="previous"
             icon={
               navigationIcons?.left ?? (
@@ -362,6 +363,7 @@ function Carousel({
           <IconButton
             data-fs-carousel-control="right"
             aria-controls={id}
+            disabled={sliderState.currentPage === sliderState.totalPages - 1}
             aria-label="next"
             icon={
               navigationIcons?.right ?? (

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -236,6 +236,20 @@ function Carousel({
     }
   }
 
+  let carouselItemsWidth = Number(
+    carouselTrackRef.current?.firstElementChild?.clientWidth
+  )
+
+  const carouselItem = carouselTrackRef.current?.firstElementChild
+
+  let marginRight: string
+
+  if (carouselItem) {
+    marginRight =
+      getComputedStyle(carouselItem).getPropertyValue('margin-right')
+    carouselItemsWidth = carouselItemsWidth + parseInt(marginRight, 10) + 1
+  }
+
   const onScrollPagination = async (
     index: number,
     slideDirection?: 'previous' | 'next'
@@ -252,9 +266,6 @@ function Carousel({
     }
 
     let scrollOffset
-    const carouselItemsWidth = Number(
-      carouselTrackRef.current?.firstElementChild?.clientWidth
-    )
 
     if (itemsPerPage > 1) {
       scrollOffset = index * carouselItemsWidth * itemsPerPage
@@ -300,17 +311,6 @@ function Carousel({
       default:
     }
   }
-
-  const element = document.querySelector('[data-fs-carousel]')
-
-  const marginRight = useMemo(() => {
-    if (element) {
-      return getComputedStyle(element).getPropertyValue(
-        '--fs-carousel-item-margin-right'
-      )
-    }
-    return null
-  }, [element])
 
   return (
     <section

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -267,11 +267,7 @@ function Carousel({
 
     let scrollOffset
 
-    if (itemsPerPage > 1) {
-      scrollOffset = index * carouselItemsWidth * itemsPerPage
-    } else {
-      scrollOffset = index * carouselItemsWidth - carouselItemsWidth * 0.125
-    }
+    scrollOffset = index * carouselItemsWidth * itemsPerPage
 
     carouselTrackRef.current?.scrollTo({
       left: scrollOffset,

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -301,6 +301,17 @@ function Carousel({
     }
   }
 
+  const element = document.querySelector('[data-fs-carousel]')
+
+  const marginRight = useMemo(() => {
+    if (element) {
+      return getComputedStyle(element).getPropertyValue(
+        '--fs-carousel-item-margin-right'
+      )
+    }
+    return null
+  }, [element])
+
   return (
     <section
       id={id}
@@ -335,6 +346,7 @@ function Carousel({
               totalItems={childrenCount}
               infiniteMode={infiniteMode}
               isScrollCarousel={isScrollCarousel}
+              marginRightValue={marginRight || '1rem'}
             >
               {currentSlide}
             </CarouselItem>

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -316,6 +316,7 @@ function Carousel({
     <section
       id={id}
       data-fs-carousel
+      data-fs-carousel-variant={variant}
       className={className}
       data-testid={testId}
       aria-label={ariaLabel}

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -359,7 +359,7 @@ function Carousel({
           <IconButton
             data-fs-carousel-control="left"
             aria-controls={id}
-            disabled={!infiniteMode && sliderState.currentPage == 0}
+            disabled={!infiniteMode && sliderState.currentPage === 0}
             aria-label="previous"
             icon={
               navigationIcons?.left ?? (

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -88,7 +88,7 @@ function Carousel({
   children,
   className,
   'aria-label': ariaLabel,
-  infiniteMode = true,
+  infiniteMode = false,
   controls = 'complete',
   testId = 'fs-carousel',
   transition = {

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -6,7 +6,7 @@ import type {
   UIEvent,
   AriaAttributes,
 } from 'react'
-import React, { useMemo, useRef } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import type { SwipeableProps } from 'react-swipeable'
 
 import { Icon, IconButton } from '../..'
@@ -120,6 +120,20 @@ function Carousel({
   })
 
   const pagesCount = Math.ceil(childrenCount / sliderState.itemsPerPage)
+
+  const [marginRight, setMarginRight] = useState('16px')
+  const [carouselItemsWidth, setCarouselItemsWidth] = useState(0)
+
+  useEffect(() => {
+    const item = carouselTrackRef.current?.firstElementChild
+
+    if (item) {
+      setMarginRight(getComputedStyle(item).getPropertyValue('margin-right'))
+      setCarouselItemsWidth(
+        Number(item.clientWidth) + parseInt(marginRight, 10) + 1
+      )
+    }
+  }, [marginRight])
 
   const showNavigationArrows =
     pagesCount !== 1 &&
@@ -236,20 +250,6 @@ function Carousel({
     }
   }
 
-  let carouselItemsWidth = Number(
-    carouselTrackRef.current?.firstElementChild?.clientWidth
-  )
-
-  const carouselItem = carouselTrackRef.current?.firstElementChild
-
-  let marginRight: string
-
-  if (carouselItem) {
-    marginRight =
-      getComputedStyle(carouselItem).getPropertyValue('margin-right')
-    carouselItemsWidth = carouselItemsWidth + parseInt(marginRight, 10) + 1
-  }
-
   const onScrollPagination = async (
     index: number,
     slideDirection?: 'previous' | 'next'
@@ -265,9 +265,7 @@ function Carousel({
       return
     }
 
-    let scrollOffset
-
-    scrollOffset = index * carouselItemsWidth * itemsPerPage
+    let scrollOffset = index * carouselItemsWidth * itemsPerPage
 
     carouselTrackRef.current?.scrollTo({
       left: scrollOffset,
@@ -343,7 +341,7 @@ function Carousel({
               totalItems={childrenCount}
               infiniteMode={infiniteMode}
               isScrollCarousel={isScrollCarousel}
-              marginRightValue={marginRight || '1rem'}
+              marginRightValue={marginRight}
             >
               {currentSlide}
             </CarouselItem>

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -96,7 +96,7 @@ function Carousel({
     property: 'transform',
   },
   id = 'fs-carousel',
-  variant = 'slide',
+  variant = 'scroll',
   itemsPerPage = 1,
   navigationIcons = undefined,
   ...swipeableConfigOverrides

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -354,7 +354,7 @@ function Carousel({
           <IconButton
             data-fs-carousel-control="left"
             aria-controls={id}
-            disabled={sliderState.currentPage == 0}
+            disabled={!infiniteMode && sliderState.currentPage == 0}
             aria-label="previous"
             icon={
               navigationIcons?.left ?? (
@@ -370,7 +370,10 @@ function Carousel({
           <IconButton
             data-fs-carousel-control="right"
             aria-controls={id}
-            disabled={sliderState.currentPage === sliderState.totalPages - 1}
+            disabled={
+              !infiniteMode &&
+              sliderState.currentPage === sliderState.totalPages - 1
+            }
             aria-label="next"
             icon={
               navigationIcons?.right ?? (

--- a/packages/components/src/molecules/Carousel/CarouselItem.tsx
+++ b/packages/components/src/molecules/Carousel/CarouselItem.tsx
@@ -8,6 +8,7 @@ export interface CarouselItemProps extends HTMLAttributes<HTMLLIElement> {
   state: SliderState
   infiniteMode: boolean
   isScrollCarousel: boolean
+  marginRightValue: string
 }
 
 function CarouselItem({
@@ -18,6 +19,7 @@ function CarouselItem({
   totalItems,
   infiniteMode,
   isScrollCarousel,
+  marginRightValue,
 }: PropsWithChildren<CarouselItemProps>) {
   const { isItemVisible, shouldRenderItem } = useSlideVisibility({
     totalItems,
@@ -28,7 +30,9 @@ function CarouselItem({
   const style =
     ((!isScrollCarousel && { width: '100%' }) as CSSProperties) ||
     ((isScrollCarousel && {
-      flex: `0 0 ${95 / state.itemsPerPage}%`,
+      flex: `0 0 calc((100% - ${marginRightValue} * ${
+        state.itemsPerPage - 1
+      })/ ${state.itemsPerPage})`,
       // maxWidth: '60%',
       display: 'inline-block',
     }) as CSSProperties)

--- a/packages/components/src/molecules/Carousel/CarouselItem.tsx
+++ b/packages/components/src/molecules/Carousel/CarouselItem.tsx
@@ -28,7 +28,8 @@ function CarouselItem({
   const style =
     ((!isScrollCarousel && { width: '100%' }) as CSSProperties) ||
     ((isScrollCarousel && {
-      maxWidth: '60%',
+      flex: `0 0 ${95 / state.itemsPerPage}%`,
+      // maxWidth: '60%',
       display: 'inline-block',
     }) as CSSProperties)
 

--- a/packages/components/src/molecules/Carousel/CarouselItem.tsx
+++ b/packages/components/src/molecules/Carousel/CarouselItem.tsx
@@ -29,12 +29,15 @@ function CarouselItem({
 
   const style =
     ((!isScrollCarousel && { width: '100%' }) as CSSProperties) ||
-    ((isScrollCarousel && {
-      flex: `0 0 calc((100% - ${marginRightValue} * ${
-        state.itemsPerPage - 1
-      })/ ${state.itemsPerPage})`,
-      maxWidth: '60%',
-      display: 'inline-block',
+    ((state.itemsPerPage > 1 &&
+      isScrollCarousel && {
+        flex: `1 1 auto`,
+        width: `calc((100% - ${marginRightValue} * ${
+          state.itemsPerPage - 1
+        })/ ${state.itemsPerPage})`,
+      }) as CSSProperties) ||
+    ((state.itemsPerPage === 1 && {
+      width: '100%',
     }) as CSSProperties)
 
   const shouldDisplayItem =

--- a/packages/components/src/molecules/Carousel/CarouselItem.tsx
+++ b/packages/components/src/molecules/Carousel/CarouselItem.tsx
@@ -27,17 +27,18 @@ function CarouselItem({
     itemsPerPage: state.itemsPerPage,
   })
 
-  const style =
-    ((!isScrollCarousel && { width: '100%' }) as CSSProperties) ||
-    ((state.itemsPerPage > 1 &&
-      isScrollCarousel && {
-        width: `calc((100% - ${marginRightValue} * ${
-          state.itemsPerPage - 1
-        })/ ${state.itemsPerPage})`,
-      }) as CSSProperties) ||
-    ((state.itemsPerPage === 1 && {
-      width: '100%',
-    }) as CSSProperties)
+  const defaultStyle = { width: '100%' } as CSSProperties
+  const scrollCarouselStyle = {
+    width: `calc((100% - ${marginRightValue} * ${state.itemsPerPage - 1}) / ${
+      state.itemsPerPage
+    })`,
+  } as CSSProperties
+
+  const style = isScrollCarousel
+    ? state.itemsPerPage > 1
+      ? { ...scrollCarouselStyle }
+      : { ...defaultStyle }
+    : { ...defaultStyle }
 
   const shouldDisplayItem =
     isScrollCarousel || shouldRenderItem(index - Number(infiniteMode))

--- a/packages/components/src/molecules/Carousel/CarouselItem.tsx
+++ b/packages/components/src/molecules/Carousel/CarouselItem.tsx
@@ -33,7 +33,7 @@ function CarouselItem({
       flex: `0 0 calc((100% - ${marginRightValue} * ${
         state.itemsPerPage - 1
       })/ ${state.itemsPerPage})`,
-      // maxWidth: '60%',
+      maxWidth: '60%',
       display: 'inline-block',
     }) as CSSProperties)
 

--- a/packages/components/src/molecules/Carousel/CarouselItem.tsx
+++ b/packages/components/src/molecules/Carousel/CarouselItem.tsx
@@ -34,10 +34,8 @@ function CarouselItem({
     })`,
   } as CSSProperties
 
-  const style = isScrollCarousel
-    ? state.itemsPerPage > 1
-      ? { ...scrollCarouselStyle }
-      : { ...defaultStyle }
+  const style = isScrollCarousel && state.itemsPerPage > 1
+    ? { ...scrollCarouselStyle }
     : { ...defaultStyle }
 
   const shouldDisplayItem =

--- a/packages/components/src/molecules/Carousel/CarouselItem.tsx
+++ b/packages/components/src/molecules/Carousel/CarouselItem.tsx
@@ -31,7 +31,6 @@ function CarouselItem({
     ((!isScrollCarousel && { width: '100%' }) as CSSProperties) ||
     ((state.itemsPerPage > 1 &&
       isScrollCarousel && {
-        flex: `1 1 auto`,
         width: `calc((100% - ${marginRightValue} * ${
           state.itemsPerPage - 1
         })/ ${state.itemsPerPage})`,

--- a/packages/core/src/components/sections/ProductShelf/section.module.scss
+++ b/packages/core/src/components/sections/ProductShelf/section.module.scss
@@ -1,10 +1,8 @@
 @layer components {
   .section {
-
-    [data-fs-content="product-shelf"] { @include layout-content-full; }
+    // [data-fs-content="product-shelf"] { @include layout-content-full; }
 
     [data-fs-product-shelf-skeleton] {
-      --fs-carousel-item-width-tablet    : 14.2rem;
       --fs-carousel-item-margin-right    : var(--fs-spacing-3);
 
       padding-bottom: var(--fs-spacing-5);
@@ -16,10 +14,6 @@
           &:not(:last-of-type) {
             margin-right: var(--fs-carousel-item-margin-right);
           }
-        }
-
-        [data-fs-product-card-skeleton] {
-          width: var(--fs-carousel-item-width-tablet);
         }
       }
     }

--- a/packages/core/src/components/sections/ProductShelf/section.module.scss
+++ b/packages/core/src/components/sections/ProductShelf/section.module.scss
@@ -1,7 +1,5 @@
 @layer components {
   .section {
-    // [data-fs-content="product-shelf"] { @include layout-content-full; }
-
     [data-fs-product-shelf-skeleton] {
       --fs-carousel-item-margin-right    : var(--fs-spacing-3);
 

--- a/packages/core/src/components/skeletons/ProductShelfSkeleton/ProductShelfSkeleton.tsx
+++ b/packages/core/src/components/skeletons/ProductShelfSkeleton/ProductShelfSkeleton.tsx
@@ -6,24 +6,24 @@ import {
   ProductShelf as UIProductShelf,
 } from '@faststore/ui'
 
-import { ITEMS_PER_SECTION } from 'src/constants'
-
 import ProductCardSkeleton from '../ProductCardSkeleton'
 
 interface Props {
   loading?: boolean
   aspectRatio?: number
+  itemsPerPage?: number
 }
 
 function ProductShelfSkeleton({
   children,
   aspectRatio,
+  itemsPerPage,
   loading = true,
 }: PropsWithChildren<Props>) {
   return loading ? (
     <UIProductShelf data-fs-product-shelf-skeleton>
       <ProductShelfItems>
-        {Array.from({ length: ITEMS_PER_SECTION }, (_, index) => (
+        {Array.from({ length: itemsPerPage }, (_, index) => (
           <ProductShelfItem key={String(index)}>
             <ProductCardSkeleton aspectRatio={aspectRatio} sectioned bordered />
           </ProductShelfItem>

--- a/packages/core/src/components/ui/Carousel/Carousel.tsx
+++ b/packages/core/src/components/ui/Carousel/Carousel.tsx
@@ -12,7 +12,7 @@ function Carousel({
   id,
   testId,
   children,
-  itemsPerPage = 5,
+  itemsPerPage,
 }: PropsWithChildren<CarouselProps>) {
   const isMobile = window.innerWidth <= 768
 

--- a/packages/core/src/components/ui/Carousel/Carousel.tsx
+++ b/packages/core/src/components/ui/Carousel/Carousel.tsx
@@ -20,9 +20,9 @@ function Carousel({
     <UICarousel
       id={id}
       testId={testId}
-      variant="slide"
-      infiniteMode={true}
-      itemsPerPage={isMobile ? 2 : 1}
+      variant="scroll"
+      infiniteMode={false}
+      itemsPerPage={isMobile ? 2.3 : itemsPerPage}
     >
       {children}
     </UICarousel>

--- a/packages/core/src/components/ui/Carousel/Carousel.tsx
+++ b/packages/core/src/components/ui/Carousel/Carousel.tsx
@@ -20,9 +20,9 @@ function Carousel({
     <UICarousel
       id={id}
       testId={testId}
-      variant="scroll"
-      infiniteMode={false}
-      itemsPerPage={isMobile ? 1 : itemsPerPage}
+      variant="slide"
+      infiniteMode={true}
+      itemsPerPage={isMobile ? 2 : 1}
     >
       {children}
     </UICarousel>

--- a/packages/core/src/components/ui/Carousel/Carousel.tsx
+++ b/packages/core/src/components/ui/Carousel/Carousel.tsx
@@ -22,7 +22,7 @@ function Carousel({
       testId={testId}
       variant="scroll"
       infiniteMode={false}
-      itemsPerPage={isMobile ? 2.3 : itemsPerPage}
+      itemsPerPage={isMobile ? 1.6 : itemsPerPage}
     >
       {children}
     </UICarousel>

--- a/packages/core/src/components/ui/Carousel/Carousel.tsx
+++ b/packages/core/src/components/ui/Carousel/Carousel.tsx
@@ -6,13 +6,20 @@ export type CarouselProps = {
   id?: string
   testId?: string
   itemsPerPage?: number
-} & Pick<UICarouselProps, 'id' | 'testId' | 'itemsPerPage'>
+  variant?: 'slide' | 'scroll'
+  infiniteMode?: boolean
+} & Pick<
+  UICarouselProps,
+  'id' | 'testId' | 'itemsPerPage' | 'variant' | 'infiniteMode'
+>
 
 function Carousel({
   id,
   testId,
   children,
   itemsPerPage,
+  variant = 'slide',
+  infiniteMode = false,
 }: PropsWithChildren<CarouselProps>) {
   const isMobile = window.innerWidth <= 768
 
@@ -20,8 +27,8 @@ function Carousel({
     <UICarousel
       id={id}
       testId={testId}
-      variant="scroll"
-      infiniteMode={false}
+      variant={variant}
+      infiniteMode={infiniteMode}
       itemsPerPage={isMobile ? 1.6 : itemsPerPage}
     >
       {children}

--- a/packages/core/src/components/ui/Carousel/Carousel.tsx
+++ b/packages/core/src/components/ui/Carousel/Carousel.tsx
@@ -18,7 +18,7 @@ function Carousel({
   testId,
   children,
   itemsPerPage,
-  variant = 'slide',
+  variant = 'scroll',
   infiniteMode = false,
 }: PropsWithChildren<CarouselProps>) {
   const isMobile = window.innerWidth <= 768

--- a/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
@@ -86,11 +86,7 @@ function ProductShelf({
         itemsPerPage={itemsPerPage}
       >
         <ProductShelfWrapper.Component {...ProductShelfWrapper.props}>
-          <Carousel.Component
-            id={titleId || id}
-            {...Carousel.props}
-            itemsPerPage={itemsPerPage}
-          >
+          <Carousel.Component id={titleId || id} {...Carousel.props}>
             {productEdges.map((product, idx) => (
               <ProductCard.Component
                 aspectRatio={aspectRatio}

--- a/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
@@ -55,6 +55,7 @@ function ProductShelf({
   const products = data?.search?.products
   const productEdges = products?.edges ?? []
   const aspectRatio = 1
+  const itemsPerPage = 5
 
   const { sendViewItemListEvent } = useViewItemListEvent({
     products: productEdges,
@@ -81,9 +82,14 @@ function ProductShelf({
       <ProductShelfSkeleton
         aspectRatio={aspectRatio}
         loading={products === undefined}
+        itemsPerPage={itemsPerPage}
       >
         <ProductShelfWrapper.Component {...ProductShelfWrapper.props}>
-          <Carousel.Component id={titleId || id} {...Carousel.props}>
+          <Carousel.Component
+            id={titleId || id}
+            {...Carousel.props}
+            itemsPerPage={itemsPerPage}
+          >
             {productEdges.map((product, idx) => (
               <ProductCard.Component
                 aspectRatio={aspectRatio}

--- a/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
@@ -24,6 +24,7 @@ type Sort =
 export type ProductShelfProps = {
   title: string
   numberOfItems?: number
+  itemsPerPage?: number
   after?: string
   sort?: Sort
   term?: string
@@ -46,6 +47,7 @@ function ProductShelf({
     showDiscountBadge = ProductCard.props.showDiscountBadge,
   } = {},
   numberOfItems,
+  itemsPerPage = 5,
   ...otherProps
 }: ProductShelfProps) {
   const titleId = textToKebabCase(title)
@@ -55,7 +57,6 @@ function ProductShelf({
   const products = data?.search?.products
   const productEdges = products?.edges ?? []
   const aspectRatio = 1
-  const itemsPerPage = 5
 
   const { sendViewItemListEvent } = useViewItemListEvent({
     products: productEdges,

--- a/packages/ui/src/components/molecules/Carousel/styles.scss
+++ b/packages/ui/src/components/molecules/Carousel/styles.scss
@@ -3,11 +3,15 @@
   // Design Tokens for Carousel
   // --------------------------------------------------------
 
+  // --fs-carousel-item-per-page              : 5;
+
+
   // Track
   --fs-carousel-padding-mobile             : var(--fs-spacing-0) var(--fs-grid-padding);
   --fs-carousel-padding-desktop            : var(--fs-spacing-0) calc((100% - var(--fs-grid-max-width))/2) var(--fs-spacing-0);
 
   // Item
+
   --fs-carousel-item-width-mobile          : 60%;
   --fs-carousel-item-width-tablet          : 14.2rem;
   --fs-carousel-item-width-desktop         : 14.4rem;
@@ -59,9 +63,16 @@
   [data-fs-carousel-controls] {
     position: relative;
     display: flex;
+    pointer-events: auto;
+    max-width: calc(var(--fs-grid-max-width) + 6 * var(--fs-grid-padding));
+    margin: auto;
     opacity: 0;
-    pointer-events: none;
-    @include media(">=tablet") { margin: var(--fs-carousel-padding-desktop); }
+
+    // @include media(">=tablet") {
+    //   opacity: 1;
+    //   pointer-events: auto;
+    // }
+
   }
 
   [data-fs-carousel-control] {
@@ -78,17 +89,11 @@
   [data-fs-carousel-control="left"] {
     position: absolute;
     left: var(--fs-carousel-controls-control-right);
-    @include media(">notebook") {
-      left: var(--fs-carousel-controls-control-max-left);
-    }
   }
 
   [data-fs-carousel-control="right"] {
     position: absolute;
     right: var(--fs-carousel-controls-control-right);
-    @include media(">notebook") {
-      right: var(--fs-carousel-controls-control-max-right);
-    }
   }
 
   [data-fs-icon] {

--- a/packages/ui/src/components/molecules/Carousel/styles.scss
+++ b/packages/ui/src/components/molecules/Carousel/styles.scss
@@ -51,15 +51,6 @@
 
   width: inherit;
 
-  &:hover {
-    [data-fs-carousel-controls] {
-      @include media(">=tablet") {
-        opacity: 1;
-        pointer-events: auto;
-      }
-    }
-  }
-
   [data-fs-carousel-controls] {
     position: relative;
     display: flex;
@@ -68,10 +59,10 @@
     margin: auto;
     opacity: 0;
 
-    // @include media(">=tablet") {
-    //   opacity: 1;
-    //   pointer-events: auto;
-    // }
+    @include media(">=tablet") {
+      opacity: 1;
+      pointer-events: auto;
+    }
 
   }
 

--- a/packages/ui/src/components/molecules/Carousel/styles.scss
+++ b/packages/ui/src/components/molecules/Carousel/styles.scss
@@ -3,16 +3,13 @@
   // Design Tokens for Carousel
   // --------------------------------------------------------
 
-  // --fs-carousel-item-per-page              : 5;
-
-
   // Track
   --fs-carousel-padding-mobile             : var(--fs-spacing-0) var(--fs-grid-padding);
   --fs-carousel-padding-desktop            : var(--fs-spacing-0) calc((100% - var(--fs-grid-max-width))/2) var(--fs-spacing-0);
 
   // Item
 
-  --fs-carousel-item-width-mobile          : 60%;
+  // --fs-carousel-item-width-mobile          : 60%;
   --fs-carousel-item-width-tablet          : 14.2rem;
   --fs-carousel-item-width-desktop         : 14.4rem;
   --fs-carousel-item-margin-right          : var(--fs-spacing-3);
@@ -108,19 +105,10 @@
   }
 
   [data-fs-carousel-item] {
-    width: var(--fs-carousel-item-width-mobile);
     flex-shrink: 0;
 
     &:not(:last-of-type) {
       margin-right: var(--fs-carousel-item-margin-right);
-    }
-
-    @include media(">=tablet") {
-      width: var(--fs-carousel-item-width-tablet);
-    }
-
-    @include media(">=desktop") {
-      width: var(--fs-carousel-item-width-desktop);
     }
   }
 

--- a/packages/ui/src/components/molecules/Carousel/styles.scss
+++ b/packages/ui/src/components/molecules/Carousel/styles.scss
@@ -51,6 +51,15 @@
 
   width: inherit;
 
+  &:hover {
+    [data-fs-carousel-controls] {
+      @include media(">=tablet") {
+        opacity: 1;
+        pointer-events: auto;
+      }
+    }
+  }
+
   [data-fs-carousel-controls] {
     position: relative;
     display: flex;
@@ -58,12 +67,6 @@
     max-width: calc(var(--fs-grid-max-width) + 6 * var(--fs-grid-padding));
     margin: auto;
     opacity: 0;
-
-    @include media(">=tablet") {
-      opacity: 1;
-      pointer-events: auto;
-    }
-
   }
 
   [data-fs-carousel-control] {

--- a/packages/ui/src/components/molecules/Carousel/styles.scss
+++ b/packages/ui/src/components/molecules/Carousel/styles.scss
@@ -46,7 +46,11 @@
   // Structural Styles
   // --------------------------------------------------------
 
+  position: relative;
   width: inherit;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
   &:hover {
     [data-fs-carousel-controls] {
@@ -58,33 +62,27 @@
   }
 
   [data-fs-carousel-controls] {
-    position: relative;
+    position: absolute;
+    bottom: 50%;
     display: flex;
-    pointer-events: auto;
-    max-width: calc(var(--fs-grid-max-width) + 6 * var(--fs-grid-padding));
+    justify-content: space-between;
+    width: 100%;
     margin: auto;
+    pointer-events: auto;
     opacity: 0;
+
+    @include media(">notebook") {
+      width: calc(100% + 2 * var(--fs-control-tap-size) + 2 * var(--fs-spacing-4));
+    }
   }
 
   [data-fs-carousel-control] {
-    bottom: calc(var(--fs-carousel-controls-height) + var(--fs-control-tap-size));
     cursor: pointer;
-    transform: translateY(-50%);
     [data-fs-button-wrapper] {
       border-radius: var(--fs-carousel-controls-border-radius);
       box-shadow: var(--fs-carousel-controls-box-shadow);
     }
     &:not(:hover) [data-fs-button-wrapper] { background-color: var(--fs-carousel-controls-bkg-color); }
-  }
-
-  [data-fs-carousel-control="left"] {
-    position: absolute;
-    left: var(--fs-carousel-controls-control-right);
-  }
-
-  [data-fs-carousel-control="right"] {
-    position: absolute;
-    right: var(--fs-carousel-controls-control-right);
   }
 
   [data-fs-icon] {
@@ -122,7 +120,7 @@
     padding-left: var(--fs-carousel-bullets-padding-left);
     padding-right: var(--fs-carousel-bullets-padding-right);
 
-    @include media(">=tablet") {
+    @include media(">tablet") {
       width: fit-content;
       align-items: center;
       justify-content: center;
@@ -140,7 +138,7 @@
         background-color: var(--fs-carousel-bullet-bkg-color);
         border-color: transparent;
         border-radius: 0;
-        @include media(">=tablet") {
+        @include media(">tablet") {
           width: var(--fs-carousel-bullet-width-desktop);
           height: var(--fs-carousel-bullet-height-desktop);
           margin: 0;

--- a/packages/ui/src/components/molecules/Carousel/styles.scss
+++ b/packages/ui/src/components/molecules/Carousel/styles.scss
@@ -8,10 +8,6 @@
   --fs-carousel-padding-desktop            : var(--fs-spacing-0) calc((100% - var(--fs-grid-max-width))/2) var(--fs-spacing-0);
 
   // Item
-
-  // --fs-carousel-item-width-mobile          : 60%;
-  --fs-carousel-item-width-tablet          : 14.2rem;
-  --fs-carousel-item-width-desktop         : 14.4rem;
   --fs-carousel-item-margin-right          : var(--fs-spacing-3);
 
   // Controls

--- a/packages/ui/src/components/molecules/Carousel/styles.scss
+++ b/packages/ui/src/components/molecules/Carousel/styles.scss
@@ -57,6 +57,10 @@
     }
   }
 
+  &[data-fs-carousel-variant='scroll'] [data-fs-carousel-item]{
+    flex-shrink: 0;
+  }
+
   [data-fs-carousel-controls] {
     position: absolute;
     bottom: 50%;
@@ -99,8 +103,6 @@
   }
 
   [data-fs-carousel-item] {
-    flex-shrink: 0;
-
     &:not(:last-of-type) {
       margin-right: var(--fs-carousel-item-margin-right);
     }


### PR DESCRIPTION
## What's the purpose of this pull request?

**Carousel**
- Adjust Carousel bugs (bullets quantity and arrows visibility)
- Removes carousel item width (now is set via JS)

One of the bug related to bullets quantity & scroll, it's happening in the following scenario:
- `itemsPerPage = 5`, but only 1.5 items are visible within the slide, and the scroll is not functioning as expected.

|bug| now|
|-|-|
|![before - bug](https://github.com/vtex/faststore/assets/3356699/e5aac439-de66-4323-80fc-31bfb4926a80)|![after](https://github.com/vtex/faststore/assets/3356699/1304f60f-6f7a-4e0b-9495-93d24d03d2f6)|

To prevent confusion, we are displaying the items in an overlapped manner. This allows users to reconsider the value set for `itemsPerPage` given  the component's structure. We also added a note for this case in our [doc](https://github.com/vtex/faststore/assets/3356699/1304f60f-6f7a-4e0b-9495-93d24d03d2f6).



- Fixes [infinite mode setting](https://faststore-site-git-chore-carousel-tweaks-faststore.vercel.app/components/molecules/carousel#infinite-scroll-mode) for the following setup: `itemsPerPage={1}`, `variant="slide"` and `infiniteMode={true}`
- Improves carousel documentation with examples and considerations: [view doc](https://faststore-site-git-chore-carousel-tweaks-faststore.vercel.app/components/molecules/carousel#usage)

**ProductShelf**
- Added `itemsPerPage` prop //TODO: enable to edit via hCMS
- Removes the `layout-content-full`

|before `layout-content-full`|
|-|
|![before](https://github.com/vtex/faststore/assets/3356699/d0ad12e4-68e0-4f4d-b1e8-05821c01c6ce)|

|after|
|-|
|![after](https://github.com/vtex/faststore/assets/3356699/a34262a2-6f3c-4892-9aea-6c6ff70946a4)|


## How to test it?
- Can use override to try it, [example](https://github.com/vtex-sites/starter.store/pull/242/commits/b80ff64d2036a04e86170c85810f8e32e5bb6261)

### Starters Deploy Preview 

https://github.com/vtex-sites/starter.store/pull/242
