### PR TITLE
Set previewData path when previewing pages

### DIFF
--- a/packages/core/src/pages/api/preview.ts
+++ b/packages/core/src/pages/api/preview.ts
@@ -50,8 +50,6 @@ const handler: NextApiHandler = async (req, res) => {
     }
 
     // Enable Preview Mode by setting the cookies
-    // Setting the path to the slug will allow other pages of the
-    // same type to remain the same while previewing a specific path
     res.setPreviewData(locator, {
       maxAge: 3600,
       path: (page.settings as Settings)?.seo?.slug,

--- a/packages/core/src/pages/api/preview.ts
+++ b/packages/core/src/pages/api/preview.ts
@@ -54,7 +54,7 @@ const handler: NextApiHandler = async (req, res) => {
     // same type to remain the same while previewing a specific path
     res.setPreviewData(locator, {
       maxAge: 3600,
-      path: (page.settings as Settings)?.seo.slug,
+      path: (page.settings as Settings)?.seo?.slug,
     })
 
     // Redirect to the path from the fetched locator

--- a/packages/core/src/pages/api/preview.ts
+++ b/packages/core/src/pages/api/preview.ts
@@ -50,7 +50,12 @@ const handler: NextApiHandler = async (req, res) => {
     }
 
     // Enable Preview Mode by setting the cookies
-    res.setPreviewData(locator, { maxAge: 3600 })
+    // Setting the path to the slug will allow other pages of the
+    // same type to remain the same while previewing a specific path
+    res.setPreviewData(locator, {
+      maxAge: 3600,
+      path: (page.settings as Settings)?.seo.slug,
+    })
 
     // Redirect to the path from the fetched locator
     if (previewRedirects[locator.contentType]) {


### PR DESCRIPTION
## What's the purpose of this pull request?

It has been reported that when you're previewing one page of a given content-type, all the pages of the same content-type will have the same content because we're not setting the path of the preview properly. 

This PR aims to fix it, by using the same information we use to define landing page URLs

## How to test it?

1. Point the preview to the linked starter deploy preview
1. Preview a landing page on our test account
2. See that it has the changes you're making
3. Navigate to another landing page. See its correct data.
4. Point the preview to the main starter domain.
5. Preview your changes. See that it affects all pages.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

[NextJS Documentation](https://nextjs.org/docs/pages/building-your-application/configuring/preview-mode#specify-the-preview-mode-duration)
