### PR TITLE
Bug Fix: Validate for order or cookie empty context 

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -286,7 +286,10 @@ const updateOrderFormShippingData = async (
 }
 
 const getCookieCheckoutOrderNumber = (ctx: string, nameCookie: string) => {
-  if (!ctx) return ''
+  if (!ctx) {
+    return ''
+  }
+
   const cookies = parse(ctx)
   const cookieValue = cookies[nameCookie]
   return cookieValue ? cookieValue.split('=')[1] : ''

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -311,7 +311,9 @@ export const validateCart = async (
 ) => {
   const orderNumber = order?.orderNumber
     ? order.orderNumber
-    : getCookieCheckoutOrderNumber(ctx.headers.cookie, 'checkout.vtex.com')
+    : ctx.headers.cookie
+      ? getCookieCheckoutOrderNumber(ctx.headers.cookie, 'checkout.vtex.com')
+      : ''
 
   const { acceptedOffer, shouldSplitItem } = order
   const {

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -286,6 +286,7 @@ const updateOrderFormShippingData = async (
 }
 
 const getCookieCheckoutOrderNumber = (ctx: string, nameCookie: string) => {
+  if (!ctx) return ''
   const cookies = parse(ctx)
   const cookieValue = cookies[nameCookie]
   return cookieValue ? cookieValue.split('=')[1] : ''
@@ -311,10 +312,8 @@ export const validateCart = async (
 ) => {
   const orderNumber = order?.orderNumber
     ? order.orderNumber
-    : ctx.headers.cookie
-      ? getCookieCheckoutOrderNumber(ctx.headers.cookie, 'checkout.vtex.com')
-      : ''
-
+    : getCookieCheckoutOrderNumber(ctx.headers.cookie, 'checkout.vtex.com')
+  
   const { acceptedOffer, shouldSplitItem } = order
   const {
     clients: { commerce },


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the validateCartMutation for cases where:
- No orderNumber is sent **and** 
- No cookie is sent to the context

## How it works?

Now we validate if theres any cookie inside the headers before calling the function that will parse it to avoid breaking the request.

## How to test it?

Call it at the final env in those conditions:

```
curl --location 'https://www.vtexfaststore.com/api/graphql?operationName=ValidateCartMutation&operationHash=87e1ba227013cb087bcbb35584c1b0b7cdf612ef' \
--header 'accept: */*' \
--header 'accept-language: pt-BR,pt;q=0.9' \
--header 'cache-control: no-cache' \
--header 'content-type: application/json' \
--header 'origin: https://www.vtexfaststore.com' \
--header 'pragma: no-cache' \
--header 'referer: https://www.vtexfaststore.com/~partytown/partytown-sandbox-sw.html?1711550070899' \
--header 'sec-ch-ua: "Google Chrome";v="123", "Not:A-Brand";v="8", "Chromium";v="123"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "macOS"' \
--header 'sec-fetch-dest: empty' \
--header 'sec-fetch-mode: cors' \
--header 'sec-fetch-site: same-origin' \
--header 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36' \
--data '{"operationName":"ValidateCartMutation","operationHash":"87e1ba227013cb087bcbb35584c1b0b7cdf612ef","variables":{"session":{"currency":{"code":"USD","symbol":"$"},"locale":"en-US","channel":"{\"salesChannel\":\"1\",\"regionId\":\"\"}","country":"USA","deliveryMode":null,"addressType":null,"postalCode":null,"geoCoordinates":null,"person":null},"cart":{"order":{"orderNumber":"","shouldSplitItem":true,"acceptedOffer":[]}}}}'
```

You should expect that:

![image](https://github.com/vtex/faststore/assets/67066494/fa851630-9f0d-4161-8d6b-47adfc0f3b83)


With the changes done the result should be:
![image](https://github.com/vtex/faststore/assets/67066494/ce06d32a-ded0-435b-a85c-99789c9bb113)

Doing a set-cookie with an orderForm with customData:
![image](https://github.com/vtex/faststore/assets/67066494/6c776f1a-8fae-4c64-9514-438bccb4dac1)

![image](https://github.com/vtex/faststore/assets/67066494/d9f6caab-b825-4854-a785-4e65ef3e38ac)


## References

PR: https://github.com/vtex/faststore/pull/2261
