### PR TITLE
fix: Toast bugs

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -163,6 +163,17 @@ export const VtexCommerce = (
           requestInit
         )
       },
+
+      clearOrderFormMessages: ({ id }: { id: string }) => {
+        return fetchAPI(
+          `${base}/api/checkout/pub/orderForm/${id}/messages/clear`,
+          {
+            ...BASE_INIT,
+            body: '{}',
+          }
+        )
+      },
+
       updateOrderFormItems: ({
         id,
         orderItems,

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -320,6 +320,7 @@ export const validateCart = async (
   const orderForm = await getOrderForm(orderNumber, ctx)
 
   // Clear messages so it doesn't keep populating toasts on a loop
+  // In the next validateCart mutation it will only have messages if a new message is created on orderForm
   if (orderForm.messages.length !== 0) {
     await clearOrderFormMessages(orderNumber, ctx)
   }
@@ -400,12 +401,13 @@ export const validateCart = async (
     .then((form: OrderForm) => setOrderFormEtag(form, commerce))
     .then(joinItems)
 
-  if (orderForm.messages.length !== updatedOrderForm.messages.length) {
-    return orderFormToCart(updatedOrderForm, skuLoader)
-  }
+  const equalMessages = deepEquals(
+    orderForm.messages,
+    updatedOrderForm.messages
+  )
 
   // Step5: If no changes detected before/after updating orderForm, the order is validated
-  if (equals(order, updatedOrderForm)) {
+  if (equals(order, updatedOrderForm) && equalMessages) {
     return null
   }
   // Step6: There were changes, convert orderForm to StoreCart

--- a/packages/components/src/hooks/UIProvider.tsx
+++ b/packages/components/src/hooks/UIProvider.tsx
@@ -66,6 +66,16 @@ const reducer = (state: State, action: Action): State => {
     }
 
     case 'pushToast': {
+      const isDuplicate = state.toasts.some(
+        (existingToast) =>
+          existingToast.message === action.payload.message &&
+          existingToast.status === action.payload.status
+      )
+
+      if (isDuplicate) {
+        return state
+      }
+
       return {
         ...state,
         toasts: [...state.toasts, action.payload],


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix a loop bug on toast: when adding more units than the max allowed for a product, a toast was shown and the cart was changed automatically decreasing the quantity to the max, but the toast kept being shown because the orderform would still have the message.
Also fixed another bug on toast: when adding a product and then changing the zip code that doesn't deliver that product, the toast wasn't being shown.

## How it works?

For the first case: [cleaning the orderform messages](https://developers.vtex.com/docs/guides/clear-orderform-message-field-from-cart) `clearOrderFormMessages(orderNumber, ctx)` fixes the loop.

For the second case: making `validateCart` check changes in the orderform messages field fixes the issue. The toast in this case will only stop being shown if the user changes the zip code to a valid one or remove the item from the cart.

## How to test it?

First case:

https://github.com/vtex/faststore/assets/19983991/fbd492e5-16a9-488d-9182-b6cc67ec82fd


Second case:


https://github.com/vtex/faststore/assets/19983991/5a73965e-0096-44a0-b14b-f582ade8b9cb


### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References
[Slack thread](https://vtex.slack.com/archives/C03L3CRCDC4/p1700595027917209)
