### PR TITLE
chore: rename init command to create

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,6 +25,7 @@ npm install -g @faststore/cli
 ```
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @faststore/cli
 $ faststore COMMAND
@@ -36,19 +37,21 @@ USAGE
   $ faststore COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 ## Commands
 
 <!-- commands -->
-* [`faststore build [PATH]`](#faststore-build-path)
-* [`faststore cms-sync [PATH]`](#faststore-cms-sync-path)
-* [`faststore dev [PATH]`](#faststore-dev-path)
-* [`faststore generate-graphql [PATH]`](#faststore-generate-graphql-path)
-* [`faststore help [COMMAND]`](#faststore-help-command)
-* [`faststore init [PATH]`](#faststore-init-path)
-* [`faststore start [PATH]`](#faststore-start-path)
-* [`faststore test [PATH]`](#faststore-test-path)
+
+- [`faststore build [PATH]`](#faststore-build-path)
+- [`faststore cms-sync [PATH]`](#faststore-cms-sync-path)
+- [`faststore dev [PATH]`](#faststore-dev-path)
+- [`faststore generate-graphql [PATH]`](#faststore-generate-graphql-path)
+- [`faststore help [COMMAND]`](#faststore-help-command)
+- [`faststore create [PATH]`](#faststore-create-path)
+- [`faststore start [PATH]`](#faststore-start-path)
+- [`faststore test [PATH]`](#faststore-test-path)
 
 ## `faststore build [PATH]`
 
@@ -124,13 +127,13 @@ DESCRIPTION
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.1.22/src/commands/help.ts)_
 
-## `faststore init [PATH]`
+## `faststore create [PATH]`
 
 Creates a discovery folder based on the starter.store template.
 
 ```
 USAGE
-  $ faststore init [PATH]
+  $ faststore create [PATH]
 
 ARGUMENTS
   PATH  The path where the Discovery folder will be created. Defaults to ./discovery.
@@ -139,10 +142,10 @@ DESCRIPTION
   Creates a discovery folder based on the starter.store template.
 
 EXAMPLES
-  $ yarn faststore init discovery
+  $ yarn faststore create discovery
 ```
 
-_See code: [dist/commands/init.ts](https://github.com/vtex/faststore/blob/v3.0.103/dist/commands/init.ts)_
+_See code: [dist/commands/create.ts](https://github.com/vtex/faststore/blob/v3.0.103/dist/commands/create.ts)_
 
 ## `faststore start [PATH]`
 
@@ -167,4 +170,5 @@ ARGUMENTS
 ```
 
 _See code: [dist/commands/test.ts](https://github.com/vtex/faststore/blob/v3.0.103/dist/commands/test.ts)_
+
 <!-- commandsstop -->

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -15,7 +15,7 @@ export default class Create extends Command {
   static description =
     'Creates a discovery folder based on the starter.store template.'
 
-  static examples = ['$ yarn faststore init discovery']
+  static examples = ['$ yarn faststore create discovery']
 
   async run() {
     const { args } = await this.parse(Create)

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -3,7 +3,7 @@ import degit from 'degit'
 import { Command } from '@oclif/core'
 import { confirm } from '@inquirer/prompts'
 
-export default class Init extends Command {
+export default class Create extends Command {
   static args = [
     {
       name: 'path',
@@ -18,7 +18,7 @@ export default class Init extends Command {
   static examples = ['$ yarn faststore init discovery']
 
   async run() {
-    const { args } = await this.parse(Init)
+    const { args } = await this.parse(Create)
 
     const discoveryPath = args.path ?? './discovery'
     const discoveryFolderExists = fs.existsSync(discoveryPath)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 export { run } from '@oclif/core'
 
-import { default as Init } from './commands/init'
+import { default as Create } from './commands/create'
 import { default as Dev } from './commands/dev'
 import { default as Build } from './commands/build'
 import { default as Serve } from './commands/start'
@@ -8,7 +8,7 @@ import { default as CmsSync } from './commands/cms-sync'
 import { default as Test } from './commands/test'
 
 export const commands = {
-  init: Init,
+  create: Create,
   dev: Dev,
   build: Build,
   serve: Serve,


### PR DESCRIPTION
## What's the purpose of this pull request?

Just to rename the `init` command to `create` to adhere to the new specification
