### PR TITLE
chore: Improve `@faststore/cli` build time

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -76,7 +76,7 @@ function copyCoreFiles() {
 }
 
 function copyPublicFiles() {
-  const allowList = ["json", "txt", "xml", "ico", "public"]
+  const allowList = ['json', 'txt', 'xml', 'ico', 'public']
   try {
     if (existsSync(`${userDir}/public`)) {
       copySync(`${userDir}/public`, `${tmpDir}/public`, {
@@ -85,7 +85,7 @@ function copyPublicFiles() {
           const allow = allowList.some((ext) => src.endsWith(ext))
 
           return allow
-        }
+        },
       })
       console.log(`${chalk.green('success')} - Public files copied`)
     }
@@ -253,7 +253,7 @@ function mergeCMSFiles() {
   mergeCMSFile('sections.json')
 }
 
-function copyUserNodeModules() {
+function createNodeModulesSymLink() {
   try {
     symlinkSync(userNodeModulesDir, tmpNodeModulesDir, 'dir')
     console.log(
@@ -275,7 +275,7 @@ export async function generate(options?: GenerateOptions) {
       copyCoreFiles(),
       copyCypressFiles(),
       copyPublicFiles(),
-      copyUserNodeModules(),
+      createNodeModulesSymLink(),
     ])
   }
 

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -6,7 +6,6 @@ import {
   readdirSync,
   readFileSync,
   removeSync,
-  symlinkSync,
   writeFileSync,
   writeJsonSync,
 } from 'fs-extra'
@@ -19,12 +18,10 @@ import {
   tmpCMSDir,
   tmpDir,
   tmpFolderName,
-  tmpNodeModulesDir,
   tmpStoreConfigFileDir,
   tmpThemesCustomizationsFileDir,
   tmpCmsWebhookUrlsFileDir,
   userCMSDir,
-  userNodeModulesDir,
   userSrcDir,
   userStoreConfigFileDir,
   userThemesFileDir,
@@ -253,17 +250,6 @@ function mergeCMSFiles() {
   mergeCMSFile('sections.json')
 }
 
-function createNodeModulesSymLink() {
-  try {
-    symlinkSync(userNodeModulesDir, tmpNodeModulesDir, 'dir')
-    console.log(
-      `${chalk.green('success')} - ${chalk.dim('node_modules')} files copied`
-    )
-  } catch (err) {
-    console.error(`${chalk.red('error')} - ${err}`)
-  }
-}
-
 export async function generate(options?: GenerateOptions) {
   const { setup = false } = options ?? {}
 
@@ -275,7 +261,6 @@ export async function generate(options?: GenerateOptions) {
       copyCoreFiles(),
       copyCypressFiles(),
       copyPublicFiles(),
-      createNodeModulesSymLink(),
     ])
   }
 

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -6,6 +6,7 @@ import {
   readdirSync,
   readFileSync,
   removeSync,
+  symlinkSync,
   writeFileSync,
   writeJsonSync,
 } from 'fs-extra'
@@ -254,7 +255,7 @@ function mergeCMSFiles() {
 
 function copyUserNodeModules() {
   try {
-    copySync(userNodeModulesDir, tmpNodeModulesDir)
+    symlinkSync(userNodeModulesDir, tmpNodeModulesDir, 'dir')
     console.log(
       `${chalk.green('success')} - ${chalk.dim('node_modules')} files copied`
     )

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -1,6 +1,5 @@
-import path from 'path'
-
 // @ts-check
+const path = require('path')
 const storeConfig = require('./faststore.config')
 
 /**

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -41,6 +41,9 @@ const nextConfig = {
       config.optimization.splitChunks.maxInitialRequests = 1
     }
 
+    // Dependencies will be able to be resolved from the symlink location
+    config.resolve.symlinks = false
+
     return config
   },
   redirects: storeConfig.redirects,

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -23,7 +23,7 @@ const nextConfig = {
   experimental: {
     scrollRestoration: true,
     // Trace user's `node_modules` dir
-    outputFileTracingRoot: path.join(__dirname, '../node_modules'),
+    outputFileTracingRoot: path.join(__dirname, '../'),
   },
   webpack: (config, { isServer, dev }) => {
     // https://github.com/vercel/next.js/discussions/11267#discussioncomment-2479112

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -1,3 +1,5 @@
+import path from 'path'
+
 // @ts-check
 const storeConfig = require('./faststore.config')
 
@@ -21,6 +23,8 @@ const nextConfig = {
   // TODO: We won't need to enable this experimental feature when migrating to Next.js 13
   experimental: {
     scrollRestoration: true,
+    // Trace user's `node_modules` dir
+    outputFileTracingRoot: path.join(__dirname, '../node_modules'),
   },
   webpack: (config, { isServer, dev }) => {
     // https://github.com/vercel/next.js/discussions/11267#discussioncomment-2479112
@@ -40,9 +44,6 @@ const nextConfig = {
     if (!isServer && !dev && config.optimization?.splitChunks) {
       config.optimization.splitChunks.maxInitialRequests = 1
     }
-
-    // Dependencies will be able to be resolved from the symlink location
-    config.resolve.symlinks = false
 
     return config
   },


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to improve the `@faststore/cli` build time setting Next's `output` config to trace files/folders outside the `.faststore` working dir (user's `node_modules`, for instance).

## How to test it?

Run `yarn build` or `yarn dev` and check if `@faststore/cli` steps don't take much time to be performed.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/366

## References

- [Next.js `output`options](https://nextjs.org/docs/pages/api-reference/next-config-js/output#caveats)