### PR TITLE
[TCM-196] Update default canonical URLs for landing pages

### DIFF
--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -29,10 +29,12 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
 
 export type LandingPageProps = {
   page: PageContentType
+  slug?: string
 }
 
 export default function LandingPage({
   page: { sections, settings },
+  slug,
 }: LandingPageProps) {
   return (
     <>
@@ -41,7 +43,9 @@ export default function LandingPage({
         title={settings?.seo?.title ?? storeConfig.seo.title}
         description={settings?.seo?.description ?? storeConfig.seo?.description}
         titleTemplate={storeConfig.seo?.titleTemplate ?? storeConfig.seo?.title}
-        canonical={settings?.seo?.canonical ?? storeConfig.storeUrl}
+        canonical={
+          settings?.seo?.canonical ?? `${storeConfig.storeUrl}/${slug}`
+        }
         openGraph={{
           type: 'website',
           url: storeConfig.storeUrl,

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -36,6 +36,7 @@ type Props = BaseProps &
       }
     | {
         type: 'page'
+        slug: string
         page: PageContentType
       }
   )
@@ -94,6 +95,7 @@ export const getStaticProps: GetStaticProps<
         page: await landingPagePromise,
         globalSections: await globalSectionsPromise,
         type: 'page',
+        slug,
       },
     }
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

This is a fix for https://github.com/vtex/faststore/issues/2144. Making it so the default behavior for landing pages that don't have a canonical set in the store's hCMS is to have `canonical` set to their full URL path.

## How it works?

When rendering a landing page that doesn't have a set `canonical` URL set via hCMS, instead of setting the `canonical` prop from `NextSeo` to `storeConfig.storeUrl` this PR makes it so `canonical` is set to `${storeConfig.storeUrl}/${slug}`, where slug is the path of the page being rendered.

## How to test it?

Go to the Vercel deploy preview commented below and check for `<head>` tags at `/testing-new-landing`. Here's a comparison between the current behavior and the updated one, in the same landing page:

**current behavior**
 
<img width="1012" alt="Screenshot 2024-01-18 at 13 44 47" src="https://github.com/vtex/faststore/assets/27777263/ae308fc7-143f-4427-a193-5608eee348bb">

**updated behavior**

<img width="911" alt="Screenshot 2024-01-18 at 13 44 20" src="https://github.com/vtex/faststore/assets/27777263/6797f0ef-857a-4da4-8f70-b4e81d3537eb">
