### PR TITLE
fix: navbar slider header props override pointing to another component

### DIFF
--- a/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
+++ b/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
@@ -49,7 +49,7 @@ function NavbarSlider({
     >
       <NavbarSliderHeader.Component
         onClose={fadeOut}
-        {...NavbarSliderWrapper.props}
+        {...NavbarSliderHeader.props}
       >
         <Link
           data-fs-navbar-slider-logo


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix error preventing the store from building

## How it works?

Fixes props used on the overrides for the NavbarSliderHeader. Changes it to right props.