### PR TITLE
Chore: Add API dep to core's dev command on turbo config

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,9 @@
     "size": {},
     "dev": {
       "cache": false
+    },
+    "@faststore/core#dev": {
+      "dependsOn": ["@faststore/api#build"]
     }
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the errors that sometimes happened when running `yarn dev` on the root.

## How it works?

The problem was happening because sometimes the file `api.cjs.development.js` from the API wasn't available yet when the dev command from the core workspace was run. 
![image](https://github.com/vtex/faststore/assets/19983991/a1a29d54-3ac0-4653-86f1-e7247e315511)

Since this dependency exists, we should prevent this issue by building the API before running the core. 
That's what this turbo config does, adds the API's `build` dependency to core's `dev` command.

## How to test it?

`yarn dev` on the root should work fine.
![image](https://github.com/vtex/faststore/assets/19983991/e408ca61-f272-44d6-a98b-5493a12a4bd6)

### Starters Deploy Preview


## References

- [Turbo docs: task dependencies](https://turbo.build/repo/docs/core-concepts/monorepos/task-dependencies#from-arbitrary-workspaces)
- [Slack thread](https://vtex.slack.com/archives/C03L3CRCDC4/p1699551581633499?thread_ts=1699537104.296799&cid=C03L3CRCDC4)