### PR TITLE
Stop running commonjs build in the background

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,7 +26,7 @@
     "dev": "concurrently \"yarn generate -w\" \"tsc --watch\" \"yarn dev:graphql\"",
     "dev:graphql": "nodemon --watch src --ext graphql --exec \"copyfiles \"src/**/*.graphql\" dist/esm\"",
     "dev:server": "tsx --no-cache ./local/server.ts",
-    "build": "graphql-codegen --config codegen.yml && (yarn build:cjs & yarn build:esm)",
+    "build": "graphql-codegen --config codegen.yml && (yarn build:cjs && yarn build:esm)",
     "build:cjs": "tsc --module commonjs --moduleResolution node10 --outDir dist/cjs && copyfiles \"src/**/*.graphql\" dist/cjs",
     "build:esm": "tsc && copyfiles \"src/**/*.graphql\" dist/esm",
     "lint": "eslint src/**/*.ts",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "tsc --watch",
-    "build": "tsc --module commonjs --outDir dist/cjs & tsc --module esnext --outDir dist/esm",
+    "build": "tsc --module commonjs --outDir dist/cjs && tsc --module esnext --outDir dist/esm",
     "lint": "eslint src/**/*.{ts,tsx}",
     "test": "jest"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "dev": "tsc --watch",
-    "build": "tsc --module commonjs --outDir dist/cjs & tsc --module esnext --outDir dist/esm",
+    "build": "tsc --module commonjs --outDir dist/cjs && tsc --module esnext --outDir dist/esm",
     "lint": "eslint src/**/*.{ts,tsx}",
     "size": "size-limit",
     "analyze": "size-limit --why"


### PR DESCRIPTION
Bash's `&` operator runs what's to the left of it on the background. Usually it's used together with the `wait` command. This was not the case. I **believe** that this command running in the background was what was causing the intermitent issue we had. Whenever the esnext build finished before the commonjs one, the process would end and kill the background process.

The side effect of this changes is that we add a couple of seconds to the overall build time.

A simplified example of this behavior can be found by running the following script:

```sh
#!/bin/bash

backgroundChild() {
	sleep 10

	echo "Background Child function is done."
}

foregroundChild() {
	sleep 3
	echo "Foreground Child is done."
}

echo "Parent running"

backgroundChild &
foregroundChild

```

and notice that we never see "Background Child function is done."