### PR TITLE
Add experimental flag to allow stores to disable NextSEO robots

### DIFF
--- a/packages/core/faststore.config.default.js
+++ b/packages/core/faststore.config.default.js
@@ -91,5 +91,6 @@ module.exports = {
   experimental: {
     cypressVersion: 12,
     enableCypressExtension: false,
+    noRobots: false,
   },
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "include-media": "^1.4.10",
     "msw": "^0.43.1",
     "next": "^12.3.1",
-    "next-seo": "^5.4.0",
+    "next-seo": "^6.4.0",
     "nextjs-progressbar": "^0.0.14",
     "postcss": "^8.4.4",
     "prettier": "^2.2.0",

--- a/packages/core/src/pages/_app.tsx
+++ b/packages/core/src/pages/_app.tsx
@@ -11,6 +11,10 @@ import Layout from 'src/Layout'
 import AnalyticsHandler from 'src/sdk/analytics'
 import ErrorBoundary from 'src/sdk/error/ErrorBoundary'
 
+import storeConfig from '../../faststore.config'
+
+import { DefaultSeo } from 'next-seo'
+
 function App({ Component, pageProps }: AppProps) {
   return (
     <ErrorBoundary>
@@ -19,6 +23,8 @@ function App({ Component, pageProps }: AppProps) {
         showOnShallow={false}
         options={{ showSpinner: false }}
       />
+
+      <DefaultSeo norobots={storeConfig.experimental.noRobots} />
 
       <AnalyticsHandler />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14945,15 +14945,15 @@ next-mdx-remote@^4.2.1:
     vfile "^5.3.0"
     vfile-matter "^3.0.1"
 
-next-seo@^5.4.0:
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-5.15.0.tgz#b1a90508599774982909ea44803323c6fb7b50f4"
-  integrity sha512-LGbcY91yDKGMb7YI+28n3g+RuChUkt6pXNpa8FkfKkEmNiJkeRDEXTnnjVtwT9FmMhG6NH8qwHTelGrlYm9rgg==
-
 next-seo@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-6.1.0.tgz#b60b06958cc77e7ed56f0a61b2d6cd0afed88ebb"
   integrity sha512-iMBpFoJsR5zWhguHJvsoBDxDSmdYTHtnVPB1ij+CD0NReQCP78ZxxbdL9qkKIf4oEuZEqZkrjAQLB0bkII7RYA==
+
+next-seo@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-6.4.0.tgz#05a75b8acae881f856eb690b1f66b5e8741aa16e"
+  integrity sha512-XQFxkOL2hw0YE+P100HbI3EAvcludlHPxuzMgaIjKb7kPK0CvjGvLFjd9hszZFEDc5oiQkGFA8+cuWcnip7eYA==
 
 next-themes@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
## What's the purpose of this pull request?

FastStore stores use NextSEO's default robot tags. This PR allows stores to opt-out of the robot tags and write their own.

Solves #2139 

## How to test it?

Check the deploy preview [of this PR](https://github.com/vtex-sites/starter.store/pull/294) and see that there are no robot tags.

## References

[Next SEO](https://github.com/garmeeh/next-seo)
