### PR TITLE
Add integration between VTEX Ad Network and Faststore

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -13,6 +13,7 @@ import type {
 } from './types/FacetSearchResult'
 import type {
   ProductSearchResult,
+  SponsoredSearchResult,
   Suggestion,
 } from './types/ProductSearchResult'
 import { getStoreCookie } from '../../utils/cookies'
@@ -31,11 +32,12 @@ export interface SearchArgs {
   query?: string
   page: number
   count: number
-  type: 'product_search' | 'facets'
+  type: 'product_search' | 'facets' | 'sponsored_products'
   sort?: Sort
   selectedFacets?: SelectedFacet[]
   fuzzy?: '0' | '1' | 'auto'
   hideUnavailableItems?: boolean
+  showSponsored?: boolean
 }
 
 export interface ProductLocator {
@@ -76,7 +78,7 @@ const isOperatorFacet = (facet: SelectedFacet): facet is OperatorFacet => {
 }
 
 export const IntelligentSearch = (
-  { account, environment, hideUnavailableItems }: Options,
+  { account, environment, hideUnavailableItems, showSponsored }: Options,
   ctx: Context
 ) => {
   const base = `https://${account}.${environment}.com.br/api/io`
@@ -170,6 +172,10 @@ export const IntelligentSearch = (
       params.append('hideUnavailableItems', hideUnavailableItems.toString())
     }
 
+    if (showSponsored !== undefined) {
+      params.append('showSponsored', showSponsored.toString())
+    }
+
     const pathname = addDefaultFacets(selectedFacets)
       .map(({ key, value }) => `${key}/${value}`)
       .join('/')
@@ -185,6 +191,9 @@ export const IntelligentSearch = (
 
   const products = (args: Omit<SearchArgs, 'type'>) =>
     search<ProductSearchResult>({ ...args, type: 'product_search' })
+
+  const sponsoredProducts = (args: Omit<SearchArgs, 'type'>) =>
+    search<SponsoredSearchResult>({ ...args, type: 'sponsored_products' })
 
   const suggestedTerms = (
     args: Omit<SearchArgs, 'type'>
@@ -219,6 +228,7 @@ export const IntelligentSearch = (
   return {
     facets,
     products,
+    sponsoredProducts,
     suggestedTerms,
     topSearches,
   }

--- a/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
+++ b/packages/api/src/platforms/vtex/clients/search/types/ProductSearchResult.ts
@@ -16,6 +16,10 @@ export interface ProductSearchResult {
   redirect?: string
 }
 
+export interface SponsoredSearchResult {
+  products: Product[]
+}
+
 interface Correction {
   misspelled: boolean
 }
@@ -92,6 +96,7 @@ export interface Product {
   properties: Array<{ name: string; values: string[] }>
   selectedProperties: Array<{ key: string; value: string }>
   releaseDate: string
+  advertisement?: Advertisement
 }
 
 interface Image {
@@ -214,6 +219,14 @@ interface SpecificationGroup {
     originalName: string
     values: string[]
   }>
+}
+
+interface Advertisement {
+  adId: string
+  campaingId: string
+  actionCost: number
+  adRequestId: string
+  adResponseId: string
 }
 
 export interface Attribute {

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -36,6 +36,7 @@ export interface Options {
   channel: string
   locale: string
   hideUnavailableItems: boolean
+  showSponsored: boolean
   incrementAddress: boolean
   flags?: FeatureFlags
 }

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -291,6 +291,7 @@ export const Query = {
       return null
     }
 
+    // TODO pass showSponsored here
     const { redirect } = await ctx.clients.search.products({
       page: 1,
       count: 1,


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds support to show sponsored products when using Intelligent Search. FastShop and probably more retailers are interested in our solution for Ads (VTEX Ad Network). This PR intends to create a frictionless integration between FastStore and VTEX Ad Network.

## How it works?


## How to test it?


### Starters Deploy Preview


## References

There are two main APIs that we are using:

* [VTEX Ad Network](https://developers.vtex.com/docs/api-reference/vtex-ad-network-api#get-/sponsored_products/-facets-)
* [Intelligent Search API] (https://developers.vtex.com/docs/api-reference/intelligent-search-api#get-/product_search/-facets-)
