### PR TITLE
Feat: Add orderFormId path param for dev env

### DIFF
--- a/packages/core/src/sdk/cart/useCheckoutButton.ts
+++ b/packages/core/src/sdk/cart/useCheckoutButton.ts
@@ -2,13 +2,20 @@ import storeConfig from '../../../faststore.config'
 import { useCart } from './index'
 
 export const useCheckoutButton = () => {
-  const { isValidating } = useCart()
+  const { isValidating, id } = useCart()
 
   const onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
+    const isDevEnv =
+      window.location.host.includes('.vtex.app') ||
+      window.location.host.includes('localhost')
 
     if (!isValidating) {
-      window.location.href = `${storeConfig.checkoutUrl}`
+      if (!isDevEnv) {
+        window.location.href = `${storeConfig.checkoutUrl}`
+      } else if (id) {
+        window.location.href = `${storeConfig.checkoutUrl}?orderFormId=${id}`
+      }
     }
   }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

To ensure smooth functionality across different environments, such as localhost and development setups, it's crucial to include the necessary parameters for checkout. 
This practice maintains the integrity of the store-to-checkout flow. While in the final environment structure, domain and subdomain configurations enable seamless checkout using the cookie implementation, it becomes essential to explicitly pass parameters during testing to uphold the continuity of the process.

## How it works?

Add ?orderFormId param when using localhost or vtex.app env.

## How to test it?

Go to the checkout using vtex.app env or localhost and check the parameter passing at the URL.
Final env will always use the cookie.

### Starters Deploy Preview
https://github.com/vtex-sites/starter.store/pull/382

https://github.com/vtex/faststore/assets/67066494/666205f8-6e8a-49ca-bab4-25840d47517e





