### PR TITLE
Revert "Fix URL update to prevent page reloads"

### DIFF
--- a/packages/core/src/sdk/search/state.ts
+++ b/packages/core/src/sdk/search/state.ts
@@ -8,7 +8,7 @@ export const useApplySearchState = () => {
     (url: URL) => {
       const newUrl = `${url.pathname}${url.search}`
       return url.searchParams.has('fuzzy') && url.searchParams.has('operator')
-        ? window.history.replaceState(window.history.state, '', newUrl)
+        ? router.replace(newUrl)
         : router.push(newUrl)
     },
     [router]


### PR DESCRIPTION
Reverts vtex/faststore#2334

When adding a new filter and refreshing the page the state is kept the same without changes.

https://github.com/vtex/faststore/assets/67066494/9ef74a81-e893-42ae-bb08-9c1279edc603


