### PR TITLE
fix: Product Gallery facets and products existence

### DIFF
--- a/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
+++ b/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
@@ -91,8 +91,8 @@ function ProductGallery({
   useProductsPrefetch(prev ? prev.cursor : null)
   useProductsPrefetch(next ? next.cursor : null)
 
-  const hasFacets =
-    Boolean(data?.search?.facets) && data.search.facets.length > 0
+  const hasFacets = Boolean(data?.search?.facets)
+  const hasProducts = Boolean(data?.search?.products)
 
   return (
     <section data-testid="product-gallery" data-fs-product-listing>
@@ -111,8 +111,10 @@ function ProductGallery({
         data-fs-content="product-gallery"
       >
         <div data-fs-product-listing-filters>
-          <FilterSkeleton loading={facets?.length === 0}>
-            <Filter facets={facets} filter={filter} />
+          <FilterSkeleton loading={!hasFacets}>
+            {hasFacets && facets?.length > 0 && (
+              <Filter facets={facets} filter={filter} />
+            )}
           </FilterSkeleton>
         </div>
         <div data-fs-product-listing-results-count data-count={totalCount}>
@@ -122,7 +124,7 @@ function ProductGallery({
             {...ResultsCountSkeleton.props}
             // Dynamic props shouldn't be overridable
             // This decision can be reviewed later if needed
-            loading={!data?.search}
+            loading={!hasProducts}
           >
             <h2 data-testid="total-product-count">
               {totalCount} {totalCountLabel}
@@ -136,7 +138,7 @@ function ProductGallery({
             {...SortSkeleton.props}
             // Dynamic props shouldn't be overridable
             // This decision can be reviewed later if needed
-            loading={facets?.length === 0}
+            loading={!hasProducts}
           >
             <Sort
               label={sortBySelector?.label}
@@ -149,34 +151,36 @@ function ProductGallery({
             {...FilterButtonSkeleton.props}
             // Dynamic props shouldn't be overridable
             // This decision can be reviewed later if needed
-            loading={facets?.length === 0}
+            loading={!hasFacets}
           >
-            <MobileFilterButton.Component
-              variant="tertiary"
-              data-testid="open-filter-button"
-              icon={
-                <FilterIcon.Component
-                  width={16}
-                  height={16}
-                  {...FilterIcon.props}
-                  name={
-                    filter?.mobileOnly?.filterButton?.icon?.icon ??
-                    FilterIcon.props.name
-                  }
-                  aria-label={
-                    filter?.mobileOnly?.filterButton?.icon?.alt ??
-                    FilterIcon.props['aria-label']
-                  }
-                />
-              }
-              iconPosition="left"
-              {...MobileFilterButton.props}
-              // Dynamic props shouldn't be overridable
-              // This decision can be reviewed later if needed
-              onClick={openFilter}
-            >
-              {filter?.mobileOnly?.filterButton?.label}
-            </MobileFilterButton.Component>
+            {hasFacets && facets?.length > 0 && (
+              <MobileFilterButton.Component
+                variant="tertiary"
+                data-testid="open-filter-button"
+                icon={
+                  <FilterIcon.Component
+                    width={16}
+                    height={16}
+                    {...FilterIcon.props}
+                    name={
+                      filter?.mobileOnly?.filterButton?.icon?.icon ??
+                      FilterIcon.props.name
+                    }
+                    aria-label={
+                      filter?.mobileOnly?.filterButton?.icon?.alt ??
+                      FilterIcon.props['aria-label']
+                    }
+                  />
+                }
+                iconPosition="left"
+                {...MobileFilterButton.props}
+                // Dynamic props shouldn't be overridable
+                // This decision can be reviewed later if needed
+                onClick={openFilter}
+              >
+                {filter?.mobileOnly?.filterButton?.label}
+              </MobileFilterButton.Component>
+            )}
           </FilterButtonSkeleton.Component>
         </div>
         <div data-fs-product-listing-results>
@@ -219,7 +223,7 @@ function ProductGallery({
             </div>
           )}
           {/* Render ALL products */}
-          {hasFacets ? (
+          {hasProducts ? (
             <Suspense fallback={GalleryPageSkeleton}>
               {pages.map((page) => (
                 <ProductGalleryPage


### PR DESCRIPTION
## What's the purpose of this pull request?

Product Gallery should double check the `facets` and `products` existence according to IS APIs, and show in the frontend if they exist.

Issue #2131 
 - https://github.com/vtex/faststore/issues/2131

## How it works?

1. IS returns facets and products.
2. IS returns only products. (notice the infinite loading in the before case)
3. IS didn't return products.

||Before|After|
|-|-|-|
|Desktop|![DeskBefore](https://github.com/vtex/faststore/assets/11325562/6375ac39-3740-4a1e-b99e-46c110315ccc)|![DeskAfter](https://github.com/vtex/faststore/assets/11325562/2f6f1d4c-b6db-4122-8146-8a1e91dd257b)|
|Mobile|![mobbef](https://github.com/vtex/faststore/assets/11325562/f9fb1f1c-06ab-4968-9354-1b0e26135e18)|![mobafter](https://github.com/vtex/faststore/assets/11325562/4850990e-7ea3-43c8-8f9e-8c4bde45dfb3)|

## How to test it?

Check this behavior in this generated version in your store.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

