### PR TITLE
fix: Pass Through PLP URL Params

### DIFF
--- a/packages/sdk/src/search/serializer.ts
+++ b/packages/sdk/src/search/serializer.ts
@@ -3,11 +3,17 @@ import { isSearchSort, setFacet } from './facets'
 import { initialize } from './useSearchState'
 import type { SearchSort, State } from '../types'
 
-function getPassThroughSearchParams(params: URLSearchParams, denyList: String[]) {
+function getPassThroughSearchParams(
+  params: URLSearchParams,
+  denyList: string[]
+) {
   const passthroughParams = new URLSearchParams()
+  const denySet = new Set(denyList)
 
-  for (const [key, value] of params.entries()) {
-    if (!denyList.includes(key)) {
+  const entriesArray = Array.from(params.entries())
+
+  for (const [key, value] of entriesArray) {
+    if (!denySet.has(key)) {
       passthroughParams.append(key, value)
     }
   }

--- a/packages/sdk/src/search/serializer.ts
+++ b/packages/sdk/src/search/serializer.ts
@@ -3,7 +3,7 @@ import { isSearchSort, setFacet } from './facets'
 import { initialize } from './useSearchState'
 import type { SearchSort, State } from '../types'
 
-function getPassthroughSearchParams(params: URLSearchParams, denyList: String[]) {
+function getPassThroughSearchParams(params: URLSearchParams, denyList: String[]) {
   const passthroughParams = new URLSearchParams()
 
   for (const [key, value] of params.entries()) {
@@ -40,7 +40,7 @@ export const parse = ({ pathname, searchParams }: URL): State => {
     }
   }
 
-  state.passThrough = getPassthroughSearchParams(searchParams, [
+  state.passThrough = getPassThroughSearchParams(searchParams, [
     'q',
     'sort',
     'page',

--- a/packages/sdk/src/search/serializer.ts
+++ b/packages/sdk/src/search/serializer.ts
@@ -3,6 +3,18 @@ import { isSearchSort, setFacet } from './facets'
 import { initialize } from './useSearchState'
 import type { SearchSort, State } from '../types'
 
+function getPassthroughSearchParams(params: URLSearchParams, denyList: String[]) {
+  const passthroughParams = new URLSearchParams()
+
+  for (const [key, value] of params.entries()) {
+    if (!denyList.includes(key)) {
+      passthroughParams.append(key, value)
+    }
+  }
+
+  return passthroughParams
+}
+
 export const parse = ({ pathname, searchParams }: URL): State => {
   const state = initialize({
     base: pathname,
@@ -27,6 +39,14 @@ export const parse = ({ pathname, searchParams }: URL): State => {
       })
     }
   }
+
+  state.passThrough = getPassthroughSearchParams(searchParams, [
+    'q',
+    'sort',
+    'page',
+    'facets',
+    ...facets,
+  ])
 
   return state
 }

--- a/packages/sdk/src/search/useSearchState.ts
+++ b/packages/sdk/src/search/useSearchState.ts
@@ -9,12 +9,14 @@ export const initialize = ({
   term = null,
   base = '/',
   page = 0,
+  passThrough = new URLSearchParams()
 }: Partial<State> | undefined = {}) => ({
   sort,
   selectedFacets,
   term,
   base,
   page,
+  passThrough,
 })
 
 const equals = (s1: State, s2: State) => format(s1).href === format(s2).href

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -30,4 +30,8 @@ export interface State {
    * @description current pagination cursor
    */
   page: number
+  /**
+   * @description params from other sources to preserve when building URLs
+   */
+  passThrough: URLSearchParams
 }

--- a/packages/sdk/src/utils/format.ts
+++ b/packages/sdk/src/utils/format.ts
@@ -22,9 +22,8 @@ const format = (params: State): URL => {
   url.searchParams.set('sort', sort)
   url.searchParams.set('page', page.toString())
 
-  if (passThrough && passThrough.size > 0) {
-    const entriesArray = Array.from(passThrough.entries())
-    for (const [key, value] of entriesArray) {
+if (passThrough) {
+    for (const [key, value] of passThrough.entries()) {
       url.searchParams.append(key, value)
     }
   }

--- a/packages/sdk/src/utils/format.ts
+++ b/packages/sdk/src/utils/format.ts
@@ -22,9 +22,10 @@ const format = (params: State): URL => {
   url.searchParams.set('sort', sort)
   url.searchParams.set('page', page.toString())
 
-  if (Array.from(passThrough?.entries())) {
-    for (const [key, value] of passThrough.entries()) {
-      url.searchParams.append(key, value);
+  if (passThrough && passThrough.size > 0) {
+    const entriesArray = Array.from(passThrough.entries())
+    for (const [key, value] of entriesArray) {
+      url.searchParams.append(key, value)
     }
   }
 

--- a/packages/sdk/src/utils/format.ts
+++ b/packages/sdk/src/utils/format.ts
@@ -2,7 +2,7 @@ import type { State } from '../types'
 
 const format = (params: State): URL => {
   const url = new URL(params.base, 'http://localhost')
-  const { page, selectedFacets, sort, term } = params
+  const { page, selectedFacets, sort, term, passThrough } = params
 
   if (term !== null) {
     url.searchParams.set('q', term)
@@ -21,6 +21,12 @@ const format = (params: State): URL => {
 
   url.searchParams.set('sort', sort)
   url.searchParams.set('page', page.toString())
+
+  if (Array.from(passThrough?.entries())) {
+    for (const [key, value] of passThrough.entries()) {
+      url.searchParams.append(key, value);
+    }
+  }
 
   return url
 }

--- a/packages/sdk/test/search/serializer.test.ts
+++ b/packages/sdk/test/search/serializer.test.ts
@@ -90,6 +90,7 @@ test('Search State Serializer: Basic parsing', async () => {
     sort: 'score_desc',
     term: 'Hello World',
     page: 0,
+    passThrough: new URLSearchParams()
   })
 
   expect(
@@ -104,6 +105,7 @@ test('Search State Serializer: Basic parsing', async () => {
     sort: 'score_desc',
     term: 'Hello World',
     page: 1,
+    passThrough: new URLSearchParams()
   })
 
   expect(
@@ -116,5 +118,56 @@ test('Search State Serializer: Basic parsing', async () => {
     sort: 'score_desc',
     term: 'Hello World',
     page: 10,
+    passThrough: new URLSearchParams()
+  })
+})
+
+test('Search State Serializer: Passthrough param parsing', async () => {
+  expect(
+    parseSearchState(
+      new URL(
+        'http://localhost/pt-br/sale?q=Hello+World&&sort=score_desc&price=10%3A100&page=0&facets=price&foo=bar'
+      )
+    )
+  ).toEqual({
+    base: '/pt-br/sale',
+    selectedFacets: [
+      {
+        key: 'price',
+        value: '10:100',
+      },
+    ],
+    sort: 'score_desc',
+    term: 'Hello World',
+    page: 0,
+    passThrough: new URLSearchParams({ foo: 'bar' })
+  })
+
+  expect(
+    parseSearchState(
+      new URL(
+        'http://localhost/pt-br/sale?q=Hello+World&sort=score_desc&page=1&foo=bar'
+      )
+    )
+  ).toEqual({
+    base: '/pt-br/sale',
+    selectedFacets: [],
+    sort: 'score_desc',
+    term: 'Hello World',
+    page: 1,
+    passThrough: new URLSearchParams({ foo: 'bar' })
+  })
+
+  expect(
+    parseSearchState(
+      new URL('http://localhost?q=Hello+World&sort=score_desc&page=10&foo=bar')
+    )
+  ).toEqual({
+    base: '/',
+    selectedFacets: [],
+    sort: 'score_desc',
+    term: 'Hello World',
+    page: 10,
+    passThrough: new URLSearchParams({ foo: 'bar' })
   })
 })


### PR DESCRIPTION
## What's the purpose of this pull request?

URL params are stripped out on inbound PLP links when the app rebuilds the URL from state. This is undesirable for end users who need to add params to their links - e.g. referral or UTM tracking codes.

## How it works?

Any params that are not included in the state allow list are grouped into a `passThrough` field in the state, and added back when the URL is rebuilt.

## How to test it?

1. Visit a PLP link with a URL param: `/my-cool-category?foo=bar`
2. Validate that the additional param is preserved after URL state updates

I'm happy to adjust naming or implementation, this set of changes was the result of a spike into preserving UTM params on inbound links.