### PR TITLE
update validateCart logic

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -348,7 +348,9 @@ export const validateCart = async (
     const newOrderForm = await setOrderFormEtag(orderForm, commerce).then(
       joinItems
     )
-    return orderFormToCart(newOrderForm, skuLoader)
+    if (isStale && orderNumber) {
+      return orderFormToCart(newOrderForm, skuLoader)
+    }
   }
 
   // Step2: Process items from both browser and checkout so they have the same shape

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -344,7 +344,7 @@ export const validateCart = async (
   // to see this new cart state instead of what's stored on the user's browser.
   const isStale = isOrderFormStale(orderForm)
 
-  if (isStale && orderNumber) {
+  if (isStale) {
     const newOrderForm = await setOrderFormEtag(orderForm, commerce).then(
       joinItems
     )

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -348,7 +348,7 @@ export const validateCart = async (
     const newOrderForm = await setOrderFormEtag(orderForm, commerce).then(
       joinItems
     )
-    if (isStale && orderNumber) {
+    if (orderNumber) {
       return orderFormToCart(newOrderForm, skuLoader)
     }
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

The validateCart creates the orderForm without the customData the first time it happens at the site because the orderNumber still do not exist at the cookies or at the cartStorage.

With this change when the orderForm is being created by FastStore we will set the new orderForm already with the customData.

The problem is that when the client just entered the site the first validateCart Mutation will only set the cookie but if the second validate Cart Mutation already is an add to Cart the orderForm will have isStale true because the customData was not set at the first request and the items wont be added. The second request would work but it causes an experience problem for the client. 

## How to test it?

Run the code locally and try the request of the validateCart to create the orderForm:

```
curl --location 'http://localhost:3000/api/graphql?operationName=ValidateCartMutation&operationHash=87e1ba227013cb087bcbb35584c1b0b7cdf612ef' \
--header 'Accept: */*' \
--header 'Cache-Control: no-cache' \
--header 'Connection: keep-alive' \
--header 'Content-Type: application/json' \
--header 'Cookie;' \
--header 'Origin: http://localhost:3000' \
--header 'Referer: http://localhost:3000/' \
--data '{
    "operationName": "ValidateCartMutation",
    "operationHash": "87e1ba227013cb087bcbb35584c1b0b7cdf612ef",
    "variables": {
        "session": {
            "currency": {
                "code": "USD",
                "symbol": "$"
            },
            "locale": "en-US",
            "channel": "{\"salesChannel\":\"1\",\"regionId\":\"\"}",
            "country": "USA",
            "deliveryMode": null,
            "addressType": null,
            "postalCode": null,
            "geoCoordinates": null,
            "person": null
        },
        "cart": {
            "order": {
                "orderNumber": "",
                "shouldSplitItem": true,
                "acceptedOffer": []
            }
        }
    }
}'
```

Validate that the orderForm is created with the customData:
```

curl --location 'https://storeframework.vtexcommercestable.com.br/api/checkout/pub/orderForm/{{orderFormId}}' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json'
```

<img width="637" alt="image" src="https://github.com/vtex/faststore/assets/67066494/492ae777-933f-42b6-aa29-3fa41bb4fc51">

Do the same using the code before and check that the first ValidateCart Mutation will set the cookie but if you do the get the customData is not set yet. Only the second request will in fact set the customData.

