### PR TITLE
Disable generating image sizes for SVGs

### DIFF
--- a/packages/core/src/components/ui/Image/loader.ts
+++ b/packages/core/src/components/ui/Image/loader.ts
@@ -2,6 +2,11 @@ import storeConfig from 'faststore.config'
 const THUMBOR_SERVER = `https://${storeConfig.api.storeId}.vtexassets.com`
 
 export default function customImageLoader({ src, width, quality }) {
+  // Special case SVGs to match stock NextJS loader
+  if (src.endsWith('.svg')) {
+    return src
+  }
+
   const preSizeComponents = [THUMBOR_SERVER, 'unsafe']
 
   // proportional to the width, enter a height of 0,


### PR DESCRIPTION
NextJS bails out early when given an SVG for their default loader, because it doesn't handle those properly. The same is true of the thumbor server, it tries to convert the SVGs to webp which doesn't look good at all.

See stock code here
https://github.com/vercel/next.js/blob/canary/packages/next/src/client/legacy/image.tsx#L170-L174
