### PR TITLE
chore: add priority to the first product's image on PLP

### DIFF
--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -629,6 +629,18 @@ export type StoreAggregateRating = {
   reviewCount: Scalars['Int']['output']
 }
 
+/** Attribute of a given product. */
+export type StoreAttribute = {
+  /** Attribute id. */
+  id: Scalars['String']['output']
+  /** Attribute name. */
+  name: Scalars['String']['output']
+  /** Attribute value. */
+  value: Scalars['String']['output']
+  /** Attribute visibility. */
+  visible: Scalars['Boolean']['output']
+}
+
 /** information about the author of a product review or rating. */
 export type StoreAuthor = {
   /** Author name. */

--- a/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
@@ -49,6 +49,7 @@ function ProductGrid({
                 width: 150,
                 height: 150,
                 sizes: '30vw',
+                loading: idx === 0 ? 'eager' : 'lazy',
               }}
               {...ProductCard.props}
               bordered={bordered ?? ProductCard.props.bordered}


### PR DESCRIPTION
## What's the purpose of this pull request?

Add priority to the 1st product's image on a PLP. It was motivated by a store that was having the performance score penalized on lighthouse because its LCP was the first product on the PLP. 
We haven't had found this issue before because our starter has a hero image on PLP (that already has the priority set). 

## How it works?

On the `ProductGrid` component we send the `loading` prop as `eager`  through the `ProductCard` component when it's the first product, then on the [Image](https://github.com/vtex/faststore/blob/76e80ae902be812e237519520a1b7159f4dab63f/packages/core/src/components/ui/Image/Image.tsx#L17) component the priority will be added.

## How to test it?

1. Run `yarn dev` and go to http://localhost:3000/technology
2. Inspect the page and check that only the first product's image has the priority set as `high`:
<table>
  <tr>
    <td>First product</td>
    <td>Other product</td>
  </tr>
  <tr>
    <td><img width="538" alt="Screenshot 2024-04-25 at 16 33 35" src="https://github.com/vtex/faststore/assets/19983991/b9ee97e1-ed78-41db-8cca-c15a699f6d58"></td>
    <td><img width="780" alt="Screenshot 2024-04-25 at 16 34 14" src="https://github.com/vtex/faststore/assets/19983991/a4f567b7-ba64-4f3a-b182-a4c79e0d166f"></td>
  </tr>
</table>

### Comparison

I've compared the LH scores from [starter](https://github.com/vtex-sites/starter.store/commits/test/image-priority-plp/) and [newstore](https://github.com/vtex-sites/newstore.store/commits/test/image-priority-plp/) to check if this change had impacted.
To be fair, I updated those stores to the latest version of faststore core (`3.0.42`) to get the "before" value and updated to this PR version of faststore core ([codesandbox](https://ci.codesandbox.io/status/vtex/faststore/pr/2293)) to get the "after" value.
Both stores increased 2 points of Performance:
<table>
  <tr>
    <td>Before</td> 
    <td>After</td> 
  </tr>
  <tr>
    <td> <img width="560" alt="newstore-before" src="https://github.com/vtex/faststore/assets/19983991/c6aefb0e-fda6-4bc5-ad95-ea72c6d2b1b2"></td>
    <td><img width="547" alt="newstore-after" src="https://github.com/vtex/faststore/assets/19983991/13e20374-cf6b-47bf-8932-26beebd37c08"></td>
   </tr> 
   <tr>
      <td><img width="558" alt="starter-before" src="https://github.com/vtex/faststore/assets/19983991/b0886710-cd83-41a6-b3c7-a5ab3e8c9545"></td>
      <td><img width="522" alt="starter-after" src="https://github.com/vtex/faststore/assets/19983991/bc5a001d-2587-40b0-bda9-d9798b45aa25">
  </td>
  </tr>
</table>

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SFS-766)
- [Next.js `next/image` `priority` prop](https://nextjs.org/docs/app/building-your-application/optimizing/images#priority)
