### PR TITLE
fix: add api to core exports and fix compatibility with moduleResoluion bundler

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
   "browserslist": "supports es6-module and not dead",
   "exports": {
     ".": "./index.ts",
+    "./api": "./api/index.ts",
     "./experimental": "./src/experimental/index.ts"
   },
   "scripts": {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR enables imports from `@faststore/core/api` on stores using `moduleResolution: bundler` in their `tsconfig.json`.

## How it works?

It works by adding the export to FastStore Core's `package.json`.

## How to test it?

Change the module resolution to "moduleResolution: bundler" in a store and try importing the `gql` function from `@faststore/core/api`