### PR TITLE
Feat: add XML to list of public filetypes copied during build

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -76,7 +76,7 @@ function copyCoreFiles() {
 }
 
 function copyPublicFiles() {
-  const allowList = ["json", "txt", "public"]
+  const allowList = ["json", "txt", "xml", "public"]
   try {
     if (existsSync(`${userDir}/public`)) {
       copySync(`${userDir}/public`, `${tmpDir}/public`, {


### PR DESCRIPTION
## What's the purpose of this pull request?

The recent change to support copying the contents of the `/public` dir during build allows users to customize the `robots.txt` file, but doesn't enable the users to upload a standard XML sitemap which the `robots.txt` file can link to.

## How it works?

Adds `xml` to the list of filetypes.

## How to test it?

Add an `xml` file to the `public` dir and run a build. Visit `localhost:3000/{newFileName}.xml` and see that it is served as expected.