### PR TITLE
Feat: adds preconnect and dns-prefetch

### DIFF
--- a/packages/core/src/pages/_document.tsx
+++ b/packages/core/src/pages/_document.tsx
@@ -1,4 +1,5 @@
 import { Head, Html, Main, NextScript } from 'next/document'
+import storeConfig from '../../faststore.config'
 
 import ThirdPartyScripts from 'src/components/ThirdPartyScripts'
 import { WebFonts } from 'src/customizations/src/GlobalOverrides'
@@ -7,6 +8,14 @@ function Document() {
   return (
     <Html>
       <Head>
+        <link
+          rel="preconnect"
+          href={`https://${storeConfig.api.storeId}.vtexassets.com`}
+        />
+        <link
+          rel="dns-prefetch"
+          href={`https://${storeConfig.api.storeId}.vtexassets.com`}
+        />
         {!process.env.DISABLE_3P_SCRIPTS && <ThirdPartyScripts />}
         <WebFonts />
       </Head>


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR is part of the Performance epic and aims to add `preconnect` and `dns-prefetch` to the `vtexassets` so that it can establish network connections early to improve perceived page speed

### Starters Deploy Preview

- https://github.com/vtex-sites/starter.store/pull/551

### PSI Snapshot

<img width="898" alt="Screenshot 2024-09-26 at 17 04 47" src="https://github.com/user-attachments/assets/338eb860-8b7e-4aa6-9d53-0edd3a9f5ac5">


## References

https://web.dev/articles/preconnect-and-dns-prefetch?hl=pt-br