### PR TITLE
fix: adds optional icon to icon prop

### DIFF
--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -22,7 +22,7 @@ interface RegionModalProps {
     text?: string
     to?: string
     icon?: {
-      icon: string
+      icon?: string
       alt: string
     }
   }
@@ -73,7 +73,7 @@ function RegionModal({
     children: (
       <>
         {idkPostalCodeLinkText}
-        {!!idkPostalCodeLinkIcon ?? (
+        {!!idkPostalCodeLinkIcon && (
           <Icon
             name={idkPostalCodeLinkIcon}
             aria-label={idkPostalCodeLinkIconAlt}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR attempts to fix type errors related to this component in some customer's stores.

```
./src/components/region/RegionModal/RegionModal.tsx:76:10
Type error: Right operand of ?? is unreachable because the left operand is never nullish.
```

## How it works?

<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `gatsby.store` AND `nextjs.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
