### PR TITLE
fix: `BannerNewsletter` toast attributes

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1316,6 +1316,56 @@
               "enumNames": ["Main", "Light", "Accent"],
               "enum": ["main", "light", "accent"],
               "default": "main"
+            },
+            "toastSubscribe": {
+              "title": "Toast Subscribe",
+              "type": "object",
+              "properties": {
+                "title": {
+                  "title": "Title",
+                  "description": "Message Title",
+                  "type": "string",
+                  "default": "Hooray!"
+                },
+                "message": {
+                  "title": "Message",
+                  "description": "Message",
+                  "type": "string",
+                  "default": "Thank for your subscription."
+                },
+                "icon": {
+                  "title": "Icon",
+                  "type": "string",
+                  "enumNames": ["CircleWavyCheck"],
+                  "enum": ["CircleWavyCheck"],
+                  "default": "CircleWavyCheck"
+                }
+              }
+            },
+            "toastSubscribeError": {
+              "title": "Toast Subscribe Error",
+              "type": "object",
+              "properties": {
+                "title": {
+                  "title": "Title",
+                  "description": "Message Title",
+                  "type": "string",
+                  "default": "Oops."
+                },
+                "message": {
+                  "title": "Message",
+                  "description": "Message",
+                  "type": "string",
+                  "default": "Something went wrong. Please Try again."
+                },
+                "icon": {
+                  "title": "Icon",
+                  "type": "string",
+                  "enumNames": ["CircleWavyWarning"],
+                  "enum": ["CircleWavyWarning"],
+                  "default": "CircleWavyWarning"
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add missing toast attributes for the `BannerNewsletter` section.

## How to test it?

Check the PDP preview on CMS using the workspace `lucasportela`