### PR TITLE
Refresh cookie on search

### DIFF
--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -21,7 +21,10 @@ const randomUUID = () =>
 const createOrRefreshCookie = (key: string, expiresSecond: number) => {
   // Setting the domain attribute specifies which host can receive it; we need it to make the cookies available on the `secure` subdomain.
   // Although https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie mentioned leading dot (.) is not needed and ignored. I couldn't set the cookies without it.
-  const urlDomain = `.${new URL(config.storeUrl).hostname}`
+  const urlDomain =
+    process.env.NODE_ENV === 'development'
+      ? '.localhost'
+      : `.${new URL(config.storeUrl).hostname}`
 
   return () => {
     let currentValue = getCookie(key)

--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -18,30 +18,29 @@ const randomUUID = () =>
     ? crypto.randomUUID()
     : (Math.random() * 1e6).toFixed(0)
 
-const createCookie = (key: string, expiresSecond: number) => {
+const createOrRefreshCookie = (key: string, expiresSecond: number) => {
   // Setting the domain attribute specifies which host can receive it; we need it to make the cookies available on the `secure` subdomain.
   // Although https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie mentioned leading dot (.) is not needed and ignored. I couldn't set the cookies without it.
   const urlDomain = `.${new URL(config.storeUrl).hostname}`
 
   return () => {
-    const isExpired = getCookie(key) === undefined
+    let currentValue = getCookie(key)
+    const isExpired = currentValue === undefined
 
     if (isExpired) {
-      const value = randomUUID()
-
-      document.cookie = `${key}=${value}; max-age=${expiresSecond}; domain=${urlDomain}; path=/;`
-      // Setting the `path=/` makes the cookie accessible on any path of the domain/subdomain
-
-      return value
+      currentValue = randomUUID()
     }
 
-    return getCookie(key)
+    // Setting the `path=/` makes the cookie accessible on any path of the domain/subdomain
+    document.cookie = `${key}=${currentValue}; max-age=${expiresSecond}; domain=${urlDomain}; path=/;`
+
+    return currentValue
   }
 }
 
 const user = {
-  anonymous: createCookie('vtex-faststore-anonymous', ONE_YEAR_S),
-  session: createCookie('vtex-faststore-session', THIRTY_MINUTES_S),
+  anonymous: createOrRefreshCookie('vtex-faststore-anonymous', ONE_YEAR_S),
+  session: createOrRefreshCookie('vtex-faststore-session', THIRTY_MINUTES_S),
 }
 
 type SearchEvent =


### PR DESCRIPTION
## What's the purpose of this pull request?

While investigating why some events weren't being triggered and tracked on IS Analytics page, @chrsmutti suggested that the proper behavior is to refresh or extend the cookie duration every time a search is made. 

## How it works?

If the cookie is not expired, we set it again, with the same value, and the same expiry in seconds.

## How to test it?

Run core locally, do a search, see the cookie value and its expiry date. Wait for some time, make another search, and see if the cookie value stays the same but the expiry date should have moved forward.
