### PR TITLE
Stop appending `/` to search state base path

### DIFF
--- a/packages/sdk/src/search/useSearchState.ts
+++ b/packages/sdk/src/search/useSearchState.ts
@@ -13,7 +13,7 @@ export const initialize = ({
   sort,
   selectedFacets,
   term,
-  base: base.endsWith('/') ? base : `${base}/`,
+  base,
   page,
 })
 

--- a/packages/sdk/test/search/serializer.test.ts
+++ b/packages/sdk/test/search/serializer.test.ts
@@ -41,7 +41,7 @@ test('Search State Serializer: serialization with base path', async () => {
   })
 
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/pt-br/sale/?sort=score_desc&page=0'
+    'http://localhost/pt-br/sale?sort=score_desc&page=0'
   )
 
   state = {
@@ -49,7 +49,7 @@ test('Search State Serializer: serialization with base path', async () => {
     term: 'Hello World',
   }
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/pt-br/sale/?q=Hello+World&sort=score_desc&page=0'
+    'http://localhost/pt-br/sale?q=Hello+World&sort=score_desc&page=0'
   )
 
   state = {
@@ -60,7 +60,7 @@ test('Search State Serializer: serialization with base path', async () => {
     ],
   }
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/pt-br/sale/?q=Hello+World&price=10%3A100&facets=price&sort=score_desc&page=0'
+    'http://localhost/pt-br/sale?q=Hello+World&price=10%3A100&facets=price&sort=score_desc&page=0'
   )
 
   state = {
@@ -68,7 +68,7 @@ test('Search State Serializer: serialization with base path', async () => {
     sort: 'price_desc',
   }
   expect(`${formatSearchState(state)}`).toBe(
-    'http://localhost/pt-br/sale/?q=Hello+World&price=10%3A100&facets=price&sort=price_desc&page=0'
+    'http://localhost/pt-br/sale?q=Hello+World&price=10%3A100&facets=price&sort=price_desc&page=0'
   )
 })
 
@@ -76,11 +76,11 @@ test('Search State Serializer: Basic parsing', async () => {
   expect(
     parseSearchState(
       new URL(
-        'http://localhost/pt-br/sale/?q=Hello+World&&sort=score_desc&price=10%3A100&page=0&facets=price'
+        'http://localhost/pt-br/sale?q=Hello+World&&sort=score_desc&price=10%3A100&page=0&facets=price'
       )
     )
   ).toEqual({
-    base: '/pt-br/sale/',
+    base: '/pt-br/sale',
     selectedFacets: [
       {
         key: 'price',
@@ -95,11 +95,11 @@ test('Search State Serializer: Basic parsing', async () => {
   expect(
     parseSearchState(
       new URL(
-        'http://localhost/pt-br/sale/?q=Hello+World&sort=score_desc&page=1'
+        'http://localhost/pt-br/sale?q=Hello+World&sort=score_desc&page=1'
       )
     )
   ).toEqual({
-    base: '/pt-br/sale/',
+    base: '/pt-br/sale',
     selectedFacets: [],
     sort: 'score_desc',
     term: 'Hello World',
@@ -108,7 +108,7 @@ test('Search State Serializer: Basic parsing', async () => {
 
   expect(
     parseSearchState(
-      new URL('http://localhost/?q=Hello+World&sort=score_desc&page=10')
+      new URL('http://localhost?q=Hello+World&sort=score_desc&page=10')
     )
   ).toEqual({
     base: '/',

--- a/packages/sdk/test/search/useSearchState.test.ts
+++ b/packages/sdk/test/search/useSearchState.test.ts
@@ -1,0 +1,7 @@
+import { initSearchState } from '../../src'
+
+test('search state initialization does not append a `/` to the base path', async () => {
+  let state = initSearchState({base: '/s'})
+
+  expect(state.base).toBe('/s')
+})


### PR DESCRIPTION
## What's the purpose of this pull request?

When clicking on a suggested product link in the search the user would be redirect to `/s/?term=blabla`. Because of how our nginx is configured, this trailing `/` would redirect the user to the cluster URL and would show a `Your connection is not private` error.

## How it works?

Stop appending `/` to the URL.

## How to test it?

Go to the preview link, start a search and click on a "Top Search" suggestion. You should see the search page without any problems.