### PR TITLE
Feat: adds new `deviceSizes` and adjust `Hero` Image

### DIFF
--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -11,7 +11,7 @@ const nextConfig = {
   swcMinify: true,
   images: {
     domains: [`${storeConfig.api.storeId}.vtexassets.com`],
-    deviceSizes: [360, 540, 768, 1280, 1440],
+    deviceSizes: [360, 412, 540, 768, 1280, 1440],
     imageSizes: [34, 68, 154, 320],
   },
   i18n: {

--- a/packages/core/src/components/sections/Hero/Hero.tsx
+++ b/packages/core/src/components/sections/Hero/Hero.tsx
@@ -59,7 +59,7 @@ const Hero = ({
             alt={image.alt}
             width={360}
             height={240}
-            sizes="(max-width: 360px) 50vw, (max-width: 768px) 90vw, 50vw"
+            sizes="(max-width: 360px) 40vw, (max-width: 768px) 90vw, 50vw"
           />
         </HeroImage.Component>
         <HeroHeader.Component

--- a/packages/core/src/components/sections/Hero/Hero.tsx
+++ b/packages/core/src/components/sections/Hero/Hero.tsx
@@ -59,7 +59,7 @@ const Hero = ({
             alt={image.alt}
             width={360}
             height={240}
-            sizes="(max-width: 360px) 40vw, (max-width: 768px) 90vw, 50vw"
+            sizes="(max-width: 412px) 40vw, (max-width: 768px) 90vw, 50vw"
           />
         </HeroImage.Component>
         <HeroHeader.Component


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR is part of the Performance epic and aims to add a new `deviceSizes` with a size of `412`. This is the size used for `Moto G Super`, the mobile device used in the PageSpees Insight (PSI).

It also changes the `Hero` Image size to fit a better config related to the LCP metric.
