### PR TITLE
fix(cli): getRoot accurately returns project root

### DIFF
--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -1,8 +1,18 @@
 import path from 'path'
 
+// build folder
+export const tmpFolderName = '.faststore'
+
+// always returns the root of the project, AKA the starter root or @faststore/core dir root when running in the monorepo
 export const getRoot = () => {
   if (process.env.OCLIF_COMPILATION) {
     return ''
+  }
+
+  if(process.cwd().endsWith(tmpFolderName)) {
+    // if the current working directory is the build folder (tmp folder), return the starter root
+    // this makes sure the semantics of the starter root are consistent with the directories declared below
+    return path.join(process.cwd(), '..')
   }
 
   return process.cwd()
@@ -14,8 +24,7 @@ export const userDir = getRoot()
 // node_modules folder for faststorer packages
 export const faststoreDir = path.join(userDir, 'node_modules', '@faststore')
 
-// build folder
-export const tmpFolderName = '.faststore'
+// build folder dir
 export const tmpDir = path.join(userDir, tmpFolderName)
 
 // node_modules folder for @faststore/core


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes a bug where the generated gql function was being copied to the wrong directory.

## How it works?

It fixes the getRoot function in case the cwd of the process is the .faststore folder. It is not aware of that possibility, and accurately returns the project root in those cases, so the dir variables declared after it have the right information.

## How to test it?

Run yarn dev while overriding fragments from the store!

### Starters Deploy Preview

🚧 

