### PR TITLE
fix: Display discount badge only when has discount

### DIFF
--- a/packages/core/src/components/product/ProductCard/ProductCard.tsx
+++ b/packages/core/src/components/product/ProductCard/ProductCard.tsx
@@ -88,6 +88,8 @@ function ProductCard({
     [availability]
   )
 
+  const hasDiscount = spotPrice <= listPrice
+
   return (
     <UIProductCard
       outOfStock={outOfStock}
@@ -117,7 +119,7 @@ function ProductCard({
         outOfStock={outOfStock}
         onButtonClick={onButtonClick}
         linkProps={linkProps}
-        showDiscountBadge={showDiscountBadge}
+        showDiscountBadge={hasDiscount && showDiscountBadge}
       />
     </UIProductCard>
   )


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR attempts to fix scenario when there is no discount applied in the product, and sale price is > listing price.

<img width="233" alt="image" src="https://github.com/vtex/faststore/assets/3356699/fef94c1e-d50f-4c29-843b-41cbeca10783">


_I wonder if this logic should be inside the `ProductCardContent` component (fs/ui library) or in the core. Any thoughts?_


## How it works?

When no discount applied, we should not display the `DiscountBadge` component.

## How to test it?

<img width="1322" alt="image" src="https://github.com/vtex/faststore/assets/3356699/3256f552-318b-4688-9ea2-08f37e7ae177">

1. Go to homepage -> Look for `Apple Magic Mouse` in the Most Wanted section.
2. The `infinity` badge should not appear.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

[FS-1482](https://vtex-dev.atlassian.net/browse/FS-1482?atlOrigin=eyJpIjoiMWU1MGFjYTZkY2RiNDY2MGE0NGI4ZDZiNmZjODRkMWEiLCJwIjoiaiJ9)


[FS-1482]: https://vtex-dev.atlassian.net/browse/FS-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ