### PR TITLE
Export commands from index.ts to plug into other CLIs

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,17 @@
 export { run } from '@oclif/core'
+
+import { default as Dev } from './commands/dev'
+import { default as Build } from './commands/build'
+import { default as Serve } from './commands/start'
+import { default as CmsSync } from './commands/cms-sync'
+import { default as GenerateGraphql } from './commands/generate-graphql'
+import { default as Test } from './commands/test'
+
+export const commands = {
+  dev: Dev,
+  build: Build,
+  serve: Serve,
+  'cms-sync': CmsSync,
+  'generate-graphql': GenerateGraphql,
+  test: Test,
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

To allow the FastStore CLI to be pluggable to another CLI we need to export the commands from the index.ts file.

This adds no behavior change on the FastStore CLI