### PR TITLE
feat: add rewrites support

### DIFF
--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -44,6 +44,7 @@ const nextConfig = {
     return config
   },
   redirects: storeConfig.redirects,
+  rewrites: storeConfig.rewrites,
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds support for Next.js [rewrites](https://nextjs.org/docs/pages/api-reference/next-config-js/rewrites). 

## How it works?

It works just like Next.js. Read their [docs](https://nextjs.org/docs/pages/api-reference/next-config-js/rewrites). If importing rewrites from a file, there's the same limitation as for redirects, that is, the file must be under the `./src` folder.

## How to test it?

See the PR in the deploy preview bellow. Access `/test/my-office`. It is configured to point to `/office`.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/261

## References

https://nextjs.org/docs/pages/api-reference/next-config-js/rewrites
#2069 