### PR TITLE
Prepare for CLI to be run on any arbitrary path

### DIFF
--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -16,7 +16,7 @@ export default class CmsSync extends Command {
     const { tmpDir } = withBasePath(basePath)
 
     await generate({ setup: true, basePath })
-    await mergeCMSFiles()
+    await mergeCMSFiles(basePath)
 
     if (flags['dry-run']) {
       return

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -1,6 +1,6 @@
 import { Command, Flags } from '@oclif/core'
 import { spawn } from 'child_process'
-import { tmpDir } from '../utils/directory'
+import { withBasePath } from '../utils/directory'
 import { generate } from '../utils/generate'
 import { mergeCMSFiles } from '../utils/hcms'
 
@@ -12,7 +12,10 @@ export default class CmsSync extends Command {
   async run() {
     const { flags } = await this.parse(CmsSync)
 
-    await generate({ setup: true })
+    const basePath = process.cwd()
+    const { tmpDir } = withBasePath(basePath)
+
+    await generate({ setup: true, basePath })
     await mergeCMSFiles()
 
     if (flags['dry-run']) {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -5,7 +5,7 @@ import dotenv from 'dotenv';
 
 import { readFileSync } from 'fs';
 import path from 'path';
-import { getRoot, tmpDir } from '../utils/directory';
+import { withBasePath } from '../utils/directory';
 import { generate } from '../utils/generate';
 
 /**
@@ -31,8 +31,8 @@ const defaultIgnored = [
 
 const devAbortController = new AbortController()
 
-async function storeDev() {
-  const envVars = dotenv.parse(readFileSync(path.join(getRoot(), 'vtex.env')))
+async function storeDev(rootDir: string, tmpDir: string) {
+  const envVars = dotenv.parse(readFileSync(path.join(rootDir, 'vtex.env')))
 
   const devProcess = spawn('yarn dev', {
     shell: true,
@@ -52,9 +52,12 @@ async function storeDev() {
 
 export default class Dev extends Command {
   async run() {
+    const basePath = process.cwd()
+
+    const { getRoot, tmpDir } = withBasePath(basePath)
 
     const queueChange = (/* path: string, remove: boolean */) => {
-      generate()
+      generate({ basePath })
     }
 
     const watcher = chokidar.watch([...defaultPatterns], {
@@ -75,7 +78,7 @@ export default class Dev extends Command {
 
     await generate({ setup: true })
 
-    storeDev()
+    storeDev(getRoot(), tmpDir)
 
     return await new Promise((resolve, reject) => {
       watcher

--- a/packages/cli/src/commands/generate-graphql.ts
+++ b/packages/cli/src/commands/generate-graphql.ts
@@ -2,7 +2,7 @@ import { Command, Flags } from '@oclif/core'
 import { existsSync } from 'fs-extra'
 import chalk from 'chalk'
 
-import { coreDir, tmpDir } from '../utils/directory'
+import { withBasePath } from '../utils/directory'
 import { runCommandSync } from '../utils/runCommandSync'
 
 export default class GenerateGraphql extends Command {
@@ -13,6 +13,9 @@ export default class GenerateGraphql extends Command {
 
   async run() {
     const { flags } = await this.parse(GenerateGraphql)
+
+    const basePath = process.cwd()
+    const { tmpDir, coreDir } = withBasePath(basePath)
 
     const debug = flags.debug ?? false
     const isCore = flags.core ?? false

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,10 +1,13 @@
 import { Command } from '@oclif/core'
 import { spawn } from 'child_process'
 import { existsSync } from 'fs-extra'
-import { tmpDir } from '../utils/directory'
+import { withBasePath } from '../utils/directory'
 
 export default class Start extends Command {
   async run() {
+    const basePath = process.cwd()
+    const { tmpDir } = withBasePath(basePath)
+
     if (!existsSync(tmpDir)) {
       throw Error(
         'The ".faststore" directory could not be found. If you are trying to serve your store, run "faststore build" first.'

--- a/packages/cli/src/utils/directory.test.ts
+++ b/packages/cli/src/utils/directory.test.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { coreCMSDir, coreDir, tmpCMSDir, tmpCMSWebhookUrlsFile, tmpCustomizationsSrcDir, tmpDir, tmpStoreConfigFile, tmpThemesCustomizationsFile, userCMSDir, userSrcDir, userStoreConfigFile, userThemesFileDir } from "./directory"
+import { withBasePath } from "./directory"
 
 const pathsToMatch = (expected: string, desired: string) => {
   const expectedResolved = path.resolve(expected)
@@ -8,77 +8,210 @@ const pathsToMatch = (expected: string, desired: string) => {
   return expectedResolved === desiredResolved
 }
 
-describe('directory with base path', () => {
+describe('withBasePath as the current dir `.`', () => {
+  const basePath = '.'
+
   describe('coreDir', () => {
-    it('is the fastsstoreDir + core', () => {
-      expect(pathsToMatch(coreDir, './node_modules/@faststore/core')).toBe(true)
+    it('is the faststoreDir + core', () => {
+      const { coreDir: basedCoreDir } = withBasePath(basePath)
+
+      expect(pathsToMatch(basedCoreDir, './node_modules/@faststore/core')).toBe(true)
+    })
+
+    describe('when is in a monorepo', () => {
+      it.todo('can look at its parent until it reaches the monorepo directory')
     })
   })
 
   describe('tmpDir', () => {
-    it('is the cwd + .faststore', () => {
-      expect(pathsToMatch(tmpDir, './.faststore')).toBe(true)
+    it('is the basePath + .faststore', () => {
+      const { tmpDir: basedTmpDir } = withBasePath(basePath)
+
+      expect(pathsToMatch(basedTmpDir, './.faststore')).toBe(true)
     })
   })
 
   describe('userDir', () => {
     it('returns the directory of the starters package.json', () => {
-      expect(pathsToMatch(userSrcDir, './src')).toBe(true)
+      const { userSrcDir: userSrcDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(userSrcDirWithBase, './src')).toBe(true)
     })
   })
 
   describe('tmpCustomizationsSrcDir', () => {
     it('returns the directory of customizations directory on the tmp dir', () => {
-      expect(pathsToMatch(tmpCustomizationsSrcDir, './.faststore/src/customizations/src')).toBe(true)
+      const { tmpCustomizationsSrcDir: tmpCustomizationsSrcDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(tmpCustomizationsSrcDirWithBase, './.faststore/src/customizations/src')).toBe(true)
     })
   })
 
   describe('userThemesFileDir', () => {
     it('returns the directory of the starters package.json', () => {
-      expect(pathsToMatch(userThemesFileDir, './src/themes')).toBe(true)
+      const { userThemesFileDir: userThemesFileDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(userThemesFileDirWithBase, './src/themes')).toBe(true)
     })
   })
 
   describe('tmpThemesCustomizationsFile', () => {
     it('returns the path of the theme file on the .faststore dir', () => {
-      expect(pathsToMatch(tmpThemesCustomizationsFile, './.faststore/src/customizations/src/themes/index.scss')).toBe(true)
+      const { tmpThemesCustomizationsFile: tmpThemesCustomizationsFileWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(tmpThemesCustomizationsFileWithBase, './.faststore/src/customizations/src/themes/index.scss')).toBe(true)
     })
   })
 
   describe('tmpCMSDir', () => {
-    it('returns the path of the CMS dir on the .faststore dir', () => {
-      expect(pathsToMatch(tmpCMSDir, './.faststore/cms/faststore')).toBe(true)
+    it('returns the path of the theme file on the .faststore dir', () => {
+      const { tmpCMSDir: tmpCMSDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(tmpCMSDirWithBase, './.faststore/cms/faststore')).toBe(true)
     })
   })
 
   describe('userCMSDir', () => {
     it('returns the path of the CMS dir on the user dir', () => {
-      expect(pathsToMatch(userCMSDir, './cms/faststore')).toBe(true)
+      const { userCMSDir: userCMSDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(userCMSDirWithBase, './cms/faststore')).toBe(true)
     })
   })
 
   describe('coreCMSDir', () => {
     it('returns the path of the CMS dir on @faststore/core package', () => {
-      expect(pathsToMatch(coreCMSDir, './node_modules/@faststore/core/cms/faststore')).toBe(true)
+      const { coreCMSDir: coreCMSDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(coreCMSDirWithBase, './node_modules/@faststore/core/cms/faststore')).toBe(true)
     })
   })
 
   describe('tmpCMSWebhookUrlsFile', () => {
     it('returns the path of the CMS webhooks file on the .faststore dir', () => {
-      expect(pathsToMatch(tmpCMSWebhookUrlsFile, './.faststore/cms-webhook-urls.json')).toBe(true)
+      const { tmpCMSWebhookUrlsFile: tmpCMSWebhookUrlsFileWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(tmpCMSWebhookUrlsFileWithBase, './.faststore/cms-webhook-urls.json')).toBe(true)
     })
   })
 
   describe('userStoreConfigFile', () => {
     it('returns the path of the user faststore.config file', () => {
-      expect(pathsToMatch(userStoreConfigFile, './faststore.config.js')).toBe(true)
+      const { userStoreConfigFile: userStoreConfigFileWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(userStoreConfigFileWithBase, './faststore.config.js')).toBe(true)
     })
   })
 
   describe('tmpStoreConfigFile', () => {
     it('returns the path of the faststore.config file in the customizations dir', () => {
-      expect(pathsToMatch(tmpStoreConfigFile, './.faststore/src/customizations/faststore.config.js')).toBe(true)
+      const { tmpStoreConfigFile: tmpStoreConfigFileWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(tmpStoreConfigFileWithBase, './.faststore/src/customizations/faststore.config.js')).toBe(true)
     })
   })
 })
 
+describe('withBasePath as an arbitrary dir', () => {
+  const basePath = path.join(__dirname, '..', '__mocks__', 'store')
+
+  describe('coreDir', () => {
+    it('is the faststoreDir + core', () => {
+      const { coreDir: coreDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(coreDirWithBase, './src/__mocks__/store/node_modules/@faststore/core')).toBe(true)
+    })
+
+    describe('when is in a monorepo', () => {
+      it.todo('can look at its parent until it reaches the monorepo directory')
+    })
+  })
+
+  describe('tmpDir', () => {
+    it('is the basePath + .faststore', () => {
+      const { tmpDir: tmpDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(tmpDirWithBase, './src/__mocks__/store/.faststore')).toBe(true)
+    })
+  })
+
+  describe('userDir', () => {
+    it('returns the directory of the starters package.json', () => {
+      const { userSrcDir: userSrcDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(userSrcDirWithBase, './src/__mocks__/store/src')).toBe(true)
+    })
+  })
+
+  describe('tmpCustomizationsSrcDir', () => {
+    it('returns the directory of customizations directory on the tmp dir', () => {
+      const { tmpCustomizationsSrcDir: tmpCustomizationsSrcDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(tmpCustomizationsSrcDirWithBase, './src/__mocks__/store/.faststore/src/customizations/src')).toBe(true)
+    })
+  })
+
+  describe('userThemesFileDir', () => {
+    it('returns the directory of the starters package.json', () => {
+      const { userThemesFileDir: userThemesFileDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(userThemesFileDirWithBase, './src/__mocks__/store/src/themes')).toBe(true)
+    })
+  })
+
+  describe('tmpThemesCustomizationsFile', () => {
+    it('returns the path of the theme file on the .faststore dir', () => {
+      const { tmpThemesCustomizationsFile: tmpThemesCustomizationsFileWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(tmpThemesCustomizationsFileWithBase, './src/__mocks__/store/.faststore/src/customizations/src/themes/index.scss')).toBe(true)
+    })
+  })
+
+  describe('tmpCMSDir', () => {
+    it('returns the path of the theme file on the .faststore dir', () => {
+      const { tmpCMSDir: tmpCMSDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(tmpCMSDirWithBase, './src/__mocks__/store/.faststore/cms/faststore')).toBe(true)
+    })
+  })
+
+  describe('userCMSDir', () => {
+    it('returns the path of the CMS dir on the user dir', () => {
+      const { userCMSDir: userCMSDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(userCMSDirWithBase, './src/__mocks__/store/cms/faststore')).toBe(true)
+    })
+  })
+
+  describe('coreCMSDir', () => {
+    it('returns the path of the CMS dir on @faststore/core package', () => {
+      const { coreCMSDir: coreCMSDirWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(coreCMSDirWithBase, './src/__mocks__/store/node_modules/@faststore/core/cms/faststore')).toBe(true)
+    })
+  })
+
+  describe('tmpCMSWebhookUrlsFile', () => {
+    it('returns the path of the CMS webhooks file on the .faststore dir', () => {
+      const { tmpCMSWebhookUrlsFile: tmpCMSWebhookUrlsFileWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(tmpCMSWebhookUrlsFileWithBase, './src/__mocks__/store/.faststore/cms-webhook-urls.json')).toBe(true)
+    })
+  })
+
+  describe('userStoreConfigFile', () => {
+    it('returns the path of the user faststore.config file', () => {
+      const { userStoreConfigFile: userStoreConfigFileWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(userStoreConfigFileWithBase, './src/__mocks__/store/faststore.config.js')).toBe(true)
+    })
+  })
+
+  describe('tmpStoreConfigFile', () => {
+    it('returns the path of the faststore.config file in the customizations dir', () => {
+      const { tmpStoreConfigFile: tmpStoreConfigFileWithBase } = withBasePath(basePath)
+
+      expect(pathsToMatch(tmpStoreConfigFileWithBase, './src/__mocks__/store/.faststore/src/customizations/faststore.config.js')).toBe(true)
+    })
+  })
+})

--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -1,69 +1,115 @@
 import path from 'path'
 
 // build folder
-export const tmpFolderName = '.faststore'
+// export const tmpFolderName = '.faststore'
+//
+// // always returns the root of the project, AKA the starter root or @faststore/core dir root when running in the monorepo
+// export const getRoot = () => {
+//   if (process.env.OCLIF_COMPILATION) {
+//     return ''
+//   }
+//
+//   if (process.cwd().endsWith(tmpFolderName)) {
+//     // if the current working directory is the build folder (tmp folder), return the starter root
+//     // this makes sure the semantics of the starter root are consistent with the directories declared below
+//     return path.join(process.cwd(), '..')
+//   }
+//
+//   return process.cwd()
+// }
 
-// always returns the root of the project, AKA the starter root or @faststore/core dir root when running in the monorepo
-export const getRoot = () => {
-  if (process.env.OCLIF_COMPILATION) {
-    return ''
+export const withBasePath = (basepath: string) => {
+  const tmpFolderName = '.faststore'
+
+  const getRoot = () => {
+    if (process.env.OCLIF_COMPILATION) {
+      return ''
+    }
+
+    if (basepath.endsWith(tmpFolderName)) {
+      // if the current working directory is the build folder (tmp folder), return the starter root
+      // this makes sure the semantics of the starter root are consistent with the directories declared below
+      return path.join(basepath, '..')
+    }
+
+    return basepath
+  }
+  const getFastStorePath = () => {
+
+    // TODO: a more complex version of this would look into the monorepo parent
+    return path.join(basepath, 'node_modules', '@faststore')
   }
 
-  if(process.cwd().endsWith(tmpFolderName)) {
-    // if the current working directory is the build folder (tmp folder), return the starter root
-    // this makes sure the semantics of the starter root are consistent with the directories declared below
-    return path.join(process.cwd(), '..')
-  }
+  const tmpDir = path.join(getRoot(), tmpFolderName)
+  const userSrcDir = path.join(getRoot(), 'src')
 
-  return process.cwd()
+  return {
+    getRoot,
+    userDir: getRoot(),
+    userSrcDir,
+    userThemesFileDir: path.join(userSrcDir, 'themes'),
+    userCMSDir: path.join(getRoot(), 'cms', 'faststore'),
+    userStoreConfigFile: path.join(getRoot(), 'faststore.config.js'),
+
+    tmpFolderName,
+    tmpDir,
+    tmpCustomizationsSrcDir: path.join(tmpDir, 'src', 'customizations', 'src'),
+    tmpThemesCustomizationsFile: path.join(tmpDir, 'src', 'customizations', 'src', 'themes', 'index.scss'),
+    tmpCMSDir: path.join(tmpDir, 'cms', 'faststore'),
+    tmpCMSWebhookUrlsFile: path.join(tmpDir, 'cms-webhook-urls.json'),
+    tmpStoreConfigFile: path.join(tmpDir, 'src', 'customizations', 'faststore.config.js'),
+
+    coreDir: path.join(getFastStorePath(), 'core'),
+    coreCMSDir: path.join(getFastStorePath(), 'core', 'cms', 'faststore'),
+  }
 }
 
-// starter root
-export const userDir = getRoot()
-
-// node_modules folder for faststorer packages
-const faststoreDir = path.join(userDir, 'node_modules', '@faststore')
-
-// build folder dir
-export const tmpDir = path.join(userDir, tmpFolderName)
-
-// node_modules folder for @faststore/core
-const coreFolderName = 'core'
-export const coreDir = path.join(faststoreDir, coreFolderName)
-
-// starter src/ folder
-const srcFolderName = 'src'
-export const userSrcDir = path.join(userDir, srcFolderName)
-
-// build folder's folder to which starter files should always be copied 
-const customizationsFolderName = 'customizations'
-// build folder's root folder for starter files 
-const tmpCustomizationsDir = path.join(tmpDir, srcFolderName, customizationsFolderName)
-// build folder's starter src files
-export const tmpCustomizationsSrcDir = path.join(tmpCustomizationsDir, srcFolderName)
-
-// starter's folder for themes
-export const userThemesFileDir = path.join(userSrcDir, 'themes')
-// build folder's dir for theme
-export const tmpThemesCustomizationsFile = path.join(tmpCustomizationsSrcDir, 'themes', 'index.scss')
-
-// path segment of cms files for faststore
-const cmsFolderName = path.join('cms', 'faststore')
-// build folder's cms folder
-export const tmpCMSDir = path.join(tmpDir, cmsFolderName)
-// node_modules folder for @faststore/core's cms folder
-export const coreCMSDir = path.join(coreDir, cmsFolderName)
-// starter folder's cms folder
-export const userCMSDir = path.join(userDir, cmsFolderName)
-
-// file name for faststore configs
-const configFileName = 'faststore.config.js'
-// starter's config file
-export const userStoreConfigFile = path.join(userDir, configFileName)
-// build folder's config file
-export const tmpStoreConfigFile = path.join(tmpCustomizationsDir, configFileName)
-
-// cms webhook config file name
-const cmsWebhookUrlsFileName = 'cms-webhook-urls.json'
-// build folder's dir for webhook config
-export const tmpCMSWebhookUrlsFile = path.join(tmpDir, cmsWebhookUrlsFileName)
+// // starter root
+// export const userDir = getRoot()
+//
+// // node_modules folder for faststorer packages
+// const faststoreDir = path.join(userDir, 'node_modules', '@faststore')
+//
+// // build folder dir
+// export const tmpDir = path.join(userDir, tmpFolderName)
+//
+// // node_modules folder for @faststore/core
+// const coreFolderName = 'core'
+// export const coreDir = path.join(faststoreDir, coreFolderName)
+//
+// // starter src/ folder
+// const srcFolderName = 'src'
+// export const userSrcDir = path.join(userDir, srcFolderName)
+//
+// // build folder's folder to which starter files should always be copied 
+// const customizationsFolderName = 'customizations'
+// // build folder's root folder for starter files 
+// const tmpCustomizationsDir = path.join(tmpDir, srcFolderName, customizationsFolderName)
+// // build folder's starter src files
+// export const tmpCustomizationsSrcDir = path.join(tmpCustomizationsDir, srcFolderName)
+//
+// // starter's folder for themes
+// export const userThemesFileDir = path.join(userSrcDir, 'themes')
+// // build folder's dir for theme
+// export const tmpThemesCustomizationsFile = path.join(tmpCustomizationsSrcDir, 'themes', 'index.scss')
+//
+// // path segment of cms files for faststore
+// const cmsFolderName = path.join('cms', 'faststore')
+// // build folder's cms folder
+// export const tmpCMSDir = path.join(tmpDir, cmsFolderName)
+// // node_modules folder for @faststore/core's cms folder
+// export const coreCMSDir = path.join(coreDir, cmsFolderName)
+// // starter folder's cms folder
+// export const userCMSDir = path.join(userDir, cmsFolderName)
+//
+// // file name for faststore configs
+// const configFileName = 'faststore.config.js'
+// // starter's config file
+// export const userStoreConfigFile = path.join(userDir, configFileName)
+// // build folder's config file
+// export const tmpStoreConfigFile = path.join(tmpCustomizationsDir, configFileName)
+//
+// // cms webhook config file name
+// const cmsWebhookUrlsFileName = 'cms-webhook-urls.json'
+// // build folder's dir for webhook config
+// export const tmpCMSWebhookUrlsFile = path.join(tmpDir, cmsWebhookUrlsFileName)

--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -1,23 +1,5 @@
 import path from 'path'
 
-// build folder
-// export const tmpFolderName = '.faststore'
-//
-// // always returns the root of the project, AKA the starter root or @faststore/core dir root when running in the monorepo
-// export const getRoot = () => {
-//   if (process.env.OCLIF_COMPILATION) {
-//     return ''
-//   }
-//
-//   if (process.cwd().endsWith(tmpFolderName)) {
-//     // if the current working directory is the build folder (tmp folder), return the starter root
-//     // this makes sure the semantics of the starter root are consistent with the directories declared below
-//     return path.join(process.cwd(), '..')
-//   }
-//
-//   return process.cwd()
-// }
-
 export const withBasePath = (basepath: string) => {
   const tmpFolderName = '.faststore'
 
@@ -63,53 +45,3 @@ export const withBasePath = (basepath: string) => {
     coreCMSDir: path.join(getFastStorePath(), 'core', 'cms', 'faststore'),
   }
 }
-
-// // starter root
-// export const userDir = getRoot()
-//
-// // node_modules folder for faststorer packages
-// const faststoreDir = path.join(userDir, 'node_modules', '@faststore')
-//
-// // build folder dir
-// export const tmpDir = path.join(userDir, tmpFolderName)
-//
-// // node_modules folder for @faststore/core
-// const coreFolderName = 'core'
-// export const coreDir = path.join(faststoreDir, coreFolderName)
-//
-// // starter src/ folder
-// const srcFolderName = 'src'
-// export const userSrcDir = path.join(userDir, srcFolderName)
-//
-// // build folder's folder to which starter files should always be copied 
-// const customizationsFolderName = 'customizations'
-// // build folder's root folder for starter files 
-// const tmpCustomizationsDir = path.join(tmpDir, srcFolderName, customizationsFolderName)
-// // build folder's starter src files
-// export const tmpCustomizationsSrcDir = path.join(tmpCustomizationsDir, srcFolderName)
-//
-// // starter's folder for themes
-// export const userThemesFileDir = path.join(userSrcDir, 'themes')
-// // build folder's dir for theme
-// export const tmpThemesCustomizationsFile = path.join(tmpCustomizationsSrcDir, 'themes', 'index.scss')
-//
-// // path segment of cms files for faststore
-// const cmsFolderName = path.join('cms', 'faststore')
-// // build folder's cms folder
-// export const tmpCMSDir = path.join(tmpDir, cmsFolderName)
-// // node_modules folder for @faststore/core's cms folder
-// export const coreCMSDir = path.join(coreDir, cmsFolderName)
-// // starter folder's cms folder
-// export const userCMSDir = path.join(userDir, cmsFolderName)
-//
-// // file name for faststore configs
-// const configFileName = 'faststore.config.js'
-// // starter's config file
-// export const userStoreConfigFile = path.join(userDir, configFileName)
-// // build folder's config file
-// export const tmpStoreConfigFile = path.join(tmpCustomizationsDir, configFileName)
-//
-// // cms webhook config file name
-// const cmsWebhookUrlsFileName = 'cms-webhook-urls.json'
-// // build folder's dir for webhook config
-// export const tmpCMSWebhookUrlsFile = path.join(tmpDir, cmsWebhookUrlsFileName)

--- a/packages/cli/src/utils/hcms.test.ts
+++ b/packages/cli/src/utils/hcms.test.ts
@@ -15,7 +15,8 @@ import {
   splitCustomDefinitions,
   mergeCMSFile,
 } from './hcms'
-import { tmpCMSDir } from './directory'
+// FIXME: use withBasePath
+// import { tmpCMSDir } from './directory'
 
 jest.mock('fs-extra', () => ({
   readFileSync: jest.fn(),
@@ -24,8 +25,9 @@ jest.mock('fs-extra', () => ({
 }))
 
 describe('mergeCMSFile', () => {
-  it("should create a resulting file that contains all core definitions if a custom definitions file doesn't exist", async () => {
+  it.skip("should create a resulting file that contains all core definitions if a custom definitions file doesn't exist", async () => {
     const { readFileSync, existsSync, writeFileSync } = require('fs-extra')
+    const tmpCMSDir = ''
 
     existsSync.mockReturnValueOnce(false)
     readFileSync.mockReturnValueOnce(JSON.stringify(coreContentTypes))
@@ -50,7 +52,7 @@ describe('mergeCMSFile', () => {
 })
 
 describe('splitCustomDefinitions', () => {
-  it('should return empty arrays if there are no custom definitions', () => {
+  it.skip('should return empty arrays if there are no custom definitions', () => {
     // content-types
     expect(splitCustomDefinitions(coreContentTypes, [], 'id')).toEqual({
       duplicates: [],
@@ -64,7 +66,7 @@ describe('splitCustomDefinitions', () => {
     })
   })
 
-  it('should return empty duplicates array if all custom definitions are new', () => {
+  it.skip('should return empty duplicates array if all custom definitions are new', () => {
     // content-types
     expect(
       splitCustomDefinitions(coreContentTypes, allNewCustomContentTypes, 'id')
@@ -82,7 +84,7 @@ describe('splitCustomDefinitions', () => {
     })
   })
 
-  it('should return expected split definitions', () => {
+  it.skip('should return expected split definitions', () => {
     // content-types
     expect(
       splitCustomDefinitions(
@@ -106,7 +108,7 @@ describe('splitCustomDefinitions', () => {
 })
 
 describe('dedupeAndMergeDefinitions', () => {
-  it('should return the exact same core definitions if there are no duplicates', () => {
+  it.skip('should return the exact same core definitions if there are no duplicates', () => {
     expect(dedupeAndMergeDefinitions(coreContentTypes, [], 'id')).toEqual(
       coreContentTypes
     )
@@ -116,7 +118,7 @@ describe('dedupeAndMergeDefinitions', () => {
     )
   })
 
-  it('should return expected merged definitions, applying overrides based on duplicates', () => {
+  it.skip('should return expected merged definitions, applying overrides based on duplicates', () => {
     expect(
       dedupeAndMergeDefinitions(coreContentTypes, contentTypeDuplicates, 'id')
     ).toEqual([

--- a/packages/cli/src/utils/hcms.test.ts
+++ b/packages/cli/src/utils/hcms.test.ts
@@ -15,8 +15,7 @@ import {
   splitCustomDefinitions,
   mergeCMSFile,
 } from './hcms'
-// FIXME: use withBasePath
-// import { tmpCMSDir } from './directory'
+import { withBasePath } from './directory'
 
 jest.mock('fs-extra', () => ({
   readFileSync: jest.fn(),
@@ -25,14 +24,14 @@ jest.mock('fs-extra', () => ({
 }))
 
 describe('mergeCMSFile', () => {
-  it.skip("should create a resulting file that contains all core definitions if a custom definitions file doesn't exist", async () => {
+  it("should create a resulting file that contains all core definitions if a custom definitions file doesn't exist", async () => {
     const { readFileSync, existsSync, writeFileSync } = require('fs-extra')
-    const tmpCMSDir = ''
+    const { tmpCMSDir } = withBasePath('.')
 
     existsSync.mockReturnValueOnce(false)
     readFileSync.mockReturnValueOnce(JSON.stringify(coreContentTypes))
 
-    await mergeCMSFile('content-types.json')
+    await mergeCMSFile('content-types.json', '.')
 
     expect(writeFileSync).toHaveBeenCalledWith(
       path.join(tmpCMSDir, 'content-types.json'),
@@ -42,7 +41,7 @@ describe('mergeCMSFile', () => {
     existsSync.mockReturnValueOnce(false)
     readFileSync.mockReturnValueOnce(JSON.stringify(coreSections))
 
-    await mergeCMSFile('sections.json')
+    await mergeCMSFile('sections.json', '.')
 
     expect(writeFileSync).toHaveBeenCalledWith(
       path.join(tmpCMSDir, 'sections.json'),
@@ -52,7 +51,7 @@ describe('mergeCMSFile', () => {
 })
 
 describe('splitCustomDefinitions', () => {
-  it.skip('should return empty arrays if there are no custom definitions', () => {
+  it('should return empty arrays if there are no custom definitions', () => {
     // content-types
     expect(splitCustomDefinitions(coreContentTypes, [], 'id')).toEqual({
       duplicates: [],
@@ -66,7 +65,7 @@ describe('splitCustomDefinitions', () => {
     })
   })
 
-  it.skip('should return empty duplicates array if all custom definitions are new', () => {
+  it('should return empty duplicates array if all custom definitions are new', () => {
     // content-types
     expect(
       splitCustomDefinitions(coreContentTypes, allNewCustomContentTypes, 'id')
@@ -84,7 +83,7 @@ describe('splitCustomDefinitions', () => {
     })
   })
 
-  it.skip('should return expected split definitions', () => {
+  it('should return expected split definitions', () => {
     // content-types
     expect(
       splitCustomDefinitions(
@@ -108,7 +107,7 @@ describe('splitCustomDefinitions', () => {
 })
 
 describe('dedupeAndMergeDefinitions', () => {
-  it.skip('should return the exact same core definitions if there are no duplicates', () => {
+  it('should return the exact same core definitions if there are no duplicates', () => {
     expect(dedupeAndMergeDefinitions(coreContentTypes, [], 'id')).toEqual(
       coreContentTypes
     )
@@ -118,7 +117,7 @@ describe('dedupeAndMergeDefinitions', () => {
     )
   })
 
-  it.skip('should return expected merged definitions, applying overrides based on duplicates', () => {
+  it('should return expected merged definitions, applying overrides based on duplicates', () => {
     expect(
       dedupeAndMergeDefinitions(coreContentTypes, contentTypeDuplicates, 'id')
     ).toEqual([

--- a/packages/cli/src/utils/hcms.ts
+++ b/packages/cli/src/utils/hcms.ts
@@ -3,7 +3,11 @@ import chalk from 'chalk'
 import { CliUx } from '@oclif/core'
 import { readFileSync, existsSync, writeFileSync } from 'fs-extra'
 
-import { userCMSDir, coreCMSDir, tmpCMSDir } from './directory'
+// FIXME: Use withBasePath
+// import { userCMSDir, coreCMSDir, tmpCMSDir } from './directory'
+const userCMSDir = ''
+const coreCMSDir = ''
+const tmpCMSDir = ''
 
 export interface ContentTypeOrSectionDefinition {
   id?: string
@@ -96,8 +100,7 @@ async function confirmUserChoice(
   fileName: string
 ) {
   const goAhead = await CliUx.ux.confirm(
-    `You are about to override default ${
-      fileName.split('.')[0]
+    `You are about to override default ${fileName.split('.')[0]
     }:\n\n${duplicates
       .map((definition) => definition.id || definition.name)
       .join('\n')}\n\nAre you sure? [yes/no]`

--- a/packages/cli/src/utils/hcms.ts
+++ b/packages/cli/src/utils/hcms.ts
@@ -3,11 +3,7 @@ import chalk from 'chalk'
 import { CliUx } from '@oclif/core'
 import { readFileSync, existsSync, writeFileSync } from 'fs-extra'
 
-// FIXME: Use withBasePath
-// import { userCMSDir, coreCMSDir, tmpCMSDir } from './directory'
-const userCMSDir = ''
-const coreCMSDir = ''
-const tmpCMSDir = ''
+import { withBasePath } from './directory'
 
 export interface ContentTypeOrSectionDefinition {
   id?: string
@@ -113,7 +109,9 @@ async function confirmUserChoice(
   return
 }
 
-export async function mergeCMSFile(fileName: string) {
+export async function mergeCMSFile(fileName: string, basePath: string) {
+  const { coreCMSDir, userCMSDir, tmpCMSDir } = withBasePath(basePath)
+
   const coreFilePath = path.join(coreCMSDir, fileName)
   const customFilePath = path.join(userCMSDir, fileName)
 
@@ -175,10 +173,10 @@ export async function mergeCMSFile(fileName: string) {
   }
 }
 
-export async function mergeCMSFiles() {
+export async function mergeCMSFiles(basePath: string) {
   try {
-    await mergeCMSFile('content-types.json')
-    await mergeCMSFile('sections.json')
+    await mergeCMSFile('content-types.json', basePath)
+    await mergeCMSFile('sections.json', basePath)
   } catch (err) {
     console.error(`${chalk.red('error')} - ${err}`)
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR still should not affect any behavior. Everything should work the same as it did before.

To prepare the FastStore CLI to run on any arbitrary path. I've created a closure called `withBasePath` that will receive the basePath and export the same values as before. To keep the same behavior, wherever the `directory.ts` file was being imported, I'll call the `withBasePath` with `process.cwd()` 

Starter PR 🔜 