### PR TITLE
fix: Avoid pushing toasts that already exists

### DIFF
--- a/packages/components/src/hooks/UIProvider.tsx
+++ b/packages/components/src/hooks/UIProvider.tsx
@@ -66,10 +66,19 @@ const reducer = (state: State, action: Action): State => {
     }
 
     case 'pushToast': {
-      return {
-        ...state,
-        toasts: [...state.toasts, action.payload],
+      const isDuplicate = state.toasts.some(existingToast =>
+        existingToast.message === action.payload.message &&
+        existingToast.status === action.payload.status
+      );
+
+      if (!isDuplicate) {
+        return {
+          ...state,
+          toasts: [...state.toasts, action.payload],
+        };
       }
+
+      return state;
     }
 
     case 'popToast': {


### PR DESCRIPTION
## What's the purpose of this pull request?
Relates to #2072. This PR uses @vivaltech solution. (thank you!)

I did some performance tests before with that solution and other solution that uses Lodash to check identical objects.

## How it works?

Before pushing a new toast, it checks it already exists in the list of toasts.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
