### PR TITLE
Remove: OrderFormId param from my account / login

### DIFF
--- a/packages/core/src/components/ui/Button/ButtonSignIn/ButtonSignIn.tsx
+++ b/packages/core/src/components/ui/Button/ButtonSignIn/ButtonSignIn.tsx
@@ -1,7 +1,6 @@
 import { Icon, LinkButton } from '@faststore/ui'
 
 import { useSession } from 'src/sdk/session'
-import { useCart } from '../../../../sdk/cart/index'
 
 const ButtonSignIn = ({
   label,
@@ -12,15 +11,12 @@ const ButtonSignIn = ({
   myAccountLabel: string
   icon: { alt: string; icon: string }
 }) => {
-  const { id } = useCart()
   const { person } = useSession()
 
   return (
     <LinkButton
       data-fs-button-signin-link
-      href={
-        person?.id ? `/account?orderFormId=${id}` : `/login?orderFormId=${id}`
-      }
+      href={person?.id ? `/account` : `/login`}
       className="text__title-mini"
       aria-label={alt}
       variant="tertiary"


### PR DESCRIPTION
## What's the purpose of this pull request?

Remove orderFormId param from /account and /login

## How it works?

This param should not be sent when the user is navigating to those pages.

## How to test it?

Go to my account and check if the param is passed at the URL.


https://github.com/vtex/faststore/assets/67066494/51ff8f80-6407-4344-97ee-d51ce26da189


### Starters Deploy Preview

[Preview](https://github.com/vtex-sites/starter.store/pull/310)

## References

The logic to get this param and add to the session was removed at this PR:
https://github.com/vtex/admin-faststore/pull/25
