### PR TITLE
[TCM-248] Add deduping and confirmation steps to `cms-sync` command

### DIFF
--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,8 +33,10 @@
     "@types/node": "^16.11.63",
     "chai": "^4",
     "eslint": "7.32.0",
+    "jest": "^29.7.0",
     "oclif": "^3",
     "shx": "^0.3.3",
+    "ts-jest": "^29.1.2",
     "ts-node": "^10.9.1",
     "tslib": "^2.3.1",
     "typescript": "^4.8.4"
@@ -55,6 +57,7 @@
   "scripts": {
     "build": "shx rm -rf dist && tsc -b",
     "lint": "eslint src/**/*.ts",
+    "test": "jest src/**/*.test.ts",
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn lint",
     "prepack": "yarn build && oclif manifest && oclif readme",

--- a/packages/cli/src/__mocks__/hcms.ts
+++ b/packages/cli/src/__mocks__/hcms.ts
@@ -1,0 +1,189 @@
+// All mocks are simplified versions, with less fields than proper sections
+// and content types. They contain just the necessary fields for our tests to
+// be useful.
+
+export const coreSections = [
+  {
+    name: 'Alert',
+    schema: {
+      title: 'Alert',
+      description: 'Add an alert',
+      properties: {},
+    },
+  },
+  {
+    name: 'BannerNewsletter',
+    schema: {
+      title: 'Banner Newsletter',
+      description: 'Add newsletter with a banner',
+      properties: {},
+    },
+  },
+  {
+    name: 'Hero',
+    schema: {
+      title: 'Hero',
+      description: 'Add a quick promotion with an image/action pair',
+      properties: {},
+    },
+  },
+  {
+    name: 'Navbar',
+    schema: {
+      title: 'Navbar',
+      description: 'Navbar configuration',
+      properties: {},
+    },
+  },
+  {
+    name: 'ProductShelf',
+    schema: {
+      title: 'Product Shelf',
+      description: 'Add custom shelves to your store',
+      properties: {},
+    },
+  },
+  {
+    name: 'Search',
+    schema: {
+      title: 'Search Bar',
+      description: 'Search Bar Configuration',
+      properties: {},
+    },
+  },
+]
+
+export const allNewCustomSections = [
+  {
+    name: 'MembershipsAccordion',
+    schema: {
+      title: 'Memberships - Accordion',
+      description: 'Why should people give us money every month.',
+      properties: {},
+    },
+  },
+  {
+    name: 'ProductShelfCustom',
+    schema: {
+      title: 'Wayne Industries Shelf',
+      description: 'Some products we sell... nothing bat related.',
+      properties: {},
+    },
+  },
+]
+
+export const sectionDuplicates = [
+  {
+    name: 'BannerNewsletter',
+    schema: {
+      title: 'Newsletter + Cool Banner',
+      description: 'Totally not spam.',
+      properties: {},
+    },
+  },
+  {
+    name: 'Hero',
+    schema: {
+      title: 'Hero',
+      description:
+        'Very careful with the image you choose here... not that we have anything to hide ;)',
+      properties: {},
+    },
+  },
+]
+
+export const customSectionsWithDuplicates = [
+  ...allNewCustomSections,
+  ...sectionDuplicates,
+]
+
+export const coreContentTypes = [
+  {
+    id: '404',
+    name: 'Error 404',
+    configurationSchemaSets: [],
+    isSingleton: true,
+  },
+  {
+    id: '500',
+    name: 'Error 500',
+    configurationSchemaSets: [],
+    isSingleton: true,
+  },
+  {
+    id: 'globalSections',
+    name: 'Global Sections',
+    configurationSchemaSets: [],
+    isSingleton: true,
+  },
+  {
+    id: 'home',
+    name: 'Home',
+    isSingleton: true,
+    configurationSchemaSets: [],
+  },
+  {
+    id: 'landingPage',
+    name: 'Landing Page',
+    configurationSchemaSets: [],
+  },
+  {
+    id: 'login',
+    name: 'Login',
+    configurationSchemaSets: [],
+    isSingleton: true,
+  },
+  {
+    id: 'pdp',
+    name: 'Product Page',
+    isSingleton: true,
+    configurationSchemaSets: [],
+  },
+  {
+    id: 'plp',
+    name: 'Product List Page',
+    isSingleton: true,
+    configurationSchemaSets: [],
+  },
+  {
+    id: 'search',
+    name: 'Search Page',
+    isSingleton: true,
+    configurationSchemaSets: [],
+  },
+]
+
+export const allNewCustomContentTypes = [
+  {
+    id: 'customPage',
+    name: 'Custom Page',
+    isSingleton: true,
+    configurationSchemaSets: [],
+  },
+  {
+    id: 'errorPage',
+    name: 'Custom Error Page',
+    isSingleton: true,
+    configurationSchemaSets: [],
+  },
+]
+
+export const contentTypeDuplicates = [
+  {
+    id: 'login',
+    name: 'Custom Login. Why not...',
+    configurationSchemaSets: [],
+    isSingleton: true,
+  },
+  {
+    id: 'search',
+    name: 'Custom Search Page',
+    isSingleton: true,
+    configurationSchemaSets: [],
+  },
+]
+
+export const customContentTypesWithDuplicates = [
+  ...allNewCustomContentTypes,
+  ...contentTypeDuplicates,
+]

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -1,12 +1,22 @@
-import { Command } from '@oclif/core'
+import { Command, Flags } from '@oclif/core'
 import { spawn } from 'child_process'
 import { tmpDir } from '../utils/directory'
 import { generate, generateCMSFiles } from '../utils/generate'
 
 export default class CmsSync extends Command {
+  static flags = {
+    ['dry-run']: Flags.boolean({ char: 'd' }),
+  }
+
   async run() {
+    const { flags } = await this.parse(CmsSync)
+
     await generate({ setup: true })
     await generateCMSFiles()
+
+    if (flags['dry-run']) {
+      return
+    }
 
     return spawn(`vtex cms sync faststore`, {
       shell: true,

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -1,10 +1,12 @@
 import { Command } from '@oclif/core'
 import { spawn } from 'child_process'
 import { tmpDir } from '../utils/directory'
-import { generate } from '../utils/generate'
+import { generate, generateCMSFiles } from '../utils/generate'
+
 export default class CmsSync extends Command {
   async run() {
     await generate({ setup: true })
+    await generateCMSFiles()
 
     return spawn(`vtex cms sync faststore`, {
       shell: true,

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -3,6 +3,7 @@ import {
   copySync,
   existsSync,
   mkdirsSync,
+  readFileSync,
   readdirSync,
   removeSync,
   writeJsonSync,

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -4,32 +4,26 @@ import {
   existsSync,
   mkdirsSync,
   readdirSync,
-  readFileSync,
   removeSync,
-  writeFileSync,
   writeJsonSync,
 } from 'fs-extra'
-
 import path from 'path'
+import chalk from 'chalk'
 
 import {
-  coreCMSDir,
   coreDir,
-  tmpCMSDir,
   tmpDir,
   tmpFolderName,
   tmpStoreConfigFileDir,
   tmpThemesCustomizationsFileDir,
   tmpCmsWebhookUrlsFileDir,
-  userCMSDir,
   userSrcDir,
   userStoreConfigFileDir,
   userThemesFileDir,
   userDir,
   tmpCustomizationsSrcDir,
 } from './directory'
-
-import chalk from 'chalk'
+import { mergeCMSFiles } from './hcms'
 
 interface GenerateOptions {
   setup?: boolean
@@ -231,47 +225,6 @@ async function copyTheme() {
   }
 }
 
-function mergeCMSFile(fileName: string) {
-  const customFilePath = path.join(userCMSDir, fileName)
-  const coreFilePath = path.join(coreCMSDir, fileName)
-
-  const coreFile = readFileSync(coreFilePath, 'utf8')
-  const output = [...JSON.parse(coreFile)]
-
-  // TODO: create a validation when has the cms files but doesn't have a component for then
-  if (existsSync(customFilePath)) {
-    const customFile = readFileSync(customFilePath, 'utf8')
-
-    try {
-      output.push(...JSON.parse(customFile))
-    } catch (err) {
-      if (err instanceof SyntaxError) {
-        console.info(
-          `${chalk.red(
-            'error'
-          )} - ${fileName} is a malformed JSON file, ignoring its contents.`
-        )
-      } else {
-        throw err
-      }
-    }
-  }
-
-  try {
-    writeFileSync(path.join(tmpCMSDir, fileName), JSON.stringify(output))
-    console.log(
-      `${chalk.green('success')} - CMS file ${chalk.dim(fileName)} created`
-    )
-  } catch (err) {
-    console.error(`${chalk.red('error')} - ${err}`)
-  }
-}
-
-function mergeCMSFiles() {
-  mergeCMSFile('content-types.json')
-  mergeCMSFile('sections.json')
-}
-
 export async function generate(options?: GenerateOptions) {
   const { setup = false } = options ?? {}
 
@@ -290,7 +243,10 @@ export async function generate(options?: GenerateOptions) {
     setupPromise,
     copyUserStarterToCustomizations(),
     copyTheme(),
-    createCmsWebhookUrlsJsonFile(),
-    mergeCMSFiles(),
   ])
+}
+
+export async function generateCMSFiles() {
+  await createCmsWebhookUrlsJsonFile()
+  await mergeCMSFiles()
 }

--- a/packages/cli/src/utils/hcms.test.ts
+++ b/packages/cli/src/utils/hcms.test.ts
@@ -67,7 +67,7 @@ describe('splitCustomDefinitions', () => {
 })
 
 describe('dedupeAndMergeDefinitions', () => {
-  it('should return the the exact same core definitions if there are no duplicates', () => {
+  it('should return the exact same core definitions if there are no duplicates', () => {
     expect(dedupeAndMergeDefinitions(coreContentTypes, [], 'id')).toEqual(
       coreContentTypes
     )

--- a/packages/cli/src/utils/hcms.test.ts
+++ b/packages/cli/src/utils/hcms.test.ts
@@ -1,0 +1,193 @@
+import {
+  allNewCustomContentTypes,
+  allNewCustomSections,
+  contentTypeDuplicates,
+  coreContentTypes,
+  coreSections,
+  customContentTypesWithDuplicates,
+  customSectionsWithDuplicates,
+  sectionDuplicates,
+} from '../__mocks__/hcms'
+import { dedupeAndMergeDefinitions, splitCustomDefinitions } from './hcms'
+
+describe('splitCustomDefinitions', () => {
+  it('should return empty arrays if there are no custom definitions', () => {
+    // content-types
+    expect(splitCustomDefinitions(coreContentTypes, [], 'id')).toEqual({
+      duplicates: [],
+      newDefinitions: [],
+    })
+
+    // sections
+    expect(splitCustomDefinitions(coreSections, [], 'name')).toEqual({
+      duplicates: [],
+      newDefinitions: [],
+    })
+  })
+
+  it('should return empty duplicates array if all custom definitions are new', () => {
+    // content-types
+    expect(
+      splitCustomDefinitions(coreContentTypes, allNewCustomContentTypes, 'id')
+    ).toEqual({
+      duplicates: [],
+      newDefinitions: allNewCustomContentTypes,
+    })
+
+    // sections
+    expect(
+      splitCustomDefinitions(coreSections, allNewCustomSections, 'name')
+    ).toEqual({
+      duplicates: [],
+      newDefinitions: allNewCustomSections,
+    })
+  })
+
+  it('should return expected split definitions', () => {
+    // content-types
+    expect(
+      splitCustomDefinitions(
+        coreContentTypes,
+        customContentTypesWithDuplicates,
+        'id'
+      )
+    ).toEqual({
+      duplicates: contentTypeDuplicates,
+      newDefinitions: allNewCustomContentTypes,
+    })
+
+    // sections
+    expect(
+      splitCustomDefinitions(coreSections, customSectionsWithDuplicates, 'name')
+    ).toEqual({
+      duplicates: sectionDuplicates,
+      newDefinitions: allNewCustomSections,
+    })
+  })
+})
+
+describe('dedupeAndMergeDefinitions', () => {
+  it('should return the the exact same core definitions if there are no duplicates', () => {
+    expect(dedupeAndMergeDefinitions(coreContentTypes, [], 'id')).toEqual(
+      coreContentTypes
+    )
+
+    expect(dedupeAndMergeDefinitions(coreSections, [], 'name')).toEqual(
+      coreSections
+    )
+  })
+
+  it('should return expected merged definitions, applying overrides based on duplicates', () => {
+    expect(
+      dedupeAndMergeDefinitions(coreContentTypes, contentTypeDuplicates, 'id')
+    ).toEqual([
+      {
+        id: '404',
+        name: 'Error 404',
+        configurationSchemaSets: [],
+        isSingleton: true,
+      },
+      {
+        id: '500',
+        name: 'Error 500',
+        configurationSchemaSets: [],
+        isSingleton: true,
+      },
+      {
+        id: 'globalSections',
+        name: 'Global Sections',
+        configurationSchemaSets: [],
+        isSingleton: true,
+      },
+      {
+        id: 'home',
+        name: 'Home',
+        isSingleton: true,
+        configurationSchemaSets: [],
+      },
+      {
+        id: 'landingPage',
+        name: 'Landing Page',
+        configurationSchemaSets: [],
+      },
+      {
+        id: 'login',
+        name: 'Custom Login. Why not...',
+        configurationSchemaSets: [],
+        isSingleton: true,
+      },
+      {
+        id: 'pdp',
+        name: 'Product Page',
+        isSingleton: true,
+        configurationSchemaSets: [],
+      },
+      {
+        id: 'plp',
+        name: 'Product List Page',
+        isSingleton: true,
+        configurationSchemaSets: [],
+      },
+      {
+        id: 'search',
+        name: 'Custom Search Page',
+        isSingleton: true,
+        configurationSchemaSets: [],
+      },
+    ])
+
+    expect(
+      dedupeAndMergeDefinitions(coreSections, sectionDuplicates, 'name')
+    ).toEqual([
+      {
+        name: 'Alert',
+        schema: {
+          title: 'Alert',
+          description: 'Add an alert',
+          properties: {},
+        },
+      },
+      {
+        name: 'BannerNewsletter',
+        schema: {
+          title: 'Newsletter + Cool Banner',
+          description: 'Totally not spam.',
+          properties: {},
+        },
+      },
+      {
+        name: 'Hero',
+        schema: {
+          title: 'Hero',
+          description:
+            'Very careful with the image you choose here... not that we have anything to hide ;)',
+          properties: {},
+        },
+      },
+      {
+        name: 'Navbar',
+        schema: {
+          title: 'Navbar',
+          description: 'Navbar configuration',
+          properties: {},
+        },
+      },
+      {
+        name: 'ProductShelf',
+        schema: {
+          title: 'Product Shelf',
+          description: 'Add custom shelves to your store',
+          properties: {},
+        },
+      },
+      {
+        name: 'Search',
+        schema: {
+          title: 'Search Bar',
+          description: 'Search Bar Configuration',
+          properties: {},
+        },
+      },
+    ])
+  })
+})

--- a/packages/cli/src/utils/hcms.ts
+++ b/packages/cli/src/utils/hcms.ts
@@ -122,7 +122,7 @@ async function mergeCMSFile(fileName: string) {
 
   let output: ContentTypeOrSectionDefinition[] = []
 
-  // TODO: create a validation when has the cms files but doesn't have a component for then
+  // TODO: create a validation when the CMS files exist but don't have a component for them
   if (existsSync(customFilePath)) {
     const customFile = readFileSync(customFilePath, 'utf8')
 

--- a/packages/cli/src/utils/hcms.ts
+++ b/packages/cli/src/utils/hcms.ts
@@ -104,13 +104,7 @@ async function confirmUserChoice(
   )
 
   if (!goAhead) {
-    console.info(
-      `${chalk.yellow(
-        'info'
-      )} - Skipping merge of local and default ${chalk.dim(fileName)} file.`
-    )
-
-    throw new Error('cms sync aborted.')
+    throw new Error('cms-sync cancelled by user.')
   }
 
   return

--- a/packages/cli/src/utils/hcms.ts
+++ b/packages/cli/src/utils/hcms.ts
@@ -1,0 +1,188 @@
+import path from 'path'
+import chalk from 'chalk'
+import { CliUx } from '@oclif/core'
+import { readFileSync, existsSync, writeFileSync } from 'fs-extra'
+
+import { userCMSDir, coreCMSDir, tmpCMSDir } from './directory'
+
+export interface ContentTypeOrSectionDefinition {
+  id?: string
+  name?: string
+  scopes?: string[]
+  isSingleton?: boolean
+  onlySettings?: boolean
+  requiredScopes?: string[]
+  schema?: Record<string, unknown>
+  configurationSchemaSets?: ConfigurationSchemaSet[]
+}
+
+export interface ConfigurationSchemaSet {
+  name?: string
+  configurations?: Array<{
+    name?: string
+    schema?: Record<string, unknown>
+  }>
+}
+
+export function splitCustomDefinitions(
+  coreDefinitions: ContentTypeOrSectionDefinition[],
+  customDefinitions: ContentTypeOrSectionDefinition[],
+  primaryIdentifier: 'id' | 'name'
+) {
+  const coreDefinitionIdentifiers = new Set<string>(
+    coreDefinitions.map((definition) => definition[primaryIdentifier] ?? '')
+  )
+
+  const duplicates: ContentTypeOrSectionDefinition[] = []
+  const newDefinitions: ContentTypeOrSectionDefinition[] = []
+
+  customDefinitions.forEach((definition) => {
+    if (!definition[primaryIdentifier]) {
+      console.error('Ignoring invalid definition:', definition)
+      return
+    }
+
+    if (
+      coreDefinitionIdentifiers.has(definition[primaryIdentifier] as string)
+    ) {
+      duplicates.push(definition)
+      return
+    }
+
+    newDefinitions.push(definition)
+  })
+
+  return { duplicates, newDefinitions }
+}
+
+export function dedupeAndMergeDefinitions(
+  coreDefinitions: ContentTypeOrSectionDefinition[],
+  duplicates: ContentTypeOrSectionDefinition[],
+  primaryIdentifier: 'id' | 'name'
+) {
+  const sortedCoreDefs = coreDefinitions.filter((definition) =>
+    Boolean(definition[primaryIdentifier])
+  )
+  sortedCoreDefs.sort((a, b) =>
+    (a[primaryIdentifier] as string) < (b[primaryIdentifier] as string) ? -1 : 1
+  )
+
+  const sortedDuplicates = duplicates.filter((definition) =>
+    Boolean(definition[primaryIdentifier])
+  )
+  sortedDuplicates.sort((a, b) =>
+    (a[primaryIdentifier] as string) < (b[primaryIdentifier] as string) ? -1 : 1
+  )
+
+  let duplicateIdx = 0
+
+  const result = sortedCoreDefs.map((currentDefinition) => {
+    const isDuplicateMatch =
+      currentDefinition[primaryIdentifier] ===
+      sortedDuplicates[duplicateIdx]?.[primaryIdentifier]
+
+    if (duplicateIdx < sortedDuplicates.length && isDuplicateMatch) {
+      return sortedDuplicates[duplicateIdx++]
+    }
+
+    return currentDefinition
+  })
+
+  return result
+}
+
+async function confirmUserChoice(
+  duplicates: ContentTypeOrSectionDefinition[],
+  fileName: string
+) {
+  const goAhead = await CliUx.ux.confirm(
+    `You are about to override default ${
+      fileName.split('.')[0]
+    }:\n\n${duplicates
+      .map((definition) => definition.id || definition.name)
+      .join('\n')}\n\nAre you sure? [yes/no]`
+  )
+
+  if (!goAhead) {
+    console.info(
+      `${chalk.yellow(
+        'info'
+      )} - Skipping merge of local and default ${chalk.dim(fileName)} file.`
+    )
+
+    throw new Error('cms sync aborted.')
+  }
+
+  return
+}
+
+async function mergeCMSFile(fileName: string) {
+  const coreFilePath = path.join(coreCMSDir, fileName)
+  const customFilePath = path.join(userCMSDir, fileName)
+
+  const coreFile = readFileSync(coreFilePath, 'utf8')
+  const coreDefinitions: ContentTypeOrSectionDefinition[] = JSON.parse(coreFile)
+
+  const primaryIdentifierForDefinitions =
+    fileName === 'content-types.json' ? 'id' : 'name'
+
+  let output: ContentTypeOrSectionDefinition[] = []
+
+  // TODO: create a validation when has the cms files but doesn't have a component for then
+  if (existsSync(customFilePath)) {
+    const customFile = readFileSync(customFilePath, 'utf8')
+
+    try {
+      const customDefinitions = JSON.parse(customFile)
+
+      const { duplicates, newDefinitions } = splitCustomDefinitions(
+        coreDefinitions,
+        customDefinitions,
+        primaryIdentifierForDefinitions
+      )
+
+      if (duplicates.length) {
+        await confirmUserChoice(duplicates, fileName)
+
+        output = [
+          ...dedupeAndMergeDefinitions(
+            coreDefinitions,
+            duplicates,
+            primaryIdentifierForDefinitions
+          ),
+          ...newDefinitions,
+        ]
+      } else {
+        output = [...coreDefinitions, ...newDefinitions]
+      }
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        console.info(
+          `${chalk.red(
+            'error'
+          )} - ${fileName} is a malformed JSON file, ignoring its contents.`
+        )
+      } else {
+        throw err
+      }
+    }
+  }
+
+  try {
+    writeFileSync(path.join(tmpCMSDir, fileName), JSON.stringify(output))
+    console.log(
+      `${chalk.green('success')} - CMS file ${chalk.dim(fileName)} created`
+    )
+  } catch (err) {
+    console.error(`${chalk.red('error')} - ${err}`)
+  }
+}
+
+export async function mergeCMSFiles() {
+  try {
+    await mergeCMSFile('content-types.json')
+    await mergeCMSFile('sections.json')
+  } catch (err) {
+    console.error(`${chalk.red('error')} - ${err}`)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16817,6 +16817,20 @@ ts-jest@29.1.1:
     semver "^7.5.3"
     yargs-parser "^21.0.1"
 
+ts-jest@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.2.tgz#7613d8c81c43c8cb312c6904027257e814c40e09"
+  integrity sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==
+  dependencies:
+    bs-logger "0.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^29.0.0"
+    json5 "^2.2.3"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    semver "^7.5.3"
+    yargs-parser "^21.0.1"
+
 ts-log@^2.2.3:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.5.tgz#aef3252f1143d11047e2cb6f7cfaac7408d96623"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR updates the process of merging `content-types.json` and `sections.json` files from `@faststore/core` and local user files. It adds an extra validation step, so that users are aware of the changes they're about to make to hCMS configuration, and adds a deduping step to override definitions from `@faststore/core` in a predictable way.

## How it works?

Running all the way:

```
➜  hearstqa.store git:(feat/scoped-sections) ✗ yarn cms-sync --dry-run
yarn run v1.22.19
$ faststore cms-sync --dry-run
success - Temporary folder .faststore created
success - Core files copied
success - Public files copied
success - Starter files copied
success - Cypress test files copied
success - menshealth theme has been applied
success - CMS webhook URLs file created
You are about to override default content-types:

globalSections

Are you sure? [yes/no]: y
success - CMS file content-types.json created
You are about to override default sections:

Navbar

Are you sure? [yes/no]: y
success - CMS file sections.json created
✨  Done in 9.41s.
```

Cancelling the process:

```
➜  hearstqa.store git:(feat/scoped-sections) ✗ yarn cms-sync --dry-run
yarn run v1.22.19
$ faststore cms-sync --dry-run
success - Temporary folder .faststore created
success - Core files copied
success - Public files copied
success - Starter files copied
success - Cypress test files copied
success - menshealth theme has been applied
success - CMS webhook URLs file created
You are about to override default content-types:

globalSections

Are you sure? [yes/no]: y
success - CMS file content-types.json created
You are about to override default sections:

Navbar

Are you sure? [yes/no]: n
error - Error: cms-sync cancelled by user.
✨  Done in 5.57s.
```

## How to test it?

1. Clone a store's repo.
2. Install `@faststore/cli` version from the Deploy Preview below.
3. Create definitions on `content-types.json` and/or `sections.json` that override any of the default ones from `@faststore/core`.
4. Run `faststore cms-sync --dry-run` (to not actuality sync the files).
5. Confirm both prompts and check the generate files at `.fastore`.

## Notes

This was motivated by this thread: https://vtex.slack.com/archives/C05HQTUBNE5/p1706312940059979?thread_ts=1705958745.777309&cid=C05HQTUBNE5.
