### PR TITLE
feat: Enable `ProductDescription` override in `ProductDetails` section

### DIFF
--- a/packages/core/src/components/sections/ProductDetails/DefaultComponents.ts
+++ b/packages/core/src/components/sections/ProductDetails/DefaultComponents.ts
@@ -15,6 +15,7 @@ import LocalImageGallery from 'src/components/ui/ImageGallery'
 import LocalShippingSimulation from 'src/components/ui/ShippingSimulation/ShippingSimulation'
 import { Image } from 'src/components/ui/Image'
 import LocalNotAvailableButton from 'src/components/product/NotAvailableButton'
+import LocalProductDescription from 'src/components/ui/ProductDescription'
 
 export const ProductDetailsDefaultComponents = {
   ProductTitle: UIProductTitle,
@@ -31,4 +32,5 @@ export const ProductDetailsDefaultComponents = {
   __experimentalImageGallery: LocalImageGallery,
   __experimentalShippingSimulation: LocalShippingSimulation,
   __experimentalNotAvailableButton: LocalNotAvailableButton,
+  __experimentalProductDescription: LocalProductDescription,
 }

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -8,7 +8,6 @@ import type { AnalyticsItem } from 'app/sdk/analytics/types'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import { useSession } from 'src/sdk/session'
 
-import ProductDescription from '../../../components/ui/ProductDescription'
 import { ProductDetailsSettings } from '../../../components/ui/ProductDetails'
 import Section from '../Section'
 
@@ -82,6 +81,7 @@ function ProductDetails({
     __experimentalImageGallery: ImageGallery,
     __experimentalShippingSimulation: ShippingSimulation,
     __experimentalNotAvailableButton: NotAvailableButton,
+    __experimentalProductDescription: ProductDescription,
   } = useOverrideComponents<'ProductDetails'>()
   const { currency } = useSession()
   const context = usePDP()
@@ -230,11 +230,19 @@ function ProductDetails({
           </section>
 
           {shouldDisplayProductDescription && (
-            <ProductDescription
-              initiallyExpanded={productDescriptionInitiallyExpanded}
-              descriptionData={[
-                { title: productDescriptionDetailsTitle, content: description },
-              ]}
+            <ProductDescription.Component
+              initiallyExpanded={
+                productDescriptionInitiallyExpanded ??
+                ProductDescription.props.initiallyExpanded
+              }
+              descriptionData={
+                [
+                  {
+                    content: description,
+                    title: productDescriptionDetailsTitle,
+                  },
+                ] ?? ProductDescription.props.descriptionData
+              }
             />
           )}
         </section>

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -235,14 +235,10 @@ function ProductDetails({
                 productDescriptionInitiallyExpanded ??
                 ProductDescription.props.initiallyExpanded
               }
-              descriptionData={
-                [
-                  {
-                    content: description,
-                    title: productDescriptionDetailsTitle,
-                  },
-                ] ?? ProductDescription.props.descriptionData
-              }
+              descriptionData={[
+                { content: description, title: productDescriptionDetailsTitle },
+              ]}
+              {...ProductDescription.props}
             />
           )}
         </section>

--- a/packages/core/src/typings/overrides.ts
+++ b/packages/core/src/typings/overrides.ts
@@ -272,6 +272,7 @@ export type SectionsOverrides = {
       __experimentalImageGallery: ComponentOverrideDefinition<any, any>
       __experimentalShippingSimulation: ComponentOverrideDefinition<any, any>
       __experimentalNotAvailableButton: ComponentOverrideDefinition<any, any>
+      __experimentalProductDescription: ComponentOverrideDefinition<any, any>
     }
   }
   ProductGallery: {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to enable override for `ProductDescription` component and props in `ProductDetails` section.

## How it works?

You can override `ProductDescription` using `__experimentalProductDescription`.

## How to test it?

#### In the `@faststore/core` package:
In `packages/core/src/customizations/src/components/overrides/ProductDetails.tsx`

change the following code:
```
const override: SectionOverride = {
  section: SECTION,
  components: {
    __experimentalProductDescription: {
      props: { descriptionData: [{ title: 'Title', content: 'Some content' }] },
    },
  },
}
```

#### In the `starter.store`:

- Follow this doc: https://developers.vtex.com/docs/guides/faststore/overrides-component-props;
- Check the Overrides migration from V1 to V2 to ensure you are creating the override in the correct way.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/446

Using the changes of the PR above, you can test by running the store locally (`yarn dev`) then go to `http://localhost:3000/api/preview?contentType=pdp&documentId=4675d165-170d-11ef-8452-12a5e84da56d&versionId=eb329256-7113-4f74-9087-6e0838e77aaa`, that's the version using the draft changes I made.

<img width="1227" alt="Screenshot 2024-05-22 at 16 40 16" src="https://github.com/vtex/faststore/assets/15722605/8284091d-44cc-44d3-b166-ead1128003d0">
<img width="1459" alt="Screenshot 2024-05-22 at 16 41 12" src="https://github.com/vtex/faststore/assets/15722605/3b283a48-91fa-4a9d-96c9-2602c6cc4fe9">
