### PR TITLE
Chore/write cookie tests

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -19,7 +19,7 @@ import type { SalesChannel } from './types/SalesChannel'
 import { MasterDataResponse } from './types/Newsletter'
 import type { Address, AddressInput } from './types/Address'
 import { DeliveryMode, SelectedAddress } from './types/ShippingData'
-import { getUpdatedCookie, getStoreCookie } from '../../utils/cookies'
+import { getStoreCookie, getWithCookie } from '../../utils/cookies'
 
 type ValueOf<T> = T extends Record<string, infer K> ? K : never
 
@@ -36,8 +36,13 @@ export const VtexCommerce = (
 ) => {
   const base = `https://${account}.${environment}.com.br`
   const storeCookies = getStoreCookie(ctx)
+  const withCookie = getWithCookie(ctx)
   // replacing www. only for testing while www.vtexfaststore.com is configured with www
-  const forwardedHost = (new Headers(ctx.headers).get('x-forwarded-host') ?? ctx.headers?.host ?? '').replace('www.', '')
+  const forwardedHost = (
+    new Headers(ctx.headers).get('x-forwarded-host') ??
+    ctx.headers?.host ??
+    ''
+  ).replace('www.', '')
 
   return {
     catalog: {
@@ -101,13 +106,10 @@ export const VtexCommerce = (
           sc: salesChannel,
         })
 
-        const headers: HeadersInit = {
+        const headers: HeadersInit = withCookie({
           'content-type': 'application/json',
           'X-FORWARDED-HOST': forwardedHost,
-        }
-
-        const cookie = getUpdatedCookie(ctx)
-        if (cookie) headers.cookie = cookie
+        })
 
         return fetchAPI(
           `${base}/api/checkout/pub/orderForms/simulation?${params.toString()}`,
@@ -151,13 +153,10 @@ export const VtexCommerce = (
           clearAddressIfPostalCodeNotFound: incrementAddress,
         }
 
-        const headers: HeadersInit = {
+        const headers: HeadersInit = withCookie({
           'content-type': 'application/json',
           'X-FORWARDED-HOST': forwardedHost,
-        }
-
-        const cookie = getUpdatedCookie(ctx)
-        if (cookie) headers.cookie = cookie
+        })
 
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm/${id}/attachments/shippingData`,
@@ -184,13 +183,10 @@ export const VtexCommerce = (
           sc: salesChannel,
         })
 
-        const headers: HeadersInit = {
+        const headers: HeadersInit = withCookie({
           'content-type': 'application/json',
           'X-FORWARDED-HOST': forwardedHost,
-        }
-
-        const cookie = getUpdatedCookie(ctx)
-        if (cookie) headers.cookie = cookie
+        })
 
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm/${id}?${params.toString()}`,
@@ -202,13 +198,10 @@ export const VtexCommerce = (
         )
       },
       clearOrderFormMessages: ({ id }: { id: string }) => {
-        const headers: HeadersInit = {
+        const headers: HeadersInit = withCookie({
           'content-type': 'application/json',
           'X-FORWARDED-HOST': forwardedHost,
-        }
-
-        const cookie = getUpdatedCookie(ctx)
-        if (cookie) headers.cookie = cookie
+        })
 
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm/${id}/messages/clear`,
@@ -237,13 +230,10 @@ export const VtexCommerce = (
           sc: salesChannel,
         })
 
-        const headers: HeadersInit = {
+        const headers: HeadersInit = withCookie({
           'content-type': 'application/json',
           'X-FORWARDED-HOST': forwardedHost,
-        }
-
-        const cookie = getUpdatedCookie(ctx)
-        if (cookie) headers.cookie = cookie
+        })
 
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm/${id}/items?${params}`,
@@ -269,13 +259,10 @@ export const VtexCommerce = (
         key: string
         value: string
       }): Promise<OrderForm> => {
-        const headers: HeadersInit = {
+        const headers: HeadersInit = withCookie({
           'content-type': 'application/json',
           'X-FORWARDED-HOST': forwardedHost,
-        }
-
-        const cookie = getUpdatedCookie(ctx)
-        if (cookie) headers.cookie = cookie
+        })
 
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm/${id}/customData/${appId}/${key}`,
@@ -305,13 +292,10 @@ export const VtexCommerce = (
             )
 
         const url = `${base}/api/checkout/pub/regions/?${params.toString()}`
-        const headers: HeadersInit = {
+        const headers: HeadersInit = withCookie({
           'content-type': 'application/json',
           'X-FORWARDED-HOST': forwardedHost,
-        }
-
-        const cookie = getUpdatedCookie(ctx)
-        if (cookie) headers.cookie = cookie
+        })
 
         return fetchAPI(
           url,
@@ -325,13 +309,10 @@ export const VtexCommerce = (
         postalCode,
         country,
       }: AddressInput): Promise<Address> => {
-        const headers: HeadersInit = {
+        const headers: HeadersInit = withCookie({
           'content-type': 'application/json',
           'X-FORWARDED-HOST': forwardedHost,
-        }
-
-        const cookie = getUpdatedCookie(ctx)
-        if (cookie) headers.cookie = cookie
+        })
 
         return fetchAPI(
           `${base}/api/checkout/pub/postal-code/${country}/${postalCode}`,
@@ -349,15 +330,11 @@ export const VtexCommerce = (
         'items',
         'profile.id,profile.email,profile.firstName,profile.lastName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol'
       )
-      const cookie = getUpdatedCookie(ctx)
-      const headers: HeadersInit = cookie
-        ? {
-            'content-type': 'application/json',
-            cookie,
-          }
-        : {
-            'content-type': 'application/json',
-          }
+
+      const headers: HeadersInit = withCookie({
+        'content-type': 'application/json',
+      })
+
       return fetchAPI(
         `${base}/api/sessions?${params.toString()}`,
         {

--- a/packages/api/src/platforms/vtex/utils/cookies.ts
+++ b/packages/api/src/platforms/vtex/utils/cookies.ts
@@ -1,5 +1,10 @@
 import type { Context } from '../index'
 
+export interface ContextForCookies {
+  headers: Context['headers']
+  storage: Pick<Context['storage'], 'cookies'>
+}
+
 const MATCH_FIRST_SET_COOKIE_KEY_VALUE = /^([^=]+)=([^;]*)/
 
 /**
@@ -12,7 +17,10 @@ const MATCH_FIRST_SET_COOKIE_KEY_VALUE = /^([^=]+)=([^;]*)/
  *       setCookie: setCookie used in browser response
  *     }
  */
-const updatesContextStorageCookies = (ctx: Context, setCookieValue: string) => {
+export const updatesContextStorageCookies = (
+  ctx: Pick<Context, 'storage'>,
+  setCookieValue: string
+) => {
   const matchCookie = setCookieValue.match(MATCH_FIRST_SET_COOKIE_KEY_VALUE)
 
   if (matchCookie) {
@@ -26,7 +34,7 @@ const updatesContextStorageCookies = (ctx: Context, setCookieValue: string) => {
   }
 }
 
-export const setCookie = (ctx: Context, headers: Headers) => {
+export const setCookie = (ctx: Pick<Context, 'storage'>, headers: Headers) => {
   headers
     .getSetCookie()
     .forEach((setCookieValue) =>
@@ -34,8 +42,9 @@ export const setCookie = (ctx: Context, headers: Headers) => {
     )
 }
 
-export const getStoreCookie = (ctx: Context) => (headers: Headers) =>
-  setCookie(ctx, headers)
+export const getStoreCookie =
+  (ctx: Pick<Context, 'storage'>) => (headers: Headers) =>
+    setCookie(ctx, headers)
 
 /**
  * This function returns a modified copy of the original cookie header (ctx.headers.cookie from the first request)
@@ -49,7 +58,7 @@ export const getStoreCookie = (ctx: Context) => (headers: Headers) =>
  *       setCookie: setCookie used in browser response
  *     }
  */
-export const getUpdatedCookie = (ctx: Context) => {
+export const getUpdatedCookie = (ctx: ContextForCookies) => {
   if (!ctx.headers?.cookie) {
     return null
   }
@@ -71,7 +80,7 @@ export const getUpdatedCookie = (ctx: Context) => {
   )
 }
 
-export const getWithCookie = (ctx: Context) =>
+export const getWithCookie = (ctx: ContextForCookies) =>
   function withCookie<T extends Record<string, any>>(
     headers: T
   ): T & { cookie?: string } {
@@ -107,7 +116,7 @@ export const updatesCookieValueByKey = (
   // replaces original cookie with the one coming from storage
   if (cookieParts) {
     return existingCookies.replace(
-      MATCH_FIRST_SET_COOKIE_KEY_VALUE,
+      cookieParts[0],
       `${cookieParts[1]}=${storageCookieValue}`
     )
   }

--- a/packages/api/src/platforms/vtex/utils/cookies.ts
+++ b/packages/api/src/platforms/vtex/utils/cookies.ts
@@ -12,8 +12,9 @@ const MATCH_FIRST_SET_COOKIE_KEY_VALUE = /^([^=]+)=([^;]*)/
  *       setCookie: setCookie used in browser response
  *     }
  */
-const updatesContextStorageCookies = (setCookieValue: string, ctx: Context) => {
+const updatesContextStorageCookies = (ctx: Context, setCookieValue: string) => {
   const matchCookie = setCookieValue.match(MATCH_FIRST_SET_COOKIE_KEY_VALUE)
+
   if (matchCookie) {
     const cookieKey = matchCookie[1]
     const cookieValue = matchCookie[2]
@@ -25,16 +26,16 @@ const updatesContextStorageCookies = (setCookieValue: string, ctx: Context) => {
   }
 }
 
-export const setCookie = (headers: Headers, ctx: Context) => {
+export const setCookie = (ctx: Context, headers: Headers) => {
   headers
     .getSetCookie()
     .forEach((setCookieValue) =>
-      updatesContextStorageCookies(setCookieValue, ctx)
+      updatesContextStorageCookies(ctx, setCookieValue)
     )
 }
 
 export const getStoreCookie = (ctx: Context) => (headers: Headers) =>
-  setCookie(headers, ctx)
+  setCookie(ctx, headers)
 
 /**
  * This function returns a modified copy of the original cookie header (ctx.headers.cookie from the first request)
@@ -69,6 +70,22 @@ export const getUpdatedCookie = (ctx: Context) => {
     ctx.headers.cookie
   )
 }
+
+export const getWithCookie = (ctx: Context) =>
+  function withCookie<T extends Record<string, any>>(
+    headers: T
+  ): T & { cookie?: string } {
+    const updatedCookie = getUpdatedCookie(ctx)
+
+    if (!updatedCookie) {
+      return headers
+    }
+
+    return {
+      ...headers,
+      cookie: updatedCookie,
+    }
+  }
 
 /**
  * This function updates the cookie value based on its key

--- a/packages/api/test/vtex.cookies.test.ts
+++ b/packages/api/test/vtex.cookies.test.ts
@@ -1,0 +1,191 @@
+import {
+  getUpdatedCookie,
+  updatesCookieValueByKey,
+  getWithCookie,
+  updatesContextStorageCookies,
+  getStoreCookie,
+} from '../src/platforms/vtex/utils/cookies'
+import type { ContextForCookies } from '../src/platforms/vtex/utils/cookies'
+import type { Context } from '../src/platforms/vtex'
+
+describe('getUpdatedCookie', () => {
+  it('Should return undefined if context has no headers', () => {
+    const ctx = {} as ContextForCookies
+
+    expect(getUpdatedCookie(ctx)).toEqual(null)
+  })
+
+  it('Should return undefined if context has no cookie header', () => {
+    const ctx = { headers: {} } as ContextForCookies
+
+    expect(getUpdatedCookie(ctx)).toEqual(null)
+  })
+
+  it('Should return original cookie headers if storage cookies are empty', () => {
+    const cookie = 'key=value'
+    const ctx = {
+      headers: { cookie },
+      storage: { cookies: new Map() },
+    }
+
+    expect(getUpdatedCookie(ctx)).toEqual(cookie)
+  })
+
+  it('Should iterate on storage cookies and call updatesCookieValueByKey', () => {
+    const cookie = 'key1=value1; key2=value2; key3=value3'
+    const cookieStorage = {
+      key1: { value: 'alteredValue1' },
+      key3: { value: 'alteredValue3' },
+    }
+
+    const ctx = {
+      headers: { cookie },
+      storage: { cookies: new Map(Object.entries(cookieStorage)) },
+    }
+
+    expect(getUpdatedCookie(ctx)).toEqual(
+      'key1=alteredValue1; key2=value2; key3=alteredValue3'
+    )
+  })
+})
+
+describe('updatesCookieValueByKey', () => {
+  it('Should replace cookie value if key matches existing cookie', () => {
+    const cookie = 'key1=value1; key2=value2; key3=value3'
+    const key = 'key1'
+    const value = 'alteredValue1'
+
+    expect(updatesCookieValueByKey(cookie, key, value)).toEqual(
+      'key1=alteredValue1; key2=value2; key3=value3'
+    )
+  })
+
+  it('Should add cookie to cookie list if key does not match any existing cookies', () => {
+    const cookie = 'key1=value1; key2=value2; key3=value3'
+    const key = 'key4'
+    const value = 'value4'
+
+    expect(updatesCookieValueByKey(cookie, key, value)).toEqual(
+      'key1=value1; key2=value2; key3=value3;key4=value4'
+    )
+  })
+})
+
+describe('getWithCookie', () => {
+  it('Should return unaltered headers if cookie is null', () => {
+    const withCookie = getWithCookie({} as ContextForCookies)
+    const headers = { 'content-type': 'application/json' }
+
+    const newHeaders = withCookie(headers)
+
+    expect(newHeaders).toEqual(headers)
+  })
+
+  it('Should return headers with cookie if cookie is present', () => {
+    const cookie = 'key=value'
+    const ctx = {
+      headers: { cookie },
+      storage: { cookies: new Map() },
+    }
+
+    const withCookie = getWithCookie(ctx)
+    const headers = { 'content-type': 'application/json' }
+
+    const newHeaders = withCookie(headers)
+
+    expect(newHeaders).toEqual({ ...headers, cookie: ctx.headers.cookie })
+  })
+})
+
+describe('updatesContextStorageCookies', () => {
+  it('Should not change storage if cookie key is not found', () => {
+    const setCookie = 'malformedSetCookie;;;;'
+
+    const ctx = {
+      storage: { cookies: new Map() },
+    } as Pick<Context, 'storage'>
+
+    updatesContextStorageCookies(ctx, setCookie)
+
+    expect(ctx.storage.cookies.entries()).toMatchObject({})
+  })
+
+  it('Should add cookie to storage if cookie key is found', () => {
+    const setCookieKey = 'checkout.vtex.com'
+    const setCookieValue = '__ofid=f9295573872f45f9b0041f40ccc4e136'
+    const setCookie =
+      'checkout.vtex.com=__ofid=f9295573872f45f9b0041f40ccc4e136; expires=Sat, 08 Jun 2024 20:12:41 GMT; domain=vtexfaststore.com; path=/; secure; samesite=lax; httponly'
+
+    const ctx = {
+      storage: { cookies: new Map() },
+    } as Pick<Context, 'storage'>
+
+    updatesContextStorageCookies(ctx, setCookie)
+
+    expect(ctx.storage.cookies.get(setCookieKey)).toEqual({
+      value: setCookieValue,
+      setCookie: setCookie,
+    })
+  })
+
+  it('Should change cookie from storage if cookie key is found and it is already in storage', () => {
+    const setCookieKey = 'checkout.vtex.com'
+    const setCookieValue = '__ofid=f9295573872f45f9b0041f40ccc4e136'
+    const setCookie =
+      'checkout.vtex.com=__ofid=f9295573872f45f9b0041f40ccc4e136; expires=Sat, 08 Jun 2024 20:12:41 GMT; domain=vtexfaststore.com; path=/; secure; samesite=lax; httponly'
+
+    const cookieStorage = {
+      'checkout.vtex.com': { value: setCookieValue, setCookie: 'oldSetCookie' },
+    }
+
+    const ctx = {
+      storage: {
+        cookies: new Map<string, Record<string, string>>(
+          Object.entries(cookieStorage)
+        ),
+      },
+    } as Pick<Context, 'storage'>
+
+    updatesContextStorageCookies(ctx, setCookie)
+
+    expect(ctx.storage.cookies.get(setCookieKey)).toEqual({
+      value: setCookieValue,
+      setCookie: setCookie,
+    })
+  })
+})
+
+describe('getStoreCookie', () => {
+  it('Should iterate on headers and call updatesContextStorageCookies for each of them', () => {
+    const ctx = {
+      storage: { cookies: new Map() },
+    } as Pick<Context, 'storage'>
+
+    const headers = new Headers()
+    headers.append(
+      'set-cookie',
+      'checkout.vtex.com=__ofid=f9295573872f45f9b0041f40ccc4e136; expires=Sat, 08 Jun 2024 20:12:41 GMT; domain=vtexfaststore.com; path=/; secure; samesite=lax; httponly'
+    )
+    headers.append(
+      'set-cookie',
+      'CheckoutOrderFormOwnership=CFEUHpzya69CNICSrc4h5cJzeQE856pULms%2BxxQdF9EOh5WPwtrzqMwl9FwAhPVM; expires=Sat, 08 Jun 2024 20:12:41 GMT; domain=vtexfaststore.com; path=/; secure; samesite=strict; httponly'
+    )
+
+    const storeCookies = getStoreCookie(ctx)
+
+    storeCookies(headers)
+
+    expect(ctx.storage.cookies.get('checkout.vtex.com')).toEqual({
+      value: '__ofid=f9295573872f45f9b0041f40ccc4e136',
+      setCookie:
+        'checkout.vtex.com=__ofid=f9295573872f45f9b0041f40ccc4e136; expires=Sat, 08 Jun 2024 20:12:41 GMT; domain=vtexfaststore.com; path=/; secure; samesite=lax; httponly',
+    })
+    expect(ctx.storage.cookies.get('CheckoutOrderFormOwnership')).toEqual({
+      value:
+        'CFEUHpzya69CNICSrc4h5cJzeQE856pULms%2BxxQdF9EOh5WPwtrzqMwl9FwAhPVM',
+      setCookie:
+        'CheckoutOrderFormOwnership=CFEUHpzya69CNICSrc4h5cJzeQE856pULms%2BxxQdF9EOh5WPwtrzqMwl9FwAhPVM; expires=Sat, 08 Jun 2024 20:12:41 GMT; domain=vtexfaststore.com; path=/; secure; samesite=strict; httponly',
+    })
+    expect(ctx.storage.cookies.size).toEqual(2)
+  })
+})


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds tests to cookie utils and fixes bug when replacing cookies during `withCookies`

## How it works?

The `replace` call on existing cookies was being made with the wrong first argument, which always matched the first key. It is now fixed.

## How to test it?

Make sure cookies behave like www.vtexfaststore.com

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/318