### PR TITLE
chore: Adds missing components layer

### DIFF
--- a/packages/core/src/components/cart/CartSidebar/section.module.scss
+++ b/packages/core/src/components/cart/CartSidebar/section.module.scss
@@ -1,18 +1,20 @@
-.section {
-  @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
-  @import "@faststore/ui/src/components/atoms/Overlay/styles.scss";
-  @import "@faststore/ui/src/components/atoms/Badge/styles.scss";
-  @import "@faststore/ui/src/components/atoms/Button/styles.scss";
-  @import "@faststore/ui/src/components/atoms/Link/styles.scss";
-  @import "@faststore/ui/src/components/atoms/List/styles.scss";
-  @import "@faststore/ui/src/components/atoms/Price/styles.scss";
-  @import "@faststore/ui/src/components/molecules/Alert/styles.scss";
-  @import "@faststore/ui/src/components/molecules/Modal/styles.scss";
-  @import "@faststore/ui/src/components/molecules/CartItem/styles.scss";
-  @import "@faststore/ui/src/components/molecules/Gift/styles.scss";
-  @import "@faststore/ui/src/components/molecules/QuantitySelector/styles.scss";
-  @import "@faststore/ui/src/components/molecules/OrderSummary/styles.scss";
-  @import "@faststore/ui/src/components/organisms/EmptyState/styles.scss";
-  @import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
-  @import "@faststore/ui/src/components/organisms/CartSidebar/styles.scss";
+@layer components {
+  .section {
+    @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
+    @import "@faststore/ui/src/components/atoms/Overlay/styles.scss";
+    @import "@faststore/ui/src/components/atoms/Badge/styles.scss";
+    @import "@faststore/ui/src/components/atoms/Button/styles.scss";
+    @import "@faststore/ui/src/components/atoms/Link/styles.scss";
+    @import "@faststore/ui/src/components/atoms/List/styles.scss";
+    @import "@faststore/ui/src/components/atoms/Price/styles.scss";
+    @import "@faststore/ui/src/components/molecules/Alert/styles.scss";
+    @import "@faststore/ui/src/components/molecules/Modal/styles.scss";
+    @import "@faststore/ui/src/components/molecules/CartItem/styles.scss";
+    @import "@faststore/ui/src/components/molecules/Gift/styles.scss";
+    @import "@faststore/ui/src/components/molecules/QuantitySelector/styles.scss";
+    @import "@faststore/ui/src/components/molecules/OrderSummary/styles.scss";
+    @import "@faststore/ui/src/components/organisms/EmptyState/styles.scss";
+    @import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
+    @import "@faststore/ui/src/components/organisms/CartSidebar/styles.scss";
+  }
 }

--- a/packages/core/src/components/common/Alert/section.module.scss
+++ b/packages/core/src/components/common/Alert/section.module.scss
@@ -1,8 +1,10 @@
-.section {
-  [data-fs-content="alert"] { @include layout-content-full; }
+@layer components {
+  .section {
+    [data-fs-content="alert"] { @include layout-content-full; }
 
-  @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
-  @import "@faststore/ui/src/components/atoms/Button/styles.scss";
-  @import "@faststore/ui/src/components/atoms/Link/styles.scss";
-  @import "@faststore/ui/src/components/molecules/Alert/styles.scss";
+    @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
+    @import "@faststore/ui/src/components/atoms/Button/styles.scss";
+    @import "@faststore/ui/src/components/atoms/Link/styles.scss";
+    @import "@faststore/ui/src/components/molecules/Alert/styles.scss";
+  }
 }

--- a/packages/core/src/components/common/Toast/section.module.scss
+++ b/packages/core/src/components/common/Toast/section.module.scss
@@ -1,4 +1,6 @@
-.section {
-  @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
-  @import "@faststore/ui/src/components/molecules/Toast/styles.scss";
+@layer components {
+  .section {
+    @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
+    @import "@faststore/ui/src/components/molecules/Toast/styles.scss";
+  }
 }

--- a/packages/core/src/components/navigation/NavbarSlider/section.module.scss
+++ b/packages/core/src/components/navigation/NavbarSlider/section.module.scss
@@ -1,12 +1,14 @@
-.section {
-  @import "@faststore/ui/src/components/atoms/Button/styles.scss";
-  @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
-  @import "@faststore/ui/src/components/atoms/Link/styles.scss";
-  @import "@faststore/ui/src/components/atoms/List/styles.scss";
-  @import "@faststore/ui/src/components/atoms/Logo/styles.scss";
-  @import "@faststore/ui/src/components/molecules/LinkButton/styles.scss";
-  @import "@faststore/ui/src/components/molecules/Modal/styles.scss";
-  @import "@faststore/ui/src/components/molecules/NavbarLinks/styles.scss";
-  @import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
-  @import "@faststore/ui/src/components/organisms/NavbarSlider/styles.scss";
+@layer components {
+  .section {
+    @import "@faststore/ui/src/components/atoms/Button/styles.scss";
+    @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
+    @import "@faststore/ui/src/components/atoms/Link/styles.scss";
+    @import "@faststore/ui/src/components/atoms/List/styles.scss";
+    @import "@faststore/ui/src/components/atoms/Logo/styles.scss";
+    @import "@faststore/ui/src/components/molecules/LinkButton/styles.scss";
+    @import "@faststore/ui/src/components/molecules/Modal/styles.scss";
+    @import "@faststore/ui/src/components/molecules/NavbarLinks/styles.scss";
+    @import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
+    @import "@faststore/ui/src/components/organisms/NavbarSlider/styles.scss";
+  }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

- Adds missing `@component` layer to sections (Alert, CartSideBar, Toast)
- Enables styling sections through theme

## How it works?

Previously, when attempting to override a style using section data-attr as mention in the [doc](https://www.faststore.dev/docs/customizing/components#customizing-a-component-within-a-section) for the sections listed above it was not working as expected. The `@theme` layer should precedence the others layers.

<img width="414" alt="image" src="https://github.com/vtex/faststore/assets/3356699/19548bb8-4989-40f4-a134-e0dd00093459">

<img width="321" alt="image" src="https://github.com/vtex/faststore/assets/3356699/d6d324e9-7ca0-4984-a6f9-5852a1952f1b">


## How to test it?

1. Try using this [branch](https://github.com/vtex-sites/starter.store/pull/252) on starter
2. Modify `custom-theme.scss` to change those sections styles, example:

```
 // Alert
    [data-fs-alert] {
      background-color: pink;
    }

    // CartSideBar
    [data-fs-cart-sidebar] {
      background-color: lightblue;
    }

    // Toast
    [data-fs-toast] {
      background-color: salmon;
    }
```
You should be able to see:
<img width="335" alt="image" src="https://github.com/vtex/faststore/assets/3356699/babb21c8-13c2-4789-8472-8e1391aae36d">



### Starters Deploy Preview
https://github.com/vtex-sites/starter.store/pull/252

