### PR TITLE
feat: Get CMS page by Release ID

### DIFF
--- a/packages/core/faststore.config.default.js
+++ b/packages/core/faststore.config.default.js
@@ -93,4 +93,5 @@ module.exports = {
     enableCypressExtension: false,
     noRobots: false,
   },
+  releaseId: '',
 }

--- a/packages/core/src/server/cms.ts
+++ b/packages/core/src/server/cms.ts
@@ -14,6 +14,7 @@ export type Options =
   | Locator
   | {
       contentType: string
+      releaseId?: string
       filters?: Partial<ContentTypeOptions>
     }
 
@@ -22,6 +23,10 @@ const isLocator = (x: any): x is Locator =>
   (typeof x.releaseId === 'string' || typeof x.documentId === 'string')
 
 export const getPage = async <T extends ContentData>(options: Options) => {
+  if (config.releaseId) {
+    options.releaseId = config.releaseId
+  }
+
   const result = await (isLocator(options)
     ? clientCMS.getCMSPage(options).then((page) => ({ data: [page] }))
     : clientCMS.getCMSPagesByContentType(options.contentType, options.filters))


### PR DESCRIPTION
## What's the purpose of this pull request?

Today we have inconsistency because of caching issues when we get CMS pages during navigation. 

## How it works?

That change enables that we use a fixed release ID when we get a CMS page, instead of using the latest release.

## How to test it?

🚧  (Still figuring it out with CMS team)

### Starters Deploy Preview

🚧 

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
