### PR TITLE
Docs: add Headless CMS onboarding requirements

### DIFF
--- a/apps/site/pages/docs/getting-started-requirements.mdx
+++ b/apps/site/pages/docs/getting-started-requirements.mdx
@@ -10,12 +10,50 @@ import { Callout, Steps, Tab, Tabs } from 'nextra-theme-docs'
 
 </header>
 
-<Steps>
-### Install the VTEX IO CLI on your machine
+## 1. Install the VTEX IO CLI on your machine
 
 For more information, please refer to [this guide](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference).
 
-### Enable the VTEX Intelligent Search app in your account
+## 2. Ensure the Headless CMS and its ependencies are installed in your account
+
+The [Headless CMS](/docs/headless-cms-overview) is the solution for managing content in FastStore projects. During the [Onboarding](/docs/getting-started/1-faststore-onboarding), 
+the initial steps to integrate your project with the Headless CMS begins are are carried out.
+To prevent content duplication, which may lead to build failures during Onboarding, it is crucial to confirm the installation of the following in your account: `vtex.admin-cms@1.x`,
+`vtex.admin-cms-graphql` and `vtex.admin-cms-graphql-rc`. To check wether you have the them installed, refer to [Installing the Headless CMS app](/docs/getting-started-requirements#installing-the-headless-cms-app).
+
+### Checking installed apps in your account
+
+1. Open the terminal and log in to your account using the following command:
+
+ ```bash copy
+ vtex login {accountName}
+ ```
+ 
+*Remember to replace `{accountName}` with your account's name, for example, `vtex login mystore`*
+
+2. Run `vtex ls` to list all the installed apps in your account.
+
+3. Check if the `vtex.admin-cms@1.x`, `vtex.admin-cms-graphql` and `vtex.admin-cms-graphql-rc` are in the list. 
+If yes, proceed to check other requirements. If not, install them by following the instructions in [Installing the Headless CMS app](/docs/getting-started-requirements#installing-the-headless-cms-app).
+
+### Installing the Headless CMS app and its dependencies
+1. After logging into your account, install `vtex.admin-cms@1.x` by running the following command:
+
+```bash copy
+vtex install `vtex.admin-cms@1.x`
+```
+A successful message will confirm the installation:
+
+![installation-message](https://vtexhelp.vtexassets.com/assets/docs/src/cms-install___7144afabf5a895ba92905926808507b2.png)
+
+2. Install the Headless CMS dependencies by running the following command:
+
+```bash copy
+vtex install vtex.admin-cms-graphql vtex.admin-cms-graphql-rc
+```
+Once the app and its dependencies are installed, proceed to check the next requirements.
+
+## 3. Enable the VTEX Intelligent Search app in your account
 
 The [VTEX Intelligent Search](https://help.vtex.com/tracks/vtex-intelligent-search) app enhances the user experience by providing accurate and personalized search results throughout the shopping journey. 
 Before developing a storefront in FastStore, you need to enable the app on your account. For more information on the Intelligent Search and its integration, please refer to the [VTEX Intelligent Search](https://help.vtex.com/tracks/vtex-intelligent-search) and [Integration Settings](https://help.vtex.com/en/tracks/vtex-intelligent-search--19wrbB7nEQcmwzDPl1l4Cb/6wKQgKmu2FT6084BJT7z5V) guides.
@@ -70,8 +108,7 @@ Based on the edition version, follow the instructions below.
   <br></br>
 </details>
 
-### Request the installation of the FastStore Onboarding app.
+## 4. Request the installation of the FastStore Onboarding app.
 
 [Open a ticket with the VTEX support team](https://help.vtex.com/support) and request the installation of the [FastStore Onboarding](/docs/getting-started/1-faststore-onboarding/overview) app.
-</Steps>
 

--- a/apps/site/pages/docs/getting-started-requirements.mdx
+++ b/apps/site/pages/docs/getting-started-requirements.mdx
@@ -10,37 +10,38 @@ import { Callout, Steps, Tab, Tabs } from 'nextra-theme-docs'
 
 </header>
 
-## 1. Install the VTEX IO CLI on your machine
+<Steps>
+
+### Install the VTEX IO CLI on your machine
 
 For more information, please refer to [this guide](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference).
 
-## 2. Ensure the Headless CMS and its ependencies are installed in your account
+### Install the Headless CMS and dependencies
 
-The [Headless CMS](/docs/headless-cms-overview) is the solution for managing content in FastStore projects. During the [Onboarding](/docs/getting-started/1-faststore-onboarding), 
-the initial steps to integrate your project with the Headless CMS begins are are carried out.
-To prevent content duplication, which may lead to build failures during Onboarding, it is crucial to confirm the installation of the following in your account: `vtex.admin-cms@1.x`,
+The [Headless CMS](/docs/headless-cms-overview) is the content management solution for FastStore projects. During the [Onboarding](/docs/getting-started/1-faststore-onboarding), 
+the integration beteween your project and the Headless CMS is initiate.
+<br></br>
+To prevent content duplicationthat could cause build failures during Onboarding, it is important to confirm the installation of the following apps in your account: `vtex.admin-cms@1.x`,
 `vtex.admin-cms-graphql` and `vtex.admin-cms-graphql-rc`. To check wether you have the them installed, refer to [Installing the Headless CMS app](/docs/getting-started-requirements#installing-the-headless-cms-app).
 
-### Checking installed apps in your account
+#### Checking installed apps in your account
 
-1. Open the terminal and log in to your account using the following command:
+1. Open the terminal and log in to your account using the following command. *Remember to replace `{accountName}` with your account's name, for example, `vtex login mystore`*.
 
  ```bash copy
  vtex login {accountName}
  ```
- 
-*Remember to replace `{accountName}` with your account's name, for example, `vtex login mystore`*
 
 2. Run `vtex ls` to list all the installed apps in your account.
 
 3. Check if the `vtex.admin-cms@1.x`, `vtex.admin-cms-graphql` and `vtex.admin-cms-graphql-rc` are in the list. 
-If yes, proceed to check other requirements. If not, install them by following the instructions in [Installing the Headless CMS app](/docs/getting-started-requirements#installing-the-headless-cms-app).
+If yes, proceed to check other requirements. If not, install them by following the instructions in [Installing the Headless CMS app](/docs/getting-started-requirements#installing-the-headless-cms-app-and-its-dependencies).
 
-### Installing the Headless CMS app and its dependencies
+#### Installing the Headless CMS app and its dependencies
 1. After logging into your account, install `vtex.admin-cms@1.x` by running the following command:
 
 ```bash copy
-vtex install `vtex.admin-cms@1.x`
+vtex install vtex.admin-cms@1.x
 ```
 A successful message will confirm the installation:
 
@@ -53,7 +54,7 @@ vtex install vtex.admin-cms-graphql vtex.admin-cms-graphql-rc
 ```
 Once the app and its dependencies are installed, proceed to check the next requirements.
 
-## 3. Enable the VTEX Intelligent Search app in your account
+### Enable the VTEX Intelligent Search app in your account
 
 The [VTEX Intelligent Search](https://help.vtex.com/tracks/vtex-intelligent-search) app enhances the user experience by providing accurate and personalized search results throughout the shopping journey. 
 Before developing a storefront in FastStore, you need to enable the app on your account. For more information on the Intelligent Search and its integration, please refer to the [VTEX Intelligent Search](https://help.vtex.com/tracks/vtex-intelligent-search) and [Integration Settings](https://help.vtex.com/en/tracks/vtex-intelligent-search--19wrbB7nEQcmwzDPl1l4Cb/6wKQgKmu2FT6084BJT7z5V) guides.
@@ -108,7 +109,8 @@ Based on the edition version, follow the instructions below.
   <br></br>
 </details>
 
-## 4. Request the installation of the FastStore Onboarding app.
+### Request the installation of the FastStore Onboarding app.
 
 [Open a ticket with the VTEX support team](https://help.vtex.com/support) and request the installation of the [FastStore Onboarding](/docs/getting-started/1-faststore-onboarding/overview) app.
 
+</Steps>

--- a/apps/site/pages/docs/getting-started/1-faststore-onboarding.mdx
+++ b/apps/site/pages/docs/getting-started/1-faststore-onboarding.mdx
@@ -1,9 +1,8 @@
 ---
 title: ' Overview'
-sidebar_label: 'one-faststore-onboarding'
 ---
 
-import { Callout, Tab, Tabs } from 'nextra-theme-docs'
+import { Callout, Tab, Tabs, Steps } from 'nextra-theme-docs'
 
 <header>
 
@@ -21,18 +20,21 @@ By the end, you'll have a GitHub repository with your project and the initial ve
 
 ---
 
-## Before you start
+## Before you begin
 
-### 1. Request the app's installation
+<Steps>
+
+### Request the app's installation
 
 Please open a ticket with the [VTEX support team](https://help.vtex.com/support) to request the installation of the FastStore Onboarding app.
 
 
-### 2. Create your store Catalog
+### Create your store Catalog
 
 Create a Catalog for populating and testing your store with features like product listing pages, search functionality, product detail pages, and checkout. Without a Catalog, testing would be incomplete, and developing without it can cause data integration issues, delays, and extra retrofitting effort.
 
 For more information on how to create a Catlog, refer to the [Catalog documentation](https://help.vtex.com/en/tracks/catalog-101--5AF0XfnjfWeopIFBgs3LIQ/3rA2tTpIoEXdv2nzC27zxR).
+</Steps>
 
 ---
 

--- a/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
+++ b/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
@@ -91,7 +91,7 @@ https://app.io.vtex.com/vtex.cms-builder-sf-jamstack/v1/{account}/{workspace}/bu
 <Callout type="info" emoji=" ℹ️ ">
   When an editor clicks to publish a page using the Headless CMS interface,
   the CMS calls the **Build Webhook URL**, which changes the status of that page
-  to `publishing`. The CMS, then, waits for the content to be built in the
+  to `Draft`. The CMS, then, waits for the content to be built in the
   background.
 </Callout>
 

--- a/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
+++ b/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
@@ -91,7 +91,7 @@ https://app.io.vtex.com/vtex.cms-builder-sf-jamstack/v1/{account}/{workspace}/bu
 <Callout type="info" emoji=" ℹ️ ">
   When an editor clicks to publish a page using the Headless CMS interface,
   the CMS calls the **Build Webhook URL**, which changes the status of that page
-  to `Draft`. The CMS, then, waits for the content to be built in the
+  to `published`. The CMS, then, waits for the content to be built in the
   background.
 </Callout>
 

--- a/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
+++ b/apps/site/pages/docs/headless-cms-integration/1-configuring-the-vtex-account.mdx
@@ -14,11 +14,15 @@ The VTEX IO CLI will help you during your development process by allowing you to
 
 ---
 
-## Before you start
+## Before you begin
 
 Before you proceed with setting up the Headless CMS in your account, please ensure the following:
 
 <Steps>
+
+### Installation of the Headless CMS and its dependencies
+
+Ensure that you have installed the `vtex.admin-cms@1.x` and its dependencies as described in the F[astStore requirements](/docs/getting-started-requirements#2-ensure-the-headless-cms-and-its-ependencies-are-installed-in-your-account).
 
 ### Successful FastStore Onboarding
 
@@ -27,7 +31,10 @@ Make sure the FastStore Onboarding process has been completed successfully. The 
 ### Installation of VTEX IO CLI
 
 Ensure that you have installed the VTEX IO CLI on your machine. This CLI is required to install the Headless CMS plugins and CMS dependencies. For more information, please refer to the [Installing VTEX IO CLI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-install) guide.
+
 </Steps>
+
+
 ---
 
 ## Step by step
@@ -66,17 +73,7 @@ Now, check if the installation of the Headless CMS plugin was successful by runn
 
 </Callout>
 
-### Step 2 - Installing the Headless CMS dependencies on your VTEX account
-
-Install the Headless CMS dependencies in your VTEX account by running the following command:
-
-```bash copy
-vtex install vtex.admin-cms@1.x
-```
-
-![installation-message](https://vtexhelp.vtexassets.com/assets/docs/src/cms-install___7144afabf5a895ba92905926808507b2.png)
-
-### Step 3 - Configuring the Headless CMS
+### Step 2 - Configuring the Headless CMS
 
 Let's configure the URLs of the webhooks used by the Headless CMS app.
 
@@ -112,7 +109,7 @@ https://{account}.vtex.com/
 
 7. Click on **SAVE**.
 
-### Step 4 - Communicating WebOps updates to the Headless CMS
+### Step 3 - Communicating WebOps updates to the Headless CMS
 
 Now, if you are developing your FastStore project with CI/CD and Headless CMS, you must ensure that CI/CD is aware of every CMS update performed via the VTEX Admin. To do so, you must configure the WebOps webhooks responsible for communicating with the Headless CMS as in the following.
 

--- a/apps/site/pages/docs/headless-cms-overview.mdx
+++ b/apps/site/pages/docs/headless-cms-overview.mdx
@@ -43,7 +43,7 @@ Notice that each page created with the Headless CMS is related to a specific URL
 | **Name**                               | Identifies a given page. This name is not available elsewhere and is used only internally in the Headless CMS for identification purposes.                                                                                                                                  |
 | **Type** *(a.k.a., Content Type)*      | Determines the nature of a page. For example, the **Type** can be a Landing Page, a Product Listing Page (PLP), a Product Detail Page (PDP), etc. You, as a developer, are the one responsible for defining which content types will be available for the editors of your store. |
 | **Last modified**                      | Indicates the last time a given page was edited.                                                                                                                                                                                                                                 |
-| **Version**                            | Identifies the state of a page, if it's _Draft_, _Publishing_, or _Published_. Notice that editors can have more than one version of the same page with distinct settings and content.                                                                                           |
+| **Version**                            | Identifies the state of a page, if it's `Draft` or `Published`. Notice that editors can have more than one version of the same page with distinct settings and content.                                                                                           |
 
 
 

--- a/apps/site/pages/docs/headless-cms-overview.mdx
+++ b/apps/site/pages/docs/headless-cms-overview.mdx
@@ -43,7 +43,7 @@ Notice that each page created with the Headless CMS is related to a specific URL
 | **Name**                               | Identifies a given page. This name is not available elsewhere and is used only internally in the Headless CMS for identification purposes.                                                                                                                                  |
 | **Type** *(a.k.a., Content Type)*      | Determines the nature of a page. For example, the **Type** can be a Landing Page, a Product Listing Page (PLP), a Product Detail Page (PDP), etc. You, as a developer, are the one responsible for defining which content types will be available for the editors of your store. |
 | **Last modified**                      | Indicates the last time a given page was edited.                                                                                                                                                                                                                                 |
-| **Version**                            | Identifies the state of a page, if it's `Draft` or `Published`. Notice that editors can have more than one version of the same page with distinct settings and content.                                                                                           |
+| **Version**                            | Identifies the state of a page, if it's `draft` or `published`. Notice that editors can have more than one version of the same page with distinct settings and content.                                                                                           |
 
 
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds a new requirement to start the Onboarding: ensure the account has the hCMS app and its dependencies installed to prevent build failures during Onboarding due to content duplication.

I also removed the mentions about the `publishing` status in CMS, which is no longer available. Check [this commit](https://github.com/vtex/faststore/pull/2114/commits/d32a1e7a650b9af0b67970cdb1bc2b314d9c3f12) to review.

## How to test it?
You can follow the instructions available in the [doc](https://faststore-site-git-docs-onboarding-requirements-faststore.vercel.app/docs/getting-started-requirements#install-the-headless-cms-and-dependencies). 


### Starters Deploy Preview

[Requirements: Install the Headless CMS and dependencies](https://faststore-site-git-docs-onboarding-requirements-faststore.vercel.app/docs/getting-started-requirements#install-the-headless-cms-and-dependencies)
