### PR TITLE
chore: removes maxInitialRequests config

### DIFF
--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -27,7 +27,7 @@ const nextConfig = {
     // Trace user's `node_modules` dir
     outputFileTracingRoot: path.join(__dirname, '../'),
   },
-  webpack: (config, { isServer, dev }) => {
+  webpack: (config) => {
     // https://github.com/vercel/next.js/discussions/11267#discussioncomment-2479112
     // camel-case style names from css modules
     config.module.rules
@@ -39,12 +39,6 @@ const nextConfig = {
           options.modules.exportLocalsConvention = 'camelCase'
         }
       })
-
-    // Reduce the number of chunks so we ship a smaller first bundle.
-    // This should help reducing TBT
-    if (!isServer && !dev && config.optimization?.splitChunks) {
-      config.optimization.splitChunks.maxInitialRequests = 1
-    }
 
     return config
   },


### PR DESCRIPTION
## What's the purpose of this pull request?

Performance: Compare the previous version with the `maxInitialRequest` option and the default version.

starter pr
https://github.com/vtex-sites/starter.store/pull/492

reference
https://webpack.js.org/plugins/split-chunks-plugin/