### PR TITLE
Feat/expand store facet range detection

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/facet.ts
+++ b/packages/api/src/platforms/vtex/resolvers/facet.ts
@@ -10,8 +10,18 @@ import type { Resolver } from '..'
 export type Root = Facet
 
 export const StoreFacet: Record<string, Resolver<Root>> = {
-  __resolveType: ({ type }) =>
-    type === 'TEXT' ? 'StoreFacetBoolean' : 'StoreFacetRange',
+  __resolveType: ({ type, values }) =>
+    {
+      if (type !== 'TEXT') {
+        return 'StoreFacetRange'
+      }
+
+      if (values.every((value) => (value as FacetValueRange).range)) {
+        return 'StoreFacetRange'
+      }
+
+      return 'StoreFacetBoolean'
+    },
 }
 
 export const StoreFacetBoolean: Record<

--- a/packages/components/src/organisms/Filter/FilterFacetRange.tsx
+++ b/packages/components/src/organisms/Filter/FilterFacetRange.tsx
@@ -16,9 +16,9 @@ export interface FilterFacetRangeProps {
    */
   facetKey: string
   /**
-   * Formatter function that transforms the raw price value and render the result.
+   * Formatter function that transforms the raw value and render the result.
    */
-  formatter: (price: number) => string
+  formatter: (value: number) => string
   /**
    * This function is called when `Checkbox` from the facet changes.
    */

--- a/packages/core/src/components/search/Filter/FilterDesktop.tsx
+++ b/packages/core/src/components/search/Filter/FilterDesktop.tsx
@@ -88,7 +88,11 @@ function FilterDesktop({
                 facetKey={facet.key}
                 min={facet.min}
                 max={facet.max}
-                formatter={useFormattedPrice}
+                formatter={
+                  facet.key.toLowerCase() === 'price'
+                    ? useFormattedPrice
+                    : undefined
+                }
                 onFacetChange={(facet) => {
                   setState({
                     ...state,

--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -126,7 +126,11 @@ function FilterSlider({
                   facetKey={facet.key}
                   min={facet.min}
                   max={facet.max}
-                  formatter={useFormattedPrice}
+                  formatter={
+                    facet.key.toLowerCase() === 'price'
+                      ? useFormattedPrice
+                      : undefined
+                  }
                   onFacetChange={(facet) =>
                     dispatch({
                       type: 'setFacet',


### PR DESCRIPTION
## What's the purpose of this pull request?

VTEX's Intelligent Search has a feature that allows convert any parameter to numeric, thus unlocking the ability to filter using ranges, just like price does. Although, the API's facet type field doesn't change the value, keeping it as "TEXT". The current StoreFacet resolver implementation only considers "RangeType" for values different from "TEXT", which restricts it to prices, that have the type "PRICERANGE" (reference: https://developers.vtex.com/docs/api-reference/intelligent-search-api#get-/facets/-facets-:~:text=Allowed%3A%20TEXT%E2%94%83PRICERANGE). This PR aims to unlock the ability to have another range filters in `ProductGallery`, then we can implement filters by dimension for example.

Screenshots:
![image](https://github.com/vtex/faststore/assets/27451066/e8c40076-5429-44d9-b705-dedb64804240)
![image](https://github.com/vtex/faststore/assets/27451066/91791468-55c0-4154-94e3-2e5a70b36812)
<img width="1337" alt="image" src="https://github.com/vtex/faststore/assets/27451066/89628b39-95a9-40ea-bf59-309dd6cf9145">



<!--- Considering the context, what is the problem we'll solve? Where in VTEX's big picture our issue fits in? Write a tweet about the context and the problem itself. --->

## How it works?
I expanded the logic to set a facet as a range and change the filter component behavior to make it more generic, because currently it's specialized for prices. It keeps coupled to price component internally, but I think it's possible to evolve it after.

<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?
Set an attribute as numeric using Intelligent Search Settings and access a category that contains the facet.
<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
