### PR TITLE
Feat: add ICO extension support to public files copy

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -76,7 +76,7 @@ function copyCoreFiles() {
 }
 
 function copyPublicFiles() {
-  const allowList = ["json", "txt", "xml", "public"]
+  const allowList = ["json", "txt", "xml", "ico", "public"]
   try {
     if (existsSync(`${userDir}/public`)) {
       copySync(`${userDir}/public`, `${tmpDir}/public`, {


### PR DESCRIPTION
## What's the purpose of this pull request?

support ICO file copy as well, so that FastStore applications can select their own favicon.

## How it works?

adds "ico" extension to allow list

## How to test it?

modify `favicon.ico` in app's `/public` dir, run build, verify that change is propagated through to favicon in browser