### PR TITLE
feat: Consider `regionId` from PDP query

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -9,6 +9,7 @@ import {
   findSkuId,
   findSlug,
   transformSelectedFacet,
+  findRegionId,
 } from '../utils/facets'
 import { SORT_MAP } from '../utils/sort'
 import { StoreCollection } from './collection'
@@ -32,6 +33,7 @@ export const Query = {
     // Insert channel in context for later usage
     const channel = findChannel(locator)
     const locale = findLocale(locator)
+    const regionId = findRegionId(locator)
     const id = findSkuId(locator)
     const slug = findSlug(locator)
 
@@ -92,6 +94,7 @@ export const Query = {
         page: 0,
         count: 1,
         query: `product:${route.id}`,
+        regionId,
       })
 
       if (!product) {

--- a/packages/api/src/platforms/vtex/utils/facets.ts
+++ b/packages/api/src/platforms/vtex/utils/facets.ts
@@ -88,3 +88,9 @@ export const findLocale = (facets?: Maybe<SelectedFacet[]>) =>
 
 export const findChannel = (facets?: Maybe<SelectedFacet[]>) =>
   facets?.find((facet) => facet.key === 'channel')?.value ?? null
+
+export const findRegionId = (facets?: Maybe<SelectedFacet[]>) => {
+  const regionId = facets?.find((facet) => facet.key === 'regionId')?.value
+
+  return regionId && regionId !== '' ? regionId : undefined
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add support to receive the `regionId` from the PDP query.

Related PRs:

- [ ] 

## How it works?

The `product` resolver will consider the `regionId` sent through the PDP query and will send it as facet to the IS request.

## How to test it?

- Install the last `@faststore/api` version generated by CodeSandbox;
- Send the `regionId` key/value inside the `ServerProductQuery`'s `locator` variable.

### Starters Deploy Preview