### PR TITLE
chore: moves env variable from dependsOn (turbo.json)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,17 +1,34 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["OCLIF_COMPILATION", "NODE_ENV", "DISABLE_3P_SCRIPTS"],
+  "globalEnv": [
+    "OCLIF_COMPILATION",
+    "NODE_ENV",
+    "DISABLE_3P_SCRIPTS"
+  ],
   "pipeline": {
     "site#build": {
-      "dependsOn": ["^build", "$BASE_SITE_URL"],
-      "outputs": [".next/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "env": [
+        "BASE_SITE_URL"
+      ],
+      "outputs": [
+        ".next/**"
+      ]
     },
     "build": {
-      "outputs": ["dist/**"],
-      "dependsOn": ["^build"]
+      "outputs": [
+        "dist/**"
+      ],
+      "dependsOn": [
+        "^build"
+      ]
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "outputs": []
     },
     "lint": {
@@ -23,7 +40,9 @@
       "cache": false
     },
     "@faststore/core#dev": {
-      "dependsOn": ["@faststore/api#build"]
+      "dependsOn": [
+        "@faststore/api#build"
+      ]
     }
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

- Moves env variable from dependsOn, to avoid the following message:
> [DEPRECATED] Declaring an environment variable in "dependsOn" is deprecated, found $BASE_SITE_URL. Use the "env" key or use `npx @turbo/codemod migrate-env-var-dependencies`.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
