### PR TITLE
Fix: Reverts multiple fetch cms pages cache strategy

### DIFF
--- a/packages/core/src/server/cms/index.ts
+++ b/packages/core/src/server/cms/index.ts
@@ -5,14 +5,6 @@ import MissingContentError from 'src/sdk/error/MissingContentError'
 import MultipleContentError from 'src/sdk/error/MultipleContentError'
 import config from '../../../faststore.config'
 
-type Cache<T> = {
-  [key: string]: { data: Array<T> }
-}
-type ExtraOptions = {
-  cmsClient?: ClientCMS
-  cache?: Cache<ContentData>
-}
-
 export type Options =
   | Locator
   | {
@@ -68,18 +60,15 @@ const getCMSPageCache = {}
 
 export const getCMSPage = async (
   options: Options,
-  extraOptions?: ExtraOptions
+  cmsClient: ClientCMS = clientCMS
 ) => {
-  const cmsClient = extraOptions?.cmsClient ?? clientCMS
-  const cache = extraOptions?.cache ?? getCMSPageCache
-
   if (isLocator(options)) {
     return await cmsClient
       .getCMSPage(options)
       .then((page) => ({ data: [page] }))
   }
 
-  if (!cache[options.contentType]) {
+  if (!getCMSPageCache[options.contentType]) {
     const pages = []
     let page = 1
     const perPage = 10
@@ -111,10 +100,10 @@ export const getCMSPage = async (
         pages.push(...response.data)
       })
     }
-    cache[options.contentType] = { data: pages }
+    getCMSPageCache[options.contentType] = { data: pages }
   }
 
-  return cache[options.contentType]
+  return getCMSPageCache[options.contentType]
 }
 
 export const getPage = async <T extends ContentData>(options: Options) => {

--- a/packages/core/src/server/cms/index.ts
+++ b/packages/core/src/server/cms/index.ts
@@ -45,19 +45,6 @@ export const clientCMS = new ClientCMS({
   tenant: config.api.storeId,
 })
 
-/*
- * This in memory cache exists because for each page (think category or department)
- * we are fetching all the pages of the same content type from the headless CMS to
- * find the one that matches the slug.
- *
- * So instead of making multiple request for the Headless CMS API for each page we make
- * one for each content-type and reuse the results for the next page.
- *
- * Since we rebuild on a CMS publication the server will go away and will "invalidate"
- * the cache
- */
-const getCMSPageCache = {}
-
 export const getCMSPage = async (
   options: Options,
   cmsClient: ClientCMS = clientCMS
@@ -68,42 +55,39 @@ export const getCMSPage = async (
       .then((page) => ({ data: [page] }))
   }
 
-  if (!getCMSPageCache[options.contentType]) {
-    const pages = []
-    let page = 1
-    const perPage = 10
-    const response = await cmsClient.getCMSPagesByContentType(
-      options.contentType,
-      { ...options.filters, page: page, perPage }
-    )
+  const pages = []
+  let page = 1
+  const perPage = 10
+  const response = await cmsClient.getCMSPagesByContentType(
+    options.contentType,
+    { ...options.filters, page: page, perPage }
+  )
 
-    pages.push(...response.data)
+  pages.push(...response.data)
 
-    const totalPagesToFetch = Math.ceil(response.totalItems / perPage) // How many pages have content
-    const pagesToFetch = Array.from(
-      { length: totalPagesToFetch - 1 }, // We want all those pages minus the first one that we fetched
-      (_, i) => i + 2 // + 1 because indices are 0 based, and + 1 because we already fetched the first
-    )
+  const totalPagesToFetch = Math.ceil(response.totalItems / perPage) // How many pages have content
+  const pagesToFetch = Array.from(
+    { length: totalPagesToFetch - 1 }, // We want all those pages minus the first one that we fetched
+    (_, i) => i + 2 // + 1 because indices are 0 based, and + 1 because we already fetched the first
+  )
 
-    if (response.totalItems > pages.length) {
-      const restOfPages = await Promise.all(
-        pagesToFetch.map((i) =>
-          cmsClient.getCMSPagesByContentType(options.contentType, {
-            ...options.filters,
-            page: i,
-            perPage,
-          })
-        )
+  if (response.totalItems > pages.length) {
+    const restOfPages = await Promise.all(
+      pagesToFetch.map((i) =>
+        cmsClient.getCMSPagesByContentType(options.contentType, {
+          ...options.filters,
+          page: i,
+          perPage,
+        })
       )
+    )
 
-      restOfPages.forEach((response) => {
-        pages.push(...response.data)
-      })
-    }
-    getCMSPageCache[options.contentType] = { data: pages }
+    restOfPages.forEach((response) => {
+      pages.push(...response.data)
+    })
   }
 
-  return getCMSPageCache[options.contentType]
+  return { data: pages }
 }
 
 export const getPage = async <T extends ContentData>(options: Options) => {

--- a/packages/core/test/server/cms/index.test.ts
+++ b/packages/core/test/server/cms/index.test.ts
@@ -29,10 +29,7 @@ describe('CMS Integration', () => {
       })
       clientCMS.getCMSPagesByContentType = mockFunction
 
-      const result = await getCMSPage(
-        { contentType: 'plp' },
-        { cmsClient: clientCMS }
-      )
+      const result = await getCMSPage({ contentType: 'plp' }, clientCMS)
 
       expect(mockFunction.mock.calls.length).toBe(1)
       expect(result.data.length).toBe(3)
@@ -59,37 +56,10 @@ describe('CMS Integration', () => {
 
       clientCMS.getCMSPagesByContentType = mockFunction
 
-      const result = await getCMSPage(
-        { contentType: 'plp' },
-        { cmsClient: clientCMS, cache: {} }
-      )
+      const result = await getCMSPage({ contentType: 'plp' }, clientCMS)
 
       expect(mockFunction.mock.calls.length).toBe(2)
       expect(result.data.length).toBe(15)
-    })
-
-    it('it makes no request if the cache is filled', async () => {
-      const mockFunction: jest.Mock<typeof clientCMS.getCMSPagesByContentType> =
-        jest.fn()
-
-      mockFunction.mockImplementationOnce(() => {
-        return Promise.resolve({
-          data: mockData(10),
-          hasNextPage: true,
-          totalItems: 15,
-        })
-      })
-
-      clientCMS.getCMSPagesByContentType = mockFunction
-
-      const cache = { plp: { data: [] } }
-      const result = await getCMSPage(
-        { contentType: 'plp' },
-        { cmsClient: clientCMS, cache: cache }
-      )
-
-      expect(mockFunction.mock.calls.length).toBe(0)
-      expect(result.data.length).toBe(0)
     })
   })
 })


### PR DESCRIPTION
## What's the purpose of this pull request?

Reverts the cache approach when fetching multiple hCMS pages.

It looks like the cache strategy used in this PR
- https://github.com/vtex/faststore/pull/2314

It is bringing some issues for clients.  So This PR aims to revert this logic.
