### PR TITLE
Fix: duplicated ClientManyProductsQuery

### DIFF
--- a/packages/core/src/sdk/auth/index.ts
+++ b/packages/core/src/sdk/auth/index.ts
@@ -1,7 +1,11 @@
 import { useSession } from '../session'
 
 export const useAuth = () => {
-  const { person, isValidating, channel: channelJson } = useSession(false)
+  const {
+    person,
+    isValidating,
+    channel: channelJson,
+  } = useSession({ filter: false })
 
   const channel = JSON.parse(channelJson) as {
     salesChannel: number

--- a/packages/core/src/sdk/auth/index.ts
+++ b/packages/core/src/sdk/auth/index.ts
@@ -1,7 +1,7 @@
 import { useSession } from '../session'
 
 export const useAuth = () => {
-  const { person, isValidating, channel: channelJson } = useSession()
+  const { person, isValidating, channel: channelJson } = useSession(false)
 
   const channel = JSON.parse(channelJson) as {
     salesChannel: number

--- a/packages/core/src/sdk/product/useLocalizedVariables.ts
+++ b/packages/core/src/sdk/product/useLocalizedVariables.ts
@@ -13,12 +13,7 @@ export const useLocalizedVariables = ({
   term,
   selectedFacets,
 }: Partial<ClientManyProductsQueryQueryVariables>) => {
-  const { channel: sessionChannel, locale } = useSession()
-  // It's not needed to send hasOnlyDefaultSalesChannel on the query,
-  // so we remove it from the channel object to avoid unnecessary cache invalidations and query executions
-  const { hasOnlyDefaultSalesChannel, ...filteredChannel } =
-    JSON.parse(sessionChannel)
-  const channel = JSON.stringify(filteredChannel)
+  const { channel, locale } = useSession()
 
   return useMemo(() => {
     const facets = toArray(selectedFacets)

--- a/packages/core/src/sdk/product/useLocalizedVariables.ts
+++ b/packages/core/src/sdk/product/useLocalizedVariables.ts
@@ -1,7 +1,7 @@
-import { useMemo } from 'react'
 import { ClientManyProductsQueryQueryVariables } from '@generated/graphql'
-import { useSession } from '../session'
+import { useMemo } from 'react'
 import { ITEMS_PER_SECTION } from 'src/constants'
+import { useSession } from '../session'
 
 const toArray = <T>(x: T[] | T | undefined) =>
   Array.isArray(x) ? x : x ? [x] : []
@@ -13,7 +13,12 @@ export const useLocalizedVariables = ({
   term,
   selectedFacets,
 }: Partial<ClientManyProductsQueryQueryVariables>) => {
-  const { channel, locale } = useSession()
+  const { channel: sessionChannel, locale } = useSession()
+  // It's not needed to send hasOnlyDefaultSalesChannel on the query,
+  // so we remove it from the channel object to avoid unnecessary cache invalidations and query executions
+  const { hasOnlyDefaultSalesChannel, ...filteredChannel } =
+    JSON.parse(sessionChannel)
+  const channel = JSON.stringify(filteredChannel)
 
   return useMemo(() => {
     const facets = toArray(selectedFacets)

--- a/packages/core/src/sdk/session/index.ts
+++ b/packages/core/src/sdk/session/index.ts
@@ -69,16 +69,22 @@ export const sessionStore = {
   },
 }
 
+interface SessionOptions {
+  filter?: boolean
+}
+
 /**
  * This custom hook is used to retrieve the session data and filter the channel object.
  * The channel object filtering removes the hasOnlyDefaultSalesChannel key.
  * This key is used only in the useAuth hook and is only required to send on the ValidateSession mutation,
  * so we remove it from the session's channel object to avoid unnecessary cache invalidations and query executions.
  *
- * @param filter - A boolean value indicating whether to filter the channel object or not. Default is true.
+ * @param options - Optional configuration for the hook.
+ * @param options.filter - A boolean value indicating whether to filter the channel object or not. Default is true.
  * @returns An object containing the session data, channel object, and a flag indicating whether the session is being validated.
  */
-export const useSession = (filter: boolean = true) => {
+
+export const useSession = ({ filter }: SessionOptions = { filter: true }) => {
   let { channel, ...session } = useStore(sessionStore)
   const isValidating = useStore(validationStore)
 

--- a/packages/core/src/sdk/session/index.ts
+++ b/packages/core/src/sdk/session/index.ts
@@ -69,15 +69,31 @@ export const sessionStore = {
   },
 }
 
-export const useSession = () => {
-  const session = useStore(sessionStore)
+/**
+ * This custom hook is used to retrieve the session data and filter the channel object.
+ * The channel object filtering removes the hasOnlyDefaultSalesChannel key.
+ * This key is used only in the useAuth hook and is only required to send on the ValidateSession mutation,
+ * so we remove it from the session's channel object to avoid unnecessary cache invalidations and query executions.
+ *
+ * @param filter - A boolean value indicating whether to filter the channel object or not. Default is true.
+ * @returns An object containing the session data, channel object, and a flag indicating whether the session is being validated.
+ */
+export const useSession = (filter: boolean = true) => {
+  let { channel, ...session } = useStore(sessionStore)
   const isValidating = useStore(validationStore)
+
+  if (filter) {
+    const { hasOnlyDefaultSalesChannel, ...filteredChannel } =
+      JSON.parse(channel)
+    channel = JSON.stringify(filteredChannel)
+  }
 
   return useMemo(
     () => ({
       ...session,
+      channel,
       isValidating,
     }),
-    [isValidating, session]
+    [isValidating, session, channel]
   )
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

The `ClientManyProductsQuery` was being fetched twice with almost the same parameters, the only difference was the `hasOnlyDefaultSalesChannel` introduced on this [PR](https://github.com/vtex/faststore/pull/2282) and used only by the `useAuth` hook. 
It doesn't need to be sent on the `ClientManyProductsQuery`, only on the `ValidateSession` mutation.
These other queries were also being affected: `ClientSearchSuggestionsQuery`, `ClientProductGalleryQuery` and `ClientProductQuery`.

## How it works?

It filters the `hasOnlyDefaultSalesChannel` key out of the `channel` object in the `useSession` before sending it on the query.

## How to test it?

Running `yarn dev` and checking on the PDP that the `ClientManyProductsQuery` is not duplicated and is not sending the `hasOnlyDefaultSalesChannel` on `channel`.
| Before | After |
| -|-|
| <img width="1167" alt="Screenshot 2024-09-02 at 14 00 24" src="https://github.com/user-attachments/assets/f697db8f-8bda-434e-bc8d-6685ef2d462b"> | <img width="1169" alt="Screenshot 2024-09-02 at 13 58 30" src="https://github.com/user-attachments/assets/78f32e0d-18b8-413b-8299-6bd467205b6e"> |
| <img width="1173" alt="Screenshot 2024-09-02 at 14 00 54" src="https://github.com/user-attachments/assets/f8f673bb-c930-4627-b3e0-f25bb7c1ea39"> | |


### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

- [Slack thread](https://vtex.slack.com/archives/C051B6LL91U/p1725284216284089)
