### PR TITLE
Add: Placeholder text for Search NavBar

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -192,6 +192,11 @@
           "type": "object",
           "required": ["sort"],
           "properties": {
+            "placeholder": {
+              "title": "Placeholder for Search Bar",
+              "type": "string",
+              "default": "Search everything at the store"
+            },
             "sort": {
               "title": "Results default sort value",
               "type": "string",

--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -120,7 +120,10 @@ function Navbar({
             </>
           )}
 
-          <SearchInput sort={searchInput?.sort} />
+          <SearchInput
+            placeholder={searchInput?.placeholder}
+            sort={searchInput?.sort}
+          />
 
           <NavbarButtons.Component
             searchExpanded={searchExpanded}

--- a/packages/core/src/components/search/SearchInput/SearchInput.tsx
+++ b/packages/core/src/components/search/SearchInput/SearchInput.tsx
@@ -36,6 +36,7 @@ export type SearchInputProps = {
   onSearchClick?: () => void
   buttonTestId?: string
   containerStyle?: CSSProperties
+  placeholder?: string
   sort?: string
 } & Omit<UISearchInputFieldProps, 'onSubmit'>
 
@@ -57,6 +58,7 @@ const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
       buttonTestId = 'fs-search-button',
       containerStyle,
       sort,
+      placeholder,
       ...otherProps
     },
     ref
@@ -113,7 +115,7 @@ const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
             onClick: onSearchClick,
             testId: buttonTestId,
           }}
-          placeholder="Search everything at the store"
+          placeholder={placeholder}
           onChange={(e) => setSearchQuery(e.target.value)}
           onSubmit={(term) => {
             const path = formatSearchPath({

--- a/packages/core/src/components/sections/Navbar/Navbar.tsx
+++ b/packages/core/src/components/sections/Navbar/Navbar.tsx
@@ -21,7 +21,7 @@ export interface NavbarProps {
     }
   }
   searchInput: {
-    placeholder: string
+    placeholder?: string
     sort: string
   }
   signInButton: {

--- a/packages/core/src/components/sections/Navbar/Navbar.tsx
+++ b/packages/core/src/components/sections/Navbar/Navbar.tsx
@@ -21,6 +21,7 @@ export interface NavbarProps {
     }
   }
   searchInput: {
+    placeholder: string
     sort: string
   }
   signInButton: {


### PR DESCRIPTION
## What's the purpose of this pull request?

Add placeholder at the search input to enable users to change the default text:

https://github.com/vtex/faststore/assets/67066494/5da24c43-3be5-4934-ae7e-4b354cf1485b


## How it works?

Change the placeHolder at the CMS inside the navbar and look at the preview.

## How to test it?

Sync the new section or you can use this account:
https://bibi--bibi.myvtex.com/admin/new-cms/faststore/globalSections/edit/72531e4c-c99f-11ee-8452-1249c7739e6b

Change the account and workspace for bibi. 

