### PR TITLE
Fix: sort SKU variations

### DIFF
--- a/packages/components/src/molecules/SkuSelector/SkuSelector.tsx
+++ b/packages/components/src/molecules/SkuSelector/SkuSelector.tsx
@@ -118,8 +118,8 @@ const SkuSelector = forwardRef<HTMLDivElement, SkuSelectorProps>(
       return !isNaN(value - parseFloat(value))
     }
 
-    const sortOptions = (options) => {
-      return options.sort((a, b) => {
+    const sortOptions = (opt) => {
+      return opt.sort((a, b) => {
         if (isNumeric(a.value) && isNumeric(b.value)) {
           return parseFloat(a.value) - parseFloat(b.value)
         }

--- a/packages/components/src/molecules/SkuSelector/SkuSelector.tsx
+++ b/packages/components/src/molecules/SkuSelector/SkuSelector.tsx
@@ -5,7 +5,6 @@ import { Label, SROnly, Link, LinkProps, LinkElementType } from '../..'
 import { useDefineVariant, Variant } from './useDefineVariant'
 import { useSkuSlug } from './useSkuSlug'
 
-
 // TODO: Change by ImageComponent when it be right
 const ImageComponentFallback: SkuSelectorProps['ImageComponent'] = ({
   src,
@@ -108,8 +107,27 @@ const SkuSelector = forwardRef<HTMLDivElement, SkuSelectorProps>(
 
     const variant = useDefineVariant(options, variantProp)
 
-    const { getItemHref } = useSkuSlug(activeVariations, slugsMap, skuPropertyName, getItemHrefProp)
+    const { getItemHref } = useSkuSlug(
+      activeVariations,
+      slugsMap,
+      skuPropertyName,
+      getItemHrefProp
+    )
 
+    const isNumeric = (value) => {
+      return !isNaN(value - parseFloat(value))
+    }
+
+    const sortOptions = (options) => {
+      return options.sort((a, b) => {
+        if (isNumeric(a.value) && isNumeric(b.value)) {
+          return parseFloat(a.value) - parseFloat(b.value)
+        }
+        return a.value.localeCompare(b.value)
+      })
+    }
+
+    const sortedOptions = sortOptions(options)
     return (
       <div
         ref={ref}
@@ -124,7 +142,7 @@ const SkuSelector = forwardRef<HTMLDivElement, SkuSelectorProps>(
           </Label>
         )}
         <ul data-fs-sku-selector-list>
-          {options.map((option, index) => {
+          {sortedOptions.map((option, index) => {
             return (
               <li
                 key={String(index)}


### PR DESCRIPTION
## What's the purpose of this pull request?
Currently, the SKU variations are not sorted

## How it works?

It now checks if the value is a number or string and sort it alphabetically or numerically ascendant

## How to test it?

Open a PDP with any of the SKU variations, number or text

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
