### PR TITLE
Feat: Next 13 initial setup

### DIFF
--- a/packages/core/app/fs-next-update/page.tsx
+++ b/packages/core/app/fs-next-update/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>placeholder</div>
+}

--- a/packages/core/app/layout.tsx
+++ b/packages/core/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/packages/core/next-env.d.ts
+++ b/packages/core/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -1,6 +1,7 @@
 // @ts-check
 const path = require('path')
 const storeConfig = require('./faststore.config')
+const webpack = require('webpack')
 
 /**
  * @type {import('next').NextConfig}
@@ -39,6 +40,15 @@ const nextConfig = {
           options.modules.exportLocalsConvention = 'camelCase'
         }
       })
+
+    config.plugins.push(
+      new webpack.BannerPlugin({
+        banner: '@layer base, components, theme;',
+        test: /\.css$/,
+        raw: true,
+        entryOnly: false,
+      })
+    )
 
     // Reduce the number of chunks so we ship a smaller first bundle.
     // This should help reducing TBT

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -41,6 +41,7 @@ const nextConfig = {
         }
       })
 
+    // Make css order works as expected in Next 13. See https://github.com/vercel/next.js/issues/51030#issuecomment-2005254907
     config.plugins.push(
       new webpack.BannerPlugin({
         banner: '@layer base, components, theme;',

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -13,6 +13,7 @@
     "allowJs": true,
     "paths": {
       "src/*": ["src/*"],
+      "app/*": ["app/*"],
       "@generated/*": ["@generated/*"],
       "@faststore/core": ["index.ts"],
       "@faststore/core/api": ["api/index.ts"],
@@ -25,8 +26,22 @@
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "skipLibCheck": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": false
   },
-  "include": ["*.d.ts", "src/**/*.ts", "src/**/*.tsx", "@generated/**/*.ts"],
+  "include": [
+    "*.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "@generated/**/*.ts",
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules", "public"]
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to: 

- [x] add the tsconfig needed to run Next 13. It also set `"strictNullChecks": false` to make the Section Override v2 API work as previously.
- [x] Fix styles order problem by adding webpack config in next.config.js. See https://github.com/vercel/next.js/issues/51030#issuecomment-2005254907 
- [x] adds the initial prefix folder, root layout and initial page layout 

## How to test it?

run locally and you should see the initial structure under: http://localhost:3000/fs-next-update

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

Next 13 file conventions
https://nextjs.org/docs/app/api-reference/file-conventions/layout

CSS order issues:

[[NEXT-1308] Css is imported multiple times and out of order in /app dir · Issue #51030 · vercel/next.js](https://github.com/vercel/next.js/issues/51030#issuecomment-2005254907) 
[Verify CSS import ordering · Issue #16630 · vercel/next.js](https://github.com/vercel/next.js/issues/16630) 
[CSS "@import <file> layer()" isn't working · Issue #55763 · vercel/next.js](https://github.com/vercel/next.js/issues/55763) 
[[NEXT-1308] Css is imported multiple times and out of order in /app dir · Issue #51030 · vercel/next.js](https://github.com/vercel/next.js/issues/51030#issuecomment-2087777390)

strictNullChecks
https://github.com/vercel/next.js/discussions/39942
https://www.typescriptlang.org/tsconfig/#strictNullChecks