### PR TITLE
feat: noImplicitAny

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -60,6 +60,25 @@ function filterAndCopyPackageJson(basePath: string) {
   })
 }
 
+const TS_CONFIG_STRICT_RULES_ENABLED = ['noImplicitAny'] as const
+
+function disableTsConfigStrictRules(basePath: string) {
+  const { coreDir, tmpDir } = withBasePath(basePath)
+
+  const coreTsConfigPath = path.join(coreDir, 'tsconfig.json')
+
+  const coreTsConfigFile = readFileSync(coreTsConfigPath, 'utf8')
+  const tsConfig = JSON.parse(coreTsConfigFile)
+
+  TS_CONFIG_STRICT_RULES_ENABLED.forEach(strictRule => {
+    tsConfig.compilerOptions[strictRule] = false
+  })
+
+  writeJsonSync(path.join(tmpDir, 'tsconfig.json'), tsConfig, {
+    spaces: 2,
+  })
+}
+
 function copyCoreFiles(basePath: string) {
   const { coreDir, tmpDir } = withBasePath(basePath)
 
@@ -76,6 +95,7 @@ function copyCoreFiles(basePath: string) {
     })
 
     filterAndCopyPackageJson(basePath)
+    disableTsConfigStrictRules(basePath)
 
     console.log(`${chalk.green('success')} - Core files copied`)
   } catch (e) {

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -66,7 +66,7 @@ const TS_CONFIG_STRICT_RULES_ENABLED = ['noImplicitAny'] as const
 /**
  * Modify TypeScript compilation settings (tsconfig.json) to disable specific strict
  * type checking rules when files are moved to the .faststore folder. 
- * When all strict rules are migrated. The idea is to only change the strict to false
+ * The idea is to change the strict to false when all strict rules are migrated.
  */
 function disableTsConfigStrictRules(basePath: string) {
   const { coreDir, tmpDir } = withBasePath(basePath)

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -60,8 +60,14 @@ function filterAndCopyPackageJson(basePath: string) {
   })
 }
 
+// Temporary array of strict rules enabled so far.
 const TS_CONFIG_STRICT_RULES_ENABLED = ['noImplicitAny'] as const
 
+/**
+ * Modify TypeScript compilation settings (tsconfig.json) to disable specific strict
+ * type checking rules when files are moved to the .faststore folder. 
+ * When all strict rules are migrated. The idea is to only change the strict to false
+ */
 function disableTsConfigStrictRules(basePath: string) {
   const { coreDir, tmpDir } = withBasePath(basePath)
 

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -66,7 +66,7 @@ const TS_CONFIG_STRICT_RULES_ENABLED = ['noImplicitAny'] as const
 /**
  * Modify TypeScript compilation settings (tsconfig.json) to disable specific strict
  * type checking rules when files are moved to the .faststore folder. 
- * The idea is to change the strict to false when all strict rules are migrated.
+ * TODO: The idea is to change the strict to false when all strict rules are migrated.
  */
 function disableTsConfigStrictRules(basePath: string) {
   const { coreDir, tmpDir } = withBasePath(basePath)

--- a/packages/core/src/components/cms/SectionBoundary.tsx
+++ b/packages/core/src/components/cms/SectionBoundary.tsx
@@ -1,11 +1,24 @@
 import { Component } from 'react'
 import type { ErrorInfo, ReactNode } from 'react'
 
-class SectionBoundary extends Component<{
+interface ErrorBoundaryProps {
   children: ReactNode
   name: string
-}> {
-  public state = { hasError: false, error: null }
+}
+
+interface ErrorBoundaryState {
+  hasError: Boolean
+  error: Error | null
+}
+
+class SectionBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  public state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+  }
 
   public static getDerivedStateFromError(error: Error) {
     return {

--- a/packages/core/src/components/common/Footer/Footer.tsx
+++ b/packages/core/src/components/common/Footer/Footer.tsx
@@ -1,14 +1,19 @@
+import { ReactNode } from 'react'
 import { mark } from 'src/sdk/tests/mark'
 
-export function FooterInfo({ children }) {
+interface FooterProps {
+  children: ReactNode
+}
+
+export function FooterInfo({ children }: FooterProps) {
   return <div data-fs-footer-info>{children}</div>
 }
 
-export function FooterNavigation({ children }) {
+export function FooterNavigation({ children }: FooterProps) {
   return <div data-fs-footer-navigation>{children}</div>
 }
 
-export function Footer({ children }) {
+export function Footer({ children }: FooterProps) {
   return (
     <footer
       data-fs-footer

--- a/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
+++ b/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
@@ -14,7 +14,12 @@ import { ProductSummary_ProductFragment } from '@generated/graphql'
 import SearchProductItem from 'src/components/search/SearchProductItem'
 import { formatSearchPath } from 'src/sdk/search/formatSearchPath'
 
-function SearchDropdown({ sort, ...otherProps }) {
+interface SearchDropdownProps {
+  sort: SearchState['sort']
+  [key: string]: any
+}
+
+function SearchDropdown({ sort, ...otherProps }: SearchDropdownProps) {
   const {
     values: { onSearchSelection, products, term, terms },
   } = useSearch()
@@ -32,14 +37,14 @@ function SearchDropdown({ sort, ...otherProps }) {
             linkProps={{
               href: formatSearchPath({
                 term: suggestion,
-                sort: sort as SearchState['sort'],
+                sort: sort,
               }),
               onClick: () =>
                 onSearchSelection?.(
                   suggestion,
                   formatSearchPath({
                     term: suggestion,
-                    sort: sort as SearchState['sort'],
+                    sort: sort,
                   })
                 ),
             }}

--- a/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
+++ b/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
@@ -37,14 +37,14 @@ function SearchDropdown({ sort, ...otherProps }: SearchDropdownProps) {
             linkProps={{
               href: formatSearchPath({
                 term: suggestion,
-                sort: sort,
+                sort,
               }),
               onClick: () =>
                 onSearchSelection?.(
                   suggestion,
                   formatSearchPath({
                     term: suggestion,
-                    sort: sort,
+                    sort,
                   })
                 ),
             }}

--- a/packages/core/src/components/search/SearchInput/SearchInput.tsx
+++ b/packages/core/src/components/search/SearchInput/SearchInput.tsx
@@ -1,5 +1,6 @@
 import type { SearchEvent, SearchState } from '@faststore/sdk'
 import { sendAnalyticsEvent } from '@faststore/sdk'
+
 import type {
   SearchInputFieldProps as UISearchInputFieldProps,
   SearchInputFieldRef as UISearchInputFieldRef,
@@ -133,7 +134,7 @@ const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
 
         {searchDropdownVisible && (
           <Suspense fallback={null}>
-            <SearchDropdown sort={sort} />
+            <SearchDropdown sort={sort as SearchState['sort']} />
           </Suspense>
         )}
       </UISearchInput>

--- a/packages/core/src/components/search/Sort/Sort.tsx
+++ b/packages/core/src/components/search/Sort/Sort.tsx
@@ -27,13 +27,18 @@ export interface SortProps {
   }
 }
 
+type SortOptionKeys = keyof SortProps['options']
+
 function Sort({ label = 'Sort by', options = OptionsMap }: SortProps) {
   const { state, setState } = useSearch()
 
-  const optionsMap = Object.keys(options).reduce((acc, currentKey) => {
-    acc[currentKey] = options[currentKey] ?? OptionsMap[currentKey]
-    return acc
-  }, {})
+  const optionsMap = Object.keys(options).reduce(
+    (acc, currentKey: SortOptionKeys) => {
+      acc[currentKey] = options[currentKey] ?? OptionsMap[currentKey]
+      return acc
+    },
+    {} as Record<SortOptionKeys, string>
+  )
 
   return (
     <SelectField

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -100,7 +100,7 @@ export const getLandingPageBySlug = async (
   try {
     if (storeConfig.cms.data) {
       const cmsData = JSON.parse(storeConfig.cms.data)
-      const pageBySlug = cmsData['landingPage'].find((page) => {
+      const pageBySlug = cmsData['landingPage'].find((page: any) => {
         slug === page.settings?.seo?.slug
       })
 

--- a/packages/core/src/components/templates/ProductListingPage/ProductListing.tsx
+++ b/packages/core/src/components/templates/ProductListingPage/ProductListing.tsx
@@ -47,7 +47,7 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
 
 // Array merging strategy from deepmerge that makes client arrays overwrite server array
 // https://www.npmjs.com/package/deepmerge
-const overwriteMerge = (_, sourceArray) => sourceArray
+const overwriteMerge = (_: any[], sourceArray: any[]) => sourceArray
 
 export default function ProductListing({
   page: { sections, settings },

--- a/packages/core/src/components/ui/Image/loader.ts
+++ b/packages/core/src/components/ui/Image/loader.ts
@@ -1,7 +1,15 @@
 import storeConfig from 'faststore.config'
 const THUMBOR_SERVER = `https://${storeConfig.api.storeId}.vtexassets.com`
 
-export default function customImageLoader({ src, width, quality }) {
+export default function customImageLoader({
+  src,
+  width,
+  quality,
+}: {
+  src: any
+  width: any
+  quality: any
+}) {
   const preSizeComponents = [THUMBOR_SERVER, 'unsafe']
 
   // proportional to the width, enter a height of 0,

--- a/packages/core/src/components/ui/Image/loader.ts
+++ b/packages/core/src/components/ui/Image/loader.ts
@@ -1,15 +1,12 @@
 import storeConfig from 'faststore.config'
+import { ImageLoaderProps } from 'next/image'
 const THUMBOR_SERVER = `https://${storeConfig.api.storeId}.vtexassets.com`
 
 export default function customImageLoader({
   src,
   width,
   quality,
-}: {
-  src: any
-  width: any
-  quality: any
-}) {
+}: ImageLoaderProps) {
   const preSizeComponents = [THUMBOR_SERVER, 'unsafe']
 
   // proportional to the width, enter a height of 0,

--- a/packages/core/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/packages/core/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -5,7 +5,13 @@ import { useRouter } from 'next/router'
 import type { ImageGalleryProps as UIImageGalleryProps } from '@faststore/ui'
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 
-const ImageComponent = ({ url, alternateName }) => {
+const ImageComponent = ({
+  url,
+  alternateName,
+}: {
+  url: string
+  alternateName?: string
+}) => {
   const { __experimentalImageGalleryImage: Image } =
     useOverrideComponents<'ProductDetails'>()
 

--- a/packages/core/src/components/ui/Newsletter/NewsletterAddendum.tsx
+++ b/packages/core/src/components/ui/Newsletter/NewsletterAddendum.tsx
@@ -14,7 +14,7 @@
  * This is a limitation not only for this component, but for every native & custom component that makes use of Rich Text.
  */
 
-// @ts-ignore motivation: cannot find the draftjs-to-html package types.
+// @ts-expect-error motivation: cannot find the draftjs-to-html package types.
 import draftToHtml from 'draftjs-to-html'
 import { NewsletterAddendum as UINewsletterAddendum } from '@faststore/ui'
 import type { NewsletterAddendumProps as UINewsletterAddendumProps } from '@faststore/ui'

--- a/packages/core/src/components/ui/Newsletter/NewsletterAddendum.tsx
+++ b/packages/core/src/components/ui/Newsletter/NewsletterAddendum.tsx
@@ -14,7 +14,7 @@
  * This is a limitation not only for this component, but for every native & custom component that makes use of Rich Text.
  */
 
-// @ts-expect-error motivation: cannot find the draftjs-to-html package types.
+// @ts-ignore motivation: cannot find the draftjs-to-html package types.
 import draftToHtml from 'draftjs-to-html'
 import { NewsletterAddendum as UINewsletterAddendum } from '@faststore/ui'
 import type { NewsletterAddendumProps as UINewsletterAddendumProps } from '@faststore/ui'

--- a/packages/core/src/components/ui/Newsletter/NewsletterAddendum.tsx
+++ b/packages/core/src/components/ui/Newsletter/NewsletterAddendum.tsx
@@ -13,6 +13,8 @@
  *
  * This is a limitation not only for this component, but for every native & custom component that makes use of Rich Text.
  */
+
+// @ts-ignore motivation: cannot find the draftjs-to-html package types.
 import draftToHtml from 'draftjs-to-html'
 import { NewsletterAddendum as UINewsletterAddendum } from '@faststore/ui'
 import type { NewsletterAddendumProps as UINewsletterAddendumProps } from '@faststore/ui'

--- a/packages/core/src/customizations/src/dynamicContent/index.ts
+++ b/packages/core/src/customizations/src/dynamicContent/index.ts
@@ -11,6 +11,6 @@
 
 // export default dynamicContent;
 
-const dynamicContent = {}
+const dynamicContent: Record<string, any> = {}
 
 export default dynamicContent

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -63,7 +63,7 @@ type Props = PDPContentType & {
 
 // Array merging strategy from deepmerge that makes client arrays overwrite server array
 // https://www.npmjs.com/package/deepmerge
-const overwriteMerge = (_, sourceArray) => sourceArray
+const overwriteMerge = (_: any[], sourceArray: any[]) => sourceArray
 
 function Page({ data: server, sections, globalSections, offers, meta }: Props) {
   const { product } = server

--- a/packages/core/src/sdk/analytics/index.tsx
+++ b/packages/core/src/sdk/analytics/index.tsx
@@ -11,7 +11,7 @@ if (typeof window !== 'undefined') {
   }
 }
 
-const AnalyticsHandler = () => {
+const AnalyticsHandler = (): null => {
   useAnalyticsEvent((event: AnalyticsEvent) => {
     // Cleans the ecommerce object before pushing a new one
     // This prevents the new data from getting merged with the previous one

--- a/packages/core/src/sdk/error/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/core/src/sdk/error/ErrorBoundary/ErrorBoundary.tsx
@@ -15,8 +15,20 @@ if (typeof window !== 'undefined') {
   window.setInterval(() => setReloads(0), 30e3)
 }
 
-class ErrorBoundary extends Component<{ children: ReactNode }> {
-  public state = { hasError: false, error: null }
+interface ErrorBoundaryProps {
+  children: ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: Boolean
+  error: Error | null
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  public state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+  }
 
   public static getDerivedStateFromError(error: Error) {
     return {

--- a/packages/core/src/sdk/overrides/overrides.ts
+++ b/packages/core/src/sdk/overrides/overrides.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import type {
   DefaultSectionComponentsDefinitions,
   ComponentOverrideDefinition,

--- a/packages/core/src/sdk/overrides/overrides.ts
+++ b/packages/core/src/sdk/overrides/overrides.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type {
   DefaultSectionComponentsDefinitions,
   ComponentOverrideDefinition,
@@ -8,6 +7,9 @@ import type {
 
 import type { SectionsOverrides } from '../../typings/overrides'
 
+/* TODO: Fix typescript errors. It is necessary to further investigate the typing 
+issues of this file. Error lines have been marked with the @ts-expect-error comment*/
+
 export function getSectionOverrides<
   SectionName extends keyof SectionsOverrides
 >(
@@ -16,38 +18,45 @@ export function getSectionOverrides<
 ): OverriddenComponents<SectionName> {
   const overriddenComponents = {} as OverriddenComponents<SectionName>
 
-  Object.entries(defaultComponents).forEach(([key, value]) => {
-    const componentOverride:
-      | ComponentOverrideDefinition<unknown, unknown>
-      | undefined = override.components?.[key]
+  Object.entries<React.ComponentType>(defaultComponents).forEach(
+    ([key, value]) => {
+      const componentOverride:
+        | ComponentOverrideDefinition<React.ComponentType, unknown>
+        | undefined =
+        // @ts-expect-error
+        override.components?.[key]
 
-    if (!componentOverride) {
-      overriddenComponents[key] = {
-        Component: value,
-        props: {},
+      if (!componentOverride) {
+        // @ts-expect-error
+        overriddenComponents[key] = {
+          Component: value,
+          props: {},
+        }
+
+        return
       }
 
-      return
-    }
-
-    if (componentOverride.Component && componentOverride.props) {
-      console.warn(
-        `Mixed use of Component and props overrides detected. Defaulting to Component override: component ${key} in the ${override.section} section.`
-      )
-    }
-
-    if (componentOverride.Component) {
-      overriddenComponents[key] = {
-        Component: componentOverride.Component,
-        props: {},
+      if (componentOverride.Component && componentOverride.props) {
+        console.warn(
+          `Mixed use of Component and props overrides detected. Defaulting to Component override: component ${key} in the ${override.section} section.`
+        )
       }
-    } else {
-      overriddenComponents[key] = {
-        Component: value,
-        props: componentOverride.props ?? {},
+
+      if (componentOverride.Component) {
+        // @ts-expect-error
+        overriddenComponents[key] = {
+          Component: componentOverride.Component,
+          props: {},
+        }
+      } else {
+        // @ts-expect-error
+        overriddenComponents[key] = {
+          Component: value,
+          props: componentOverride.props ?? {},
+        }
       }
     }
-  })
+  )
 
   return overriddenComponents
 }

--- a/packages/core/src/sdk/overrides/overrides.ts
+++ b/packages/core/src/sdk/overrides/overrides.ts
@@ -8,7 +8,7 @@ import type {
 import type { SectionsOverrides } from '../../typings/overrides'
 
 /* TODO: Fix typescript errors. It is necessary to further investigate the typing 
-issues of this file. Error lines have been marked with the @ts-expect-error comment*/
+issues of this file. Error lines have been marked with the @ts-ignore comment*/
 
 export function getSectionOverrides<
   SectionName extends keyof SectionsOverrides
@@ -23,11 +23,11 @@ export function getSectionOverrides<
       const componentOverride:
         | ComponentOverrideDefinition<React.ComponentType, unknown>
         | undefined =
-        // @ts-expect-error
+        // @ts-ignore
         override.components?.[key]
 
       if (!componentOverride) {
-        // @ts-expect-error
+        // @ts-ignore
         overriddenComponents[key] = {
           Component: value,
           props: {},
@@ -43,13 +43,13 @@ export function getSectionOverrides<
       }
 
       if (componentOverride.Component) {
-        // @ts-expect-error
+        // @ts-ignore
         overriddenComponents[key] = {
           Component: componentOverride.Component,
           props: {},
         }
       } else {
-        // @ts-expect-error
+        // @ts-ignore
         overriddenComponents[key] = {
           Component: value,
           props: componentOverride.props ?? {},

--- a/packages/core/src/sdk/product/useProductGalleryQuery.ts
+++ b/packages/core/src/sdk/product/useProductGalleryQuery.ts
@@ -7,6 +7,7 @@ import { useLocalizedVariables } from './useLocalizedVariables'
 import { useSession } from 'src/sdk/session'
 
 import type {
+  ClientManyProductsQueryQueryVariables,
   ClientProductGalleryQueryQuery as Query,
   ClientProductGalleryQueryQueryVariables as Variables,
 } from '@generated/graphql'
@@ -61,12 +62,19 @@ export const fragment = gql(`
   }
 `)
 
+type ProductGalleryQueryOptions = {
+  itemsPerPage: number
+  selectedFacets: Facet[]
+  sort: ClientManyProductsQueryQueryVariables['sort']
+  term: ClientManyProductsQueryQueryVariables['term']
+}
+
 export const useProductGalleryQuery = ({
   term,
   sort,
   selectedFacets,
   itemsPerPage,
-}) => {
+}: ProductGalleryQueryOptions) => {
   const { locale } = useSession()
   const { state, setState } = useSearch()
 

--- a/packages/core/test/utils/multipleTemplates.test.ts
+++ b/packages/core/test/utils/multipleTemplates.test.ts
@@ -61,7 +61,7 @@ describe('Multiple page templates', () => {
     })
 
     it('should return false when the rewrites is empty array', () => {
-      const rewritesArr = []
+      const rewritesArr: Rewrite[] = []
       const result = hasRewritesConfigForSlug({
         rewrites: rewritesArr,
         templateValue: '/test/my-office',

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -22,13 +22,14 @@
       ]
     },
     "forceConsistentCasingInFileNames": true,
-    "strict": false,
+    "noImplicitAny": true,
     "incremental": true,
     "isolatedModules": true,
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "skipLibCheck": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": false
   },
   "include": ["*.d.ts", "src/**/*.ts", "src/**/*.tsx", "@generated/**/*.ts"],
   "exclude": ["node_modules", "public"]


### PR DESCRIPTION
## What's the purpose of this pull request?

Strict mode in TypeScript is a way to opt into a more strict type-checking behavior to catch more potential issues at compile time. When enabled, it activates a set of stricter type-checking options that enforce more constraints on your code. Here's how it works and what it does:


**No Implicit Any (noImplicitAny)**: This prevents variables and parameters from defaulting to the any type when TypeScript is unable to infer a more specific type. This helps catch cases where you might have forgotten to specify a type or TypeScript can't infer one for you.


To enable strict mode, you can set "**strict": true** in your `tsconfig.json` file. This is equivalent to enabling all of the above options individually.

The idea of ​​this initiative is to enable rule by rule incrementally so that it is possible to open smaller PRs with low risk.

Task: https://vtex-dev.atlassian.net/browse/SFS-1124

## How it works?

The first PR enables `noImplicitAny` rule. So codes like that will not work: 

What's the type of address? 
```
function printAddresss(address) {
    console.log(address) 
}
``` 

## How to test it?

- The pipeline (build, tests, and lint) should work for **@faststore** packages and their dependencies (current branch). 

- Install the version of this PR in the [starter.store](https://github.com/vtex-sites/starter.store) and test if the build, tests and override feature works. 

"@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/1b7aa312/@faststore/core"
"@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/1b7aa312/@faststore/cli",


I welcome other suggestions and help with testing 🥇 

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
