### PR TITLE
fix: copy public folder back to root dir (fix vercel build)

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -2,7 +2,7 @@ import { Command } from '@oclif/core'
 import chalk from 'chalk'
 import { spawnSync } from 'child_process'
 import { existsSync } from 'fs'
-import { copySync, removeSync, moveSync, readdirSync } from 'fs-extra'
+import { copySync, moveSync, readdirSync, removeSync } from 'fs-extra'
 import { tmpDir, userDir } from '../utils/directory'
 import { generate } from '../utils/generate'
 
@@ -65,4 +65,5 @@ async function normalizeStandaloneBuildDir() {
 async function copyResources() {
   await copyResource(`${tmpDir}/.next`, `${userDir}/.next`)
   await copyResource(`${tmpDir}/lighthouserc.js`, `${userDir}/lighthouserc.js`)
+  await copyResource(`${tmpDir}/public`, `${userDir}/public`)
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

When we use the public folder in the root from the starter, maybe to add a new favicon, the build from projects from FSW does not load other files, like the `icons.svg`. This PR aims to copy back the public folder from `.faststore/public` to the `public` folder from the root directory after the build command so that the build can leverage all files over there.

## How to test it?

see the starter PR
- https://github.com/vtex-sites/starter.store/pull/471
preview: https://starter-enk8eefs6-faststore.vercel.app/

Please take a look at the different favicon and also the icons that are being loaded.

The previous preview without the changes from this PR with the favicon but without the icons:
https://starter-1sjtb4i7u-faststore.vercel.app/

with favicon + Without icons /  with favicon + with icons
<img width="1918" alt="Screenshot 2024-06-17 at 19 29 08" src="https://github.com/vtex/faststore/assets/11325562/2cf74054-d8d9-406d-b4fa-bbe215166a3e">


### Starters Deploy Preview

- https://github.com/vtex-sites/starter.store/pull/471
