### PR TITLE
Load environments variables in dev

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
     "@oclif/plugin-not-found": "^2.3.3",
     "chalk": "~4.1.2",
     "chokidar": "^3.5.3",
+    "dotenv": "^16.4.5",
     "fs-extra": "^10.1.0",
     "path": "^0.12.7"
   },

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,9 +1,12 @@
 import { Command } from '@oclif/core'
 import { spawn } from 'child_process'
 import chokidar from 'chokidar'
+import dotenv from 'dotenv';
 
 import { getRoot, tmpDir } from '../utils/directory'
 import { generate } from '../utils/generate'
+import { readFileSync } from 'fs';
+import path from 'path'
 
 /**
  * Taken from toolbelt
@@ -29,11 +32,17 @@ const defaultIgnored = [
 const devAbortController = new AbortController()
 
 async function storeDev() {
+  const envVars = dotenv.parse(readFileSync(path.join(getRoot(), 'vtex.env')))
+
   const devProcess = spawn('yarn dev', {
     shell: true,
     cwd: tmpDir,
     signal: devAbortController.signal,
     stdio: 'inherit',
+    env: {
+      ...process.env,
+      ...envVars,
+    }
   })
 
   devProcess.on('close', () => {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,12 +1,12 @@
-import { Command } from '@oclif/core'
-import { spawn } from 'child_process'
-import chokidar from 'chokidar'
+import { Command } from '@oclif/core';
+import { spawn } from 'child_process';
+import chokidar from 'chokidar';
 import dotenv from 'dotenv';
 
-import { getRoot, tmpDir } from '../utils/directory'
-import { generate } from '../utils/generate'
 import { readFileSync } from 'fs';
-import path from 'path'
+import path from 'path';
+import { getRoot, tmpDir } from '../utils/directory';
+import { generate } from '../utils/generate';
 
 /**
  * Taken from toolbelt

--- a/yarn.lock
+++ b/yarn.lock
@@ -7127,6 +7127,11 @@ dotenv@^16.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
   integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
 
+dotenv@^16.4.5:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
 dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"


### PR DESCRIPTION
## What's the purpose of this pull request?

Env vars aren't available on development. So in this pr, I allow to load `vtex.env` in the process.env in development.

## How it works?

All env var in `vtex.env` are available on `process.env` during development.

## How to test it?

Create a custom env var in `vtex.env` and try to use it on your store.