### PR TITLE
fix: Sku variants sort

### DIFF
--- a/packages/api/src/platforms/vtex/utils/skuVariants.ts
+++ b/packages/api/src/platforms/vtex/utils/skuVariants.ts
@@ -132,12 +132,13 @@ function sortVariants(variantsByName: SkuVariantsByName) {
   const sortedVariants = variantsByName
 
   for (const variantProperty in variantsByName) {
-
-    const allNumbers = variantsByName[variantProperty].every(
-      (option: any) => !Number.isNaN(option.label)
+    const areAllNumbers = variantsByName[variantProperty].every(
+      (option: any) => !Number.isNaN(Number(option.value))
     )
 
-    allNumbers ?? variantsByName[variantProperty].sort((a, b) => compare(a.value, b.value))
+    // Preserve Admin's variants order for cases variants are strings
+    areAllNumbers &&
+      variantsByName[variantProperty].sort((a, b) => compare(a.value, b.value))
   }
 
   return sortedVariants
@@ -187,7 +188,10 @@ export function getFormattedVariations(
 
       previouslySeenPropertyValues.add(nameValueIdentifier)
 
-      const variantImageToUse = findSkuVariantImage(variant.images, dominantVariantName)
+      const variantImageToUse = findSkuVariantImage(
+        variant.images,
+        dominantVariantName
+      )
 
       const formattedVariant = {
         src: variantImageToUse.imageUrl,
@@ -214,7 +218,10 @@ export function getFormattedVariations(
 
       previouslySeenPropertyValues.add(nameValueIdentifier)
 
-      const variantImageToUse = findSkuVariantImage(variant.images, variationProperty.name)
+      const variantImageToUse = findSkuVariantImage(
+        variant.images,
+        variationProperty.name
+      )
 
       const formattedVariant = {
         src: variantImageToUse.imageUrl,

--- a/packages/api/test/vtex.skuVariants.test.ts
+++ b/packages/api/test/vtex.skuVariants.test.ts
@@ -111,16 +111,16 @@ describe('getFormattedVariations', () => {
     const expected = {
       Color: [
         {
-          src: 'https://storecomponents.vtexassets.com/arquivos/ids/155559/pink-sku-variation.png?v=637087508159070000',
-          alt: 'skuvariation',
-          label: 'Color: Green',
-          value: 'Green',
-        },
-        {
           src: 'https://storecomponents.vtexassets.com/arquivos/ids/155560/pink-cool-sku-variation.png?v=637063239809000000',
           alt: 'skuvariation',
           label: 'Color: Red',
           value: 'Red',
+        },
+        {
+          src: 'https://storecomponents.vtexassets.com/arquivos/ids/155559/pink-sku-variation.png?v=637087508159070000',
+          alt: 'skuvariation',
+          label: 'Color: Green',
+          value: 'Green',
         },
         {
           src: 'https://storecomponents.vtexassets.com/arquivos/ids/155561/white-sku-variation.png?v=637087507771770000',


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the SKU variants sort implementation. It will preserve Admin's variants order for cases that variants are not numbers. (e.g. Sizes: ['S', 'M', 'L'] should be rendered as it is)

## How it works?

Example:

`{
      Size: [
        {
          ...,
          label: 'Size: L',
          value: 'L'
        },
        {
          ...,
          label: 'Size: M',
          value: 'M'
        },
        {
          ...,
          label: 'Size: S,
          value: 'S'
        },
      ]
}`

The expected result is to keep this order:

But for the following case:

`{
      Size: [
        {
          ...,
          label: 'Size: 2',
          value: '2'
        },
        {
          ...,
          label: 'Size: 3',
          value: '3'
        },
        {
          ...,
          label: 'Size: 1',
          value: '1'
        },
      ]
}`

The result should be sorted, so Sizes: [1, 2, 3]

## How to test it?

Run `yarn test` and check the results.

### Related PRs

#2374