### PR TITLE
fix: Removes duplicate h1 on search page

### DIFF
--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -94,7 +94,7 @@ function Page({ page: searchContentType, globalSections }: Props) {
           }}
         />
 
-        <UISROnly as="h1" text={title} />
+        <UISROnly text={title} />
 
         {/*
           WARNING: Do not import or render components from any


### PR DESCRIPTION
## What's the purpose of this pull request?

Refers to https://github.com/vtex/faststore/issues/2093

## How it works?

Removes duplicated h1 tag in search results page 

## How to test it?

1. Navigate to the search results page
2. Only one h1 tag should appear