### PR TITLE
metatag generated at

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -3,17 +3,17 @@ import chalk from 'chalk'
 import { spawnSync } from 'child_process'
 import { existsSync } from 'fs'
 import { copySync, moveSync, readdirSync, removeSync } from 'fs-extra'
+import { getPreferredPackageManager } from '../utils/commands'
 import { withBasePath } from '../utils/directory'
 import { generate } from '../utils/generate'
-import { getPreferredPackageManager } from '../utils/commands'
 
 export default class Build extends Command {
-
   static args = [
     {
       name: 'path',
-      description: 'The path where the FastStore being built is. Defaults to cwd.',
-    }
+      description:
+        'The path where the FastStore being built is. Defaults to cwd.',
+    },
   ]
 
   async run() {
@@ -26,6 +26,8 @@ export default class Build extends Command {
     await generate({ setup: true, basePath })
 
     const packageManager = getPreferredPackageManager()
+
+    console.log('tmpDir', tmpDir)
 
     const buildResult = spawnSync(`${packageManager} run build`, {
       shell: true,

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -27,8 +27,6 @@ export default class Build extends Command {
 
     const packageManager = getPreferredPackageManager()
 
-    console.log('tmpDir', tmpDir)
-
     const buildResult = spawnSync(`${packageManager} run build`, {
       shell: true,
       cwd: tmpDir,

--- a/packages/cli/src/utils/commands.ts
+++ b/packages/cli/src/utils/commands.ts
@@ -1,8 +1,13 @@
-import { spawnSync } from "node:child_process"
+import { spawnSync } from 'node:child_process'
 
 // Retrieves the package manager based on the developer lockfile, using `ni`.
 export function getPreferredPackageManager() {
-  const agent = spawnSync("na", ['\?'], { encoding: 'utf8', shell: true }).stdout.trim()
+  const agent = spawnSync('na', ['?'], {
+    encoding: 'utf8',
+    shell: true,
+  }).stdout.trim()
+
+  if (agent === '') return 'yarn' // Default to Yarn
 
   return agent
 }

--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -53,7 +53,8 @@ export const withBasePath = (basepath: string) => {
     userThemesFileDir: path.join(userSrcDir, 'themes'),
     userCMSDir: path.join(getRoot(), 'cms', 'faststore'),
     userStoreConfigFile: path.join(getRoot(), 'faststore.config.js'),
-
+    
+    tmpSeoConfig: path.join(tmpDir, 'next-seo.config.ts'),
     tmpFolderName,
     tmpDir,
     tmpCustomizationsSrcDir: path.join(tmpDir, 'src', 'customizations', 'src'),

--- a/packages/core/next-env.d.ts
+++ b/packages/core/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/core/next-seo.config.ts
+++ b/packages/core/next-seo.config.ts
@@ -1,8 +1,10 @@
 import { DefaultSeoProps } from 'next-seo'
+import storeConfig from './faststore.config'
 
 const buildTime = new Date().toISOString()
 
 const config: DefaultSeoProps = {
+  norobots: storeConfig.experimental.noRobots,
   additionalMetaTags: [
     {
       name: 'data-generated-at',

--- a/packages/core/next-seo.config.ts
+++ b/packages/core/next-seo.config.ts
@@ -7,7 +7,7 @@ const config: DefaultSeoProps = {
   norobots: storeConfig.experimental.noRobots,
   additionalMetaTags: [
     {
-      name: 'data-generated-at',
+      name: 'generated-at',
       content: buildTime,
     },
   ],

--- a/packages/core/next-seo.config.ts
+++ b/packages/core/next-seo.config.ts
@@ -1,0 +1,14 @@
+import { DefaultSeoProps } from 'next-seo'
+
+const buildTime = new Date().toISOString()
+
+const config: DefaultSeoProps = {
+  additionalMetaTags: [
+    {
+      name: 'data-generated-at',
+      content: buildTime,
+    },
+  ],
+}
+
+export default config

--- a/packages/core/src/pages/_app.tsx
+++ b/packages/core/src/pages/_app.tsx
@@ -1,17 +1,12 @@
-// FastStore UI's base styles
-import '../styles/global/index.scss'
-
-import '../customizations/src/themes/index.scss'
-
+import { UIProvider } from '@faststore/ui'
 import type { AppProps } from 'next/app'
 import NextNProgress from 'nextjs-progressbar'
-
-import { UIProvider } from '@faststore/ui'
 import Layout from 'src/Layout'
 import AnalyticsHandler from 'src/sdk/analytics'
 import ErrorBoundary from 'src/sdk/error/ErrorBoundary'
-
-import storeConfig from '../../faststore.config'
+import SEO from '../../next-seo.config'
+import '../customizations/src/themes/index.scss'
+import '../styles/global/index.scss'
 
 import { DefaultSeo } from 'next-seo'
 
@@ -24,7 +19,7 @@ function App({ Component, pageProps }: AppProps) {
         options={{ showSpinner: false }}
       />
 
-      <DefaultSeo norobots={storeConfig.experimental.noRobots} />
+      <DefaultSeo {...SEO} />
 
       <AnalyticsHandler />
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -29,8 +29,20 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "strict": false
+    "strict": false,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
   },
-  "include": ["*.d.ts", "src/**/*.ts", "src/**/*.tsx", "@generated/**/*.ts"],
+  "include": [
+    "*.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "@generated/**/*.ts",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules", "public"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -29,20 +29,8 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "strict": false,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "strictNullChecks": true
+    "strict": false
   },
-  "include": [
-    "*.d.ts",
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "@generated/**/*.ts",
-    ".next/types/**/*.ts"
-  ],
+  "include": ["*.d.ts", "src/**/*.ts", "src/**/*.tsx", "@generated/**/*.ts"],
   "exclude": ["node_modules", "public"]
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

create a metatag in build time in order to know when the build was created.

## How it works?

using the faststore cli we generate a date and insert on store html

## How to test it?

finding the `data-generated-at` metatag on source code.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
