### PR TITLE
remove logic from postalCode

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -13,7 +13,7 @@ export const validateSession = async (
   { clients }: Context
 ): Promise<StoreSession | null> => {
   const channel = ChannelMarshal.parse(oldSession.channel ?? '')
-  const postalCode = oldSession.postalCode ?? ''
+  const postalCode = String(oldSession.postalCode ?? '')
   const geoCoordinates = oldSession.geoCoordinates ?? null
 
   const country = oldSession.country ?? ''

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -13,7 +13,7 @@ export const validateSession = async (
   { clients }: Context
 ): Promise<StoreSession | null> => {
   const channel = ChannelMarshal.parse(oldSession.channel ?? '')
-  const postalCode = String(oldSession.postalCode ?? '').replace(/\D/g, '')
+  const postalCode = oldSession.postalCode ?? ''
   const geoCoordinates = oldSession.geoCoordinates ?? null
 
   const country = oldSession.country ?? ''


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the postalCode for regions like UK.

Today the postalCode when it has an input like "SE10 0GP" will:

const postalCode = String(oldSession.postalCode ?? '').replace(/\D/g, '')
// output "100"

With this change the output will be:
const postalCode = String(oldSession.postalCode ?? '')
// output "SE10 0GP"

## How it works?

The client should send the input for the postalCode and we should not do any replace to edit it because we have different rules depending on the country.

For UK:
Example WITH space:
https://demogrocery.vtexcommercestable.com.br/api/checkout/pub/regions?country=GBR&postalCode=SE10 0GP ✅ 

Example WITHOUT space:
https://demogrocery.vtexcommercestable.com.br/api/checkout/pub/regions?country=GBR&postalCode=SE100GP ❌ 

For Portugal:
Example WITH "-":
https://indolaiberia.vtexcommercestable.com.br/api/checkout/pub/regions?country=PRT&postalCode=02580-551 ✅ 

Example WITHOUT "-"
https://indolaiberia.vtexcommercestable.com.br/api/checkout/pub/regions?country=PRT&postalCode=02580551 ✅ 


For Brasil:
Example WITH "-":
https://zonasul.vtexcommercestable.com.br/api/checkout/pub/regions?country=BRA&postalCode=20510-310 ✅ 

Example WITHOUT "-":
https://zonasul.vtexcommercestable.com.br/api/checkout/pub/regions?country=BRA&postalCode=20510310 ✅ 

For USA:
https://canalius.vtexcommercestable.com.br/api/checkout/pub/regions?country=USA&postalCode=10001 ✅ 

Taking into account that each region has their own patterns for Postal Code FastStore should not be the one responsible to apply those rules changing the input done by the store.


PR open to test:
https://github.com/vtex-sites/demogrocery.store/pull/20

Try https://demogrocery.vtex.app/ adding the zip code SE10 0GP.
The output for the region ID should be "v2.1BB18CE648B5111D0933734ED83EC783" -> no sellers ❌ 

Try https://sfj-1863556--demogrocery.preview.vtex.app/ with the new package adding the zip code SE10 0GP.
The output for the region ID should be "v2.4EDE7BFDDB9627069E02F08EA5F93DDA" ✅ 