### PR TITLE
fix(api): slugify breaking category with pipe in its name

### DIFF
--- a/packages/api/src/platforms/vtex/utils/slugify.ts
+++ b/packages/api/src/platforms/vtex/utils/slugify.ts
@@ -40,7 +40,7 @@ const slugifySpecialCharacters = (str: string) => {
 
 export function slugify(str: string) {
   const noCommas = str.replace(/,/g, '')
-  const replaced = noCommas.replace(/[*+~.()'"!:@&\[\]`/ %$#?{}|><=_^]/g, '-')
+  const replaced = noCommas.replace(/[*+~.()'"!:@&\[\]`/ %$#?{}><=_^]/g, '-')
   const slugified = slugifySpecialCharacters(removeDiacritics(replaced))
 
   return slugified.toLowerCase()


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the breadcrumb list when there is a category with pipe `|` in its name. 

## How it works?

Removes the `|` from the `slugify` function. 
Example: the category `vitrola | receiver` would be slugified to `vitrola---receiver` instead of `vitrola-|-receiver` and it would go to a not found page.

## How to test it?

I've changed the category `Chairs` to use a pipe (`Furniture | Chairs`). So if you run the code and access this PDP page `/gorgeous-cotton-shirt-19863970/p`, you should be able to click on the breadcrumb link to this category and go to its page without getting a 404. 

![Screenshot 2024-10-03 at 10 34 10](https://github.com/user-attachments/assets/d7d49944-7681-4643-a54c-47314770f02a)
![Screenshot 2024-10-03 at 10 34 22](https://github.com/user-attachments/assets/e473f72e-8e8c-46df-9da0-fe90c2e84e8a)

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/561
## References

- [Slack thread](https://vtex.slack.com/archives/C051B6LL91U/p1726495723479679)