### PR TITLE
Add: new logic for subDomainPrefix

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -37,10 +37,11 @@ export const VtexCommerce = (
   const base = `https://${account}.${environment}.com.br`
   const storeCookies = getStoreCookie(ctx)
   const withCookie = getWithCookie(ctx)
-  // replacing www. only for testing while www.vtexfaststore.com is configured with www
 
   const selectedPrefix =
-    subDomainPrefix.find((prefix) => ctx.headers?.host?.includes(prefix)) || ''
+    subDomainPrefix
+      .map((prefix) => prefix + '.')
+      .find((prefix) => ctx.headers?.host?.includes(prefix)) || ''
 
   const forwardedHost = (
     new Headers(ctx.headers).get('x-forwarded-host') ??


### PR DESCRIPTION
## What's the purpose of this pull request?

In order to no change the current logic and make the setup for the user more friendly for the subDomainPrefix.

## How it works?

The user will configure the subDomainPrefix he wants to use and we are gonna add to the array the "." to remove it from the x-forwarded-host.