### PR TITLE
Add `an` attribute to activity-flow initializer script

### DIFF
--- a/packages/core/src/components/ThirdPartyScripts/vtex.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/vtex.tsx
@@ -1,3 +1,5 @@
+import storeConfig from '../../../faststore.config'
+
 function VTEX() {
   return (
     <>
@@ -26,6 +28,7 @@ function VTEX() {
       <script
         key="vtex-af.js-script"
         type="text/partytown"
+        an={storeConfig.api.storeId}
         async
         src="https://activity-flow.vtex.com/af/af.js"
       />

--- a/packages/core/src/components/ThirdPartyScripts/vtex.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/vtex.tsx
@@ -28,7 +28,7 @@ function VTEX() {
       <script
         key="vtex-af.js-script"
         type="text/partytown"
-        an={storeConfig.api.storeId}
+        data-an={storeConfig.api.storeId}
         async
         src="https://activity-flow.vtex.com/af/af.js"
       />


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix ActivityFlow integration on FastStore by adding the non-standard `an` attribute to the initializing script of ActivityFlow.

## How to test it?

Run the core locally and see that the `pageView` event has the correct `accountName`

