### PR TITLE
fix: get first available item (sku) instead of first item (sku)

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -46,9 +46,10 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const skus = productSearchResult.products
       .map((product) => {
-        const maybeSku = product.items.find((item) =>
-          item.sellers.some((item) => inStock(item.commertialOffer))
-        )
+        const maybeSku =
+          product.items.find((item) =>
+            item.sellers.some((item) => inStock(item.commertialOffer))
+          ) ?? product.items[0]
 
         return maybeSku && enhanceSku(maybeSku, product)
       })
@@ -66,9 +67,10 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const skus = productSearchResult.products
       .map((product) => {
-        const maybeSku = product.items.find((item) =>
-          item.sellers.some((item) => inStock(item.commertialOffer))
-        )
+        const maybeSku =
+          product.items.find((item) =>
+            item.sellers.some((item) => inStock(item.commertialOffer))
+          ) ?? product.items[0]
 
         return maybeSku && enhanceSku(maybeSku, product)
       })

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -3,6 +3,7 @@ import type { Resolver } from '..'
 import type { SearchArgs } from '../clients/search'
 import type { Facet } from '../clients/search/types/FacetSearchResult'
 import { ProductSearchResult } from '../clients/search/types/ProductSearchResult'
+import { inStock } from '../utils/productStock'
 
 export type Root = {
   searchArgs: Omit<SearchArgs, 'type'>
@@ -45,7 +46,9 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const skus = productSearchResult.products
       .map((product) => {
-        const [maybeSku] = product.items
+        const maybeSku = product.items.find((item) =>
+          item.sellers.some((item) => inStock(item.commertialOffer))
+        )
 
         return maybeSku && enhanceSku(maybeSku, product)
       })
@@ -63,7 +66,9 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     const skus = productSearchResult.products
       .map((product) => {
-        const [maybeSku] = product.items
+        const maybeSku = product.items.find((item) =>
+          item.sellers.some((item) => inStock(item.commertialOffer))
+        )
 
         return maybeSku && enhanceSku(maybeSku, product)
       })


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR aims to get first available item (sku) instead of first item (sku) in `products` and `suggestions` queries.

Reference in v1: https://github.com/vtex/faststore/pull/1834

Address this issue
- https://github.com/vtex/faststore/issues/2132

## How it works?

While in search Page and PLP, FastStore API products/suggestions search query was getting always the first `item` (sku) from the `product.items`. In this case, we should get the first available item.

|Before|After|
|-|-|
|<img width="1642" alt="Screenshot 2023-11-30 at 19 29 12" src="https://github.com/vtex/faststore/assets/11325562/89c546bc-49b2-4d7b-b660-0c6685059fae">|<img width="1969" alt="Screenshot 2023-12-01 at 18 11 04" src="https://github.com/vtex/faststore/assets/11325562/6070edb5-4174-49ff-b2dc-06e39bc71fce">|

## How to test it?

Check the preview link from starters store, with the tests mentioned [in the issue](https://github.com/vtex/faststore/issues/2132).

### Starters Deploy Preview
PR 
- https://github.com/vtex-sites/starter.store/pull/295


Preview
 - https://sfj-41c253b--starter.preview.vtex.app/s?q=apple+magic&sort=score_desc&page=0

### References

https://storeframework.myvtex.com/api/io/_v/api/intelligent-search/product_search/trade-policy/1/?hideUnavailableItems=true&q=Apple%20Magic%20Mouse
