### PR TITLE
feat: Next 13 root `layout.tsx` default SEO metatags

### DIFF
--- a/packages/core/app/layout.tsx
+++ b/packages/core/app/layout.tsx
@@ -3,6 +3,8 @@ import 'src/styles/global/index.scss'
 
 import 'src/customizations/src/themes/index.scss'
 
+import { Metadata } from 'next'
+
 import ThirdPartyScripts from 'app/components/ThirdPartyScripts'
 import AnalyticsHandler from 'app/sdk/analytics'
 import ErrorBoundary from 'app/sdk/error/ErrorBoundary'
@@ -47,6 +49,23 @@ async function getGlobalSectionsData() {
   return { sections }
 }
 
+// SEO metadata and tags
+export const metadata: Metadata = {
+  robots: {
+    /*******************
+     * TODO: This will be the default config when the `app` directory be in use
+     *  // index: !storeConfig.experimental.noRobots,
+     *  // follow: !storeConfig.experimental.noRobots,
+     */
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+    },
+  },
+}
+
 export default async function RootLayout({
   children,
 }: {
@@ -56,9 +75,6 @@ export default async function RootLayout({
 
   return (
     <ErrorBoundary>
-      {/* TODO: we should use metadata api from Next 13 */}
-      {/* <DefaultSeo norobots={storeConfig.experimental.noRobots} /> */}
-
       <AnalyticsHandler />
 
       <html>


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to set the default SEO metatags for the root `layout.tsx` file.

## How to test it?

- Run the local server (`yarn turbo run dev --filter=@faststore/core`);
- Make sure that all the current pages are working as expected (`/`, `/office` and some `/<slug>/p`);
- Make sure `/fs-next-update` is rendering (blank) without errors and both `<meta "robots">` and `<meta "googlebot">` exist with the `noindex,nofollow` tags.

## References

- https://nextjs.org/learn-pages-router/seo/crawling-and-indexing/metatags
- https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#step-3-migrating-nexthead
- https://nextjs.org/docs/app/api-reference/functions/generate-metadata#robots
