### PR TITLE
fix: useQuery types & module resolution

### DIFF
--- a/packages/core/src/sdk/graphql/prefetchQuery.ts
+++ b/packages/core/src/sdk/graphql/prefetchQuery.ts
@@ -3,11 +3,10 @@ import type { Cache } from 'swr'
 
 import { request } from './request'
 import { getKey } from './useQuery'
-import type { RequestOptions } from './request'
-import { TypedDocumentString } from '@generated/graphql'
+import type { Operation, RequestOptions } from './request'
 
 export const prefetchQuery = <Data, Variables = Record<string, unknown>>(
-  operation: TypedDocumentString<any, any>,
+  operation: Operation,
   variables: Variables,
   { cache, ...options }: Partial<RequestOptions> & { cache: Cache }
 ) => {

--- a/packages/core/src/sdk/graphql/request.ts
+++ b/packages/core/src/sdk/graphql/request.ts
@@ -1,6 +1,7 @@
 import { TypedDocumentString } from '@generated/graphql'
 
 export type RequestOptions = Omit<BaseRequestOptions, 'operation' | 'variables'>
+export type Operation = Pick<TypedDocumentString<any, any>, '__meta__'>
 
 export interface GraphQLResponse<D = any> {
   data: D
@@ -8,7 +9,7 @@ export interface GraphQLResponse<D = any> {
 }
 
 export interface BaseRequestOptions<V = any> {
-  operation: TypedDocumentString<any, any>
+  operation: Operation
   variables: V
   fetchOptions?: RequestInit
 }
@@ -20,7 +21,7 @@ const DEFAULT_HEADERS_BY_VERB: Record<string, Record<string, string>> = {
 }
 
 export const request = async <Query = unknown, Variables = unknown>(
-  operation: TypedDocumentString<any, any>,
+  operation: Operation,
   variables: Variables,
   options?: RequestOptions
 ) => {

--- a/packages/core/src/sdk/graphql/useLazyQuery.ts
+++ b/packages/core/src/sdk/graphql/useLazyQuery.ts
@@ -1,12 +1,11 @@
 import useSWR from 'swr'
 
-import { request } from './request'
+import { type Operation, request } from './request'
 import { DEFAULT_OPTIONS, getKey } from './useQuery'
 import type { QueryOptions } from './useQuery'
-import { TypedDocumentString } from '@generated/graphql'
 
 export const useLazyQuery = <Data, Variables = Record<string, unknown>>(
-  operation: TypedDocumentString<any, any>,
+  operation: Operation,
   variables: Variables,
   options?: QueryOptions
 ) => {

--- a/packages/core/src/sdk/graphql/useQuery.ts
+++ b/packages/core/src/sdk/graphql/useQuery.ts
@@ -2,8 +2,7 @@ import useSWR from 'swr'
 import type { SWRConfiguration } from 'swr'
 
 import { request } from './request'
-import type { RequestOptions } from './request'
-import { TypedDocumentString } from '@generated/graphql'
+import type { Operation, RequestOptions } from './request'
 
 export type QueryOptions = SWRConfiguration &
   RequestOptions & { doNotRun?: boolean }
@@ -23,7 +22,7 @@ export const DEFAULT_OPTIONS = {
 }
 
 export const useQuery = <Data, Variables = Record<string, unknown>>(
-  operation: TypedDocumentString<any, any>,
+  operation: Operation,
   variables: Variables,
   options?: QueryOptions
 ) =>

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -27,10 +27,10 @@ import vtexExtensionsResolvers from '../customizations/src/graphql/vtex/resolver
 import thirdPartyResolvers from '../customizations/src/graphql/thirdParty/resolvers'
 
 import { apiOptions } from './options'
-import { TypedDocumentString } from '@generated/graphql'
+import { Operation } from '../sdk/graphql/request'
 
 interface ExecuteOptions<V = Record<string, unknown>> {
-  operation: Pick<TypedDocumentString<any, any>, '__meta__'>
+  operation: Operation
   variables: V
   query?: string | null
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -14,6 +14,11 @@
     "paths": {
       "src/*": ["src/*"],
       "@generated/*": ["@generated/*"],
+      /**
+       * This makes @faststore/core/api and @faststore/core/experimental imports
+       * inside .faststore source from .faststore, not from @faststore/core package
+       */
+      "@faststore/core/api": ["api/index.ts"],
       "@faststore/core/experimental": ["src/experimental/index.ts"]
     },
     "forceConsistentCasingInFileNames": true,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -14,10 +14,6 @@
     "paths": {
       "src/*": ["src/*"],
       "@generated/*": ["@generated/*"],
-      /**
-       * This makes @faststore/core/api and @faststore/core/experimental imports
-       * inside .faststore source from .faststore, not from @faststore/core package
-       */
       "@faststore/core/api": ["api/index.ts"],
       "@faststore/core/experimental": ["src/experimental/index.ts"]
     },

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -14,6 +14,7 @@
     "paths": {
       "src/*": ["src/*"],
       "@generated/*": ["@generated/*"],
+      "@faststore/core": ["index.ts"],
       "@faststore/core/api": ["api/index.ts"],
       "@faststore/core/experimental": ["src/experimental/index.ts"]
     },

--- a/packages/graphql-utils/package.json
+++ b/packages/graphql-utils/package.json
@@ -28,9 +28,5 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@babel/traverse": "^7.15.4",
-    "@babel/types": "^7.15.6",
-    "@graphql-codegen/plugin-helpers": "^2.2.0",
-    "@graphql-tools/relay-operation-optimizer": "^6.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,14 +63,6 @@
     "@babel/highlight" "^7.22.13"
     chalk "^2.4.2"
 
-"@babel/code-frame@^7.23.5":
-  version "7.23.5"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
-  integrity sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==
-  dependencies:
-    "@babel/highlight" "^7.23.4"
-    chalk "^2.4.2"
-
 "@babel/compat-data@^7.20.5":
   version "7.20.10"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.10.tgz#9d92fa81b87542fff50e848ed585b4212c1d34ec"
@@ -129,16 +121,6 @@
   integrity sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==
   dependencies:
     "@babel/types" "^7.23.3"
-    "@jridgewell/gen-mapping" "^0.3.2"
-    "@jridgewell/trace-mapping" "^0.3.17"
-    jsesc "^2.5.1"
-
-"@babel/generator@^7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.6.tgz#9e1fca4811c77a10580d17d26b57b036133f3c2e"
-  integrity sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==
-  dependencies:
-    "@babel/types" "^7.23.6"
     "@jridgewell/gen-mapping" "^0.3.2"
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
@@ -314,11 +296,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
   integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
 
-"@babel/helper-string-parser@^7.23.4":
-  version "7.23.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz#9478c707febcbbe1ddb38a3d91a2e054ae622d83"
-  integrity sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==
-
 "@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
@@ -380,24 +357,10 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/highlight@^7.23.4":
-  version "7.23.4"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.23.4.tgz#edaadf4d8232e1a961432db785091207ead0621b"
-  integrity sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.22.20"
-    chalk "^2.4.2"
-    js-tokens "^4.0.0"
-
 "@babel/parser@^7.1.0", "@babel/parser@^7.13.0", "@babel/parser@^7.14.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.8", "@babel/parser@^7.20.7", "@babel/parser@^7.22.15", "@babel/parser@^7.22.5", "@babel/parser@^7.22.7", "@babel/parser@^7.23.0":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.3.tgz#0ce0be31a4ca4f1884b5786057cadcb6c3be58f9"
   integrity sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==
-
-"@babel/parser@^7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.6.tgz#ba1c9e512bda72a47e285ae42aff9d2a635a9e3b"
-  integrity sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==
 
 "@babel/plugin-proposal-class-properties@^7.0.0":
   version "7.18.6"
@@ -762,37 +725,12 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.15.4":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.6.tgz#b53526a2367a0dd6edc423637f3d2d0f2521abc5"
-  integrity sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==
-  dependencies:
-    "@babel/code-frame" "^7.23.5"
-    "@babel/generator" "^7.23.6"
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-function-name" "^7.23.0"
-    "@babel/helper-hoist-variables" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.6"
-    "@babel/parser" "^7.23.6"
-    "@babel/types" "^7.23.6"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
 "@babel/types@^7.0.0", "@babel/types@^7.16.8", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.3", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.3.tgz#d5ea892c07f2ec371ac704420f4dcdb07b5f9598"
   integrity sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==
   dependencies:
     "@babel/helper-string-parser" "^7.22.5"
-    "@babel/helper-validator-identifier" "^7.22.20"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.15.6", "@babel/types@^7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.6.tgz#be33fdb151e1f5a56877d704492c240fc71c7ccd"
-  integrity sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==
-  dependencies:
-    "@babel/helper-string-parser" "^7.23.4"
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
@@ -1264,7 +1202,7 @@
     auto-bind "~4.0.0"
     tslib "~2.5.0"
 
-"@graphql-codegen/plugin-helpers@^2.1.0", "@graphql-codegen/plugin-helpers@^2.1.1", "@graphql-codegen/plugin-helpers@^2.2.0":
+"@graphql-codegen/plugin-helpers@^2.1.0", "@graphql-codegen/plugin-helpers@^2.1.1":
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz#6544f739d725441c826a8af6a49519f588ff9bed"
   integrity sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==
@@ -1688,7 +1626,7 @@
     tslib "^2.4.0"
     yaml-ast-parser "^0.0.43"
 
-"@graphql-tools/relay-operation-optimizer@^6.3.7", "@graphql-tools/relay-operation-optimizer@^6.4.0", "@graphql-tools/relay-operation-optimizer@^6.5.0":
+"@graphql-tools/relay-operation-optimizer@^6.3.7", "@graphql-tools/relay-operation-optimizer@^6.5.0":
   version "6.5.18"
   resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz#a1b74a8e0a5d0c795b8a4d19629b654cf66aa5ab"
   integrity sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes an issue where incompatible types between the return type of the `gql` function and the `useQuery_unstable` experimental hook would prevent the store from building.

It also fixes the issue where the module resolution for `@faststore/core` exports would sometimes be referencing the exports from the `.faststore` folder, which could lead to issues and inaccurate types.

## How it works?

It works by better specifying the `useQuery` type for the operation, and by removing exports from `.faststore/package.json` file. To compensate for that, path aliases were added for `@faststore/core` exports in `tsconfig.json`, so the `.faststore` uses its own definitions of the exports when building.

## How to test it?

Define a query with `gql` and call it using `useQuery_unstable`. There should be no errors. Then, build the store. There should be no errors.

### Starters Deploy Preview
https://github.com/vtex-sites/starter.store/pull/390
