### PR TITLE
fix: Adjust price with taxes

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/aggregateOffer.ts
@@ -17,7 +17,7 @@ const getHighPrice = (
     return highPrice
   }
 
-  return withTax(highPrice, highOffer.Tax, highOffer.product.unitMultiplier)
+  return withTax(highPrice, highOffer?.Tax, highOffer?.product?.unitMultiplier)
 }
 
 const getLowPrice = (
@@ -32,7 +32,7 @@ const getLowPrice = (
     return lowPrice
   }
 
-  return withTax(lowPrice, lowOffer.Tax, lowOffer.product.unitMultiplier)
+  return withTax(lowPrice, lowOffer?.Tax, lowOffer?.product?.unitMultiplier)
 }
 
 export const StoreAggregateOffer: Record<string, Resolver<Root>> & {

--- a/packages/api/src/platforms/vtex/resolvers/offer.ts
+++ b/packages/api/src/platforms/vtex/resolvers/offer.ts
@@ -86,7 +86,7 @@ export const StoreOffer: Record<string, Resolver<Root>> = {
   },
   priceWithTaxes: (root) => {
     if (isSearchItem(root)) {
-      return withTax(price(root), root.Tax, root.product.unitMultiplier)
+      return withTax(price(root), root?.Tax, root.product.unitMultiplier)
     }
 
     if (isOrderFormItem(root)) {
@@ -119,7 +119,7 @@ export const StoreOffer: Record<string, Resolver<Root>> = {
   },
   listPriceWithTaxes: (root) => {
     if (isSearchItem(root)) {
-      return withTax(root.ListPrice ?? 0, root.Tax, root.product.unitMultiplier)
+      return withTax(root.ListPrice ?? 0, root?.Tax, root.product.unitMultiplier)
     }
 
     if (isOrderFormItem(root)) {

--- a/packages/api/src/platforms/vtex/utils/taxes.ts
+++ b/packages/api/src/platforms/vtex/utils/taxes.ts
@@ -1,6 +1,6 @@
 export const withTax = (
   price: number,
-  tax: number,
+  tax: number = 0,
   unitMultiplier: number = 1
 ) => {
   const unitTax = tax / unitMultiplier


### PR DESCRIPTION
## What's the purpose of this pull request?

Add Optional Chaining in Faststore Tax calculation

Related with this [#2363](https://github.com/vtex/faststore/issues/2363) 
