### PR TITLE
fix: see events in GTM preview

### DIFF
--- a/packages/core/src/components/ThirdPartyScripts/GoogleTagManager.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/GoogleTagManager.tsx
@@ -3,7 +3,7 @@ interface Props {
   dataLayerName?: string
 }
 
-const GTM_DEBUG_QUERY_STRING = 'gtm_debug'
+export const GTM_DEBUG_QUERY_STRING = 'gtm_debug'
 
 const useSnippet = (opts: Props & { partytownScript: boolean }) => `${
   opts.partytownScript ? '!' : ''

--- a/packages/core/src/components/ThirdPartyScripts/ThirdPartyScripts.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/ThirdPartyScripts.tsx
@@ -21,7 +21,7 @@ function ThirdPartyScripts() {
 
   return (
     <>
-      {/* We're setting the partytown config (forward property) dynamicly based on the gtm_debug query string
+      {/* We're setting the partytown config (forward property) dynamically based on the gtm_debug query string
        * This helps users see the GTM events properly when using GTM preview. All it does is NOT forward dataLayer.push
        * calls to partytown when the gtm_debug query string is present.
        *

--- a/packages/core/src/components/ThirdPartyScripts/ThirdPartyScripts.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/ThirdPartyScripts.tsx
@@ -1,10 +1,8 @@
 import { Partytown } from '@builder.io/partytown/react'
 import OverrideComponents from 'src/customizations/src/GlobalOverrides'
 import storeConfig from '../../../faststore.config'
-import GoogleTagManager from './GoogleTagManager'
+import GoogleTagManager, { GTM_DEBUG_QUERY_STRING } from './GoogleTagManager'
 import VTEX from './vtex'
-
-const isString = (obj: unknown): obj is string => typeof obj === 'string'
 
 const gtmContainerId = storeConfig.analytics?.gtmContainerId
 
@@ -20,18 +18,26 @@ if (process.env.NODE_ENV === 'development' && !includeGTM) {
 function ThirdPartyScripts() {
   const forwards = []
   if (includeVTEX) forwards.push('sendrc', 'vtexaf')
-  if (includeGTM) forwards.push('dataLayer.push')
 
   return (
     <>
+      {/* We're setting the partytown config (forward property) dynamicly based on the gtm_debug query string
+       * This helps users see the GTM events properly when using GTM preview. All it does is NOT forward dataLayer.push
+       * calls to partytown when the gtm_debug query string is present.
+       *
+       * This is not done in the component because the window var is not available yet.
+       */}
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `var partytown={forward:[...${JSON.stringify(
+            forwards
+          )},!window.location.search.includes('${GTM_DEBUG_QUERY_STRING}=')&&${includeGTM}?'dataLayer.push':null].filter(Boolean)}`,
+        }}
+      />
       {includeGTM && <GoogleTagManager containerId={gtmContainerId} />}
       {includeVTEX && <VTEX />}
       <OverrideComponents.ThirdPartyScripts />
-      <Partytown
-        key="partytown"
-        // Variables to forward to from main to worker
-        forward={forwards}
-      />
+      <Partytown key="partytown" />
     </>
   )
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes an issue where it wasn't possible to see events at the GTM Preview while debugging.

## How it works?

It no longer forwards `dataLayer.push` calls to partytown when the `gtm_debug` query string is enabled.

## How to test it?

Open tagmanager.google.com and choose the `GTM-PGHZ95N` container. Now, click in preview and put the deplooy preview link below. Navigate the store and see the events being shown in the GTM preview tab.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/280