### PR TITLE
Enable sign in Button override

### DIFF
--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -77,6 +77,7 @@ function Navbar({
     NavbarRow,
     NavbarButtons,
     IconButton,
+    _experimentalSignInButton: SignInButton,
   } = useOverrideComponents<'Navbar'>()
   const scrollDirection = useScrollDirection()
   const { openNavbar, navbar: displayNavbar } = useUI()
@@ -152,7 +153,7 @@ function Navbar({
               aria-hidden={!searchExpanded}
             />
 
-            <ButtonSignIn {...signInButton} />
+            <SignInButton.Component {...signInButton} />
 
             <CartToggle {...cart} />
           </NavbarButtons.Component>

--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -11,7 +11,6 @@ import NavbarSlider from 'src/components/navigation/NavbarSlider'
 import CartToggle from 'src/components/cart/CartToggle'
 import Logo from 'src/components/ui/Logo'
 import Link from 'src/components/ui/Link'
-import { ButtonSignIn } from 'src/components/ui/Button'
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 
 import type { NavbarProps as SectionNavbarProps } from '../../sections/Navbar'
@@ -77,7 +76,7 @@ function Navbar({
     NavbarRow,
     NavbarButtons,
     IconButton,
-    _experimentalSignInButton: SignInButton,
+    _experimentalButtonSignIn: ButtonSignIn,
   } = useOverrideComponents<'Navbar'>()
   const scrollDirection = useScrollDirection()
   const { openNavbar, navbar: displayNavbar } = useUI()
@@ -153,7 +152,7 @@ function Navbar({
               aria-hidden={!searchExpanded}
             />
 
-            <SignInButton.Component {...signInButton} />
+            <ButtonSignIn.Component {...signInButton} />
 
             <CartToggle {...cart} />
           </NavbarButtons.Component>

--- a/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
+++ b/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
@@ -1,7 +1,7 @@
 import { useFadeEffect, useUI } from '@faststore/ui'
 import { Suspense } from 'react'
 
-import { ButtonSignIn, ButtonSignInFallback } from 'src/components/ui/Button'
+import { ButtonSignInFallback } from 'src/components/ui/Button'
 import Link from 'src/components/ui/Link'
 import NavbarLinks from 'src/components/navigation/NavbarLinks'
 import Logo from 'src/components/ui/Logo'
@@ -32,6 +32,7 @@ function NavbarSlider({
     NavbarSliderHeader,
     NavbarSliderContent,
     NavbarSliderFooter,
+    _experimentalButtonSignIn: ButtonSignIn,
   } = useOverrideComponents<'Navbar'>()
 
   const { closeNavbar } = useUI()
@@ -65,7 +66,7 @@ function NavbarSlider({
       </NavbarSliderContent.Component>
       <NavbarSliderFooter.Component {...NavbarSliderFooter.props}>
         <Suspense fallback={<ButtonSignInFallback />}>
-          <ButtonSignIn {...signInButton} />
+          <ButtonSignIn.Component {...signInButton} />
         </Suspense>
       </NavbarSliderFooter.Component>
     </NavbarSliderWrapper.Component>

--- a/packages/core/src/components/sections/Navbar/DefaultComponents.ts
+++ b/packages/core/src/components/sections/Navbar/DefaultComponents.ts
@@ -26,5 +26,5 @@ export const NavbarDefaultComponents = {
   NavbarRow: UINavbarRow,
   NavbarButtons: UINavbarButtons,
   IconButton: UIIconButton,
-  _experimentalSignInButton: ButtonSignIn,
+  _experimentalButtonSignIn: ButtonSignIn,
 } as const

--- a/packages/core/src/components/sections/Navbar/DefaultComponents.ts
+++ b/packages/core/src/components/sections/Navbar/DefaultComponents.ts
@@ -12,6 +12,8 @@ import {
   IconButton as UIIconButton,
 } from '@faststore/ui'
 
+import { ButtonSignIn } from 'src/components/ui/Button'
+
 export const NavbarDefaultComponents = {
   Navbar: UINavbar,
   NavbarLinks: UINavbarLinks,
@@ -24,4 +26,5 @@ export const NavbarDefaultComponents = {
   NavbarRow: UINavbarRow,
   NavbarButtons: UINavbarButtons,
   IconButton: UIIconButton,
+  _experimentalSignInButton: ButtonSignIn,
 } as const

--- a/packages/core/src/experimental/index.ts
+++ b/packages/core/src/experimental/index.ts
@@ -38,4 +38,4 @@ export { useShippingSimulation as useShippingSimulation_unstable } from '../../s
 export { Image as Image_unstable } from '../../src/components/ui/Image'
 export { ProfileChallenge as ProfileChallenge_unstable } from '../../src/components/auth/ProfileChallenge'
 export { default as Selectors_unstable } from '../../src/components/ui/SkuSelector'
-export { ButtonSignIn as SignInButton_unstable } from '../../src/components/ui/Button'
+export { ButtonSignIn as ButtonSignIn_unstable } from '../../src/components/ui/Button'

--- a/packages/core/src/experimental/index.ts
+++ b/packages/core/src/experimental/index.ts
@@ -38,3 +38,4 @@ export { useShippingSimulation as useShippingSimulation_unstable } from '../../s
 export { Image as Image_unstable } from '../../src/components/ui/Image'
 export { ProfileChallenge as ProfileChallenge_unstable } from '../../src/components/auth/ProfileChallenge'
 export { default as Selectors_unstable } from '../../src/components/ui/SkuSelector'
+export { ButtonSignIn as SignInButton_unstable } from '../../src/components/ui/Button'

--- a/packages/core/src/typings/overrides.ts
+++ b/packages/core/src/typings/overrides.ts
@@ -195,7 +195,7 @@ export type SectionsOverrides = {
         IconButtonProps,
         Omit<IconButtonProps, 'onClick'>
       >
-      _experimentalSignInButton: ComponentOverrideDefinition<any, any>
+      _experimentalButtonSignIn: ComponentOverrideDefinition<any, any>
     }
   }
   Newsletter: {

--- a/packages/core/src/typings/overrides.ts
+++ b/packages/core/src/typings/overrides.ts
@@ -81,19 +81,19 @@ export type SectionOverride = {
 export type OverrideComponentsForSection<
   Section extends SectionsOverrides[keyof SectionsOverrides]['Section']
 > = {
-  // The first 'extends' condition is used to filter out sections that don't have overrides (typed 'never')
-  [K in keyof SectionsOverrides as SectionsOverrides[K] extends {
-    Section: never
-  }
+    // The first 'extends' condition is used to filter out sections that don't have overrides (typed 'never')
+    [K in keyof SectionsOverrides as SectionsOverrides[K] extends {
+      Section: never
+    }
     ? never
     : // In the second 'extends' condition, we check if the section matches the one we're looking for
     SectionsOverrides[K] extends {
-        Section: Section
-      }
+      Section: Section
+    }
     ? // If it does, we return the components. Otherwise, we return 'never', which is filtered out
-      K
+    K
     : never]: SectionsOverrides[K]['components']
-}
+  }
 
 // This type is used to extract only the list of components from the section override
 export type ComponentsFromSection<
@@ -195,6 +195,7 @@ export type SectionsOverrides = {
         IconButtonProps,
         Omit<IconButtonProps, 'onClick'>
       >
+      _experimentalSignInButton: ComponentOverrideDefinition<any, any>
     }
   }
   Newsletter: {


### PR DESCRIPTION
## What's the purpose of this pull request?

During the development of the B2B Self Management feature, we need to customize and add new behaviors to the "My Account" button, making it open a modal instead of going to the `/account` page. While most of this development will happen in an external library, the ability to override this button is important for us. 

This PR enables just that, the ability to completely override the default SignIn / My Account button. 

- [ ] Add documentation of the override

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
