### PR TITLE
fix(cli/dev): ensure `shell: true` is passed when spawning `na`

### DIFF
--- a/packages/cli/src/utils/commands.ts
+++ b/packages/cli/src/utils/commands.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process"
 
 // Retrieves the package manager based on the developer lockfile, using `ni`.
 export function getPreferredPackageManager() {
-  const agent = spawnSync("na", ['\?'], { encoding: 'utf8' }).stdout.trim()
+  const agent = spawnSync("na", ['\?'], { encoding: 'utf8', shell: true }).stdout.trim()
 
   return agent
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

It fixes a critical issue reported on Windows, reported by a Hearst developer while attempting to run `faststore dev` on their Windows machine:
![image](https://github.com/user-attachments/assets/80540ecb-818f-4f46-8bfa-9f3403e01486)

Related thread on Slack: https://vtex.slack.com/archives/C06E1DCFPCZ/p1722283695110209

## How it works?

It adds `shell: true` to the command spawn to ensure that the script must be run under the scope of a `shell`. Discussion can be found here: https://stackoverflow.com/a/54515183 as well as the doc specs: https://nodejs.org/dist/latest-v10.x/docs/api/child_process.html#child_process_child_process_exec_command_options_callback

## How to test it?

- On a Windows machine, run `yarn faststore dev` under your test store, with the CLI version available from this PR
- Repeat the previous step for Mac and Linux

## References

Related issue: https://stackoverflow.com/a/54515183
Doc specs: https://nodejs.org/dist/latest-v10.x/docs/api/child_process.html#child_process_child_process_exec_command_options_callback
