### PR TITLE
Fix: use router replace to change URL and fix fuzzy bugs

### DIFF
--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -629,6 +629,18 @@ export type StoreAggregateRating = {
   reviewCount: Scalars['Int']['output']
 }
 
+/** Attribute of a given product. */
+export type StoreAttribute = {
+  /** Attribute id. */
+  id: Scalars['String']['output']
+  /** Attribute name. */
+  name: Scalars['String']['output']
+  /** Attribute value. */
+  value: Scalars['String']['output']
+  /** Attribute visibility. */
+  visible: Scalars['Boolean']['output']
+}
+
 /** information about the author of a product review or rating. */
 export type StoreAuthor = {
   /** Author name. */

--- a/packages/core/src/sdk/search/state.ts
+++ b/packages/core/src/sdk/search/state.ts
@@ -6,16 +6,10 @@ export const useApplySearchState = () => {
 
   return useCallback(
     (url: URL) => {
-      if (url.searchParams.has('fuzzy') && url.searchParams.has('operator')) {
-        const newUrl = [url.pathname, url.searchParams]
-          .filter(Boolean)
-          .join('?')
-
-        window.history.replaceState(window.history.state, '', newUrl)
-        return
-      }
-
-      return router.push(`${url.pathname}${url.search}`)
+      const newUrl = `${url.pathname}${url.search}`
+      return url.searchParams.has('fuzzy') && url.searchParams.has('operator')
+        ? router.replace(newUrl)
+        : router.push(newUrl)
     },
     [router]
   )

--- a/packages/core/src/sdk/search/state.ts
+++ b/packages/core/src/sdk/search/state.ts
@@ -5,7 +5,18 @@ export const useApplySearchState = () => {
   const router = useRouter()
 
   return useCallback(
-    (url: URL) => router.push(`${url.pathname}${url.search}`),
+    (url: URL) => {
+      if (url.searchParams.has('fuzzy') && url.searchParams.has('operator')) {
+        const newUrl = [url.pathname, url.searchParams]
+          .filter(Boolean)
+          .join('?')
+
+        window.history.replaceState(window.history.state, '', newUrl)
+        return
+      }
+
+      return router.push(`${url.pathname}${url.search}`)
+    },
     [router]
   )
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix bugs related to the addition of fuzzy parameters to the URL on PLP (category page and search page). See jira tasks on the references section below.

## How it works?

By using the `replace` function instead of `push` we are able to update the URL adding the fuzzy parameters to it without triggering the navigation. Thus, it doesn't re-render the page and it doesn't affect the back button to previous page.
It happens because the `replace` doesn't add the new URL as a new entry on the `history` stack.

## How to test it?

Test a category page (example: `/office`) and test search also. Both pages should have its URL updated to add the fuzzy and operator params, but shouldn't re-render. Also, if you click the browser return button you should go to the previous page (Home, for example, if you were on the Home page and then went to the category page) normally.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References
- https://github.com/vtex/faststore/pull/2204
- [[Jira task] Fuzzy bug: return to previous page](https://vtex-dev.atlassian.net/jira/software/c/projects/SFS/boards/1051?selectedIssue=SFS-802)
- [[Jira task] Fuzzy bug: re-render](https://vtex-dev.atlassian.net/browse/SFS-515)
- [History: `replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState)
- [Next router: `replace` function](https://nextjs.org/docs/pages/api-reference/functions/use-router#routerreplace)
