### PR TITLE
Chore: Removes `BannerNewsletter` section from home

### DIFF
--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -4,7 +4,6 @@ import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
 import type { ComponentType } from 'react'
 
 import RenderSections from 'src/components/cms/RenderSections'
-import BannerNewsletter from 'src/components/sections/BannerNewsletter/BannerNewsletter'
 import { OverriddenDefaultBannerText as BannerText } from 'src/components/sections/BannerText/OverriddenDefaultBannerText'
 import { OverriddenDefaultHero as Hero } from 'src/components/sections/Hero/OverriddenDefaultHero'
 import Incentives from 'src/components/sections/Incentives'
@@ -30,7 +29,6 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
   ProductShelf,
   ProductTiles,
   BannerText,
-  BannerNewsletter,
   Newsletter,
   ...CUSTOM_COMPONENTS,
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

We had already removed this section from CMS, but it remained in the code.

## How it works?

By default we already have the `Newsletter` section in homepage, and  `BannerNewsletter` section should be in the PDP.

|Before| After|
|-|-|
|<img width="500" alt="before_homepage" src="https://github.com/user-attachments/assets/92ec8754-9629-4bd1-8144-fa6fb4d39959">|<img width="500" alt="no_bannernewsletter_homepage" src="https://github.com/user-attachments/assets/ce8e2fc2-50fb-48a9-9600-5bd7384afc2d">

Removed from CMS:
![cms](https://github.com/user-attachments/assets/a7d83b42-2f68-4b77-9b73-bee53131ae79)


No other unused section was detected. BannerNewsletter still being used in PDP as expected.

## How to test it?

Run `yarn dev` in the core, in the homepage you shouldn't be able to see the `BannerNewsletter` section



### Starters Deploy Preview
https://github.com/vtex-sites/starter.store/pull/557

## References

https://vtex-dev.atlassian.net/browse/SFS-1453