### PR TITLE
Get order number from checkout cookie

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -31,19 +31,22 @@ const BASE_INIT = {
 }
 
 export const VtexCommerce = (
-  { account, environment, incrementAddress }: Options,
+  { account, environment, incrementAddress, subDomainPrefix }: Options,
   ctx: Context
 ) => {
   const base = `https://${account}.${environment}.com.br`
   const storeCookies = getStoreCookie(ctx)
   const withCookie = getWithCookie(ctx)
   // replacing www. only for testing while www.vtexfaststore.com is configured with www
+
+  const selectedPrefix =
+    subDomainPrefix.find((prefix) => ctx.headers?.host?.includes(prefix)) || ''
+
   const forwardedHost = (
     new Headers(ctx.headers).get('x-forwarded-host') ??
     ctx.headers?.host ??
     ''
-  ).replace('www.', '')
-
+  ).replace(selectedPrefix, '')
   return {
     catalog: {
       salesChannel: (sc: string): Promise<SalesChannel> =>

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -32,6 +32,7 @@ export interface Options {
   account: string
   environment: 'vtexcommercestable' | 'vtexcommercebeta'
   // Default sales channel to use for fetching products
+  subDomainPrefix: string[]
   channel: string
   locale: string
   hideUnavailableItems: boolean

--- a/packages/api/test/mutations.test.ts
+++ b/packages/api/test/mutations.test.ts
@@ -24,6 +24,7 @@ const apiOptions = {
   environment: 'vtexcommercestable',
   channel: '{"salesChannel":"1"}',
   locale: 'en-US',
+  subDomainPrefix: ['www'],
   hideUnavailableItems: false,
   incrementAddress: false,
   flags: {

--- a/packages/api/test/queries.test.ts
+++ b/packages/api/test/queries.test.ts
@@ -46,6 +46,7 @@ const apiOptions = {
   environment: 'vtexcommercestable',
   channel: '{"salesChannel":"1"}',
   locale: 'en-US',
+  subDomainPrefix: ['www'],
   hideUnavailableItems: false,
   incrementAddress: false,
   flags: {

--- a/packages/api/test/schema.test.ts
+++ b/packages/api/test/schema.test.ts
@@ -80,6 +80,7 @@ beforeAll(async () => {
     environment: 'vtexcommercestable',
     channel: '{"salesChannel":"1"}',
     locale: 'en-US',
+    subDomainPrefix: ['www'],
     hideUnavailableItems: false,
     incrementAddress: false,
     flags: {

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -629,18 +629,6 @@ export type StoreAggregateRating = {
   reviewCount: Scalars['Int']['output']
 }
 
-/** Attribute of a given product. */
-export type StoreAttribute = {
-  /** Attribute id. */
-  id: Scalars['String']['output']
-  /** Attribute name. */
-  name: Scalars['String']['output']
-  /** Attribute value. */
-  value: Scalars['String']['output']
-  /** Attribute visibility. */
-  visible: Scalars['Boolean']['output']
-}
-
 /** information about the author of a product review or rating. */
 export type StoreAuthor = {
   /** Author name. */

--- a/packages/core/faststore.config.default.js
+++ b/packages/core/faststore.config.default.js
@@ -16,6 +16,7 @@ module.exports = {
   api: {
     storeId: 'storeframework',
     workspace: 'master',
+    subDomainPrefix: ['www'],
     environment: 'vtexcommercestable',
     hideUnavailableItems: false,
     incrementAddress: true,

--- a/packages/core/src/server/options.ts
+++ b/packages/core/src/server/options.ts
@@ -6,6 +6,7 @@ export const apiOptions: APIOptions = {
   platform: storeConfig.platform as APIOptions['platform'],
   account: storeConfig.api.storeId,
   environment: storeConfig.api.environment as APIOptions['environment'],
+  subDomainPrefix: storeConfig.api.subDomainPrefix,
   hideUnavailableItems: storeConfig.api.hideUnavailableItems,
   incrementAddress: storeConfig.api.incrementAddress,
   channel: storeConfig.session.channel,


### PR DESCRIPTION
## What's the purpose of this pull request?

Add a fallback for the orderNumber from orderFormId from the cookie.

## How it works?

When a user creates a cart at a subDomain from FastStore the cookie is sharable between those.

The behaviour today:
- OrderForm A at cookie created at the subDomain
- User goes to FastStore
- isStable = true (no eTag) and orderNumber would be null since there is nothing at the local cart
- ValidateCart delete all items from OrderForm A

Behaviour after this change:
- OrderForm A at cookie created at the subDomain
- User goes to FastStore
- isStable = true (no eTag) and orderNumber do not get the value from the local cart so the fallback is the value from the cookie orderForm A
- ValidateCart returns the same orderForm setting the eTag to it

## How to test it?

You can simulate this behaviour as following:
- Create the cart at FS
- Delete the local cart
- Delete the custom data from the orderForm
- Validate that the cart at FastStore is not erased.


https://github.com/vtex/faststore/assets/67066494/b0ed7abe-30f2-41bc-8044-d0a2eafb91ef


