### PR TITLE
Added BannerText to allowed sections in pdp

### DIFF
--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@generated/graphql'
 import RenderSections from 'src/components/cms/RenderSections'
 import BannerNewsletter from 'src/components/sections/BannerNewsletter/BannerNewsletter'
+import BannerText from 'src/components/sections/BannerText'
 import Breadcrumb from 'src/components/sections/Breadcrumb'
 import CrossSellingShelf from 'src/components/sections/CrossSellingShelf'
 import ProductDetails from 'src/components/sections/ProductDetails'
@@ -39,6 +40,7 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
   ProductDetails,
   CrossSellingShelf,
   BannerNewsletter,
+  BannerText
   ...CUSTOM_COMPONENTS,
 }
 

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -40,7 +40,7 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
   ProductDetails,
   CrossSellingShelf,
   BannerNewsletter,
-  BannerText
+  BannerText,
   ...CUSTOM_COMPONENTS,
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

- Make the component BannerText available in the Product Details Page.

## How to test it?

- When trying to add a BannerText component in a Product Details Page, you get this error, and the component doesn't render 
![image](https://github.com/vtex/faststore/assets/88553996/7672e427-9755-4bff-9c1b-3588a08b593b)
- After this PR, the component should render and this message shouldn't appear in the console.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

