### PR TITLE
feat: trigger critical events for analytics

### DIFF
--- a/packages/core/src/Layout.tsx
+++ b/packages/core/src/Layout.tsx
@@ -1,6 +1,11 @@
-import type { PropsWithChildren } from 'react'
+import { useEffect, type PropsWithChildren } from 'react'
+import { usePageViewEvent } from './sdk/analytics/hooks/usePageViewEvent'
 
 function Layout({ children }: PropsWithChildren) {
+  const { sendPageViewEvent } = usePageViewEvent({})
+
+  useEffect(sendPageViewEvent, [])
+
   return <>{children}</>
 }
 

--- a/packages/core/src/Layout.tsx
+++ b/packages/core/src/Layout.tsx
@@ -1,10 +1,9 @@
-import { useEffect, type PropsWithChildren } from 'react'
+import { type PropsWithChildren } from 'react'
+
 import { usePageViewEvent } from './sdk/analytics/hooks/usePageViewEvent'
 
 function Layout({ children }: PropsWithChildren) {
-  const { sendPageViewEvent } = usePageViewEvent({})
-
-  useEffect(sendPageViewEvent, [])
+  usePageViewEvent()
 
   return <>{children}</>
 }

--- a/packages/core/src/sdk/analytics/hooks/usePageViewEvent.ts
+++ b/packages/core/src/sdk/analytics/hooks/usePageViewEvent.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react'
+import { sendAnalyticsEvent } from '@faststore/sdk'
+import type { PageViewEvent } from '@faststore/sdk'
+
+export const usePageViewEvent = ({
+  send_page_view = true,
+}: {
+  send_page_view?: boolean
+}) => {
+  const sendPageViewEvent = useCallback(() => {
+    sendAnalyticsEvent<PageViewEvent>({
+      name: 'page_view',
+      params: {
+        page_title: document.title,
+        page_location: location.href,
+        send_page_view,
+      },
+    })
+  }, [])
+
+  return { sendPageViewEvent }
+}

--- a/packages/core/src/sdk/analytics/hooks/usePageViewEvent.ts
+++ b/packages/core/src/sdk/analytics/hooks/usePageViewEvent.ts
@@ -1,22 +1,31 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
+import { useRouter } from 'next/router'
 import { sendAnalyticsEvent } from '@faststore/sdk'
 import type { PageViewEvent } from '@faststore/sdk'
 
-export const usePageViewEvent = ({
-  send_page_view = true,
-}: {
-  send_page_view?: boolean
-}) => {
+export const usePageViewEvent = () => {
   const sendPageViewEvent = useCallback(() => {
     sendAnalyticsEvent<PageViewEvent>({
       name: 'page_view',
       params: {
         page_title: document.title,
         page_location: location.href,
-        send_page_view,
+        send_page_view: true,
       },
     })
   }, [])
+
+  const router = useRouter()
+
+  useEffect(() => {
+    sendPageViewEvent()
+
+    router.events.on('routeChangeComplete', sendPageViewEvent)
+
+    return () => {
+      router.events.off('routeChangeComplete', sendPageViewEvent)
+    }
+  }, [router])
 
   return { sendPageViewEvent }
 }

--- a/packages/core/src/sdk/analytics/hooks/usePageViewEvent.ts
+++ b/packages/core/src/sdk/analytics/hooks/usePageViewEvent.ts
@@ -18,8 +18,6 @@ export const usePageViewEvent = () => {
   const router = useRouter()
 
   useEffect(() => {
-    sendPageViewEvent()
-
     router.events.on('routeChangeComplete', sendPageViewEvent)
 
     return () => {

--- a/packages/sdk/src/analytics/events/page_view.ts
+++ b/packages/sdk/src/analytics/events/page_view.ts
@@ -1,7 +1,7 @@
 export interface PageViewParams {
   page_title?: string,
   location?: string,
-  send_page_view?: string,
+  send_page_view?: boolean,
 }
 
 export interface PageViewEvent {

--- a/packages/sdk/src/analytics/events/page_view.ts
+++ b/packages/sdk/src/analytics/events/page_view.ts
@@ -1,6 +1,6 @@
 export interface PageViewParams {
   page_title?: string,
-  location?: string,
+  page_location?: string,
   send_page_view?: boolean,
 }
 

--- a/packages/sdk/src/analytics/events/page_view.ts
+++ b/packages/sdk/src/analytics/events/page_view.ts
@@ -1,0 +1,10 @@
+export interface PageViewParams {
+  page_title?: string,
+  location?: string,
+  send_page_view?: string,
+}
+
+export interface PageViewEvent {
+  name: 'page_view'
+  params: PageViewParams
+}

--- a/packages/sdk/src/analytics/wrap.ts
+++ b/packages/sdk/src/analytics/wrap.ts
@@ -16,6 +16,7 @@ import type { SelectPromotionEvent } from './events/select_promotion'
 import type { ViewPromotionEvent } from './events/view_promotion'
 import type { ViewItemEvent } from './events/view_item'
 import type { ViewItemListEvent } from './events/view_item_list'
+import { PageViewEvent } from './events/page_view'
 
 /**
  * All these events are based on the official GA4 docs. https://developers.google.com/gtagjs/reference/ga4-events
@@ -39,6 +40,7 @@ export type AnalyticsEvent =
   | LoginEvent
   | SignupEvent
   | ShareEvent
+  | PageViewEvent
 
 export interface UnknownEvent {
   name: string

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -58,6 +58,10 @@ export type {
   ViewItemListParams,
 } from "./analytics/events/view_item_list";
 export type {
+  PageViewEvent,
+  PageViewParams,
+} from "./analytics/events/page_view";
+export type {
   CurrencyCode,
   Item,
   ItemId,


### PR DESCRIPTION
## What's the purpose of this pull request?

Trigger some critical events for analytics tools. They are:

| TOPIC | BEHAVIOR | NOTES |
|--------|--------|--------|
| 01.CE - page_view | not fired on first page, second page, third page, etc. | only fired after purchase |
| 03.CE - view_item_list | duplicate |   |
| 05.CE - add_to_cart | did not fire after adding to cart on item page | did fire on cart page |
| 05.CE - add_to_cart_enriched | did not fire after adding to cart on item page | did fire on cart page |
| 07.CE - GA4 - view_item | did not fire after viewing pdp |   |  
