### PR TITLE
Fix missing Checkbox props on CheckboxField component

### DIFF
--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jest-environment-jsdom',
+}
+

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "dev": "tsc --watch",
     "build": "tsc --module commonjs --outDir dist/cjs & tsc --module esnext --outDir dist/esm",
-    "lint": "eslint src/**/*.{ts,tsx}"
+    "lint": "eslint src/**/*.{ts,tsx}",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -36,9 +37,13 @@
   "devDependencies": {
     "@faststore/eslint-config": "^3.0.24",
     "@faststore/shared": "^3.0.24",
+    "@testing-library/react": "^14.3.0",
     "@types/react": "^18.2.42",
     "@types/react-dom": "^18.2.17",
     "eslint": "7.32.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.1.2",
     "typescript": "^4.8.4"
   },
   "volta": {

--- a/packages/components/src/molecules/CheckboxField/CheckboxField.tsx
+++ b/packages/components/src/molecules/CheckboxField/CheckboxField.tsx
@@ -23,16 +23,44 @@ export interface CheckboxFieldProps {
    * Identify checkbox in the same group.
    */
   name?: string
+  /**
+   * Should the checkbox be checked by default.
+   */
+  checked?: boolean
+
+  /**
+   * Identifies whether the checkbox should be disabled.
+   */
+  disabled?: boolean
+
+  /**
+   * Boolean that represents a partial state.
+   */
+  partial?: boolean
 }
 
 const CheckboxField = forwardRef<HTMLDivElement, CheckboxFieldProps>(
   function CheckboxField(
-    { testId = 'fs-checkbox-field', id, label, value, name, ...otherProps },
+    {
+      testId = 'fs-checkbox-field',
+      id,
+      label,
+      value,
+      name,
+      checked,
+      ...otherProps
+    },
     ref
   ) {
     return (
       <div ref={ref} data-fs-checkbox-field data-testid={testId}>
-        <Checkbox id={id} value={value ?? label} name={name} {...otherProps} />
+        <Checkbox
+          id={id}
+          value={value ?? label}
+          name={name}
+          defaultChecked={checked}
+          {...otherProps}
+        />
         <Label htmlFor={id}>{label}</Label>
       </div>
     )

--- a/packages/components/src/molecules/CheckboxField/CheckboxField.tsx
+++ b/packages/components/src/molecules/CheckboxField/CheckboxField.tsx
@@ -1,42 +1,12 @@
 import React, { forwardRef } from 'react'
-import Checkbox from '../../atoms/Checkbox'
+import Checkbox, { CheckboxProps } from '../../atoms/Checkbox'
 import Label from '../../atoms/Label'
 
-export interface CheckboxFieldProps {
-  /**
-   * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
-   */
-  testId?: string
-  /**
-   * ID to identify input and corresponding label.
-   */
-  id: string
+export interface CheckboxFieldProps extends CheckboxProps {
   /**
    * The text displayed to identify the input checkbox.
    */
   label: string
-  /**
-   * The value to identify the input checkbox.
-   */
-  value?: string
-  /**
-   * Identify checkbox in the same group.
-   */
-  name?: string
-  /**
-   * Should the checkbox be checked by default.
-   */
-  checked?: boolean
-
-  /**
-   * Identifies whether the checkbox should be disabled.
-   */
-  disabled?: boolean
-
-  /**
-   * Boolean that represents a partial state.
-   */
-  partial?: boolean
 }
 
 const CheckboxField = forwardRef<HTMLDivElement, CheckboxFieldProps>(

--- a/packages/components/test/molecules/CheckboxField/CheckboxField.test.tsx
+++ b/packages/components/test/molecules/CheckboxField/CheckboxField.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { CheckboxField } from '../../../src/index'
+
+describe('CheckboxField', () => {
+  it('renders all examples from the documentation', () => {
+    render(<CheckboxField label="Default" id="checkboxfield-default" />)
+    render(<CheckboxField label="Checked" id="checkboxfield-checked" checked />)
+    render(
+      <CheckboxField label="Disabled" id="checkboxfield-disabled" disabled />
+    )
+    render(
+      <CheckboxField
+        label="Checked & Partial"
+        id="checkboxfield-checked-partial"
+        checked
+        partial
+      />
+    )
+  })
+})
+
+describe('#checked', () => {
+  it('should allow the checked property to be passed', () => {
+    render(<CheckboxField id="identifier" label="Label" checked />)
+    const input = screen.getByLabelText('Label') as HTMLInputElement
+
+    expect(input.checked).toBe(true)
+  })
+
+  it('should not be checked if the `checked `prop is not passed', () => {
+    render(<CheckboxField id="identifier" label="Label" />)
+    const input = screen.getByLabelText('Label') as HTMLInputElement
+
+    expect(input.checked).toBe(false)
+  })
+})

--- a/packages/components/test/molecules/CheckboxField/CheckboxField.test.tsx
+++ b/packages/components/test/molecules/CheckboxField/CheckboxField.test.tsx
@@ -20,20 +20,20 @@ describe('CheckboxField', () => {
       />
     )
   })
-})
 
-describe('#checked', () => {
-  it('should allow the checked property to be passed', () => {
-    render(<CheckboxField id="identifier" label="Label" checked />)
-    const input = screen.getByLabelText('Label') as HTMLInputElement
+  describe('#checked', () => {
+    it('should allow the checked property to be passed', () => {
+      render(<CheckboxField id="identifier" label="Label" checked />)
+      const input = screen.getByLabelText('Label') as HTMLInputElement
 
-    expect(input.checked).toBe(true)
-  })
+      expect(input.checked).toBe(true)
+    })
 
-  it('should not be checked if the `checked `prop is not passed', () => {
-    render(<CheckboxField id="identifier" label="Label" />)
-    const input = screen.getByLabelText('Label') as HTMLInputElement
+    it('should not be checked if the `checked `prop is not passed', () => {
+      render(<CheckboxField id="identifier" label="Label" />)
+      const input = screen.getByLabelText('Label') as HTMLInputElement
 
-    expect(input.checked).toBe(false)
+      expect(input.checked).toBe(false)
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,6 +3574,15 @@
     "@babel/runtime" "^7.12.5"
     react-error-boundary "^3.1.0"
 
+"@testing-library/react@^14.3.0":
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.3.0.tgz#8183eb5a5f465b5b8cc495fcbd9bad0a16b8dd3b"
+  integrity sha512-AYJGvNFMbCa5vt1UtDCa/dcaABrXq8gph6VN+cffIx0UeA0qiGqS+sT60+sb+Gjc8tGXdECWYQgaF0khf8b+Lg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^9.0.0"
+    "@types/react-dom" "^18.0.0"
+
 "@theguild/remark-mermaid@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@theguild/remark-mermaid/-/remark-mermaid-0.0.3.tgz#247e8e84aacf483d2f99d8d12ccd34f3cf7ce543"
@@ -3955,6 +3964,13 @@
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/react-dom@^18.0.0":
+  version "18.2.24"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.24.tgz#8dda8f449ae436a7a6e91efed8035d4ab03ff759"
+  integrity sha512-cN6upcKd8zkGy4HU9F1+/s98Hrp6D4MOcippK4PoE8OZRngohHZpbJn1GsaDLz87MqvHNoT13nHvNqM9ocRHZg==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-dom@^18.2.17":
   version "18.2.17"


### PR DESCRIPTION
## What's the purpose of this pull request?

Our `CheckboxField` was inconsistent with its documentation. It was not accepting the `checked`, `disabled`, and `partial` props from Checkbox. This PR fixes this.

As a bonus, I've added Jest and React Testing Library so we can start adding those tests to our components. I've first created a failing test and then implemented the props.

## How to test it?

Just run `yarn test` and you should have all success specs.

### Starters Deploy Preview

For some reason we don't use the `CheckboxField` on our starter.

