### PR TITLE
docs: comment middleware

### DIFF
--- a/apps/site/middleware.ts
+++ b/apps/site/middleware.ts
@@ -1,21 +1,21 @@
 import { NextResponse, NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const { pathname } = new URL(request.url)
-  if (pathname.startsWith('/docs')) {
-    return NextResponse.redirect(
-      `https://developers.vtex.com/docs/guides/faststore${pathname.replace(
-        '/docs',
-        ''
-      )}`
-    )
-  }
-  if (pathname.startsWith('/components')) {
-    return NextResponse.redirect(
-      `https://developers.vtex.com/docs/guides/faststore${pathname
-        .replace('/components', '')
-        .replace(/\/([^\/]*)\//, '/$1-')}`
-    )
-  }
+  // const { pathname } = new URL(request.url)
+  // if (pathname.startsWith('/docs')) {
+  //   return NextResponse.redirect(
+  //     `https://developers.vtex.com/docs/guides/faststore${pathname.replace(
+  //       '/docs',
+  //       ''
+  //     )}`
+  //   )
+  // }
+  // if (pathname.startsWith('/components')) {
+  //   return NextResponse.redirect(
+  //     `https://developers.vtex.com/docs/guides/faststore${pathname
+  //       .replace('/components', '')
+  //       .replace(/\/([^\/]*)\//, '/$1-')}`
+  //   )
+  // }
   return NextResponse.next()
 }

--- a/apps/site/pages/components/molecules/order-summary.mdx
+++ b/apps/site/pages/components/molecules/order-summary.mdx
@@ -129,6 +129,20 @@ Follow the instructions in the [Importing FastStore UI component styles](/docs/c
     token="--fs-order-summary-total-text-font-weight"
     value="var(--fs-text-weight-bold)"
   />
+  <TokenDivider />
+  <TokenRow
+    token="--fs-order-summary-taxes-label-color"
+    value="var(--fs-color-info-text)"
+    isColor
+  />
+  <TokenRow
+    token="--fs-order-summary-taxes-text-size"
+    value="var(--fs-text-size-tiny)"
+  />
+  <TokenRow
+    token="--fs-order-summary-taxes-text-weight"
+    value="var(--fs-text-weight-regular)"
+  />
 </TokenTable>
 
 ---
@@ -154,3 +168,5 @@ Follow the instructions in the [Importing FastStore UI component styles](/docs/c
 `data-fs-order-summary-total-label`
 
 `data-fs-order-summary-total-value`
+
+`data-fs-order-summary-taxes-label`

--- a/apps/site/pages/components/molecules/product-card.mdx
+++ b/apps/site/pages/components/molecules/product-card.mdx
@@ -431,6 +431,25 @@ All product card related components support all attributes also supported by the
   />
 </TokenTable>
 
+#### Tax Label
+
+<TokenTable>
+  <TokenRow
+    token="--fs-order-summary-taxes-label-color"
+    value="var(--fs-color-info-text)"
+    isColor
+  />
+  <TokenRow
+    token="--fs-order-summary-taxes-text-size"
+    value="var(--fs-text-size-tiny)"
+  />
+  <TokenRow
+    token="--fs-order-summary-taxes-text-weight"
+    value="var(--fs-text-weight-regular)"
+  />
+</TokenTable>
+
+
 ### Variants
 
 #### Default
@@ -761,6 +780,8 @@ Use the `ProductCard` to:
 `data-fs-product-card-prices`
 
 `data-fs-product-card-actions`
+
+`data-fs-product-card-taxes-label`
 
 ---
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Add Price With Taxes documentation

## How it works?

This PR adds news token and Props comming from Price wIth Taxes feature.

## How to test it?

Access the Doc Portal
[Order Summary](https://faststore-site-git-docs-add-price-wit-taxes-docs-faststore.vercel.app/components/molecules/order-summary)

### Props

![Screenshot 2024-07-15 at 10 47 14](https://github.com/user-attachments/assets/1c94d106-3027-43b2-b275-b99175b3134d)

### Tokens

![Screenshot 2024-07-15 at 10 47 23](https://github.com/user-attachments/assets/c5a6ce0a-664e-43a0-9430-ffaff2b388d9)


[Product Card](https://faststore-site-git-docs-add-price-wit-taxes-docs-faststore.vercel.app/components/molecules/product-card#design-tokens)

### Tokens

![Screenshot 2024-07-15 at 10 46 57](https://github.com/user-attachments/assets/6e7b113b-6c45-4ff3-aa90-71aa7de9d5f3)

### Props

![Screenshot 2024-07-15 at 10 46 42](https://github.com/user-attachments/assets/b0381e69-bf22-4dfb-8713-eaf3a4774c8d)


### Starters Deploy Preview

https://vercel.live/open-feedback/faststore-site-git-docs-add-price-wit-taxes-docs-faststore.vercel.app?via=pr-comment-visit-preview-link&passThrough=1


