### PR TITLE
Feat: remove lazy imports from Home

### DIFF
--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -1,7 +1,7 @@
 import { Locator, Section } from '@vtex/client-cms'
 import storeConfig from 'faststore.config'
 import type { ComponentType } from 'react'
-import { PropsWithChildren, lazy } from 'react'
+import { PropsWithChildren } from 'react'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import { PageContentType, getPage } from 'src/server/cms'
 
@@ -13,8 +13,8 @@ import Footer from 'src/components/sections/Footer'
 import { OverriddenDefaultNavbar as Navbar } from 'src/components/sections/Navbar/OverriddenDefaultNavbar'
 import { OverriddenDefaultRegionBar as RegionBar } from 'src/components/sections/RegionBar/OverriddenDefaultRegionBar'
 
-const RegionModal = lazy(() => import('src/components/region/RegionModal'))
-const CartSidebar = lazy(() => import('src/components/cart/CartSidebar'))
+import CartSidebar from 'src/components/cart/CartSidebar'
+import RegionModal from 'src/components/region/RegionModal'
 
 export const GLOBAL_SECTIONS_CONTENT_TYPE = 'globalSections'
 

--- a/packages/core/src/components/search/SearchInput/SearchInput.tsx
+++ b/packages/core/src/components/search/SearchInput/SearchInput.tsx
@@ -14,7 +14,6 @@ import type { CSSProperties } from 'react'
 import {
   Suspense,
   forwardRef,
-  lazy,
   useDeferredValue,
   useImperativeHandle,
   useRef,
@@ -26,9 +25,7 @@ import useSearchHistory from 'src/sdk/search/useSearchHistory'
 import useSuggestions from 'src/sdk/search/useSuggestions'
 import useOnClickOutside from 'src/sdk/ui/useOnClickOutside'
 
-const SearchDropdown = lazy(
-  () => import('src/components/search/SearchDropdown')
-)
+import SearchDropdown from 'src/components/search/SearchDropdown'
 
 const MAX_SUGGESTIONS = 5
 


### PR DESCRIPTION
## What's the purpose of this pull request?

|Before|After|
|-|-|
|~640kb|~630kb|
|<img width="1503" alt="Screenshot 2024-07-16 at 16 47 30" src="https://github.com/user-attachments/assets/91c65221-c828-4b44-975b-1caaa8709d0e">|<img width="1507" alt="Screenshot 2024-07-16 at 16 51 42" src="https://github.com/user-attachments/assets/ade6869e-7c96-4d37-95e4-1be4f12f4ef4">|

UPDATE: fake news 😆 
When compared using the PSI Treemap, we've got
|Before|After|
|-|-|
|~544kb|~551kb|
|<img width="1509" alt="Screenshot 2024-07-16 at 17 31 49" src="https://github.com/user-attachments/assets/123c7945-069c-47b9-b4fa-b62a60eebe40">|<img width="1510" alt="Screenshot 2024-07-16 at 17 32 04" src="https://github.com/user-attachments/assets/7f944788-a0e4-4fe7-84ed-18507866a5d7">|

Starter PR
- https://github.com/vtex-sites/starter.store/pull/494