### PR TITLE
Fix: Rollback fuzzy params in PLP 

### DIFF
--- a/packages/api/mocks/AllProductsQuery.ts
+++ b/packages/api/mocks/AllProductsQuery.ts
@@ -78,7 +78,7 @@ export const AllProductsQueryFirst5 = `query AllProducts {
 `
 
 export const productSearchPage1Count5Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
   init: undefined,
   options: { storeCookies: expect.any(Function) },
   result: {
@@ -86,8 +86,8 @@ export const productSearchPage1Count5Fetch = {
       {
         cacheId: 'sp-99995946',
         productId: '99995946',
-        description: '4k Philips Monitor 27"',
-        productName: '4k Philips Monitor 27"',
+        description: '4k Philips Monitor 27\"',
+        productName: '4k Philips Monitor 27\"',
         linkText: '4k-philips-monitor',
         brand: 'adidas',
         brandId: 2000004,
@@ -209,7 +209,7 @@ export const productSearchPage1Count5Fetch = {
             ],
             itemId: '99988213',
             name: 'Monitor 27',
-            nameComplete: '4k Philips Monitor 27" Monitor 27',
+            nameComplete: '4k Philips Monitor 27\" Monitor 27',
             complementName: '',
             referenceId: [
               {
@@ -831,36 +831,36 @@ export const productSearchPage1Count5Fetch = {
       current: {
         index: 1,
         proxyUrl:
-          'search/trade-policy/1?page=1&count=5&query=&sort=&operator=and&fuzzy=0',
+          'search/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=auto&operator=and',
       },
       before: [],
       after: [
         {
           index: 2,
           proxyUrl:
-            'search/trade-policy/1?page=2&count=5&query=&sort=&operator=and&fuzzy=0',
+            'search/trade-policy/1?page=2&count=5&query=&sort=&fuzzy=auto&operator=and',
         },
         {
           index: 3,
           proxyUrl:
-            'search/trade-policy/1?page=3&count=5&query=&sort=&operator=and&fuzzy=0',
+            'search/trade-policy/1?page=3&count=5&query=&sort=&fuzzy=auto&operator=and',
         },
         {
           index: 4,
           proxyUrl:
-            'search/trade-policy/1?page=4&count=5&query=&sort=&operator=and&fuzzy=0',
+            'search/trade-policy/1?page=4&count=5&query=&sort=&fuzzy=auto&operator=and',
         },
         {
           index: 5,
           proxyUrl:
-            'search/trade-policy/1?page=5&count=5&query=&sort=&operator=and&fuzzy=0',
+            'search/trade-policy/1?page=5&count=5&query=&sort=&fuzzy=auto&operator=and',
         },
       ],
       perPage: 5,
       next: {
         index: 2,
         proxyUrl:
-          'search/trade-policy/1?page=2&count=5&query=&sort=&operator=and&fuzzy=0',
+          'search/trade-policy/1?page=2&count=5&query=&sort=&fuzzy=auto&operator=and',
       },
       previous: {
         index: 0,
@@ -871,7 +871,7 @@ export const productSearchPage1Count5Fetch = {
       last: {
         index: 50,
         proxyUrl:
-          'search/trade-policy/1?page=50&count=5&query=&sort=&operator=and&fuzzy=0',
+          'search/trade-policy/1?page=50&count=5&query=&sort=&fuzzy=auto&operator=and',
       },
     },
   },

--- a/packages/api/mocks/ProductQuery.ts
+++ b/packages/api/mocks/ProductQuery.ts
@@ -63,7 +63,7 @@ export const ProductByIdQuery = `query ProductQuery {
 `
 
 export const productSearchFetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A64953394&sort=&locale=en-US&hideUnavailableItems=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A64953394&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
   init: undefined,
   options: { storeCookies: expect.any(Function) },
   result: {
@@ -229,7 +229,7 @@ export const productSearchFetch = {
     correction: {
       misspelled: true,
     },
-    fuzzy: '0',
+    fuzzy: 'auto',
     operator: 'and',
     translated: false,
     pagination: {
@@ -237,7 +237,7 @@ export const productSearchFetch = {
       current: {
         index: 1,
         proxyUrl:
-          'search/trade-policy/1?page=1&count=1&query=sku:64953394&sort=&locale=en-US&hide-unavailable-items=false&operator=and&fuzzy=0',
+          'search/trade-policy/1?page=1&count=1&query=sku:64953394&sort=&fuzzy=auto&operator=and',
       },
       before: [],
       after: [],

--- a/packages/api/mocks/RedirectQuery.ts
+++ b/packages/api/mocks/RedirectQuery.ts
@@ -6,36 +6,36 @@ export const RedirectQueryTermTech = `query RedirectSearch {
   `
 
 export const redirectTermTechFetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=2&count=1&query=tech&sort=&locale=en-US&hideUnavailableItems=false',
-  init: undefined,
-  options: { storeCookies: expect.any(Function) },
-  result: {
-    products: [],
-    recordsFiltered: 0,
-    fuzzy: 'auto',
-    operator: 'and',
-    redirect: '/technology',
-    translated: false,
-    pagination: {
-      count: 1,
-      current: {
-        index: 0,
-      },
-      before: [],
-      after: [],
-      perPage: 0,
-      next: {
-        index: 0,
-      },
-      previous: {
-        index: 0,
-      },
-      first: {
-        index: 0,
-      },
-      last: {
-        index: 0,
-      },
+    info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=2&count=1&query=tech&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
+    init: undefined,
+    options: { storeCookies: expect.any(Function) },
+    result: {
+        products: [],
+        recordsFiltered: 0,
+        fuzzy: 'auto',
+        operator: 'and',
+        redirect: '/technology',
+        translated: false,
+        pagination: {
+            count: 1,
+            current: {
+                index: 0,
+            },
+            before: [],
+            after: [],
+            perPage: 0,
+            next: {
+                index: 0,
+            },
+            previous: {
+                index: 0,
+            },
+            first: {
+                index: 0,
+            },
+            last: {
+                index: 0,
+            },
+        },
     },
-  },
 }

--- a/packages/api/mocks/SearchQuery.ts
+++ b/packages/api/mocks/SearchQuery.ts
@@ -101,7 +101,7 @@ export const SearchQueryFirst5Products = `query SearchQuery {
 }`
 
 export const productSearchCategory1Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
   init: undefined,
   options: { storeCookies: expect.any(Function) },
   result: {
@@ -1348,36 +1348,36 @@ export const productSearchCategory1Fetch = {
       current: {
         index: 1,
         proxyUrl:
-          'search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&operator=and&fuzzy=0',
+          'search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=auto&operator=and',
       },
       before: [],
       after: [
         {
           index: 2,
           proxyUrl:
-            'search/category-1/office/trade-policy/1?page=2&count=5&query=&sort=&operator=and&fuzzy=0',
+            'search/category-1/office/trade-policy/1?page=2&count=5&query=&sort=&fuzzy=auto&operator=and',
         },
         {
           index: 3,
           proxyUrl:
-            'search/category-1/office/trade-policy/1?page=3&count=5&query=&sort=&operator=and&fuzzy=0',
+            'search/category-1/office/trade-policy/1?page=3&count=5&query=&sort=&fuzzy=auto&operator=and',
         },
         {
           index: 4,
           proxyUrl:
-            'search/category-1/office/trade-policy/1?page=4&count=5&query=&sort=&operator=and&fuzzy=0',
+            'search/category-1/office/trade-policy/1?page=4&count=5&query=&sort=&fuzzy=auto&operator=and',
         },
         {
           index: 5,
           proxyUrl:
-            'search/category-1/office/trade-policy/1?page=5&count=5&query=&sort=&operator=and&fuzzy=0',
+            'search/category-1/office/trade-policy/1?page=5&count=5&query=&sort=&fuzzy=auto&operator=and',
         },
       ],
       perPage: 5,
       next: {
         index: 2,
         proxyUrl:
-          'search/category-1/office/trade-policy/1?page=2&count=5&query=&sort=&operator=and&fuzzy=0',
+          'search/category-1/office/trade-policy/1?page=2&count=5&query=&sort=&fuzzy=auto&operator=and',
       },
       previous: {
         index: 0,
@@ -1388,14 +1388,14 @@ export const productSearchCategory1Fetch = {
       last: {
         index: 50,
         proxyUrl:
-          'search/category-1/office/trade-policy/1?page=50&count=5&query=&sort=&operator=and&fuzzy=0',
+          'search/category-1/office/trade-policy/1?page=50&count=5&query=&sort=&fuzzy=auto&operator=and',
       },
     },
   },
 }
 
 export const attributeSearchCategory1Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/facets/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/facets/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
   init: undefined,
   options: { storeCookies: expect.any(Function) },
   result: {

--- a/packages/api/mocks/ValidateCartMutation.ts
+++ b/packages/api/mocks/ValidateCartMutation.ts
@@ -347,7 +347,7 @@ export const checkoutOrderFormCustomDataInvalidFetch = {
 }
 
 export const productSearchPage1Count1Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A2737806&sort=&locale=en-US&hideUnavailableItems=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A2737806&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
   init: undefined,
   options: { storeCookies: expect.any(Function) },
   result: {
@@ -523,7 +523,7 @@ export const productSearchPage1Count1Fetch = {
       current: {
         index: 1,
         proxyUrl:
-          'search/trade-policy/1?page=1&count=1&query=sku:2737806&sort=&locale=en-US&hide-unavailable-items=false&operator=and&fuzzy=0',
+          'search/trade-policy/1?page=1&count=1&query=sku:2737806&sort=&fuzzy=auto&operator=and',
       },
       before: [],
       after: [],

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -509,8 +509,6 @@ export type QueryShippingArgs = {
 /** Search result. */
 export type SearchMetadata = {
   __typename?: 'SearchMetadata';
-  /** Indicates how the search engine corrected the misspelled word by using fuzzy logic. */
-  fuzzy: Scalars['String'];
   /** Indicates if the search term was misspelled. */
   isTermMisspelled: Scalars['Boolean'];
   /** Logical operator used to run the search. */

--- a/packages/api/src/platforms/vtex/resolvers/searchResult.ts
+++ b/packages/api/src/platforms/vtex/resolvers/searchResult.ts
@@ -14,8 +14,8 @@ const isRootFacet = (facet: Facet, isDepartment: boolean, isBrand: boolean) =>
   isDepartment
     ? facet.key === 'category-1'
     : isBrand
-      ? facet.key === 'brand'
-      : false
+    ? facet.key === 'brand'
+    : false
 
 export const StoreSearchResult: Record<string, Resolver<Root>> = {
   suggestions: async (root, _, ctx) => {
@@ -117,12 +117,16 @@ export const StoreSearchResult: Record<string, Resolver<Root>> = {
 
     return filteredFacets
   },
-  metadata: async ({ productSearchPromise }) => {
+  metadata: async ({ searchArgs, productSearchPromise }) => {
+    if (!searchArgs.query) {
+      return null
+    }
+
     const productSearchResult = await productSearchPromise
+
     return {
       isTermMisspelled: productSearchResult.correction?.misspelled ?? false,
       logicalOperator: productSearchResult.operator,
-      fuzzy: productSearchResult.fuzzy,
     }
   },
 }

--- a/packages/api/src/platforms/vtex/utils/facets.ts
+++ b/packages/api/src/platforms/vtex/utils/facets.ts
@@ -6,28 +6,18 @@ export interface SelectedFacet {
   value: string
 }
 
-export type FuzzyFacet = {
-  key: 'fuzzy'
-  value: '0' | '1' | 'auto'
-}
-
-export type OperatorFacet = {
-  key: 'operator'
-  value: 'and' | 'or'
-}
-
 export interface CrossSellingFacet {
   key: keyof typeof FACET_CROSS_SELLING_MAP
   value: string
 }
 
 export const FACET_CROSS_SELLING_MAP = {
-  buy: 'whoboughtalsobought',
-  view: 'whosawalsosaw',
-  similars: 'similars',
-  viewAndBought: 'whosawalsobought',
-  accessories: 'accessories',
-  suggestions: 'suggestions',
+  buy: "whoboughtalsobought",
+  view: "whosawalsosaw",
+  similars: "similars",
+  viewAndBought: "whosawalsobought",
+  accessories: "accessories",
+  suggestions: "suggestions",
 } as const
 
 /**

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -160,10 +160,6 @@ type SearchMetadata {
   Logical operator used to run the search.
   """
   logicalOperator: String!
-  """
-  Indicates how the search engine corrected the misspelled word by using fuzzy logic.
-  """
-  fuzzy: String!
 }
 
 """

--- a/packages/core/@generated/gql.ts
+++ b/packages/core/@generated/gql.ts
@@ -44,10 +44,8 @@ const documents = {
     types.SubscribeToNewsletterDocument,
   '\n  query ClientManyProductsQuery(\n    $first: Int!\n    $after: String\n    $sort: StoreSort!\n    $term: String!\n    $selectedFacets: [IStoreSelectedFacet!]!\n  ) {\n    ...ClientManyProducts\n    search(\n      first: $first\n      after: $after\n      sort: $sort\n      term: $term\n      selectedFacets: $selectedFacets\n    ) {\n      products {\n        pageInfo {\n          totalCount\n        }\n        edges {\n          node {\n            ...ProductSummary_product\n          }\n        }\n      }\n    }\n  }\n':
     types.ClientManyProductsQueryDocument,
-  '\n  query ClientProductGalleryQuery(\n    $first: Int!\n    $after: String!\n    $sort: StoreSort!\n    $term: String!\n    $selectedFacets: [IStoreSelectedFacet!]!\n  ) {\n    ...ClientProductGallery\n    redirect(term: $term, selectedFacets: $selectedFacets) {\n      url\n    }\n    search(\n      first: $first\n      after: $after\n      sort: $sort\n      term: $term\n      selectedFacets: $selectedFacets\n    ) {\n      products {\n        pageInfo {\n          totalCount\n        }\n      }\n      facets {\n        ...Filter_facets\n      }\n      metadata {\n        ...SearchEvent_metadata\n      }\n    }\n  }\n':
+  '\n  query ClientProductGalleryQuery(\n    $first: Int!\n    $after: String!\n    $sort: StoreSort!\n    $term: String!\n    $selectedFacets: [IStoreSelectedFacet!]!\n  ) {\n    ...ClientProductGallery\n    redirect(term: $term, selectedFacets: $selectedFacets) {\n      url\n    }\n    search(\n      first: $first\n      after: $after\n      sort: $sort\n      term: $term\n      selectedFacets: $selectedFacets\n    ) {\n      products {\n        pageInfo {\n          totalCount\n        }\n      }\n      facets {\n        ...Filter_facets\n      }\n      metadata {\n        ...SearchEvent_metadata\n      }\n    }\n  }\n\n  fragment SearchEvent_metadata on SearchMetadata {\n    isTermMisspelled\n    logicalOperator\n  }\n':
     types.ClientProductGalleryQueryDocument,
-  '\n  fragment SearchEvent_metadata on SearchMetadata {\n    isTermMisspelled\n    logicalOperator\n    fuzzy\n  }\n':
-    types.SearchEvent_MetadataFragmentDoc,
   '\n  query ClientProductQuery($locator: [IStoreSelectedFacet!]!) {\n    ...ClientProduct\n    product(locator: $locator) {\n      ...ProductDetailsFragment_product\n    }\n  }\n':
     types.ClientProductQueryDocument,
   '\n  query ClientSearchSuggestionsQuery(\n    $term: String!\n    $selectedFacets: [IStoreSelectedFacet!]\n  ) {\n    ...ClientSearchSuggestions\n    search(first: 5, term: $term, selectedFacets: $selectedFacets) {\n      suggestions {\n        terms {\n          value\n        }\n        products {\n          ...ProductSummary_product\n        }\n      }\n      products {\n        pageInfo {\n          totalCount\n        }\n      }\n      metadata {\n        ...SearchEvent_metadata\n      }\n    }\n  }\n':
@@ -160,14 +158,8 @@ export function gql(
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function gql(
-  source: '\n  query ClientProductGalleryQuery(\n    $first: Int!\n    $after: String!\n    $sort: StoreSort!\n    $term: String!\n    $selectedFacets: [IStoreSelectedFacet!]!\n  ) {\n    ...ClientProductGallery\n    redirect(term: $term, selectedFacets: $selectedFacets) {\n      url\n    }\n    search(\n      first: $first\n      after: $after\n      sort: $sort\n      term: $term\n      selectedFacets: $selectedFacets\n    ) {\n      products {\n        pageInfo {\n          totalCount\n        }\n      }\n      facets {\n        ...Filter_facets\n      }\n      metadata {\n        ...SearchEvent_metadata\n      }\n    }\n  }\n'
+  source: '\n  query ClientProductGalleryQuery(\n    $first: Int!\n    $after: String!\n    $sort: StoreSort!\n    $term: String!\n    $selectedFacets: [IStoreSelectedFacet!]!\n  ) {\n    ...ClientProductGallery\n    redirect(term: $term, selectedFacets: $selectedFacets) {\n      url\n    }\n    search(\n      first: $first\n      after: $after\n      sort: $sort\n      term: $term\n      selectedFacets: $selectedFacets\n    ) {\n      products {\n        pageInfo {\n          totalCount\n        }\n      }\n      facets {\n        ...Filter_facets\n      }\n      metadata {\n        ...SearchEvent_metadata\n      }\n    }\n  }\n\n  fragment SearchEvent_metadata on SearchMetadata {\n    isTermMisspelled\n    logicalOperator\n  }\n'
 ): typeof import('./graphql').ClientProductGalleryQueryDocument
-/**
- * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function gql(
-  source: '\n  fragment SearchEvent_metadata on SearchMetadata {\n    isTermMisspelled\n    logicalOperator\n    fuzzy\n  }\n'
-): typeof import('./graphql').SearchEvent_MetadataFragmentDoc
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -1473,18 +1473,13 @@ export type ClientProductGalleryQueryQuery = {
           max: { selected: number; absolute: number }
         }
     >
-    metadata: {
-      isTermMisspelled: boolean
-      logicalOperator: string
-      fuzzy: string
-    } | null
+    metadata: { isTermMisspelled: boolean; logicalOperator: string } | null
   }
 }
 
 export type SearchEvent_MetadataFragment = {
   isTermMisspelled: boolean
   logicalOperator: string
-  fuzzy: string
 }
 
 export type ClientProductQueryQueryVariables = Exact<{
@@ -1570,11 +1565,7 @@ export type ClientSearchSuggestionsQueryQuery = {
       }>
     }
     products: { pageInfo: { totalCount: number } }
-    metadata: {
-      isTermMisspelled: boolean
-      logicalOperator: string
-      fuzzy: string
-    } | null
+    metadata: { isTermMisspelled: boolean; logicalOperator: string } | null
   }
 }
 
@@ -2019,7 +2010,6 @@ export const SearchEvent_MetadataFragmentDoc = new TypedDocumentString(
     fragment SearchEvent_metadata on SearchMetadata {
   isTermMisspelled
   logicalOperator
-  fuzzy
 }
     `,
   { fragmentName: 'SearchEvent_metadata' }
@@ -2072,7 +2062,7 @@ export const ClientManyProductsQueryDocument = {
 export const ClientProductGalleryQueryDocument = {
   __meta__: {
     operationName: 'ClientProductGalleryQuery',
-    operationHash: 'bfc40da32b60f9404a4adb96b0856e3fbb04b076',
+    operationHash: '177fe68cb385737b0901fc9e105f0a4813e18a20',
   },
 } as unknown as TypedDocumentString<
   ClientProductGalleryQueryQuery,
@@ -2090,7 +2080,7 @@ export const ClientProductQueryDocument = {
 export const ClientSearchSuggestionsQueryDocument = {
   __meta__: {
     operationName: 'ClientSearchSuggestionsQuery',
-    operationHash: '47af7b9c9e0fb18b01050767daf3e765f67819ac',
+    operationHash: '71809c86cb940861f01bcc57dbaf57e6f41cb378',
   },
 } as unknown as TypedDocumentString<
   ClientSearchSuggestionsQueryQuery,

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -503,8 +503,6 @@ export type QueryShippingArgs = {
 
 /** Search result. */
 export type SearchMetadata = {
-  /** Indicates how the search engine corrected the misspelled word by using fuzzy logic. */
-  fuzzy: Scalars['String']['output']
   /** Indicates if the search term was misspelled. */
   isTermMisspelled: Scalars['Boolean']['output']
   /** Logical operator used to run the search. */

--- a/packages/core/src/sdk/search/state.ts
+++ b/packages/core/src/sdk/search/state.ts
@@ -5,12 +5,7 @@ export const useApplySearchState = () => {
   const router = useRouter()
 
   return useCallback(
-    (url: URL) => {
-      const newUrl = `${url.pathname}${url.search}`
-      return url.searchParams.has('fuzzy') && url.searchParams.has('operator')
-        ? router.replace(newUrl)
-        : router.push(newUrl)
-    },
+    (url: URL) => router.push(`${url.pathname}${url.search}`),
     [router]
   )
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR reverts the following PRs:
- https://github.com/vtex/faststore/pull/2307
- https://github.com/vtex/faststore/pull/2204

Also, it resolves the conflicts from the current main branch.

## How it works?

We are removing the reload issue caused by the use of fuzzy logic and operators in handling IS requests. 

The team will try another approach to address the usage of fuzzy logic and operators in IS requests allowing the search engine decide the best parameters for the search.

## How to test it?

You can run the project locally and double-check if the PLP/Search page just loads once.
Also, you can use the preview URL from starter PR:
PLP: https://sfj-728d5af--starter.preview.vtex.app/office
Search: https://sfj-728d5af--starter.preview.vtex.app/s?q=shirt&sort=score_desc&page=0

### Starters Deploy Preview

- https://github.com/vtex-sites/starter.store/pull/517

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
