### PR TITLE
fix: Passes missing `itemsPerPage` prop

### DIFF
--- a/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
@@ -86,7 +86,11 @@ function ProductShelf({
         itemsPerPage={itemsPerPage}
       >
         <ProductShelfWrapper.Component {...ProductShelfWrapper.props}>
-          <Carousel.Component id={titleId || id} {...Carousel.props}>
+          <Carousel.Component
+            id={titleId || id}
+            itemsPerPage={itemsPerPage}
+            {...Carousel.props}
+          >
             {productEdges.map((product, idx) => (
               <ProductCard.Component
                 aspectRatio={aspectRatio}


### PR DESCRIPTION
## What's the purpose of this pull request?

follow up of https://github.com/vtex/faststore/pull/2088
- Adds missing `itemsPerPage` prop to carousel 😬 
