### PR TITLE
Fix URL update to prevent page reloads

### DIFF
--- a/packages/core/src/sdk/search/state.ts
+++ b/packages/core/src/sdk/search/state.ts
@@ -6,15 +6,10 @@ export const useApplySearchState = () => {
 
   return useCallback(
     (url: URL) => {
-      const currentUrl = new URL(window.location.href)
       const newUrl = `${url.pathname}${url.search}`
-      if (currentUrl.href !== newUrl) {
-        if (url.searchParams.has('fuzzy') && url.searchParams.has('operator')) {
-          window.history.replaceState({}, '', newUrl)
-        } else {
-          router.push(newUrl)
-        }
-      }
+      return url.searchParams.has('fuzzy') && url.searchParams.has('operator')
+        ? window.history.replaceState(window.history.state, '', newUrl)
+        : router.push(newUrl)
     },
     [router]
   )

--- a/packages/core/src/sdk/search/state.ts
+++ b/packages/core/src/sdk/search/state.ts
@@ -6,10 +6,15 @@ export const useApplySearchState = () => {
 
   return useCallback(
     (url: URL) => {
+      const currentUrl = new URL(window.location.href)
       const newUrl = `${url.pathname}${url.search}`
-      return url.searchParams.has('fuzzy') && url.searchParams.has('operator')
-        ? router.replace(newUrl)
-        : router.push(newUrl)
+      if (currentUrl.href !== newUrl) {
+        if (url.searchParams.has('fuzzy') && url.searchParams.has('operator')) {
+          window.history.replaceState({}, '', newUrl)
+        } else {
+          router.push(newUrl)
+        }
+      }
     },
     [router]
   )


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the blink for Dunnes project when the param is added at the URL:

https://github.com/vtex/faststore/assets/67066494/65af813c-d604-4594-b04c-cd61340ea76a

## How it works?

Added `window.history.replaceState({}, '', newUrl)` to stop the page from reloading unnecessarily.
## How to test it?

Core Before:

https://github.com/vtex/faststore/assets/67066494/571673df-e4bc-4da4-9874-939fe13ec492

Core After:

https://github.com/vtex/faststore/assets/67066494/56ee0b93-1ba3-4a93-8fab-6715745ee18c


<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

Beta package:
https://partnerintegrationbra-clvfdw8vd00danzcdwpy08ig3-rd740v8hj.b.vtex.app/
Enter a category like clothing:
https://partnerintegrationbra-clvfdw8vd00danzcdwpy08ig3-rd740v8hj.b.vtex.app/clothing 

## References

No specific reference here :)
