### PR TITLE
docs: Fixes api extension troubleshooting link path

### DIFF
--- a/apps/site/pages/docs/api-extensions/extending-api-schema.mdx
+++ b/apps/site/pages/docs/api-extensions/extending-api-schema.mdx
@@ -168,7 +168,9 @@ export default resolvers
 Once you have defined these files in the `vtex` folder, the new fields are already available for use. To consume the fields, refer to the [Consuming FastStore API extension with custom components](/docs/api-extensions/consuming-api-extensions) guide.
 
 <Callout type="warning" emoji="⚠️">
-  If the changes you made are still not available, refer to the troubleshooting section [GraphQL changes not visible during development](/docs/api-extension/troubleshooting#graphql-changes-not-visible-during-development).
+  If the changes you made are still not available, refer to the troubleshooting
+  section [GraphQL changes not visible during
+  development](/docs/api-extensions/troubleshooting#graphql-changes-not-visible-during-development).
 </Callout>
  
 
@@ -306,6 +308,8 @@ query {
 Once you have defined these files in the `thirdParty` folder, you can query the data you defined. 
 
 <Callout type="warning" emoji="⚠️">
-  If the changes you made are still not available, refer to the troubleshooting section [GraphQL changes not visible during development](/docs/api-extension/troubleshooting#graphql-changes-not-visible-during-development).
+  If the changes you made are still not available, refer to the troubleshooting
+  section [GraphQL changes not visible during
+  development](/docs/api-extensions/troubleshooting#graphql-changes-not-visible-during-development).
 </Callout>
  

--- a/apps/site/pages/docs/api-extensions/extending-queries-using-fragments.mdx
+++ b/apps/site/pages/docs/api-extensions/extending-queries-using-fragments.mdx
@@ -12,12 +12,15 @@ import { ExtendableQueryTable } from './../../../components/ExtendableQueryTable
 
 </header>
 
-After [defining the new fields exposed by the FastStore API Extension](/docs/api-extension/extending-api-schema), the next step is to specify where these fields will be utilized within GraphQL fragments.
+After [defining the new fields exposed by the FastStore API Extension](/docs/api-extensions/extending-api-schema), the next step is to specify where these fields will be utilized within GraphQL fragments.
 
 [Fragments](https://graphql.org/learn/queries/#fragments) in GraphQL are reusable units that enhance query functionality. FastStore associates these fragments with the existing queries used on its pages to incorporate the newly exposed fields.
 
 <Callout type="info" emoji="ℹ️">
-  To access the list of queries and their corresponding fragments, refer to the [extendable queries](/docs/api-extension/extending-queries-using-fragments#extendable-queries) section.
+  To access the list of queries and their corresponding fragments, refer to the
+  [extendable
+  queries](/docs/api-extensions/extending-queries-using-fragments#extendable-queries)
+  section.
 </Callout>
 
 follow the steps below to add custom fields to an [existing query](/docs/api-extensions#extendable-queries). We will use the `ServerProduct` query as an example to illustrate how to extend.

--- a/apps/site/pages/docs/api-extensions/troubleshooting.mdx
+++ b/apps/site/pages/docs/api-extensions/troubleshooting.mdx
@@ -31,7 +31,7 @@ Follow these steps to trigger the optimization:
 If you notice differences between the GraphQL schema in your deploy preview or production environment compared to your development setup, it may be due to the schema not being optimized since the development server's initiation. 
 The build process optimizes the schema before deployment to accurately reflect the schema declared in the store's code.
 
-Refer to the [GraphQL changes not visible during development](/docs/api-extension/troubleshooting#graphql-changes-not-visible-during-development) topic, to fix the issue.
+Refer to the [GraphQL changes not visible during development](/docs/api-extensions/troubleshooting#graphql-changes-not-visible-during-development) topic, to fix the issue.
 
 ---
 
@@ -73,4 +73,4 @@ To access more detailed error information, use the `--debug` flag when manually 
 
 During the build step, the GraphQL optimization and type files are always generated fresh, which means they always reflect the most recent changes present in the code.
 
-If your changes are not visible in production, this means you must not have committed them to the branch you're currently working on. If you see a different GraphQL Schema, queries, or data during development, refer to the [GraphQL changes not visible during development](/docs/api-extension/troubleshooting#graphql-changes-not-visible-during-development) topic.
+If your changes are not visible in production, this means you must not have committed them to the branch you're currently working on. If you see a different GraphQL Schema, queries, or data during development, refer to the [GraphQL changes not visible during development](/docs/api-extensions/troubleshooting#graphql-changes-not-visible-during-development) topic.


### PR DESCRIPTION
## What's the purpose of this pull request?

- Fixes api extension troubleshooting link path in the doc

[Preview](https://faststore-site-git-docs-updates-troubleshooting-link-faststore.vercel.app/docs/api-extensions/extending-api-schema)

