### PR TITLE
Fix: Add 'show-invisible-items' parameter to IntelligentSearch API

### DIFF
--- a/packages/api/mocks/ValidateCartMutation.ts
+++ b/packages/api/mocks/ValidateCartMutation.ts
@@ -347,7 +347,7 @@ export const checkoutOrderFormCustomDataInvalidFetch = {
 }
 
 export const productSearchPage1Count1Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A2737806&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A2737806&sort=&fuzzy=auto&locale=en-US&show-invisible-items=true&hideUnavailableItems=false',
   init: undefined,
   options: { storeCookies: expect.any(Function) },
   result: {

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -32,6 +32,7 @@ export interface SearchArgs {
   selectedFacets?: SelectedFacet[]
   fuzzy?: '0' | '1' | 'auto'
   hideUnavailableItems?: boolean
+  showInvisibleItems?: boolean
 }
 
 export interface ProductLocator {
@@ -112,6 +113,7 @@ export const IntelligentSearch = (
     selectedFacets = [],
     type,
     fuzzy = 'auto',
+    showInvisibleItems,
   }: SearchArgs): Promise<T> => {
     const params = new URLSearchParams({
       page: (page + 1).toString(),
@@ -121,6 +123,10 @@ export const IntelligentSearch = (
       fuzzy,
       locale: ctx.storage.locale,
     })
+
+    if (showInvisibleItems) {
+      params.append('show-invisible-items', 'true')
+    }
 
     if (hideUnavailableItems !== undefined) {
       params.append('hideUnavailableItems', hideUnavailableItems.toString())

--- a/packages/api/src/platforms/vtex/loaders/sku.ts
+++ b/packages/api/src/platforms/vtex/loaders/sku.ts
@@ -7,11 +7,15 @@ import type { Options } from '..'
 import type { Clients } from '../clients'
 
 export const getSkuLoader = (_: Options, clients: Clients) => {
-  const loader = async (skuIds: readonly string[]) => {
+  const loader = async (keys: readonly string[]) => {
+    const skuIds = keys.map((key) => key.split('-')[0]);
+    const showInvisibleItems = keys.some((key) => key.split('-')[1] === 'invisibleItems')
+
     const { products } = await clients.search.products({
       query: `sku:${skuIds.join(';')}`,
       page: 0,
       count: skuIds.length,
+      showInvisibleItems
     })
 
     const skuBySkuId = products.reduce((acc, product) => {

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -156,7 +156,7 @@ const orderFormToCart = async (
       orderNumber: form.orderFormId,
       acceptedOffer: form.items.map(async (item) => ({
         ...item,
-        product: await skuLoader.load(item.id),
+        product: await skuLoader.load(`${item.id}-invisibleItems`),
       })),
     },
     messages: form.messages.map(({ text, status }) => ({
@@ -316,7 +316,7 @@ export const validateCart = async (
   const orderNumber = order?.orderNumber
     ? order.orderNumber
     : getCookieCheckoutOrderNumber(ctx.headers.cookie, 'checkout.vtex.com')
-  
+
   const { acceptedOffer, shouldSplitItem } = order
   const {
     clients: { commerce },


### PR DESCRIPTION
In this PR we add the `show-invisible-items` param to IS api in order to enhance the invisible SKU