### PR TITLE
feat: Send `regionId` on PDP query

### DIFF
--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -1,12 +1,15 @@
+import { Suspense, useRef, useState } from 'react'
+
 import {
   Icon,
   RegionModal as UIRegionModal,
   RegionModalProps as UIRegionModalProps,
   useUI,
 } from '@faststore/ui'
-import { Suspense, useRef, useState } from 'react'
+import type { Session } from '@faststore/sdk'
 
 import { sessionStore, useSession, validateSession } from 'src/sdk/session'
+import { setCookie } from 'src/utils/cookies'
 
 import styles from './section.module.scss'
 
@@ -45,6 +48,13 @@ function RegionModal({
   const [input, setInput] = useState<string>('')
   const { modal: displayModal } = useUI()
 
+  async function setRegionIdCookie(session: Session) {
+    const THIRTY_DAYS_S = 30 * 24 * 3600
+    const channel = JSON.parse(session.channel ?? 'null')
+
+    setCookie('fs_regionid', channel?.regionId as string, THIRTY_DAYS_S)
+  }
+
   const handleSubmit = async () => {
     const postalCode = inputRef.current?.value
 
@@ -61,6 +71,9 @@ function RegionModal({
       }
 
       const validatedSession = await validateSession(newSession)
+
+      // Set cookie for the regionId
+      await setRegionIdCookie(validatedSession ?? newSession)
 
       sessionStore.set(validatedSession ?? newSession)
     } catch (error) {

--- a/packages/core/src/utils/cookies.ts
+++ b/packages/core/src/utils/cookies.ts
@@ -1,0 +1,18 @@
+export function getCookie(name: string): string | undefined {
+  const cookieString = decodeURIComponent(document.cookie)
+  const cookies = cookieString.split(';')
+
+  for (const cookie of cookies) {
+    const [cookieName, cookieValue] = cookie.trim().split('=')
+
+    if (cookieName === name) {
+      return cookieValue
+    }
+  }
+
+  return undefined // Cookie not found
+}
+
+export function setCookie(key: string, value: string, seconds: number) {
+  document.cookie = `${key}=${value}; max-age=${seconds}; path=/`
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR is related to an ongoing RFC that intends to change the PDP's data fetching method from SSG ([getStaticProps](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-props)) to SSR ([getServerSideProps](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props)).

This change is necessary to enable fetch dynamic data (such as the region data from request) before rendering the page. All of the caveats will be discussed in the RFC, but implementation details or suggestions can be discussed here.

### Starters Deploy Preview