### PR TITLE
Fix SKU selector

### DIFF
--- a/packages/api/src/platforms/vtex/utils/skuVariants.ts
+++ b/packages/api/src/platforms/vtex/utils/skuVariants.ts
@@ -14,6 +14,11 @@ type FormattedSkuVariant = {
 
 const SKU_IMAGE_LABEL = 'skuvariation'
 
+/**
+ * Attempts to find an image labeled by the specific variationName
+ * if none is found, search for the `skuvariation`, defaulting to the
+ * first image of the SKU
+ */
 function findSkuVariantImage(
   availableImages: Item['images'],
   variationName?: string

--- a/packages/components/src/molecules/SkuSelector/useDefineVariant.ts
+++ b/packages/components/src/molecules/SkuSelector/useDefineVariant.ts
@@ -9,6 +9,10 @@ const getImageName = (src: string) => {
   return imageName
 }
 
+/**
+ * This hook infers what kind of SKU Selector will be displayed on the UI. 
+ * There are three different options, color, image, and label (default version).
+ */
 export const useDefineVariant = (options: SkuOption[], variant?: Variant): Variant =>
   useMemo(() => {
     if(variant) return variant
@@ -28,6 +32,15 @@ export const useDefineVariant = (options: SkuOption[], variant?: Variant): Varia
       return optionImageName === firstImageName
     })
 
+    /* There is currently a bug on this line. 
+     *
+     * If there's only one option (options.length === 1) and there is an image
+     * the correct return value is 'image'. But since there's only one image
+     * and they are all equal (it's equal to itself) then this conditional will
+     * fail
+     *
+     * TODO: add a test for this case and fix it
+     * */
     if (!areSourcesEqualsOrNull) {
       return 'image'
     }

--- a/packages/components/src/molecules/SkuSelector/useDefineVariant.ts
+++ b/packages/components/src/molecules/SkuSelector/useDefineVariant.ts
@@ -24,6 +24,14 @@ export const useDefineVariant = (options: SkuOption[], variant?: Variant): Varia
 
     const firstImageName = options[0]?.src && getImageName(options[0].src)
 
+    /* 
+     * If there's only one option (options.length === 1) and there is an image
+     * the correct return value is 'image'. 
+     * */
+    if (firstImageName && options.length === 1) {
+      return 'image'
+    }
+
     const areSourcesEqualsOrNull = options.every((option) => {
       if (!option.src) {
         return true
@@ -32,15 +40,6 @@ export const useDefineVariant = (options: SkuOption[], variant?: Variant): Varia
       return optionImageName === firstImageName
     })
 
-    /* There is currently a bug on this line. 
-     *
-     * If there's only one option (options.length === 1) and there is an image
-     * the correct return value is 'image'. But since there's only one image
-     * and they are all equal (it's equal to itself) then this conditional will
-     * fail
-     *
-     * TODO: add a test for this case and fix it
-     * */
     if (!areSourcesEqualsOrNull) {
       return 'image'
     }


### PR DESCRIPTION
## What's the purpose of this pull request?

When implementing the Variant Swatch Image I noticed that if a SKU Selector had only one option the image would not appear. Upon inspecting this hook I noticed that if there's ony one image the code would infer they were all the same and only show the label, but there's the special case of only one image. This PR fixes this.

## How to test it?

Go to the preview and see the [awesome-chair](https://sfj-5b2ff3a--starter.preview.vtex.app/awesome-chair-99988218/p) product and switch to the Plastic or Iron material SKUs. You should see an image on the Size selector. On the starter store [awesome-chair](https://starter.vtex.app/awesome-chair-99988218/p) will **not** show the image.
