### PR TITLE
[TCM-328] Prevent generated files for hCMS from being empty

### DIFF
--- a/packages/cli/src/utils/hcms.test.ts
+++ b/packages/cli/src/utils/hcms.test.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import {
   allNewCustomContentTypes,
   allNewCustomSections,
@@ -8,7 +9,45 @@ import {
   customSectionsWithDuplicates,
   sectionDuplicates,
 } from '../__mocks__/hcms'
-import { dedupeAndMergeDefinitions, splitCustomDefinitions } from './hcms'
+
+import {
+  dedupeAndMergeDefinitions,
+  splitCustomDefinitions,
+  mergeCMSFile,
+} from './hcms'
+import { tmpCMSDir } from './directory'
+
+jest.mock('fs-extra', () => ({
+  readFileSync: jest.fn(),
+  existsSync: jest.fn(),
+  writeFileSync: jest.fn(),
+}))
+
+describe('mergeCMSFile', () => {
+  it("should create a resulting file that contains all core definitions if a custom definitions file doesn't exist", async () => {
+    const { readFileSync, existsSync, writeFileSync } = require('fs-extra')
+
+    existsSync.mockReturnValueOnce(false)
+    readFileSync.mockReturnValueOnce(JSON.stringify(coreContentTypes))
+
+    await mergeCMSFile('content-types.json')
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      path.join(tmpCMSDir, 'content-types.json'),
+      JSON.stringify(coreContentTypes)
+    )
+
+    existsSync.mockReturnValueOnce(false)
+    readFileSync.mockReturnValueOnce(JSON.stringify(coreSections))
+
+    await mergeCMSFile('sections.json')
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      path.join(tmpCMSDir, 'sections.json'),
+      JSON.stringify(coreSections)
+    )
+  })
+})
 
 describe('splitCustomDefinitions', () => {
   it('should return empty arrays if there are no custom definitions', () => {

--- a/packages/cli/src/utils/hcms.ts
+++ b/packages/cli/src/utils/hcms.ts
@@ -110,7 +110,7 @@ async function confirmUserChoice(
   return
 }
 
-async function mergeCMSFile(fileName: string) {
+export async function mergeCMSFile(fileName: string) {
   const coreFilePath = path.join(coreCMSDir, fileName)
   const customFilePath = path.join(userCMSDir, fileName)
 

--- a/packages/cli/src/utils/hcms.ts
+++ b/packages/cli/src/utils/hcms.ts
@@ -120,7 +120,7 @@ async function mergeCMSFile(fileName: string) {
   const primaryIdentifierForDefinitions =
     fileName === 'content-types.json' ? 'id' : 'name'
 
-  let output: ContentTypeOrSectionDefinition[] = []
+  let output: ContentTypeOrSectionDefinition[] = coreDefinitions
 
   // TODO: create a validation when the CMS files exist but don't have a component for them
   if (existsSync(customFilePath)) {


### PR DESCRIPTION
## What's the purpose of this pull request?

Fixing a bug on how files for hCMS are being generated. If a store did not define their own `content-types.json` or `sections.json` files, the default content from `@faststore/core` would be ignored when `faststore cms-sync` is executed.

## How to test it?

- Clone a store's repo, or the starter.
- Install `@faststore/cli` version from the Deploy Preview below.
- Run `faststore cms-sync --dry-run` (to not actuality sync the files), without creating a `/cms` folder or creating one that's laking either `content-types.json` or `sections.json`.
- Check the generate files at .faststore. They should not contain empty arrays.

## References

Motivated by: https://vtex.slack.com/archives/C0164SHMAV9/p1710332274381219.
