### PR TITLE
Fix validation to enable playground to run locally

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -41,10 +41,11 @@ export const VtexCommerce = (
   const host =
     new Headers(ctx.headers).get('x-forwarded-host') ?? ctx.headers?.host ?? ''
 
-  const selectedPrefix =
+  const selectedPrefix = subDomainPrefix ?
     subDomainPrefix
       .map((prefix) => prefix + '.')
       .find((prefix) => host.includes(prefix)) || ''
+    : ''
 
   const forwardedHost = host.replace(selectedPrefix, '')
 
@@ -141,9 +142,9 @@ export const VtexCommerce = (
       ): Promise<OrderForm> => {
         const deliveryWindow = setDeliveryWindow
           ? {
-              startDateUtc: deliveryMode?.deliveryWindow?.startDate,
-              endDateUtc: deliveryMode?.deliveryWindow?.endDate,
-            }
+            startDateUtc: deliveryMode?.deliveryWindow?.startDate,
+            endDateUtc: deliveryMode?.deliveryWindow?.endDate,
+          }
           : null
 
         const mappedBody = {
@@ -291,9 +292,9 @@ export const VtexCommerce = (
         postalCode
           ? params.append('postalCode', postalCode)
           : params.append(
-              'geoCoordinates',
-              `${geoCoordinates?.longitude};${geoCoordinates?.latitude}`
-            )
+            'geoCoordinates',
+            `${geoCoordinates?.longitude};${geoCoordinates?.latitude}`
+          )
 
         const url = `${base}/api/checkout/pub/regions/?${params.toString()}`
         const headers: HeadersInit = withCookie({


### PR DESCRIPTION
## What's the purpose of this pull request?

Small fix to allow graphiQl playground to run locally

## How to test it?

On the `packages/api` directory, run `yarn dev:server`
The playground should be available at `localhost:4000/graphql`

![image](https://github.com/vtex/faststore/assets/56592231/4529b3d4-72b9-4ad8-933b-1e2ddd312cfd)

