### PR TITLE
Fix: Remove First Selected Filter at Search Page

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -9,8 +9,8 @@ export type Root = {
   productSearchPromise: Promise<ProductSearchResult>
 }
 
-const isRootFacet = (facet: Facet, isDepartament: boolean) =>
-  isDepartament ? facet.key === 'category-1' : facet.key === 'brand'
+const isRootFacet = (facet: Facet, isDepartment: boolean) =>
+  isDepartment ? facet.key === 'category-1' : facet.key === 'brand'
 
 export const StoreSearchResult: Record<string, Resolver<Root>> = {
   suggestions: async (root, _, ctx) => {
@@ -96,9 +96,7 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const filteredFacets = facets
       // Remove root facet on category and brand pages
-      .filter(
-        (facet) => !isCollectionPage || !isRootFacet(facet, isDepartment)
-      )
+      .filter((facet) => !isCollectionPage || !isRootFacet(facet, isDepartment))
 
     return filteredFacets
   },

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -9,8 +9,12 @@ export type Root = {
   productSearchPromise: Promise<ProductSearchResult>
 }
 
-const isRootFacet = (facet: Facet, isDepartment: boolean) =>
-  isDepartment ? facet.key === 'category-1' : facet.key === 'brand'
+const isRootFacet = (facet: Facet, isDepartment: boolean, isBrand: boolean) =>
+  isDepartment
+    ? facet.key === 'category-1'
+    : isBrand
+    ? facet.key === 'brand'
+    : false
 
 export const StoreSearchResult: Record<string, Resolver<Root>> = {
   suggestions: async (root, _, ctx) => {
@@ -94,9 +98,16 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
       ? searchArgs.selectedFacets[0].key === 'category-1'
       : false
 
+    const isBrand = searchArgs.selectedFacets?.length
+      ? searchArgs.selectedFacets[0].key === 'brand'
+      : false
+
     const filteredFacets = facets
       // Remove root facet on category and brand pages
-      .filter((facet) => !isCollectionPage || !isRootFacet(facet, isDepartment))
+      .filter(
+        (facet) =>
+          !isCollectionPage || !isRootFacet(facet, isDepartment, isBrand)
+      )
 
     return filteredFacets
   },

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -8,9 +8,9 @@ export type Root = {
   searchArgs: Omit<SearchArgs, 'type'>
   productSearchPromise: Promise<ProductSearchResult>
 }
-const rootFacets = ['category-1', 'brand']
 
-const isRootFacet = (facet: Facet) => rootFacets?.includes(facet.key)
+const isRootFacet = (facet: Facet, isDepartament: boolean) =>
+  isDepartament ? facet.key === 'category-1' : facet.key === 'brand'
 
 export const StoreSearchResult: Record<string, Resolver<Root>> = {
   suggestions: async (root, _, ctx) => {
@@ -90,9 +90,15 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const isCollectionPage = !searchArgs.query
 
+    const isDepartment = searchArgs.selectedFacets?.length
+      ? searchArgs.selectedFacets[0].key === 'category-1'
+      : false
+
     const filteredFacets = facets
-      // Remove root facet on category pages
-      .filter((facet) => !isCollectionPage || !isRootFacet(facet))
+      // Remove root facet on category and brand pages
+      .filter(
+        (facet) => !isCollectionPage || !isRootFacet(facet, isDepartment)
+      )
 
     return filteredFacets
   },

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -104,6 +104,7 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const filteredFacets = facets
       // Remove root facet on category and brand pages
+      // TODO: Hide category filters for category pages. E.g. /office/desks
       .filter(
         (facet) =>
           !isCollectionPage || !isRootFacet(facet, isDepartment, isBrand)

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -8,8 +8,9 @@ export type Root = {
   searchArgs: Omit<SearchArgs, 'type'>
   productSearchPromise: Promise<ProductSearchResult>
 }
+const rootFacets = ['category-1', 'brand']
 
-const isRootFacet = (facet: Facet) => facet.key === 'category-1'
+const isRootFacet = (facet: Facet) => rootFacets?.includes(facet.key)
 
 export const StoreSearchResult: Record<string, Resolver<Root>> = {
   suggestions: async (root, _, ctx) => {

--- a/packages/sdk/src/search/facets.ts
+++ b/packages/sdk/src/search/facets.ts
@@ -24,7 +24,7 @@ export const removeFacet = (facets: Facet[], facet: Facet): Facet[] => {
     throw new SDKError(`Cannot remove ${value} from search params`)
   }
 
-  return facets.filter((_, it) => it === 0 || it !== index)
+  return facets.filter((_, it) => it !== index)
 }
 
 export const setFacet = (

--- a/packages/sdk/test/search/Provider.test.tsx
+++ b/packages/sdk/test/search/Provider.test.tsx
@@ -263,14 +263,13 @@ test('SearchProvider: Remove initial facet', async () => {
     ),
   })
 
-  /** Cannot remove the first facet */
   act(() => {
     result.current.setState({
       ...result.current.state,
       selectedFacets: removeFacet(result.current.state.selectedFacets, facet1),
     })
   })
-  expect(mock).not.toHaveBeenCalled()
+  expect(mock).toHaveBeenCalledTimes(1)
 })
 
 test('SearchProvider: Toggle Facet', async () => {
@@ -302,14 +301,13 @@ test('SearchProvider: Toggle Facet', async () => {
 
   expect(result.current.state.selectedFacets).toEqual([facet1, facet2])
 
-  /** Cannot remove the first facet */
   act(() => {
     result.current.setState({
       ...result.current.state,
       selectedFacets: toggleFacet(result.current.state.selectedFacets, facet1),
     })
   })
-  expect(mock).not.toHaveBeenCalled()
+  expect(mock).toHaveBeenCalledTimes(1)
 
   act(() => {
     result.current.setState({


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix filters behaviour when removing the first filter selected at a search page

## How it works?

The user should be able to remove the first filter selected.
For other types of pages the validation work because you already have a pre-selected filter.

Ex: 
https://storeframework.vtex.app/office
**You have when first filter selected:** https://storeframework.vtex.app/office?category-1=office&category-2=chairs&facets=category-1%2Ccategory-2&sort=score_desc&page=0
So the first filter that is the context will always be the index 0.

But for search pages this logic fails.

Ex:
https://storeframework.vtex.app/s?q=tasty&sort=score_desc&page=0
**You have when first filter selected:** 
https://storeframework.vtex.app/s?q=tasty&category-2=appliances&facets=category-2&sort=score_desc&page=0

The first filter is the index 0 and the validation do not pass: 

`it === 0` because first selected filter the index is 0.

## How to test it?

Starter Preview: https://github.com/vtex-sites/starter.store/pull/281

Go to a search page: 
https://storeframework.vtex.app/s?q=tasty&sort=score_desc&page=0
Select a filter:
https://storeframework.vtex.app/s?q=tasty&brand=acer&facets=brand&sort=score_desc&page=0
**Try to remove it and wont be possible**

**BEFORE**

https://github.com/vtex/faststore/assets/67066494/4c48300f-a7a1-4c67-aa9c-ece7a676ff02

**AFTER**

https://github.com/vtex/faststore/assets/67066494/938fb82d-86bb-420a-9b56-7d182804a935

