### PR TITLE
fix: Don't render PDP with no price

### DIFF
--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -214,9 +214,13 @@ export const getStaticProps: GetStaticProps<
 
   const { data, errors = [] } = searchResult
 
+  const hasPrice = data?.product?.offers.offers.some(
+    (offer) => offer.price !== 0
+  )
+
   const notFound = errors.find(isNotFoundError)
 
-  if (notFound) {
+  if (notFound || !hasPrice) {
     return {
       notFound: true,
     }


### PR DESCRIPTION
## What's the purpose of this pull request?

Related to #2085, we were rendering PDPs with no associated price. They doesn't show in PLPs, but we can access the URL.

## How it works?

This PR fixes that triggering the 404 page when we have no price associated.

## How to test it?

Check those products, they're without price:

https://sfj-da92366--starter.preview.vtex.app/awesome-granite-cheese/p
https://sfj-da92366--starter.preview.vtex.app/sleek-wooden-chair-16834618/p

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
