### PR TITLE
feat: seo - pdp - spread product in `ProductJsonLd`

### DIFF
--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -115,6 +115,7 @@ function Page({ data: server, sections, globalSections, offers, meta }: Props) {
         itemListElements={product.breadcrumbList.itemListElement}
       />
       <ProductJsonLd
+        {...product}
         productName={product.name}
         description={product.description}
         brand={product.brand.name}


### PR DESCRIPTION
## What's the purpose of this pull request?

Spread all product props in the PDP `ProductJsonLd`.
Some clients requested more attributes (e..g. the ones from API extension) for SEO purposes.

Thread with context: https://vtex.slack.com/archives/C051B6LL91U/p1722867149443899
