### PR TITLE
[patch] fix: `Carousel` icon color cascade

### DIFF
--- a/packages/ui/src/components/molecules/Carousel/styles.scss
+++ b/packages/ui/src/components/molecules/Carousel/styles.scss
@@ -83,10 +83,11 @@
       box-shadow: var(--fs-carousel-controls-box-shadow);
     }
     &:not(:hover) [data-fs-button-wrapper] { background-color: var(--fs-carousel-controls-bkg-color); }
-  }
+    &:hover:not(:disabled) [data-fs-button-wrapper] { box-shadow: var(--fs-carousel-controls-box-shadow); }
 
-  [data-fs-icon] {
-    color: var(--fs-carousel-controls-icon-color);
+    [data-fs-icon] {
+      color: var(--fs-carousel-controls-icon-color);
+    }
   }
 
   [data-fs-carousel-track] {


### PR DESCRIPTION
## What's the purpose of this pull request?
The Carousel Icons styles where affecting other unrelated icons inside the `ProductCard`, so I fixed the specificity of the code.

## How it works?
|Before|After|
|-|-|
|<img width="1392" alt="image" src="https://github.com/vtex/faststore/assets/11613011/a5d42191-6a66-4d4b-ac3e-b78f35bdc355">|<img width="1392" alt="image" src="https://github.com/vtex/faststore/assets/11613011/0ee707b5-cafa-403f-bac9-6c0afe0f1a34">|

## How to test it?
1. Change line 120 on `packages/core/src/components/product/ProductCard/ProductCard.tsx` to `onButtonClick={() => {}}`
2. Run `yarn dev`
3. Go to homepage and hover a Carousel