### PR TITLE
Fix: exports server functions on its own module

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./index.ts",
     "./api": "./api/index.ts",
-    "./experimental": "./src/experimental/index.ts"
+    "./experimental": "./src/experimental/index.ts",
+    "./experimental/server": "./src/experimental/server/index.ts"
   },
   "scripts": {
     "generate:schema": "tsx src/server/generator/generateGraphQLSchemaFile.ts",

--- a/packages/core/src/experimental/index.ts
+++ b/packages/core/src/experimental/index.ts
@@ -37,6 +37,3 @@ export { useShippingSimulation as useShippingSimulation_unstable } from '../../s
 // Components
 export { Image as Image_unstable } from '../../src/components/ui/Image'
 export { ProfileChallenge as ProfileChallenge_unstable } from '../../src/components/auth/ProfileChallenge'
-
-// Server GraphQL
-export { execute as execute_unstable } from '../../src/server'

--- a/packages/core/src/experimental/server/index.ts
+++ b/packages/core/src/experimental/server/index.ts
@@ -1,0 +1,2 @@
+// Server GraphQL
+export { execute as execute_unstable } from '../../../src/server'

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,7 +17,10 @@
       "@generated/*": ["@generated/*"],
       "@faststore/core": ["index.ts"],
       "@faststore/core/api": ["api/index.ts"],
-      "@faststore/core/experimental": ["src/experimental/index.ts"]
+      "@faststore/core/experimental": ["src/experimental/index.ts"],
+      "@faststore/core/experimental/server": [
+        "src/experimental/server/index.ts"
+      ]
     },
     "forceConsistentCasingInFileNames": true,
     "strict": false,


### PR DESCRIPTION
## What's the purpose of this pull request?

- https://github.com/vtex/faststore/pull/2242
introduces a problem:
<img width="1333" alt="Screenshot 2024-05-15 at 12 29 37" src="https://github.com/vtex/faststore/assets/11325562/e02f10f4-81cb-4afa-899a-6afc79e5c9cb">

We are exporting a server function in the experimental module, and then when we try to use other functions from this file in the starter, like some hook/component/function, we get some errors like:

<img width="1101" alt="Screenshot 2024-05-15 at 11 38 47" src="https://github.com/vtex/faststore/assets/11325562/54069f56-6a07-4ece-a145-b037276c012a">

I think this is happening because this is not tree-shakable, and then the execute function comes together with the module.

In that way, we export the server functions to their module: `@faststore/core/experimental/server`.


### Starters Deploy Preview

I use the codesandbox version from this PR in a starter PR for which we are testing API Extension and section Overrides.
- https://github.com/vtex-sites/starter.store/pull/199
(see [this commit](https://github.com/vtex-sites/starter.store/pull/199/commits/e27d2fe2f05053efe754abe1176e9f16156c68a3)).
