### PR TITLE
Fix: Updates eslint-config version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
-     TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-     TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-     TURBO_REMOTE_ONLY: true
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_REMOTE_ONLY: true
 
     steps:
       - name: Check out code
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 18
-          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 18
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "apps/*"
   ],
   "devDependencies": {
-    "@faststore/eslint-config": "^2.2.0-alpha.0",
+    "@faststore/eslint-config": "^3.0.0",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "lerna": "^8.0.0",
     "prettier": "^3.1.0",

--- a/packages/graphql-utils/src/index.ts
+++ b/packages/graphql-utils/src/index.ts
@@ -1,5 +1,5 @@
 export const gql = (_: TemplateStringsArray) => {
   throw new Error(
-    `[graphql-utils]: Depreciation notice: the gql function should be imported from @faststore/core. Follow this migration guide: faststore.dev/docs/migration/graphql-utils`
+    `[graphql-utils]: Depreciation notice: the gql function should be imported from @faststore/core. Follow this migration guide: faststore.dev/docs/api-extensions/api-extensions-improvements`
   )
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

- Updates eslint-config version in package.json
- We're getting errors like this one when running yarn:
<img width="1191" alt="image" src="https://github.com/vtex/faststore/assets/3356699/db7035fc-82ed-4e6e-94d1-f13890047d09">
<img width="1213" alt="image" src="https://github.com/vtex/faststore/assets/3356699/b16d67ac-f9f3-42d1-92d0-c0ea0bf179eb">

https://ci.codesandbox.io/status/vtex/faststore/pr/2215/builds/467587

## How to test it?

You shouldn't get any error after running `yarn --force` or `yarn`. (Installing all the packages dependencies)

### Starters Deploy Preview

WIP


