### PR TITLE
fix: use canonical as key for pdp pages

### DIFF
--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -252,7 +252,7 @@ export const getStaticProps: GetStaticProps<
       meta,
       offers,
       globalSections,
-      key: slug,
+      key: seo.canonical,
     },
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR allows the state and overall page structure to be preserved while navigating between SKUs of the same product.

## How it works?

All SKUs of a product have the same canonical URL. We use that canonical path as key for the page component, so React understands it should preserve state and overall page structure when navigating between pages with the same canonical URL, that is, SKUs of the same product.

This means quantity selector should preserve the quantity when navigating between SKUs of the same product, but restart it when navigating to another product.

## How to test it?

Go to a PDP, navigate between SKUs and check the key property of the Page component in the React Components extension inspector.

### Starters Deploy Preview

Try it locally

## References
https://github.com/vtex/faststore/pull/2043
