### PR TITLE
fix: dynamic nextjs i18n config

### DIFF
--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -12,8 +12,8 @@ const nextConfig = {
     imageSizes: [34, 68, 154, 320],
   },
   i18n: {
-    locales: ['en-US'],
-    defaultLocale: 'en-US',
+    locales: [storeConfig.session.locale],
+    defaultLocale: storeConfig.session.locale,
   },
   sassOptions: {
     additionalData: `@import "src/customizations/src/styles/custom-mixins.scss";`,


### PR DESCRIPTION
## What's the purpose of this pull request?

<!--- Considering the context, what is the problem we'll solve? Where in VTEX's big picture our issue fits in? Write a tweet about the context and the problem itself. --->
This PR makes the NextJS i18n config from the `next.config.js` dynamic.
It will fix SEO issues when the store is created using different languages.

## How it works?

<!--- Tell us the role of the new feature, or component, in its context. --->

Setting the `session.locale` param on the `faststore.config.js` file will update the `i18n (locales array and defaultLocale param)` configs on the `next.config.js` file.





## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->


| Set locale as `fr-FR` | Preview |
|------|------|
| ![image](https://github.com/vtex/faststore/assets/57547336/671f6bd5-95d1-4ab4-bcad-0face004a503) | ![image](https://github.com/vtex/faststore/assets/57547336/f24b630b-d781-4daf-b29c-743f7b50b943) |


| Set locale as `pt-BR` | Preview |
|------|------|
| ![image](https://github.com/vtex/faststore/assets/57547336/3dccbac1-a10f-4279-95cb-65472b9cdef4) | ![image](https://github.com/vtex/faststore/assets/57547336/98a2fe95-8487-43dd-b27f-df304b6aaa15)|


### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->
https://sfj-dc7f350--devmarinbrasil.preview.vtex.app/
<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->


