### PR TITLE
Add: subDomainPrefix as a store config

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -31,19 +31,22 @@ const BASE_INIT = {
 }
 
 export const VtexCommerce = (
-  { account, environment, incrementAddress }: Options,
+  { account, environment, incrementAddress, subDomainPrefix }: Options,
   ctx: Context
 ) => {
   const base = `https://${account}.${environment}.com.br`
   const storeCookies = getStoreCookie(ctx)
   const withCookie = getWithCookie(ctx)
   // replacing www. only for testing while www.vtexfaststore.com is configured with www
+
+  const selectedPrefix =
+    subDomainPrefix.find((prefix) => ctx.headers?.host?.includes(prefix)) || ''
+
   const forwardedHost = (
     new Headers(ctx.headers).get('x-forwarded-host') ??
     ctx.headers?.host ??
     ''
-  ).replace('www.', '')
-
+  ).replace(selectedPrefix, '')
   return {
     catalog: {
       salesChannel: (sc: string): Promise<SalesChannel> =>

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -32,6 +32,7 @@ export interface Options {
   account: string
   environment: 'vtexcommercestable' | 'vtexcommercebeta'
   // Default sales channel to use for fetching products
+  subDomainPrefix: string[]
   channel: string
   locale: string
   hideUnavailableItems: boolean

--- a/packages/api/test/mutations.test.ts
+++ b/packages/api/test/mutations.test.ts
@@ -24,6 +24,7 @@ const apiOptions = {
   environment: 'vtexcommercestable',
   channel: '{"salesChannel":"1"}',
   locale: 'en-US',
+  subDomainPrefix: ['www'],
   hideUnavailableItems: false,
   incrementAddress: false,
   flags: {

--- a/packages/api/test/queries.test.ts
+++ b/packages/api/test/queries.test.ts
@@ -46,6 +46,7 @@ const apiOptions = {
   environment: 'vtexcommercestable',
   channel: '{"salesChannel":"1"}',
   locale: 'en-US',
+  subDomainPrefix: ['www'],
   hideUnavailableItems: false,
   incrementAddress: false,
   flags: {

--- a/packages/api/test/schema.test.ts
+++ b/packages/api/test/schema.test.ts
@@ -80,6 +80,7 @@ beforeAll(async () => {
     environment: 'vtexcommercestable',
     channel: '{"salesChannel":"1"}',
     locale: 'en-US',
+    subDomainPrefix: ['www'],
     hideUnavailableItems: false,
     incrementAddress: false,
     flags: {

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -629,18 +629,6 @@ export type StoreAggregateRating = {
   reviewCount: Scalars['Int']['output']
 }
 
-/** Attribute of a given product. */
-export type StoreAttribute = {
-  /** Attribute id. */
-  id: Scalars['String']['output']
-  /** Attribute name. */
-  name: Scalars['String']['output']
-  /** Attribute value. */
-  value: Scalars['String']['output']
-  /** Attribute visibility. */
-  visible: Scalars['Boolean']['output']
-}
-
 /** information about the author of a product review or rating. */
 export type StoreAuthor = {
   /** Author name. */

--- a/packages/core/faststore.config.default.js
+++ b/packages/core/faststore.config.default.js
@@ -16,6 +16,7 @@ module.exports = {
   api: {
     storeId: 'storeframework',
     workspace: 'master',
+    subDomainPrefix: ['www'],
     environment: 'vtexcommercestable',
     hideUnavailableItems: false,
     incrementAddress: true,

--- a/packages/core/src/server/options.ts
+++ b/packages/core/src/server/options.ts
@@ -6,6 +6,7 @@ export const apiOptions: APIOptions = {
   platform: storeConfig.platform as APIOptions['platform'],
   account: storeConfig.api.storeId,
   environment: storeConfig.api.environment as APIOptions['environment'],
+  subDomainPrefix: storeConfig.api.subDomainPrefix,
   hideUnavailableItems: storeConfig.api.hideUnavailableItems,
   incrementAddress: storeConfig.api.incrementAddress,
   channel: storeConfig.session.channel,


### PR DESCRIPTION
## What's the purpose of this pull request?

Add a config to allow replacing other subDomain prefixes for the forwardedHost to be sent.

## How it works?

The client configs an array that contains the subDomain prefixes at faststore.config:

```
  api: {
    storeId: 'storeframework',
    workspace: 'master',
    subDomainPrefix: ['www', 'shop'],
    environment: 'vtexcommercestable',
    hideUnavailableItems: false,
    incrementAddress: true,
  }
```

With that in case of the host is https://www.vtexfaststore.com we should send .vtexfaststore.com
in case its https://shop.vtexfaststore.com we should send .vtexfaststore.com

## How to test it?

Add the subDomainPrefix to the array list and access a domain with the current version and check the host where the checkout cookie was created.


