### PR TITLE
feat: allows to override ProductCard of CrossSellingShelf

### DIFF
--- a/packages/core/src/components/sections/CrossSellingShelf/OverriddenDefaultCrossSellingShelf.ts
+++ b/packages/core/src/components/sections/CrossSellingShelf/OverriddenDefaultCrossSellingShelf.ts
@@ -1,8 +1,13 @@
-import { override } from 'src/customizations/src/components/overrides/ProductShelf'
+import { override } from 'src/customizations/src/components/overrides/CrossSellingShelf'
 import { getOverriddenSection } from 'src/sdk/overrides/getOverriddenSection'
 import type { SectionOverrideDefinitionV1 } from 'src/typings/overridesDefinition'
 import CrossSellingShelf from '.'
 
+/**
+ * This component exists to support overrides 1.0
+ *
+ * This allows users to override the default CrossSellingShelf section present in the Headless CMS
+ */
 export const OverriddenDefaultCrossSellingShelf = getOverriddenSection({
   ...(override as SectionOverrideDefinitionV1<'CrossSellingShelf'>),
   Section: CrossSellingShelf,

--- a/packages/core/src/components/sections/CrossSellingShelf/OverriddenDefaultCrossSellingShelf.ts
+++ b/packages/core/src/components/sections/CrossSellingShelf/OverriddenDefaultCrossSellingShelf.ts
@@ -1,6 +1,9 @@
+import { override } from 'src/customizations/src/components/overrides/ProductShelf'
 import { getOverriddenSection } from 'src/sdk/overrides/getOverriddenSection'
+import type { SectionOverrideDefinitionV1 } from 'src/typings/overridesDefinition'
 import CrossSellingShelf from '.'
 
 export const OverriddenDefaultCrossSellingShelf = getOverriddenSection({
+  ...(override as SectionOverrideDefinitionV1<'CrossSellingShelf'>),
   Section: CrossSellingShelf,
 })

--- a/packages/core/src/customizations/src/components/overrides/CrossSellingShelf.tsx
+++ b/packages/core/src/customizations/src/components/overrides/CrossSellingShelf.tsx
@@ -1,0 +1,11 @@
+// This is an example of how it can be used on the starter.
+
+import { SectionOverride } from 'src/typings/overrides'
+
+const SECTION = 'CrossSellingShelf' as const
+
+const override: SectionOverride = {
+  section: SECTION,
+}
+
+export { override }


### PR DESCRIPTION
## What's the purpose of this pull request?

The override component `__experimentalProductCard` doesn't work because overriden definitions of `CrossSellingShelf` section doesn't extend `ProductShelf` section overriden definitions.

The proposal follows a pattern already coded at [OverriddenDefaultProductGallery.ts](https://github.com/vtex/faststore/blob/main/packages/core/src/components/sections/ProductGallery/OverriddenDefaultProductGallery.ts) and [OverriddenDefaultProductShelf.ts](https://github.com/vtex/faststore/blob/main/packages/core/src/components/sections/ProductShelf/OverriddenDefaultProductShelf.ts).

## How it works?

Extends `CrossSellingShelf` section overriden definitions with `ProductShelf` section overriden definitions.

## How to test it?

Override `CrossSellingShelf` section creating a file `src/components/overrides/CrossSellingShelf.tsx` like this:

```typescript
import { SectionOverride } from "@faststore/core";
import CustomProductCard from "./CustomProductCard";

const SECTION = "CrossSellingShelf" as const;

const override: SectionOverride = {
  section: SECTION,
  components: {
    __experimentalProductCard: {
      Component: CustomProductCard,
    },
  },
};

export { override };
```

The `CustomProductCard` custom component must works as expected after changes of this PR.