### PR TITLE
feat: Change order of sku selector

### DIFF
--- a/packages/api/src/platforms/vtex/utils/skuVariants.ts
+++ b/packages/api/src/platforms/vtex/utils/skuVariants.ts
@@ -132,7 +132,12 @@ function sortVariants(variantsByName: SkuVariantsByName) {
   const sortedVariants = variantsByName
 
   for (const variantProperty in variantsByName) {
-    variantsByName[variantProperty].sort((a, b) => compare(a.value, b.value))
+
+    const allNumbers = variantsByName[variantProperty].every(
+      (option: any) => !Number.isNaN(option.label)
+    )
+
+    allNumbers ?? variantsByName[variantProperty].sort((a, b) => compare(a.value, b.value))
   }
 
   return sortedVariants

--- a/packages/components/src/atoms/Button/Button.tsx
+++ b/packages/components/src/atoms/Button/Button.tsx
@@ -74,7 +74,6 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       {...otherProps}
     >
       <div data-fs-button-wrapper>
-        testing
         {loading && (
           <p data-fs-button-loading-label>
             {loadingLabel}

--- a/packages/components/src/atoms/Button/Button.tsx
+++ b/packages/components/src/atoms/Button/Button.tsx
@@ -74,6 +74,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       {...otherProps}
     >
       <div data-fs-button-wrapper>
+        testing
         {loading && (
           <p data-fs-button-loading-label>
             {loadingLabel}


### PR DESCRIPTION
## What's the purpose of this pull request?

Makes the sku selector follow the order of the admin

## How it works?

Same adjust was done while ago to IO!
The code needs to validates if it's number prior sorting this. For example, if you sort `a - b` for sizes, you will have different orders, mostly thinking in cross language.

e.g, sorting sizes in PT:

G - M - P 

Commit in IO: https://github.com/vtex-apps/store-components/blob/2fe597cf00b0d2968487189f99ccaf80b73e5da6/react/components/SKUSelector/components/SKUSelector.tsx#L247



## How to test it?

This [product](https://vysk.myvtex.com/adidas-womens-microdot-polo-night-indigo/p): admin / IO / stable / fast.


![image](https://github.com/vtex/faststore/assets/25616893/82956811-f7a4-4a63-a522-245f10b09acc)

![image](https://github.com/vtex/faststore/assets/25616893/6eef3cf0-d4d3-428f-8ae1-78d7e39e95fa)

![image](https://github.com/vtex/faststore/assets/25616893/6b2dec79-3e0c-4bb5-bcf8-48fbf03183a9)

![image](https://github.com/vtex/faststore/assets/25616893/68972492-dfe8-4e95-979f-1d32bf166a0d)


After fix:

![image](https://github.com/vtex/faststore/assets/25616893/61dc16d2-1ab3-4a92-a907-736769e1aefa)

