### PR TITLE
chore: update OrderSummary and ProductCard props description

### DIFF
--- a/packages/components/src/molecules/OrderSummary/OrderSummary.tsx
+++ b/packages/components/src/molecules/OrderSummary/OrderSummary.tsx
@@ -28,6 +28,10 @@ export interface OrderSummaryProps extends HTMLAttributes<HTMLUListElement> {
   /**
    * Label for the total value of the order.
    */
+  totalLabel?: string
+  /**
+   * Total value of the order.
+   */
   totalValue?: string
   /**
    * Specifies whether the displayed price should include taxes.

--- a/packages/components/src/molecules/OrderSummary/OrderSummary.tsx
+++ b/packages/components/src/molecules/OrderSummary/OrderSummary.tsx
@@ -5,40 +5,36 @@ import { Label, List } from '../../'
 
 export interface OrderSummaryProps extends HTMLAttributes<HTMLUListElement> {
   /**
-   * ID to find this component in testing tools (e.g.: cypress,
+   * ID to find this component in testing tools (e.g., cypress,
    * testing-library, and jest).
    */
   testId?: string
   /**
-   * Label for the subtotal value of the order. Will only show if subtotalValue is provided.
+   * Label for the subtotal value of the order. It will only show if subtotalValue is provided.
    */
   subtotalLabel?: string
   /**
-   * Subtotal value of the order. If provided, subtotal label and value will be shown.
+   * Subtotal value of the order. If provided, a subtotal label and value will be shown.
    */
   subtotalValue?: string
   /**
-   * Label for the discount value for the order. Will only show if discountValue is provided.
+   * Label for the discount value for the order. It will only show if discountValue is provided.
    */
   discountLabel?: string
   /**
-   * Discount value for the order. If provided, discount label and value will be shown.
+   * Discount value for the order. If provided, a discount label and value will be shown.
    */
   discountValue?: string
   /**
    * Label for the total value of the order.
    */
-  totalLabel?: string
-  /**
-   * Total value of the order.
-   */
   totalValue?: string
   /**
-   * Enables to include taxes status.
+   * Specifies whether the displayed price should include taxes.
    */
   includeTaxes?: boolean
   /**
-   * Label to determine if the price is with taxes included.
+   * Label to determine if the price includes taxes.
    */
   includeTaxesLabel?: string
 }

--- a/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
+++ b/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
@@ -26,7 +26,7 @@ export interface ProductCardContentProps extends HTMLAttributes<HTMLElement> {
    */
   title: string
   /**
-   * Props for the link from ProductCard component.
+   * Props for the link from the ProductCard component.
    */
   linkProps?: Partial<LinkProps<LinkElementType>>
   /**
@@ -34,7 +34,7 @@ export interface ProductCardContentProps extends HTMLAttributes<HTMLElement> {
    */
   price?: PriceDefinition
   /**
-   * Enables a outOfStock status.
+   * Enables an outOfStock status.
    */
   outOfStock?: boolean
   /**
@@ -42,7 +42,7 @@ export interface ProductCardContentProps extends HTMLAttributes<HTMLElement> {
    */
   outOfStockLabel?: string
   /**
-   * Specifies Rating Value of the product.
+   * Specifies the Rating Value of the product.
    */
   ratingValue?: number
   /**
@@ -54,15 +54,15 @@ export interface ProductCardContentProps extends HTMLAttributes<HTMLElement> {
    */
   showDiscountBadge?: boolean
   /**
-   * Callback function when button is clicked.
+   * Callback function when the button is clicked.
    */
   onButtonClick?: () => void
   /**
-   * Enables to include taxes status.
+   * Specifies whether the displayed price should include taxes.
    */
   includeTaxes?: boolean
   /**
-   * Label to determine if the price is with taxes included.
+   * Label to determine if the price includes taxes.
    */
   includeTaxesLabel?: string
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to update the props descriptions for [OrderSummary](https://developers.vtex.com/docs/guides/faststore/molecules-order-summary) and [ProductCard](https://developers.vtex.com/docs/guides/faststore/molecules-product-card).

## How it works?

This PR fixes some typos in the `OrderSummary` and `ProductCard` props description. However, the main fixes are related to the taxes related props as you can see in the following screenshot:

<img width="366" alt="Screenshot_578" src="https://github.com/user-attachments/assets/72242278-14d4-48f4-ba85-de033e005b2e">


## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

https://vercel.live/open-feedback/faststore-site-git-chore-update-props-description-faststore.vercel.app?via=pr-comment-visit-preview-link&passThrough=1

## References

Dev Portal PR (updating the documentation): https://github.com/vtexdocs/dev-portal-content/pull/1298#pullrequestreview-2178476553
