### PR TITLE
fix: added missing prop to fix pdp NextSeo component

### DIFF
--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -60,6 +60,7 @@ const overwriteMerge = (_, sourceArray) => sourceArray
 function Page({ data: server, sections, globalSections, offers, meta }: Props) {
   const { product } = server
   const { currency } = useSession()
+  const { titleTemplate } = storeConfig.seo
 
   // Stale while revalidate the product for fetching the new price etc
   const { data: client, isValidating } = useProductQuery(product.id, {
@@ -100,6 +101,7 @@ function Page({ data: server, sections, globalSections, offers, meta }: Props) {
             content: currency.code,
           },
         ]}
+        titleTemplate={titleTemplate}
       />
       <BreadcrumbJsonLd
         itemListElements={product.breadcrumbList.itemListElement}


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the PDP seo title. The NextSeo component of the product page does not have the titleTemplate property, which is responsible for adding the titleTemplate to the title.

https://github.com/vtex/faststore/assets/138598003/4f10623f-17e2-4b0d-9d8d-0cc04f0f1f1e

For example, the SearchPage component does have this property and works correctly:

![image](https://github.com/vtex/faststore/assets/138598003/ba63216e-9d57-4979-8def-dedd42dfd0d0)

## How it works?

Adding the same property to the PDP component resolves the issue:

![image](https://github.com/vtex/faststore/assets/138598003/40c11b39-1aac-4c99-9076-ee8568720e26)

<!--- Tell us the role of the new feature, or component, in its context. --->
