### PR TITLE
[TCM-184] Add `scopes` and `requiredScopes` to CMS files

### DIFF
--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -2,12 +2,14 @@
   {
     "id": "globalSections",
     "name": "Global Sections",
+    "scopes": [],
     "configurationSchemaSets": [],
     "isSingleton": true
   },
   {
     "id": "landingPage",
     "name": "Landing Page",
+    "scopes": ["landing", "custom"],
     "configurationSchemaSets": [
       {
         "name": "Settings",
@@ -53,6 +55,7 @@
   {
     "id": "home",
     "name": "Home",
+    "scopes": ["home"],
     "isSingleton": true,
     "configurationSchemaSets": [
       {
@@ -99,12 +102,14 @@
   {
     "id": "pdp",
     "name": "Product Page",
+    "scopes": ["pdp"],
     "isSingleton": true,
     "configurationSchemaSets": []
   },
   {
     "id": "plp",
     "name": "Product List Page",
+    "scopes": ["plp"],
     "isSingleton": true,
     "configurationSchemaSets": [
       {
@@ -158,6 +163,7 @@
   {
     "id": "search",
     "name": "Search Page",
+    "scopes": ["plp", "search"],
     "isSingleton": true,
     "configurationSchemaSets": [
       {

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -2,7 +2,7 @@
   {
     "id": "globalSections",
     "name": "Global Sections",
-    "scopes": [],
+    "scopes": ["global"],
     "configurationSchemaSets": [],
     "isSingleton": true
   },

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "Search",
+    "requiredScopes": [],
     "schema": {
       "title": "Search Bar",
       "type": "object",
@@ -145,6 +146,7 @@
   },
   {
     "name": "Navbar",
+    "requiredScopes": [],
     "schema": {
       "title": "Navbar",
       "type": "object",
@@ -369,6 +371,7 @@
   },
   {
     "name": "Alert",
+    "requiredScopes": [],
     "schema": {
       "title": "Alert",
       "description": "Add an alert",
@@ -416,6 +419,7 @@
   },
   {
     "name": "Footer",
+    "requiredScopes": [],
     "schema": {
       "title": "Footer",
       "description": "Footer displayed on all pages",
@@ -661,6 +665,7 @@
   },
   {
     "name": "BannerText",
+    "requiredScopes": [],
     "schema": {
       "title": "Banner Text",
       "description": "Add a quick promotion with a text/action pair",
@@ -712,6 +717,7 @@
   },
   {
     "name": "Hero",
+    "requiredScopes": [],
     "schema": {
       "title": "Hero",
       "description": "Add a quick promotion with an image/action pair",
@@ -779,6 +785,7 @@
   },
   {
     "name": "Incentives",
+    "requiredScopes": [],
     "schema": {
       "title": "Incentives",
       "description": "Add Incentives to your shopper",
@@ -836,6 +843,7 @@
   },
   {
     "name": "ProductShelf",
+    "requiredScopes": [],
     "schema": {
       "title": "Product Shelf",
       "description": "Add custom shelves to your store",
@@ -937,6 +945,7 @@
   },
   {
     "name": "CrossSellingShelf",
+    "requiredScopes": ["pdp", "custom"],
     "schema": {
       "title": "Cross Selling Shelf",
       "description": "Add cross selling product data to your users",
@@ -971,6 +980,7 @@
   },
   {
     "name": "ProductTiles",
+    "requiredScopes": [],
     "schema": {
       "title": "Product Tiles",
       "description": "Add custom highlights to your store",
@@ -1050,6 +1060,7 @@
   },
   {
     "name": "Newsletter",
+    "requiredScopes": [],
     "schema": {
       "title": "Newsletter",
       "description": "Allow users to subscribe to your updates",
@@ -1191,6 +1202,7 @@
   },
   {
     "name": "BannerNewsletter",
+    "requiredScopes": [],
     "schema": {
       "title": "Banner Newsletter",
       "description": "Add newsletter with a banner",
@@ -1374,6 +1386,7 @@
   },
   {
     "name": "Breadcrumb",
+    "requiredScopes": ["pdp", "plp"],
     "schema": {
       "title": "Breadcrumb",
       "description": "Configure the breadcrumb icon and depth",
@@ -1395,6 +1408,7 @@
   },
   {
     "name": "ProductDetails",
+    "requiredScopes": ["pdp"],
     "schema": {
       "title": "Product Details",
       "type": "object",
@@ -1530,6 +1544,7 @@
   },
   {
     "name": "ProductGallery",
+    "requiredScopes": ["plp", "search"],
     "schema": {
       "title": "Product Gallery",
       "type": "object",
@@ -1726,6 +1741,7 @@
   },
   {
     "name": "CartSidebar",
+    "requiredScopes": [],
     "schema": {
       "title": "Cart Sidebar",
       "type": "object",
@@ -1821,6 +1837,7 @@
   },
   {
     "name": "RegionBar",
+    "requiredScopes": [],
     "schema": {
       "title": "Region Bar",
       "type": "object",
@@ -1878,6 +1895,7 @@
   },
   {
     "name": "RegionModal",
+    "requiredScopes": [],
     "schema": {
       "title": "Region Modal",
       "type": "object",


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR makes use of a new feature recently added to hCMS: Section and Content Type scopes. This is a feature that allows developers to prevent certain sections from being added to documents of any type, hopefully preventing changes made via hCMS from breaking live pages due to a new section being added and not rendering correctly. 

An example of a use case for this would be developing components that only work on PDPs, such as a `ProductDetails` section that requires information about a product to function correctly (via contexts or any other way). Yes, the developer should probably implement a fallback in their code to simply render `null` or something else if no product information is available, but using `scopes` and `requiredScopes` would make it even safer, since they could just add `requiredScopes: ["pdp"]` to their section's definition.

## How it works?

A more detailed explanation of how this works can be found at:

- https://vtex.slack.com/archives/C05HQTUBNE5/p1705958745777309.
- https://github.com/vtex/admin-cms/pull/414.
- https://github.com/vtex/admin-cms-graphql-rc/pull/333.

## How to test it?

I've setup a workspace at Hearst QA that is using this version of FastStore and custom sections from their store that are also using `requiredScopes`: [hearstqa/victormiranda](https://victormiranda--hearstqa.myvtex.com/admin/headless-cms/faststore). You can check the updated definitions at: [hearstqa.store](https://github.com/vtex-sites/hearstqa.store/pull/475).

When you try to add a new section into any of their pages, you'll notice that:

- `PLPHero` - will only show up on PLPs
- `HeroCarousel` - will only show up on Home and Landing Page
- `CustomProductDetails` - will only show up on PDPs

All other sections will be available to be added into any page.

## Notes

There will be an announcement for the new hCMS feature in the coming weeks, so it will be better documented 😅 .

Also, note that I'm restricting some sections based on what I think makes sense, but since this will actually change something for merchants, I would like confirmation that you agree with the restrictions I'm introducing, namely:

- `CrossSellingShelf` - will only be usable in PDPs and landing/custom pages.
- `Breadcrumb` - will only be usable in PDPs, PLPs and landing/custom pages.
- `ProductDetails` - will only be usable in PDPs.
- `ProductGallery` - will only be usable in PLPs and Seach pages.

All other sections will still be available to be added into any content type. I tried to be as permissive as possible here and not add too many restrictions, but I'm open to adding more if you think it makes sense. 

Also, the `scopes` that I'm giving to each content-type can have **arbitrary** names. We just match `requiredScopes` and `scopes`, so if don't want to go with a `pdp` scope and instead use `product`, it would work the same as long as your sections have `requiredScopes: ["product"]` in them. That said, I'm open to changing the names I used here too 😄 .
