### PR TITLE
feat: Get CMS Pages by Version ID with fallback

### DIFF
--- a/packages/core/faststore.config.default.js
+++ b/packages/core/faststore.config.default.js
@@ -89,7 +89,7 @@ module.exports = {
   },
 
   cms: {
-    data: JSON.parse(process.env.CMS_DATA),
+    data: process.env.CMS_DATA,
   },
 
   experimental: {

--- a/packages/core/faststore.config.default.js
+++ b/packages/core/faststore.config.default.js
@@ -89,7 +89,7 @@ module.exports = {
   },
 
   cms: {
-    data: process.env.CMS_DATA,
+    data: JSON.parse(process.env.CMS_DATA),
   },
 
   experimental: {

--- a/packages/core/faststore.config.default.js
+++ b/packages/core/faststore.config.default.js
@@ -88,6 +88,10 @@ module.exports = {
     gtmContainerId: 'GTM-PGHZ95N',
   },
 
+  cms: {
+    data: process.env.CMS_DATA,
+  },
+
   experimental: {
     cypressVersion: 12,
     enableCypressExtension: false,

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -1,6 +1,7 @@
 import { Locator, Section } from '@vtex/client-cms'
 import type { ComponentType } from 'react'
 import { PropsWithChildren, lazy } from 'react'
+import storeConfig from 'faststore.config'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import { PageContentType, getPage, getPageByVersionId } from 'src/server/cms'
 
@@ -50,8 +51,8 @@ export default GlobalSections
 export const getGlobalSectionsData = async (
   previewData: Locator
 ): Promise<GlobalSectionsData> => {
-  if (process.env.CMS_DATA) {
-    const cmsData = process.env.CMS_DATA
+  if (storeConfig.cms.data) {
+    const cmsData = storeConfig.cms.data
     const page = cmsData[GLOBAL_SECTIONS_CONTENT_TYPE][0]
 
     if (page) {

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -51,7 +51,6 @@ export default GlobalSections
 export const getGlobalSectionsData = async (
   previewData: Locator
 ): Promise<GlobalSectionsData> => {
-  console.log(storeConfig.cms)
   if (storeConfig.cms.data) {
     const cmsData = JSON.parse(storeConfig.cms.data)
     const page = cmsData[GLOBAL_SECTIONS_CONTENT_TYPE][0]

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -52,7 +52,7 @@ export const getGlobalSectionsData = async (
   previewData: Locator
 ): Promise<GlobalSectionsData> => {
   if (storeConfig.cms.data) {
-    const cmsData = storeConfig.cms.data
+    const cmsData = JSON.parse(storeConfig.cms.data)
     const page = cmsData[GLOBAL_SECTIONS_CONTENT_TYPE][0]
 
     if (page) {

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -2,7 +2,7 @@ import { Locator, Section } from '@vtex/client-cms'
 import type { ComponentType } from 'react'
 import { PropsWithChildren, lazy } from 'react'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
-import { PageContentType, getPage } from 'src/server/cms'
+import { PageContentType, getPage, getPageByVersionId } from 'src/server/cms'
 
 import Toast from 'src/components/common/Toast'
 import RenderSections from './RenderSections'
@@ -50,6 +50,21 @@ export default GlobalSections
 export const getGlobalSectionsData = async (
   previewData: Locator
 ): Promise<GlobalSectionsData> => {
+  if (process.env.CMS_PAGE) {
+    const cmsData = process.env.CMS_PAGE
+    const page = cmsData[GLOBAL_SECTIONS_CONTENT_TYPE][0]
+
+    if (page) {
+      const pageData = await getPageByVersionId<PageContentType>({
+        contentType: GLOBAL_SECTIONS_CONTENT_TYPE,
+        documentId: page.documentId,
+        versionId: page.versionId,
+      })
+
+      return pageData
+    }
+  }
+
   const { sections } = await getPage<PageContentType>({
     ...(previewData?.contentType === GLOBAL_SECTIONS_CONTENT_TYPE &&
       previewData),

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -50,8 +50,8 @@ export default GlobalSections
 export const getGlobalSectionsData = async (
   previewData: Locator
 ): Promise<GlobalSectionsData> => {
-  if (process.env.CMS_PAGE) {
-    const cmsData = process.env.CMS_PAGE
+  if (process.env.CMS_DATA) {
+    const cmsData = process.env.CMS_DATA
     const page = cmsData[GLOBAL_SECTIONS_CONTENT_TYPE][0]
 
     if (page) {

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -51,6 +51,7 @@ export default GlobalSections
 export const getGlobalSectionsData = async (
   previewData: Locator
 ): Promise<GlobalSectionsData> => {
+  console.log(storeConfig.cms)
   if (storeConfig.cms.data) {
     const cmsData = JSON.parse(storeConfig.cms.data)
     const page = cmsData[GLOBAL_SECTIONS_CONTENT_TYPE][0]

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -1,5 +1,4 @@
 import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
-import type { ComponentType } from 'react'
 import type { Locator } from '@vtex/client-cms'
 
 import MissingContentError from 'src/sdk/error/MissingContentError/MissingContentError'
@@ -10,7 +9,7 @@ import { OverriddenDefaultNewsletter as Newsletter } from 'src/components/sectio
 import { OverriddenDefaultProductShelf as ProductShelf } from 'src/components/sections/ProductShelf/OverriddenDefaultProductShelf'
 import Incentives from 'src/components/sections/Incentives'
 import ProductTiles from 'src/components/sections/ProductTiles'
-import { getPage } from 'src/server/cms'
+import { getPage, getPageByVersionId } from 'src/server/cms'
 import type { PageContentType } from 'src/server/cms'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 
@@ -85,6 +84,23 @@ export const getLandingPageBySlug = async (
   previewData: Locator
 ) => {
   try {
+    if (process.env.CMS_PAGE) {
+      const cmsData = process.env.CMS_PAGE
+      const pageBySlug = cmsData['landingPage'].find((page) => {
+        slug === page.slug
+      })
+
+      if (pageBySlug) {
+        const pageData = await getPageByVersionId<PageContentType>({
+          contentType: 'landingPage',
+          documentId: pageBySlug.documentId,
+          versionId: pageBySlug.versionId,
+        })
+
+        return pageData
+      }
+    }
+
     const landingPageData = await getPage<PageContentType>({
       ...(previewData?.contentType === 'landingPage'
         ? previewData

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -14,7 +14,7 @@ import { getPage, getPageByVersionId } from 'src/server/cms'
 import type { PageContentType } from 'src/server/cms'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 
-import storeConfig from '../../../../faststore.config'
+import storeConfig from 'faststore.config'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -85,8 +85,8 @@ export const getLandingPageBySlug = async (
   previewData: Locator
 ) => {
   try {
-    if (process.env.CMS_DATA) {
-      const cmsData = process.env.CMS_DATA
+    if (storeConfig.cms.data) {
+      const cmsData = storeConfig.cms.data
       const pageBySlug = cmsData['landingPage'].find((page) => {
         slug === page.slug
       })

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -86,7 +86,7 @@ export const getLandingPageBySlug = async (
 ) => {
   try {
     if (storeConfig.cms.data) {
-      const cmsData = storeConfig.cms.data
+      const cmsData = JSON.parse(storeConfig.cms.data)
       const pageBySlug = cmsData['landingPage'].find((page) => {
         slug === page.slug
       })

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -88,17 +88,17 @@ export const getLandingPageBySlug = async (
     if (storeConfig.cms.data) {
       const cmsData = JSON.parse(storeConfig.cms.data)
       const pageBySlug = cmsData['landingPage'].find((page) => {
-        slug === page.slug
+        slug === page.settings?.seo?.slug
       })
 
       if (pageBySlug) {
-        const pageData = await getPageByVersionId<PageContentType>({
+        const landingPageData = await getPageByVersionId<PageContentType>({
           contentType: 'landingPage',
           documentId: pageBySlug.documentId,
           versionId: pageBySlug.versionId,
         })
 
-        return pageData
+        return landingPageData
       }
     }
 

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -85,8 +85,8 @@ export const getLandingPageBySlug = async (
   previewData: Locator
 ) => {
   try {
-    if (process.env.CMS_PAGE) {
-      const cmsData = process.env.CMS_PAGE
+    if (process.env.CMS_DATA) {
+      const cmsData = process.env.CMS_DATA
       const pageBySlug = cmsData['landingPage'].find((page) => {
         slug === page.slug
       })

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
+import type { ComponentType } from 'react'
 import type { Locator } from '@vtex/client-cms'
 
 import MissingContentError from 'src/sdk/error/MissingContentError/MissingContentError'

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -119,7 +119,7 @@ export const getStaticProps: GetStaticProps<
   let pageData
 
   if (storeConfig.cms.data) {
-    const cmsData = storeConfig.cms.data
+    const cmsData = JSON.parse(storeConfig.cms.data)
     const page = cmsData['plp'][0]
 
     if (page) {

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -1,5 +1,6 @@
 import { isNotFoundError } from '@faststore/api'
 import type { GetStaticPaths, GetStaticProps } from 'next'
+import storeConfig from 'faststore.config'
 
 import { gql } from '@generated'
 import type {
@@ -117,8 +118,8 @@ export const getStaticProps: GetStaticProps<
 
   let pageData
 
-  if (process.env.CMS_DATA) {
-    const cmsData = process.env.CMS_DATA
+  if (storeConfig.cms.data) {
+    const cmsData = storeConfig.cms.data
     const page = cmsData['plp'][0]
 
     if (page) {

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -14,7 +14,12 @@ import GlobalSections, {
   getGlobalSectionsData,
   GlobalSectionsData,
 } from 'src/components/cms/GlobalSections'
-import { getPage, PageContentType, PLPContentType } from 'src/server/cms'
+import {
+  getPage,
+  getPageByVersionId,
+  PageContentType,
+  PLPContentType,
+} from 'src/server/cms'
 import ProductListingPage, {
   ProductListingPageProps,
 } from 'src/components/templates/ProductListingPage'
@@ -108,10 +113,25 @@ export const getStaticProps: GetStaticProps<
       variables: { slug },
       operation: query,
     }),
-    getPage<PLPContentType>({
-      ...(previewData?.contentType === 'plp' ? previewData : null),
-      contentType: 'plp',
-    }),
+    () => {
+      if (process.env.CMS_PAGE) {
+        const cmsData = process.env.CMS_PAGE
+        const page = cmsData['plp'][0]
+
+        if (page) {
+          return getPageByVersionId<PLPContentType>({
+            contentType: 'plp',
+            documentId: page.documentId,
+            versionId: page.versionId,
+          })
+        }
+      }
+
+      return getPage<PLPContentType>({
+        ...(previewData?.contentType === 'plp' ? previewData : null),
+        contentType: 'plp',
+      })
+    },
   ])
 
   const notFound = errors.find(isNotFoundError)

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -117,8 +117,8 @@ export const getStaticProps: GetStaticProps<
 
   let pageData
 
-  if (process.env.CMS_PAGE) {
-    const cmsData = process.env.CMS_PAGE
+  if (process.env.CMS_DATA) {
+    const cmsData = process.env.CMS_DATA
     const page = cmsData['plp'][0]
 
     if (page) {

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -27,7 +27,7 @@ import GlobalSections, {
   GlobalSectionsData,
   getGlobalSectionsData,
 } from 'src/components/cms/GlobalSections'
-import storeConfig from '../../../faststore.config'
+import storeConfig from 'faststore.config'
 import { useProductQuery } from 'src/sdk/product/useProductQuery'
 import PageProvider, { PDPContext } from 'src/sdk/overrides/PageProvider'
 
@@ -210,8 +210,8 @@ export const getStaticProps: GetStaticProps<
 
   let cmsPage
 
-  if (process.env.CMS_DATA) {
-    const cmsData = process.env.CMS_DATA
+  if (storeConfig.cms.data) {
+    const cmsData = storeConfig.cms.data
     const page = cmsData['pdp'][0]
 
     if (page) {

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -210,8 +210,8 @@ export const getStaticProps: GetStaticProps<
 
   let cmsPage
 
-  if (process.env.CMS_PAGE) {
-    const cmsData = process.env.CMS_PAGE
+  if (process.env.CMS_DATA) {
+    const cmsData = process.env.CMS_DATA
     const page = cmsData['pdp'][0]
 
     if (page) {

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -211,7 +211,7 @@ export const getStaticProps: GetStaticProps<
   let cmsPage
 
   if (storeConfig.cms.data) {
-    const cmsData = storeConfig.cms.data
+    const cmsData = JSON.parse(storeConfig.cms.data)
     const page = cmsData['pdp'][0]
 
     if (page) {

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -21,7 +21,7 @@ import { useSession } from 'src/sdk/session'
 import { mark } from 'src/sdk/tests/mark'
 import { execute } from 'src/server'
 import type { PDPContentType } from 'src/server/cms'
-import { getPage } from 'src/server/cms'
+import { getPage, getPageByVersionId } from 'src/server/cms'
 
 import GlobalSections, {
   GlobalSectionsData,
@@ -205,10 +205,25 @@ export const getStaticProps: GetStaticProps<
       variables: { locator: [{ key: 'slug', value: slug }] },
       operation: query,
     }),
-    getPage<PDPContentType>({
-      ...(previewData?.contentType === 'pdp' ? previewData : null),
-      contentType: 'pdp',
-    }),
+    () => {
+      if (process.env.CMS_PAGE) {
+        const cmsData = process.env.CMS_PAGE
+        const page = cmsData['pdp'][0]
+
+        if (page) {
+          return getPageByVersionId<PDPContentType>({
+            contentType: 'pdp',
+            documentId: page.documentId,
+            versionId: page.versionId,
+          })
+        }
+      }
+
+      return getPage<PDPContentType>({
+        ...(previewData?.contentType === 'pdp' ? previewData : null),
+        contentType: 'pdp',
+      })
+    },
     getGlobalSectionsData(previewData),
   ])
 

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -200,32 +200,33 @@ export const getStaticProps: GetStaticProps<
   Locator
 > = async ({ params, previewData }) => {
   const slug = params?.slug ?? ''
-  const [searchResult, cmsPage, globalSections] = await Promise.all([
+  const [searchResult, globalSections] = await Promise.all([
     execute<ServerProductQueryQueryVariables, ServerProductQueryQuery>({
       variables: { locator: [{ key: 'slug', value: slug }] },
       operation: query,
     }),
-    () => {
-      if (process.env.CMS_PAGE) {
-        const cmsData = process.env.CMS_PAGE
-        const page = cmsData['pdp'][0]
-
-        if (page) {
-          return getPageByVersionId<PDPContentType>({
-            contentType: 'pdp',
-            documentId: page.documentId,
-            versionId: page.versionId,
-          })
-        }
-      }
-
-      return getPage<PDPContentType>({
-        ...(previewData?.contentType === 'pdp' ? previewData : null),
-        contentType: 'pdp',
-      })
-    },
     getGlobalSectionsData(previewData),
   ])
+
+  let cmsPage
+
+  if (process.env.CMS_PAGE) {
+    const cmsData = process.env.CMS_PAGE
+    const page = cmsData['pdp'][0]
+
+    if (page) {
+      cmsPage = getPageByVersionId<PDPContentType>({
+        contentType: 'pdp',
+        documentId: page.documentId,
+        versionId: page.versionId,
+      })
+    }
+  } else {
+    cmsPage = getPage<PDPContentType>({
+      ...(previewData?.contentType === 'pdp' ? previewData : null),
+      contentType: 'pdp',
+    })
+  }
 
   const { data, errors = [] } = searchResult
 

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -87,8 +87,8 @@ export const getStaticProps: GetStaticProps<
 > = async ({ previewData }) => {
   const globalSections = await getGlobalSectionsData(previewData)
 
-  if (process.env.CMS_DATA) {
-    const cmsData = process.env.CMS_DATA
+  if (storeConfig.cms.data) {
+    const cmsData = storeConfig.cms.data
     const page = cmsData['home'][0]
 
     if (page) {

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -87,8 +87,8 @@ export const getStaticProps: GetStaticProps<
 > = async ({ previewData }) => {
   const globalSections = await getGlobalSectionsData(previewData)
 
-  if (process.env.CMS_PAGE) {
-    const cmsData = process.env.CMS_PAGE
+  if (process.env.CMS_DATA) {
+    const cmsData = process.env.CMS_DATA
     const page = cmsData['home'][0]
 
     if (page) {

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -13,7 +13,7 @@ import ProductTiles from 'src/components/sections/ProductTiles'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import { mark } from 'src/sdk/tests/mark'
 import type { PageContentType } from 'src/server/cms'
-import { getPage } from 'src/server/cms'
+import { getPage, getPageByVersionId } from 'src/server/cms'
 
 import GlobalSections, {
   GlobalSectionsData,
@@ -85,13 +85,29 @@ export const getStaticProps: GetStaticProps<
   Record<string, string>,
   Locator
 > = async ({ previewData }) => {
-  const [page, globalSections] = await Promise.all([
-    getPage<PageContentType>({
-      ...(previewData?.contentType === 'home' && previewData),
-      contentType: 'home',
-    }),
-    getGlobalSectionsData(previewData),
-  ])
+  const globalSections = await getGlobalSectionsData(previewData)
+
+  if (process.env.CMS_PAGE) {
+    const cmsData = process.env.CMS_PAGE
+    const page = cmsData['home'][0]
+
+    if (page) {
+      const pageData = await getPageByVersionId<PageContentType>({
+        contentType: 'home',
+        documentId: page.documentId,
+        versionId: page.versionId,
+      })
+
+      return {
+        props: { page: pageData, globalSections },
+      }
+    }
+  }
+
+  const page = await getPage<PageContentType>({
+    ...(previewData?.contentType === 'home' && previewData),
+    contentType: 'home',
+  })
 
   return {
     props: { page, globalSections },

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -88,7 +88,7 @@ export const getStaticProps: GetStaticProps<
   const globalSections = await getGlobalSectionsData(previewData)
 
   if (storeConfig.cms.data) {
-    const cmsData = storeConfig.cms.data
+    const cmsData = JSON.parse(storeConfig.cms.data)
     const page = cmsData['home'][0]
 
     if (page) {

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -121,7 +121,7 @@ export const getStaticProps: GetStaticProps<
   const globalSections = await getGlobalSectionsData(previewData)
 
   if (storeConfig.cms.data) {
-    const cmsData = storeConfig.cms.data
+    const cmsData = JSON.parse(storeConfig.cms.data)
     const page = cmsData['search'][0]
 
     if (page) {

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -20,7 +20,7 @@ import GlobalSections, {
   GlobalSectionsData,
 } from 'src/components/cms/GlobalSections'
 import { getPage, getPageByVersionId, SearchContentType } from 'src/server/cms'
-import storeConfig from '../../faststore.config'
+import storeConfig from 'faststore.config'
 import SearchPage from 'src/components/templates/SearchPage/SearchPage'
 
 type Props = {
@@ -120,8 +120,8 @@ export const getStaticProps: GetStaticProps<
 > = async ({ previewData }) => {
   const globalSections = await getGlobalSectionsData(previewData)
 
-  if (process.env.CMS_DATA) {
-    const cmsData = process.env.CMS_DATA
+  if (storeConfig.cms.data) {
+    const cmsData = storeConfig.cms.data
     const page = cmsData['search'][0]
 
     if (page) {

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -120,8 +120,8 @@ export const getStaticProps: GetStaticProps<
 > = async ({ previewData }) => {
   const globalSections = await getGlobalSectionsData(previewData)
 
-  if (process.env.CMS_PAGE) {
-    const cmsData = process.env.CMS_PAGE
+  if (process.env.CMS_DATA) {
+    const cmsData = process.env.CMS_DATA
     const page = cmsData['search'][0]
 
     if (page) {

--- a/packages/core/src/server/cms.ts
+++ b/packages/core/src/server/cms.ts
@@ -39,6 +39,32 @@ export const getPage = async <T extends ContentData>(options: Options) => {
   return pages[0] as T
 }
 
+export type VersionOptions = {
+  contentType: string
+  documentId: string
+  versionId: string
+}
+
+export const getPageByVersionId = async <T extends ContentData>(
+  options: VersionOptions
+) => {
+  const result = await clientCMS
+    .getCMSPage(options)
+    .then((page) => ({ data: [page] }))
+
+  const pages = result.data
+
+  if (!pages[0]) {
+    throw new MissingContentError(options)
+  }
+
+  if (pages.length !== 1) {
+    throw new MultipleContentError(options)
+  }
+
+  return pages[0] as T
+}
+
 type ProductGallerySettings = {
   settings: {
     productGallery: {

--- a/packages/core/src/server/cms.ts
+++ b/packages/core/src/server/cms.ts
@@ -48,7 +48,6 @@ export type VersionOptions = {
 export const getPageByVersionId = async <T extends ContentData>(
   options: VersionOptions
 ) => {
-  console.log({ options })
   const result = await clientCMS
     .getCMSPage(options)
     .then((page) => ({ data: [page] }))

--- a/packages/core/src/server/cms.ts
+++ b/packages/core/src/server/cms.ts
@@ -48,6 +48,7 @@ export type VersionOptions = {
 export const getPageByVersionId = async <T extends ContentData>(
   options: VersionOptions
 ) => {
+  console.log({ options })
   const result = await clientCMS
     .getCMSPage(options)
     .then((page) => ({ data: [page] }))

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
     "OCLIF_COMPILATION",
     "NODE_ENV",
     "DISABLE_3P_SCRIPTS",
-    "CMS_PAGE"
+    "CMS_DATA"
   ],
   "pipeline": {
     "site#build": {

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,8 @@
   "globalEnv": [
     "OCLIF_COMPILATION",
     "NODE_ENV",
-    "DISABLE_3P_SCRIPTS"
+    "DISABLE_3P_SCRIPTS",
+    "CMS_PAGE"
   ],
   "pipeline": {
     "site#build": {


### PR DESCRIPTION
## What's the purpose of this pull request?

We need to stop getting the latest CMS page because of caching issues, so we're going to retrieve the contents during the build time and using those versions to request the necessary pages by version ID.

## How it works?

This PR uses the versionId to retrieve CMS page data, maintaining the previous way of getting the latest version as fallback.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
