### PR TITLE
chore: ensure generate the cms webhook file in generate method

### DIFF
--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -1,7 +1,8 @@
 import { Command, Flags } from '@oclif/core'
 import { spawn } from 'child_process'
 import { tmpDir } from '../utils/directory'
-import { generate, generateCMSFiles } from '../utils/generate'
+import { generate } from '../utils/generate'
+import { mergeCMSFiles } from '../utils/hcms'
 
 export default class CmsSync extends Command {
   static flags = {
@@ -12,7 +13,7 @@ export default class CmsSync extends Command {
     const { flags } = await this.parse(CmsSync)
 
     await generate({ setup: true })
-    await generateCMSFiles()
+    await mergeCMSFiles()
 
     if (flags['dry-run']) {
       return

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import {
   copyFileSync,
   copySync,
@@ -9,22 +10,20 @@ import {
   writeJsonSync,
 } from 'fs-extra'
 import path from 'path'
-import chalk from 'chalk'
 
 import {
   coreDir,
+  tmpCmsWebhookUrlsFileDir,
+  tmpCustomizationsSrcDir,
   tmpDir,
   tmpFolderName,
   tmpStoreConfigFileDir,
   tmpThemesCustomizationsFileDir,
-  tmpCmsWebhookUrlsFileDir,
+  userDir,
   userSrcDir,
   userStoreConfigFileDir,
   userThemesFileDir,
-  userDir,
-  tmpCustomizationsSrcDir,
 } from './directory'
-import { mergeCMSFiles } from './hcms'
 
 interface GenerateOptions {
   setup?: boolean
@@ -244,10 +243,6 @@ export async function generate(options?: GenerateOptions) {
     setupPromise,
     copyUserStarterToCustomizations(),
     copyTheme(),
+    createCmsWebhookUrlsJsonFile(),
   ])
-}
-
-export async function generateCMSFiles() {
-  await createCmsWebhookUrlsJsonFile()
-  await mergeCMSFiles()
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

The releases/CMS team reported that Sometimes, we do not get the webhook call at the end of the publishing.
This PR aims to ensure the generation of the cms webhook file using the `generate` method.

This file has been generated in the cms-sync command since [this PR](https://github.com/vtex/faststore/pull/2240/files).


## Starter PR

- https://github.com/vtex-sites/starter.store/pull/420

