### PR TITLE
feat: Consider `regionId` from PDP query

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -32,6 +32,7 @@ export interface SearchArgs {
   fuzzy?: '0' | '1' | 'auto'
   hideUnavailableItems?: boolean
   showInvisibleItems?: boolean
+  regionId?: string
 }
 
 export interface ProductLocator {
@@ -66,27 +67,28 @@ export const IntelligentSearch = (
     }
   }
 
-  const getRegionFacet = (): IStoreSelectedFacet | null => {
+  const getRegionFacet = (regionIdFromQuery?: string): IStoreSelectedFacet | null => {
     const { regionId } = ctx.storage.channel
+    const facet = regionIdFromQuery ?? regionId
 
-    if (!regionId) {
+    if (!facet) {
       return null
     }
 
     return {
       key: REGION_KEY,
-      value: regionId,
+      value: facet,
     }
   }
 
-  const addDefaultFacets = (facets: SelectedFacet[]) => {
+  const addDefaultFacets = (facets: SelectedFacet[], regionIdFromQuery?: string) => {
     const withDefaltFacets = facets.filter(({ key }) => !CHANNEL_KEYS.has(key))
 
     const policyFacet =
       facets.find(({ key }) => key === POLICY_KEY) ?? getPolicyFacet()
 
     const regionFacet =
-      facets.find(({ key }) => key === REGION_KEY) ?? getRegionFacet()
+      facets.find(({ key }) => key === REGION_KEY) ?? getRegionFacet(regionIdFromQuery)
 
     if (policyFacet !== null) {
       withDefaltFacets.push(policyFacet)
@@ -108,6 +110,7 @@ export const IntelligentSearch = (
     type,
     fuzzy = 'auto',
     showInvisibleItems,
+    regionId,
   }: SearchArgs): Promise<T> => {
     const params = new URLSearchParams({
       page: (page + 1).toString(),
@@ -126,7 +129,7 @@ export const IntelligentSearch = (
       params.append('hideUnavailableItems', hideUnavailableItems.toString())
     }
 
-    const pathname = addDefaultFacets(selectedFacets)
+    const pathname = addDefaultFacets(selectedFacets, regionId)
       .map(({ key, value }) => `${key}/${value}`)
       .join('/')
 

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -9,6 +9,7 @@ import {
   findSkuId,
   findSlug,
   transformSelectedFacet,
+  findRegionId,
 } from "../utils/facets"
 import { SORT_MAP } from "../utils/sort"
 import { StoreCollection } from "./collection"
@@ -31,6 +32,7 @@ export const Query = {
     // Insert channel in context for later usage
     const channel = findChannel(locator)
     const locale = findLocale(locator)
+    const regionId = findRegionId(locator)
     const id = findSkuId(locator)
     const slug = findSlug(locator)
 
@@ -90,6 +92,7 @@ export const Query = {
         page: 0,
         count: 1,
         query: `product:${route.id}`,
+        regionId,
       })
 
       if (!product) {

--- a/packages/api/src/platforms/vtex/utils/facets.ts
+++ b/packages/api/src/platforms/vtex/utils/facets.ts
@@ -104,3 +104,6 @@ export const findLocale = (facets?: Maybe<SelectedFacet[]>) =>
 
 export const findChannel = (facets?: Maybe<SelectedFacet[]>) =>
   facets?.find((facet) => facet.key === 'channel')?.value ?? null
+
+export const findRegionId = (facets?: Maybe<SelectedFacet[]>) =>
+  facets?.find((facet) => facet.key === 'regionId')?.value ?? undefined


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add support to receive the `regionId` from the PDP query.

## How it works?

The `product` resolver will consider the `regionId` sent through the PDP query and will send it as facet to the IS request.

## How to test it?

- Install the last `@faststore/api` version generated by CodeSandbox;
- Send the `regionId` key/value inside the `ServerProductQuery`'s `locator` variable.

### Starters Deploy Preview