### PR TITLE
fix: pickBestSku instead of first sku in products query

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -46,7 +46,7 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const skus = productSearchResult.products
       .map((product) => {
-        const [maybeSku] = product.items
+        const maybeSku = pickBestSku(product.items)
 
         return maybeSku && enhanceSku(maybeSku, product)
       })

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -3,6 +3,7 @@ import type { Resolver } from '..'
 import type { SearchArgs } from '../clients/search'
 import type { Facet } from '../clients/search/types/FacetSearchResult'
 import { ProductSearchResult } from '../clients/search/types/ProductSearchResult'
+import { pickBestSku } from '../utils/sku'
 
 export type Root = {
   searchArgs: Omit<SearchArgs, 'type'>
@@ -63,7 +64,7 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const skus = productSearchResult.products
       .map((product) => {
-        const [maybeSku] = product.items
+        const maybeSku = pickBestSku(product.items)
 
         return maybeSku && enhanceSku(maybeSku, product)
       })

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -46,6 +46,8 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const skus = productSearchResult.products
       .map((product) => {
+        // What determines the presentation of the SKU is the price order
+        // https://help.vtex.com/pt/tutorial/ordenando-imagens-na-vitrine-e-na-pagina-de-produto--tutorials_278
         const maybeSku = pickBestSku(product.items)
 
         return maybeSku && enhanceSku(maybeSku, product)
@@ -64,6 +66,8 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const skus = productSearchResult.products
       .map((product) => {
+        // What determines the presentation of the SKU is the price order
+        // https://help.vtex.com/pt/tutorial/ordenando-imagens-na-vitrine-e-na-pagina-de-produto--tutorials_278
         const maybeSku = pickBestSku(product.items)
 
         return maybeSku && enhanceSku(maybeSku, product)


### PR DESCRIPTION
## What's the purpose of this pull request?

Address this issue
- https://github.com/vtex/faststore/issues/2132

## How it works?

While in search Page and PLP, FastStore API products search query was getting always the first `item` (sku) from the `product.items`. In this case, we should get the best item (item available with smallest value).

|Before|After|
|-|-|
|<img width="1642" alt="Screenshot 2023-11-30 at 19 29 12" src="https://github.com/vtex/faststore/assets/11325562/89c546bc-49b2-4d7b-b660-0c6685059fae">|<img width="1603" alt="Screenshot 2023-11-30 at 19 27 11" src="https://github.com/vtex/faststore/assets/11325562/978beba9-6a6f-4929-ba45-41c17d0fa3b8">|

## How to test it?

Check the preview link from starters store, with the tests mentioned [in the issue](https://github.com/vtex/faststore/issues/2132).

### Starters Deploy Preview

Preview 
- https://sfj-4b57e5c--starter.preview.vtex.app/
- https://github.com/vtex-sites/starter.store/pull/292

## References
- https://help.vtex.com/pt/tutorial/ordenando-imagens-na-vitrine-e-na-pagina-de-produto--tutorials_278
- https://storeframework.myvtex.com/api/io/_v/api/intelligent-search/product_search/trade-policy/1/?hideUnavailableItems=true&q=Apple%20Magic%20Mouse



