### PR TITLE
fix: validateCart mutation merging orderForm items with assemply options

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -110,11 +110,11 @@ const equals = (storeOrder: IStoreOrder, orderForm: OrderForm) => {
 }
 
 function hasChildItem(items: OrderFormItem[], itemId: string) {
-  return items.some(item => item.parentItemIndex && items[item.parentItemIndex].id === itemId)
+  return items?.some(item => item.parentItemIndex && items[item.parentItemIndex].id === itemId)
 }
 
 function hasParentItem(items: OrderFormItem[], itemId: string) {
-  return items.some(item => item.id === itemId && item.parentItemIndex !== null)
+  return items?.some(item => item.id === itemId && item.parentItemIndex !== null)
 }
 
 const joinItems = (form: OrderForm) => {

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -109,18 +109,18 @@ const equals = (storeOrder: IStoreOrder, orderForm: OrderForm) => {
   return isSameOrder && orderItemsAreSync
 }
 
-function hasChild(items: OrderFormItem[], itemId: string) {
+function hasChildItem(items: OrderFormItem[], itemId: string) {
   return items.some(item => item.parentItemIndex && items[item.parentItemIndex].id === itemId)
 }
 
-function hasParent(items: OrderFormItem[], itemId: string) {
+function hasParentItem(items: OrderFormItem[], itemId: string) {
   return items.some(item => item.id === itemId && item.parentItemIndex !== null)
 }
 
 const joinItems = (form: OrderForm) => {
   const itemsById = form.items.reduce(
     (acc, item, idx) => {
-      const id = hasParent(form.items, item.id) || hasChild(form.items, item.id) ? 
+      const id = hasParentItem(form.items, item.id) || hasChildItem(form.items, item.id) ? 
         `${getId(orderFormItemToOffer(item))}::${idx}` : 
         getId(orderFormItemToOffer(item))
 
@@ -388,10 +388,10 @@ export const validateCart = async (
       // Update existing items
       const [head, ...tail] = maybeOriginItem
 
-      if(hasParent(orderForm.items, head.itemOffered.sku) || hasChild(orderForm.items, head.itemOffered.sku)) {
+      if(hasParentItem(orderForm.items, head.itemOffered.sku) || hasChildItem(orderForm.items, head.itemOffered.sku)) {
         acc.itemsToUpdate.push(head)
 
-        return acc;
+        return acc
       }
 
       const totalQuantity = items.reduce((acc, curr) => acc + curr.quantity, 0)

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -109,10 +109,20 @@ const equals = (storeOrder: IStoreOrder, orderForm: OrderForm) => {
   return isSameOrder && orderItemsAreSync
 }
 
+function hasChild(items: OrderFormItem[], itemId: string) {
+  return items.some(item => item.parentItemIndex && items[item.parentItemIndex].id === itemId)
+}
+
+function hasParent(items: OrderFormItem[], itemId: string) {
+  return items.some(item => item.id === itemId && item.parentItemIndex !== null)
+}
+
 const joinItems = (form: OrderForm) => {
   const itemsById = form.items.reduce(
-    (acc, item) => {
-      const id = getId(orderFormItemToOffer(item))
+    (acc, item, idx) => {
+      const id = hasParent(form.items, item.id) || hasChild(form.items, item.id) ? 
+        `${getId(orderFormItemToOffer(item))}::${idx}` : 
+        getId(orderFormItemToOffer(item))
 
       if (!acc[id]) {
         acc[id] = []
@@ -377,6 +387,13 @@ export const validateCart = async (
 
       // Update existing items
       const [head, ...tail] = maybeOriginItem
+
+      if(hasParent(orderForm.items, head.itemOffered.sku) || hasChild(orderForm.items, head.itemOffered.sku)) {
+        acc.itemsToUpdate.push(head)
+
+        return acc;
+      }
+
       const totalQuantity = items.reduce((acc, curr) => acc + curr.quantity, 0)
 
       // set total quantity to first item


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the validateCart mutation resolver that is overriding the orderForm for items that should be splitted.

## How it works?

When adding different assembly options for the same product, it must be kept separate in the orderForm. To prevent this merge, the parentItemIndex field is checked to see if that item is associated with the assembly of another item.

## How to test it?

In https://devjoelson--jwpepperdev.myvtex.com/1309475/p

Add different combinations to your cart, for example:

![image](https://github.com/user-attachments/assets/b86c9367-f025-4fae-a221-350e94f5ee7a)
![image](https://github.com/user-attachments/assets/48792798-a636-4c01-990a-25522570f267)

As a result, we will have the same product duplicated in the cart:

![image](https://github.com/user-attachments/assets/c8a95ca8-481b-475b-bf94-5994b5b4ddc8)

When we copy and paste the cookie from orderForm to faststore, it should not change the cart as it does in this example:

![image](https://github.com/user-attachments/assets/1bd4c6b9-bd2b-4a49-bb37-6bc7e1df1a62)

and then, when updating the cart in IO, we have the change that shouldn't happen:

![image](https://github.com/user-attachments/assets/54b97ec6-01ac-454e-aef9-d5d989bf2d83)
