### PR TITLE
Add: Import styles for Button and SlideOver

### DIFF
--- a/packages/core/src/styles/global/index.scss
+++ b/packages/core/src/styles/global/index.scss
@@ -8,4 +8,6 @@
 @import "@faststore/ui/src/components/atoms/Skeleton/styles.scss";
 @import "@faststore/ui/src/components/atoms/Overlay/styles.scss";
 @import "@faststore/ui/src/components/atoms/SROnly/styles.scss";
+@import "@faststore/ui/src/components/atoms/Button/styles.scss";
+@import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
 @import "src/components/sections/Section/section.scss";


### PR DESCRIPTION
## What's the purpose of this pull request?

Import Styles at the core to make it available for customizations.


Before:
https://github.com/vtex/faststore/assets/67066494/92c6f824-e591-4105-b860-b9e87f414389

After:
https://github.com/vtex/faststore/assets/67066494/5338cbb7-6699-4122-a1f6-3c5545349d2a


