### PR TITLE
Add `path` arg to all commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ storybook-static/
 node_modules/
 jspm_packages/
 
+!packages/cli/src/__mocks__/**/node_modules
+
 # Optional npm cache directory
 .npm
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -5,10 +5,21 @@ import { existsSync } from 'fs'
 import { copySync, moveSync, readdirSync, removeSync } from 'fs-extra'
 import { withBasePath } from '../utils/directory'
 import { generate } from '../utils/generate'
+import { ArgInput } from '@oclif/core/lib/interfaces'
 
 export default class Build extends Command {
+
+  static args: ArgInput = [
+    {
+      name: 'path',
+      description: 'The path where the FastStore being built is. Defaults to cwd.',
+    }
+  ]
+
   async run() {
-    const basePath = process.cwd()
+    const { args } = await this.parse(Build)
+
+    const basePath = args.path ?? process.cwd()
 
     const { tmpDir } = withBasePath(basePath)
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -5,11 +5,10 @@ import { existsSync } from 'fs'
 import { copySync, moveSync, readdirSync, removeSync } from 'fs-extra'
 import { withBasePath } from '../utils/directory'
 import { generate } from '../utils/generate'
-import { ArgInput } from '@oclif/core/lib/interfaces'
 
 export default class Build extends Command {
 
-  static args: ArgInput = [
+  static args = [
     {
       name: 'path',
       description: 'The path where the FastStore being built is. Defaults to cwd.',

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -9,10 +9,18 @@ export default class CmsSync extends Command {
     ['dry-run']: Flags.boolean({ char: 'd' }),
   }
 
-  async run() {
-    const { flags } = await this.parse(CmsSync)
+  static args = [
+    {
+      name: 'path',
+      description: 'The path where the FastStore being synched with the CMS is. Defaults to cwd.',
+    }
+  ]
 
-    const basePath = process.cwd()
+
+  async run() {
+    const { flags, args } = await this.parse(CmsSync)
+
+    const basePath = args.path ?? process.cwd()
     const { tmpDir } = withBasePath(basePath)
 
     await generate({ setup: true, basePath })

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -51,8 +51,16 @@ async function storeDev(rootDir: string, tmpDir: string) {
 }
 
 export default class Dev extends Command {
+  static args = [
+    {
+      name: 'path',
+      description: 'The path where the FastStore being run is. Defaults to cwd.',
+    }
+  ]
+
   async run() {
-    const basePath = process.cwd()
+    const { args } = await this.parse(Dev)
+    const basePath = args.path ?? process.cwd()
 
     const { getRoot, tmpDir } = withBasePath(basePath)
 

--- a/packages/cli/src/commands/generate-graphql.ts
+++ b/packages/cli/src/commands/generate-graphql.ts
@@ -11,10 +11,17 @@ export default class GenerateGraphql extends Command {
     core: Flags.boolean({ char: 'c', hidden: true }),
   }
 
-  async run() {
-    const { flags } = await this.parse(GenerateGraphql)
+  static args = [
+    {
+      name: 'path',
+      description: 'The path where the FastStore GraphQL customization is. Defaults to cwd.',
+    }
+  ]
 
-    const basePath = process.cwd()
+  async run() {
+    const { flags, args } = await this.parse(GenerateGraphql)
+
+    const basePath = args.path ?? process.cwd()
     const { tmpDir, coreDir } = withBasePath(basePath)
 
     const debug = flags.debug ?? false

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -4,8 +4,16 @@ import { existsSync } from 'fs-extra'
 import { withBasePath } from '../utils/directory'
 
 export default class Start extends Command {
+  static args = [
+    {
+      name: 'path',
+      description: 'The path where the FastStore being run is. Defaults to cwd.',
+    }
+  ]
+
   async run() {
-    const basePath = process.cwd()
+    const { args } = await this.parse(Start)
+    const basePath = args.path ?? process.cwd()
     const { tmpDir } = withBasePath(basePath)
 
     if (!existsSync(tmpDir)) {

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -42,8 +42,16 @@ async function storeTest(tmpDir: string) {
 }
 
 export default class Test extends Command {
+  static args = [
+    {
+      name: 'path',
+      description: 'The path where the FastStore being tested is. Defaults to cwd.',
+    }
+  ]
+
   async run() {
-    const basePath = process.cwd()
+    const { args } = await this.parse(Test)
+    const basePath = args.path ?? process.cwd()
     const { getRoot, tmpDir } = withBasePath(basePath)
 
     const watcher = chokidar.watch([...defaultPatterns], {

--- a/packages/cli/src/utils/directory.test.ts
+++ b/packages/cli/src/utils/directory.test.ts
@@ -11,18 +11,6 @@ const pathsToMatch = (expected: string, desired: string) => {
 describe('withBasePath as the current dir `.`', () => {
   const basePath = '.'
 
-  describe('coreDir', () => {
-    it('is the faststoreDir + core', () => {
-      const { coreDir: coreDirWithBase } = withBasePath(basePath)
-
-      expect(pathsToMatch(coreDirWithBase, './node_modules/@faststore/core')).toBe(true)
-    })
-
-    describe('when is in a monorepo', () => {
-      it.todo('can look at its parent until it reaches the monorepo directory')
-    })
-  })
-
   describe('tmpDir', () => {
     it('is the basePath + .faststore', () => {
       const { tmpDir: tmpDirWithBase } = withBasePath(basePath)

--- a/packages/cli/src/utils/directory.test.ts
+++ b/packages/cli/src/utils/directory.test.ts
@@ -67,14 +67,6 @@ describe('withBasePath as the current dir `.`', () => {
     })
   })
 
-  describe('coreCMSDir', () => {
-    it('returns the path of the CMS dir on @faststore/core package', () => {
-      const { coreCMSDir: coreCMSDirWithBase } = withBasePath(basePath)
-
-      expect(pathsToMatch(coreCMSDirWithBase, './node_modules/@faststore/core/cms/faststore')).toBe(true)
-    })
-  })
-
   describe('tmpCMSWebhookUrlsFile', () => {
     it('returns the path of the CMS webhooks file on the .faststore dir', () => {
       const { tmpCMSWebhookUrlsFile: tmpCMSWebhookUrlsFileWithBase } = withBasePath(basePath)
@@ -111,7 +103,11 @@ describe('withBasePath as an arbitrary dir', () => {
     })
 
     describe('when is in a monorepo', () => {
-      it.todo('can look at its parent until it reaches the monorepo directory')
+      it('can look at its parent until it reaches the monorepo directory', () => {
+        const { coreDir: coreDirWithBase } = withBasePath(path.join(__dirname, '..', '__mocks__', 'monorepo', 'discovery'))
+
+        expect(pathsToMatch(coreDirWithBase, './src/__mocks__/monorepo/node_modules/@faststore/core')).toBe(true)
+      })
     })
   })
 

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -15,7 +15,7 @@ import { withBasePath } from './directory'
 
 interface GenerateOptions {
   setup?: boolean
-  basePath?: string
+  basePath: string
 }
 
 // package.json is copied manually after filtering its content
@@ -225,8 +225,8 @@ async function copyTheme(basePath: string) {
   }
 }
 
-export async function generate(options?: GenerateOptions) {
-  const { setup = false, basePath = process.cwd() } = options ?? {}
+export async function generate(options: GenerateOptions) {
+  const { basePath, setup = false } = options
 
   let setupPromise: Promise<unknown> | null = null
 

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -118,7 +118,7 @@ async function copyCypressFiles(basePath: string) {
       copySync(`${userDir}/cypress.config.ts`, `${tmpDir}/cypress.config.ts`)
     }
 
-    const userStoreConfig = await import(userStoreConfigFile)
+    const userStoreConfig = await import(path.resolve(userStoreConfigFile))
 
     // Copy custom Cypress folder and files
     if (
@@ -165,7 +165,7 @@ function copyUserStarterToCustomizations(basePath: string) {
 
 async function createCmsWebhookUrlsJsonFile(basePath: string) {
   const { userStoreConfigFile, tmpCMSWebhookUrlsFile } = withBasePath(basePath)
-  const userStoreConfig = await import(userStoreConfigFile)
+  const userStoreConfig = await import(path.resolve(userStoreConfigFile))
 
   if (
     userStoreConfig?.vtexHeadlessCms &&
@@ -190,7 +190,7 @@ async function createCmsWebhookUrlsJsonFile(basePath: string) {
 
 async function copyTheme(basePath: string) {
   const { userStoreConfigFile, userThemesFileDir, tmpThemesCustomizationsFile } = withBasePath(basePath)
-  const storeConfig = await import(userStoreConfigFile)
+  const storeConfig = await import(path.resolve(userStoreConfigFile))
   if (storeConfig.theme) {
     const customTheme = path.join(
       userThemesFileDir,

--- a/packages/core/postinstall.js
+++ b/packages/core/postinstall.js
@@ -1,6 +1,3 @@
-if (
-  process.cwd().includes('node_modules') ||
-  process.cwd().includes('.faststore')
-) {
+if (__dirname.includes('node_modules') || __dirname.includes('.faststore')) {
   process.exitCode = 1
 }

--- a/packages/core/src/server/generator/schema.ts
+++ b/packages/core/src/server/generator/schema.ts
@@ -69,7 +69,6 @@ export function writeGraphqlSchemaFile(apiSchema: GraphQLSchema) {
     const schema = printSchemaWithDirectives(apiSchema)
     writeFileSync(
       path.join(__dirname, '..', '..', '..', '@generated', 'schema.graphql'),
-      // path.join(process.cwd(), '@generated', 'schema.graphql'),
       schema
     )
 

--- a/packages/core/src/server/generator/schema.ts
+++ b/packages/core/src/server/generator/schema.ts
@@ -68,7 +68,8 @@ export function writeGraphqlSchemaFile(apiSchema: GraphQLSchema) {
     // getting the schema before write because somehow this fixes the validation step of codegen from codesandbox
     const schema = printSchemaWithDirectives(apiSchema)
     writeFileSync(
-      path.join(process.cwd(), '@generated', 'schema.graphql'),
+      path.join(__dirname, '..', '..', '..', '@generated', 'schema.graphql'),
+      // path.join(process.cwd(), '@generated', 'schema.graphql'),
       schema
     )
 

--- a/packages/core/src/server/generator/schema.ts
+++ b/packages/core/src/server/generator/schema.ts
@@ -68,7 +68,7 @@ export function writeGraphqlSchemaFile(apiSchema: GraphQLSchema) {
     // getting the schema before write because somehow this fixes the validation step of codegen from codesandbox
     const schema = printSchemaWithDirectives(apiSchema)
     writeFileSync(
-      path.join(__dirname, '..', '..', '..', '@generated', 'schema.graphql'),
+      path.join(process.cwd(), '@generated', 'schema.graphql'),
       schema
     )
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -51,7 +51,7 @@ const formatError: FormatErrorHandler = (err) => {
 
 function loadGeneratedSchema(): TypeSource {
   return loadFilesSync(
-    path.join(__dirname, '..', '..', '@generated', 'schema.graphql'),
+    path.join(process.cwd(), '@generated', 'schema.graphql'),
     {
       extensions: ['graphql'],
     }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -50,9 +50,12 @@ const formatError: FormatErrorHandler = (err) => {
 }
 
 function loadGeneratedSchema(): TypeSource {
-  return loadFilesSync(path.join(process.cwd(), '@generated'), {
-    extensions: ['graphql'],
-  })
+  return loadFilesSync(
+    path.join(__dirname, '..', '..', '@generated', 'schema.graphql'),
+    {
+      extensions: ['graphql'],
+    }
+  )
 }
 
 function getFinalAPISchema() {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -50,12 +50,9 @@ const formatError: FormatErrorHandler = (err) => {
 }
 
 function loadGeneratedSchema(): TypeSource {
-  return loadFilesSync(
-    path.join(process.cwd(), '@generated', 'schema.graphql'),
-    {
-      extensions: ['graphql'],
-    }
-  )
+  return loadFilesSync(path.join(process.cwd(), '@generated'), {
+    extensions: ['graphql'],
+  })
 }
 
 function getFinalAPISchema() {


### PR DESCRIPTION
## What's the purpose of this pull request?

To allow FastStore to be run from a monorepo we need to add this path argument so the FastStore CLI can locate the directory where the actual customizations are.

## How it works?

After https://github.com/vtex/faststore/2366 and https://github.com/vtex/faststore/2368 this PR just adds the arg to the OCLIF command class and pass it down to the code, to be used with `withBasePath`. 
