### PR TITLE
Docs: Update the announcement bar for the FastStore content migration

### DIFF
--- a/apps/site/theme.config.tsx
+++ b/apps/site/theme.config.tsx
@@ -75,7 +75,7 @@ const config: DocsThemeConfig = {
       <p>
         ⚠️ After March 18, 2024, the FastStore documentation will be migrated to the Developer Portal. For more information, access the official{' '}
         <a href="https://developers.vtex.com/updates/release-notes/2024-03-07-faststore-content-in-the-developer-portal" target="_blank" rel="noreferrer">
-          release note.
+          release note →
         </a>
       </p>
     ),

--- a/apps/site/theme.config.tsx
+++ b/apps/site/theme.config.tsx
@@ -75,7 +75,7 @@ const config: DocsThemeConfig = {
       <p>
         ⚠️ After March 18, 2024, the FastStore documentation will be migrated to the Developer Portal. For more information, access the official{' '}
         <a href="https://developers.vtex.com/updates/release-notes/2024-03-07-faststore-content-in-the-developer-portal" target="_blank" rel="noreferrer">
-          release note →
+          release note.
         </a>
       </p>
     ),

--- a/apps/site/theme.config.tsx
+++ b/apps/site/theme.config.tsx
@@ -74,7 +74,7 @@ const config: DocsThemeConfig = {
     text: (
       <p>
         ⚠️ After March 18, 2024, the FastStore documentation will be migrated to the Developer Portal. For more information, access the official{' '}
-        <a className="nx-button-primary:hover" href="https://developers.vtex.com/updates/release-notes/2024-03-07-faststore-content-in-the-developer-portal" target="_blank" rel="noreferrer">
+        <a href="https://developers.vtex.com/updates/release-notes/2024-03-07-faststore-content-in-the-developer-portal" target="_blank" rel="noreferrer">
           release note →
         </a>
       </p>

--- a/apps/site/theme.config.tsx
+++ b/apps/site/theme.config.tsx
@@ -73,10 +73,9 @@ const config: DocsThemeConfig = {
     key: '2.0-release',
     text: (
       <p>
-        🎉 We are thrilled to introduce FastStore v2. If you are looking for
-        documentation of the previous version of FastStore, please refer to{' '}
-        <a href="https://v1.faststore.dev/" target="_blank" rel="noreferrer">
-          FastStore v1.
+        ⚠️ After March 18, 2024, the FastStore documentation will be migrated to the Developer Portal. For more information, access the official{' '}
+        <a href="https://developers.vtex.com/updates/release-notes/2024-03-07-faststore-content-in-the-developer-portal" target="_blank" rel="noreferrer">
+          release note.
         </a>
       </p>
     ),

--- a/apps/site/theme.config.tsx
+++ b/apps/site/theme.config.tsx
@@ -75,7 +75,7 @@ const config: DocsThemeConfig = {
       <p>
         ⚠️ After March 18, 2024, the FastStore documentation will be migrated to the Developer Portal. For more information, access the official{' '}
         <a className="nx-button-primary:hover" href="https://developers.vtex.com/updates/release-notes/2024-03-07-faststore-content-in-the-developer-portal" target="_blank" rel="noreferrer">
-          release note.
+          release note →
         </a>
       </p>
     ),


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR updates the announcement bar in `faststore.dev` informing users about the FastStore content migration to the [Developer Portal](https://developers.vtex.com/docs/guides/faststore/docs-what-is-faststore).