### PR TITLE
Rename vtex search cookie to keep it uniform

### DIFF
--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -1,5 +1,5 @@
 /**
- * More info at: https://www.notion.so/vtexhandbook/Event-API-Documentation-48eee26730cf4d7f80f8fd7262231f84
+ * More info at: https://developers.vtex.com/docs/api-reference/intelligent-search-events-api-headless
  */
 import type { AnalyticsEvent } from '@faststore/sdk'
 import type {
@@ -15,7 +15,7 @@ const ONE_YEAR_S = 365 * 24 * 3600
 
 const randomUUID = () =>
   typeof crypto.randomUUID === 'function'
-    ? crypto.randomUUID()
+    ? crypto.randomUUID().replaceAll('-', '')
     : (Math.random() * 1e6).toFixed(0)
 
 const createOrRefreshCookie = (key: string, expiresSecond: number) => {
@@ -42,8 +42,8 @@ const createOrRefreshCookie = (key: string, expiresSecond: number) => {
 }
 
 const user = {
-  anonymous: createOrRefreshCookie('vtex-faststore-anonymous', ONE_YEAR_S),
-  session: createOrRefreshCookie('vtex-faststore-session', THIRTY_MINUTES_S),
+  anonymous: createOrRefreshCookie('vtex-search-anonymous', ONE_YEAR_S),
+  session: createOrRefreshCookie('vtex-search-session', THIRTY_MINUTES_S),
 }
 
 type SearchEvent =


### PR DESCRIPTION
## What's the purpose of this pull request?

<!--- Considering the context, what is the problem we'll solve? Where in VTEX's big picture our issue fits in? Write a tweet about the context and the problem itself. --->
The `vtex.sae-analytics` will start using the same name
`vtex-search-{anonymous,session}` for cookies created in the Store
Framework context. Keeping this consistent across storefronts will
enable easier management of the cookies required by the platform.


## How it works?

<!--- Tell us the role of the new feature, or component, in its context. --->
The same as #2012, but now the cookie names are: `vtex-search-anonymous` and
`vtex-search-session`.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->
Run core locally, do a search, see the cookie name.


## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->
https://github.com/vtex/sae-analytics/pull/26
<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
