### PR TITLE
Feat: Make simulationBehavior search param configurable

### DIFF
--- a/packages/api/mocks/AllProductsQuery.ts
+++ b/packages/api/mocks/AllProductsQuery.ts
@@ -78,7 +78,7 @@ export const AllProductsQueryFirst5 = `query AllProducts {
 `
 
 export const productSearchPage1Count5Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip',
   init: undefined,
   options: { storeCookies: expect.any(Function) },
   result: {

--- a/packages/api/mocks/ProductQuery.ts
+++ b/packages/api/mocks/ProductQuery.ts
@@ -63,7 +63,7 @@ export const ProductByIdQuery = `query ProductQuery {
 `
 
 export const productSearchFetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A64953394&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A64953394&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip',
   init: undefined,
   options: { storeCookies: expect.any(Function) },
   result: {

--- a/packages/api/mocks/RedirectQuery.ts
+++ b/packages/api/mocks/RedirectQuery.ts
@@ -6,36 +6,36 @@ export const RedirectQueryTermTech = `query RedirectSearch {
   `
 
 export const redirectTermTechFetch = {
-    info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=2&count=1&query=tech&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
-    init: undefined,
-    options: { storeCookies: expect.any(Function) },
-    result: {
-        products: [],
-        recordsFiltered: 0,
-        fuzzy: 'auto',
-        operator: 'and',
-        redirect: '/technology',
-        translated: false,
-        pagination: {
-            count: 1,
-            current: {
-                index: 0,
-            },
-            before: [],
-            after: [],
-            perPage: 0,
-            next: {
-                index: 0,
-            },
-            previous: {
-                index: 0,
-            },
-            first: {
-                index: 0,
-            },
-            last: {
-                index: 0,
-            },
-        },
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=2&count=1&query=tech&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip',
+  init: undefined,
+  options: { storeCookies: expect.any(Function) },
+  result: {
+    products: [],
+    recordsFiltered: 0,
+    fuzzy: 'auto',
+    operator: 'and',
+    redirect: '/technology',
+    translated: false,
+    pagination: {
+      count: 1,
+      current: {
+        index: 0,
+      },
+      before: [],
+      after: [],
+      perPage: 0,
+      next: {
+        index: 0,
+      },
+      previous: {
+        index: 0,
+      },
+      first: {
+        index: 0,
+      },
+      last: {
+        index: 0,
+      },
     },
+  },
 }

--- a/packages/api/mocks/SearchQuery.ts
+++ b/packages/api/mocks/SearchQuery.ts
@@ -101,7 +101,7 @@ export const SearchQueryFirst5Products = `query SearchQuery {
 }`
 
 export const productSearchCategory1Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip',
   init: undefined,
   options: { storeCookies: expect.any(Function) },
   result: {
@@ -1395,7 +1395,7 @@ export const productSearchCategory1Fetch = {
 }
 
 export const attributeSearchCategory1Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/facets/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/facets/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip',
   init: undefined,
   options: { storeCookies: expect.any(Function) },
   result: {

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -4,11 +4,13 @@ import { getStoreCookie } from '../../utils/cookies'
 import type { SelectedFacet } from '../../utils/facets'
 import { fetchAPI } from '../fetch'
 import type {
-  Facet, FacetSearchResult, FacetValueBoolean
+  Facet,
+  FacetSearchResult,
+  FacetValueBoolean,
 } from './types/FacetSearchResult'
 import type {
   ProductSearchResult,
-  Suggestion
+  Suggestion,
 } from './types/ProductSearchResult'
 
 export type Sort =
@@ -47,11 +49,7 @@ export const isFacetBoolean = (
 ): facet is Facet<FacetValueBoolean> => facet.type === 'TEXT'
 
 export const IntelligentSearch = (
-  {
-    account,
-    environment,
-    searchOptions: { hideUnavailableItems, simulationBehavior },
-  }: Options,
+  { account, environment, hideUnavailableItems, simulationBehavior }: Options,
   ctx: Context
 ) => {
   const base = `https://${account}.${environment}.com.br/api/io`

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -1,17 +1,15 @@
-import { fetchAPI } from '../fetch'
-import type { IStoreSelectedFacet } from '../../../../__generated__/schema'
 import type { Context, Options } from '../../'
+import type { IStoreSelectedFacet } from '../../../../__generated__/schema'
+import { getStoreCookie } from '../../utils/cookies'
 import type { SelectedFacet } from '../../utils/facets'
+import { fetchAPI } from '../fetch'
 import type {
-  Facet,
-  FacetValueBoolean,
-  FacetSearchResult,
+  Facet, FacetSearchResult, FacetValueBoolean
 } from './types/FacetSearchResult'
 import type {
   ProductSearchResult,
-  Suggestion,
+  Suggestion
 } from './types/ProductSearchResult'
-import { getStoreCookie } from '../../utils/cookies'
 
 export type Sort =
   | 'price:desc'
@@ -49,7 +47,11 @@ export const isFacetBoolean = (
 ): facet is Facet<FacetValueBoolean> => facet.type === 'TEXT'
 
 export const IntelligentSearch = (
-  { account, environment, hideUnavailableItems }: Options,
+  {
+    account,
+    environment,
+    searchOptions: { hideUnavailableItems, simulationBehavior },
+  }: Options,
   ctx: Context
 ) => {
   const base = `https://${account}.${environment}.com.br/api/io`
@@ -130,6 +132,10 @@ export const IntelligentSearch = (
 
     if (hideUnavailableItems !== undefined) {
       params.append('hideUnavailableItems', hideUnavailableItems.toString())
+    }
+
+    if (simulationBehavior !== undefined) {
+      params.append('simulationBehavior', simulationBehavior.toString())
     }
 
     const pathname = addDefaultFacets(selectedFacets)

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -35,10 +35,8 @@ export interface Options {
   subDomainPrefix: string[]
   channel: string
   locale: string
-  searchOptions: {
-    hideUnavailableItems: boolean
-    simulationBehavior?: 'default' | 'skip' | 'only1P'
-  }
+  hideUnavailableItems: boolean
+  simulationBehavior?: 'default' | 'skip' | 'only1P'
   incrementAddress: boolean
   flags?: FeatureFlags
 }

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -1,4 +1,7 @@
+import type { Clients } from './clients'
 import { getClients } from './clients'
+import type { SearchArgs } from './clients/search'
+import type { Loaders } from './loaders'
 import { getLoaders } from './loaders'
 import { StoreAggregateOffer } from './resolvers/aggregateOffer'
 import { StoreAggregateRating } from './resolvers/aggregateRating'
@@ -6,7 +9,7 @@ import { StoreCollection } from './resolvers/collection'
 import {
   StoreFacet,
   StoreFacetBoolean,
-  StoreFacetRange,
+  StoreFacetRange
 } from './resolvers/facet'
 import { StoreFacetValueBoolean } from './resolvers/faceValue'
 import { Mutation } from './resolvers/mutation'
@@ -21,11 +24,8 @@ import { StoreSearchResult } from './resolvers/searchResult'
 import { StoreSeo } from './resolvers/seo'
 import { ShippingSLA } from './resolvers/shippingSLA'
 import { SkuVariants } from './resolvers/skuVariations'
-import ChannelMarshal from './utils/channel'
-import type { Loaders } from './loaders'
-import type { Clients } from './clients'
 import type { Channel } from './utils/channel'
-import type { SearchArgs } from './clients/search'
+import ChannelMarshal from './utils/channel'
 
 export interface Options {
   platform: 'vtex'
@@ -35,7 +35,10 @@ export interface Options {
   subDomainPrefix: string[]
   channel: string
   locale: string
-  hideUnavailableItems: boolean
+  searchOptions: {
+    hideUnavailableItems: boolean
+    simulationBehavior?: 'default' | 'skip' | 'only1P'
+  }
   incrementAddress: boolean
   flags?: FeatureFlags
 }

--- a/packages/api/test/mutations.test.ts
+++ b/packages/api/test/mutations.test.ts
@@ -13,7 +13,7 @@ import {
   InvalidCart,
   productSearchPage1Count1Fetch,
   ValidateCartMutation,
-  ValidCart
+  ValidCart,
 } from '../mocks/ValidateCartMutation'
 import type { Options } from '../src'
 import { getContextFactory, getSchema } from '../src'
@@ -25,9 +25,7 @@ const apiOptions = {
   channel: '{"salesChannel":"1"}',
   locale: 'en-US',
   subDomainPrefix: ['www'],
-  searchOptions: {
-    hideUnavailableItems: false,
-  },
+  hideUnavailableItems: false,
   incrementAddress: false,
   flags: {
     enableOrderFormSync: true,

--- a/packages/api/test/mutations.test.ts
+++ b/packages/api/test/mutations.test.ts
@@ -1,5 +1,6 @@
 import { execute, parse } from 'graphql'
 
+import { salesChannelStaleFetch } from '../mocks/salesChannel'
 import {
   checkoutOrderFormCustomDataInvalidFetch,
   checkoutOrderFormCustomDataStaleFetch,
@@ -12,11 +13,10 @@ import {
   InvalidCart,
   productSearchPage1Count1Fetch,
   ValidateCartMutation,
-  ValidCart,
+  ValidCart
 } from '../mocks/ValidateCartMutation'
-import { getContextFactory, getSchema } from '../src'
-import { salesChannelStaleFetch } from '../mocks/salesChannel'
 import type { Options } from '../src'
+import { getContextFactory, getSchema } from '../src'
 
 const apiOptions = {
   platform: 'vtex',
@@ -25,7 +25,9 @@ const apiOptions = {
   channel: '{"salesChannel":"1"}',
   locale: 'en-US',
   subDomainPrefix: ['www'],
-  hideUnavailableItems: false,
+  searchOptions: {
+    hideUnavailableItems: false,
+  },
   incrementAddress: false,
   flags: {
     enableOrderFormSync: true,
@@ -106,7 +108,7 @@ test('`validateCart` mutation should return `null` when a valid cart is passed',
     expect(mockedFetch).toHaveBeenCalledWith(
       fetchAPICall.info,
       fetchAPICall.init,
-      fetchAPICall.options,
+      fetchAPICall.options
     )
   })
 

--- a/packages/api/test/queries.test.ts
+++ b/packages/api/test/queries.test.ts
@@ -1,18 +1,5 @@
 import { execute, parse } from 'graphql'
 
-import type { Options } from '../src'
-import { getSchema, getContextFactory } from '../src'
-import {
-  AllProductsQueryFirst5,
-  productSearchPage1Count5Fetch,
-} from '../mocks/AllProductsQuery'
-import {
-  CollectionDesksQuery,
-  pageTypeDesksFetch,
-  pageTypeOfficeDesksFetch,
-  pageTypeOfficeFetch,
-} from '../mocks/CollectionQuery'
-import { ProductByIdQuery, productSearchFetch } from '../mocks/ProductQuery'
 import {
   AllCollectionsQueryFirst5,
   catalogBrandListFetch,
@@ -21,24 +8,37 @@ import {
   catalogPageTypeAdidas,
   catalogPageTypeBrand,
   catalogPageTypeIRobot,
-  catalogPageTypeSkechers,
+  catalogPageTypeSkechers
 } from '../mocks/AllCollectionsQuery'
 import {
-  SearchQueryFirst5Products,
-  productSearchCategory1Fetch,
-  attributeSearchCategory1Fetch,
-} from '../mocks/SearchQuery'
-import { salesChannelStaleFetch } from '../mocks/salesChannel'
+  AllProductsQueryFirst5,
+  productSearchPage1Count5Fetch
+} from '../mocks/AllProductsQuery'
 import {
-  shippingSimulationFetch,
-  addressFetch,
-  ShippingSimulationQueryResult,
-} from '../mocks/ShippingQuery'
+  CollectionDesksQuery,
+  pageTypeDesksFetch,
+  pageTypeOfficeDesksFetch,
+  pageTypeOfficeFetch
+} from '../mocks/CollectionQuery'
+import { ProductByIdQuery, productSearchFetch } from '../mocks/ProductQuery'
 import {
   RedirectQueryTermTech,
-  redirectTermTechFetch,
+  redirectTermTechFetch
 } from '../mocks/RedirectQuery'
-import { SellersQueryResult, regionFetch } from '../mocks/SellersQuery'
+import { salesChannelStaleFetch } from '../mocks/salesChannel'
+import {
+  attributeSearchCategory1Fetch,
+  productSearchCategory1Fetch,
+  SearchQueryFirst5Products
+} from '../mocks/SearchQuery'
+import { regionFetch, SellersQueryResult } from '../mocks/SellersQuery'
+import {
+  addressFetch,
+  shippingSimulationFetch,
+  ShippingSimulationQueryResult
+} from '../mocks/ShippingQuery'
+import type { Options } from '../src'
+import { getContextFactory, getSchema } from '../src'
 
 const apiOptions = {
   platform: 'vtex',
@@ -47,7 +47,10 @@ const apiOptions = {
   channel: '{"salesChannel":"1"}',
   locale: 'en-US',
   subDomainPrefix: ['www'],
-  hideUnavailableItems: false,
+  searchOptions: {
+    hideUnavailableItems: false,
+    simulationBehavior: 'skip',
+  },
   incrementAddress: false,
   flags: {
     enableOrderFormSync: true,
@@ -128,7 +131,7 @@ test('`collection` query', async () => {
     expect(mockedFetch).toHaveBeenCalledWith(
       fetchAPICall.info,
       fetchAPICall.init,
-      fetchAPICall.options,
+      fetchAPICall.options
     )
   })
 
@@ -150,7 +153,7 @@ test('`product` query', async () => {
     expect(mockedFetch).toHaveBeenCalledWith(
       fetchAPICall.info,
       fetchAPICall.init,
-      fetchAPICall.options,
+      fetchAPICall.options
     )
   })
 
@@ -180,7 +183,7 @@ test('`allCollections` query', async () => {
     expect(mockedFetch).toHaveBeenCalledWith(
       fetchAPICall.info,
       fetchAPICall.init,
-      fetchAPICall.options,
+      fetchAPICall.options
     )
   })
 
@@ -202,7 +205,7 @@ test('`allProducts` query', async () => {
     expect(mockedFetch).toHaveBeenCalledWith(
       fetchAPICall.info,
       fetchAPICall.init,
-      fetchAPICall.options,
+      fetchAPICall.options
     )
   })
 
@@ -228,7 +231,7 @@ test('`search` query', async () => {
     expect(mockedFetch).toHaveBeenCalledWith(
       fetchAPICall.info,
       fetchAPICall.init,
-      fetchAPICall.options,
+      fetchAPICall.options
     )
   })
 
@@ -293,7 +296,7 @@ test('`sellers` query', async () => {
     expect(mockedFetch).toHaveBeenCalledWith(
       fetchAPICall.info,
       fetchAPICall.init,
-      fetchAPICall.options,
+      fetchAPICall.options
     )
   })
   expect(response).toMatchSnapshot()

--- a/packages/api/test/queries.test.ts
+++ b/packages/api/test/queries.test.ts
@@ -47,10 +47,8 @@ const apiOptions = {
   channel: '{"salesChannel":"1"}',
   locale: 'en-US',
   subDomainPrefix: ['www'],
-  searchOptions: {
-    hideUnavailableItems: false,
-    simulationBehavior: 'skip',
-  },
+  hideUnavailableItems: false,
+  simulationBehavior: 'skip',
   incrementAddress: false,
   flags: {
     enableOrderFormSync: true,

--- a/packages/api/test/schema.test.ts
+++ b/packages/api/test/schema.test.ts
@@ -81,7 +81,9 @@ beforeAll(async () => {
     channel: '{"salesChannel":"1"}',
     locale: 'en-US',
     subDomainPrefix: ['www'],
-    hideUnavailableItems: false,
+    searchOptions: {
+      hideUnavailableItems: false,
+    },
     incrementAddress: false,
     flags: {
       enableOrderFormSync: true,

--- a/packages/api/test/schema.test.ts
+++ b/packages/api/test/schema.test.ts
@@ -81,9 +81,7 @@ beforeAll(async () => {
     channel: '{"salesChannel":"1"}',
     locale: 'en-US',
     subDomainPrefix: ['www'],
-    searchOptions: {
-      hideUnavailableItems: false,
-    },
+    hideUnavailableItems: false,
     incrementAddress: false,
     flags: {
       enableOrderFormSync: true,

--- a/packages/core/src/server/options.ts
+++ b/packages/core/src/server/options.ts
@@ -7,11 +7,9 @@ export const apiOptions: APIOptions = {
   account: storeConfig.api.storeId,
   environment: storeConfig.api.environment as APIOptions['environment'],
   subDomainPrefix: storeConfig.api.subDomainPrefix ?? ['www'],
-  searchOptions: {
-    hideUnavailableItems: storeConfig.api.hideUnavailableItems,
-    simulationBehavior: (storeConfig.api as Record<string, any>)
-      .simulationBehavior,
-  },
+  hideUnavailableItems: storeConfig.api.hideUnavailableItems,
+  simulationBehavior: (storeConfig.api as Record<string, any>)
+    .simulationBehavior,
   incrementAddress: storeConfig.api.incrementAddress,
   channel: storeConfig.session.channel,
   locale: storeConfig.session.locale,

--- a/packages/core/src/server/options.ts
+++ b/packages/core/src/server/options.ts
@@ -7,7 +7,11 @@ export const apiOptions: APIOptions = {
   account: storeConfig.api.storeId,
   environment: storeConfig.api.environment as APIOptions['environment'],
   subDomainPrefix: storeConfig.api.subDomainPrefix ?? ['www'],
-  hideUnavailableItems: storeConfig.api.hideUnavailableItems,
+  searchOptions: {
+    hideUnavailableItems: storeConfig.api.hideUnavailableItems,
+    simulationBehavior: (storeConfig.api as Record<string, any>)
+      .simulationBehavior,
+  },
   incrementAddress: storeConfig.api.incrementAddress,
   channel: storeConfig.session.channel,
   locale: storeConfig.session.locale,


### PR DESCRIPTION
## What's the purpose of this pull request?

Make the `simulationBehavior` param from IS configurable through the faststore.config file.

## How it works?

When the `simulationBehavior` is present on the config file it'll be used on the IS fetch, example: 
`https://{{account}}.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=12&query=&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip`

Otherwise, if it's not present, it'll continue working as it already was:
`https://{{account}}.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=12&query=&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false`

## How to test it?

Run `yarn dev` and ensure it's working as expected. Then, add the `simulationBehavior` param to the `faststore.config.default.js` file inside the `api` object. Use one of the following values: `default`, `skip` or `only1P`. Also, ensure it's working as expected.

### Starters Deploy Preview

I've set the `simulationBehavior` to `skip` on [this](https://github.com/vtex-sites/starter.store/pull/524/files) preview: https://sfj-2fb19ff--starter.preview.vtex.app/

And in this [one](https://github.com/vtex-sites/starter.store/pull/525/files) there isn't a `simulationBehavior` being set on faststore.config: https://sfj-e8d957e--starter.preview.vtex.app/

One visible difference is that the Magic Mouse product when the `simulationBehavior` is `skip`, IS returns an `AvailableQuantity` of `10000` while when the `simulationBehavior` isn't configured it returns `0`. I've confirmed using the IS API directly:
- `https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/productClusterIds/140/trade-policy/1?page=1&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false&count=10&query=` and 
- `https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/productClusterIds/140/trade-policy/1?page=1&sort=&fuzzy=auto&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&count=10&query=`

Here are the screenshots showing the previews and the IS return:

| SimulationBehavior = skip | SimulationBehavior not on config |
| ---- | ---- |
|<img width="1438" alt="Screenshot 2024-09-05 at 17 08 34" src="https://github.com/user-attachments/assets/836c8b24-9aa1-40c5-ab29-7bffd58978c2"> | <img width="1436" alt="Screenshot 2024-09-05 at 17 09 29" src="https://github.com/user-attachments/assets/4a6dc47a-7b55-46cf-bef7-7999b9000ebd">|
| <img width="493" alt="Screenshot 2024-09-05 at 17 35 12" src="https://github.com/user-attachments/assets/b91cfc45-e6df-4f5c-8797-2e8762f6525b">|<img width="496" alt="Screenshot 2024-09-05 at 17 35 20" src="https://github.com/user-attachments/assets/de405e6e-477a-4902-8c10-8d6de6da2088"> |

## References

- [Slack thread](https://vtex.slack.com/archives/C03L3CRCDC4/p1725470335934909)
