### PR TITLE
fix: Changes prop type to string instead of react node

### DIFF
--- a/packages/core/src/components/common/Alert/Alert.tsx
+++ b/packages/core/src/components/common/Alert/Alert.tsx
@@ -16,7 +16,7 @@ export interface AlertProps extends UIAlertProps {
    *
    * TODO: Remove it? It's not being used
    */
-  content?: string
+  content?: ReactNode | string
 }
 
 function Alert({

--- a/packages/core/src/components/common/Alert/Alert.tsx
+++ b/packages/core/src/components/common/Alert/Alert.tsx
@@ -16,7 +16,7 @@ export interface AlertProps extends UIAlertProps {
    *
    * TODO: Remove it? It's not being used
    */
-  content?: ReactNode
+  content?: string
 }
 
 function Alert({


### PR DESCRIPTION
## What's the purpose of this pull request?

Attempt to avoid type error: (when upgrading `@types/react` package)
<img width="649" alt="image" src="https://github.com/vtex/faststore/assets/3356699/8e38d0d6-8899-42ec-900c-81f17169305e">

We are receiving a string as prop from CMS, so it makes sense to be a string prop in the common alert.
actually, there is a ` TODO: Remove it? It's not being used`  - should we just remove this prop?

## How to test it?

Everything should work as before, but the build should not fail.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/272

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
