### PR TITLE
chore: adjust CLI to meet FSP Spec

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -10,6 +10,11 @@ import { generate } from '../utils/generate'
 export default class Build extends Command {
   static args = [
     {
+      name: 'account',
+      description:
+        'The account for which the Discovery is running. Currently noop.',
+    },
+    {
       name: 'path',
       description:
         'The path where the FastStore being built is. Defaults to cwd.',

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -96,7 +96,7 @@ export default class Dev extends Command {
     },
     {
       name: 'port',
-      description: 'The port where FastStore should run.',
+      description: 'The port where FastStore should run. Defaults to 3000.',
     },
   ]
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,15 +1,16 @@
-import { Command } from '@oclif/core'
-import { spawn } from 'child_process'
-import chalk from 'chalk'
-import chokidar from 'chokidar'
-import dotenv from 'dotenv'
+import { Command } from '@oclif/core';
+import { spawn } from 'child_process';
+import chalk from 'chalk';
+import chokidar from 'chokidar';
+import dotenv from 'dotenv';
 
-import { readFileSync, cpSync } from 'fs'
-import path from 'path'
-import { withBasePath } from '../utils/directory'
-import { generate } from '../utils/generate'
-import { getPreferredPackageManager } from '../utils/commands'
-import { runCommandSync } from '../utils/runCommandSync'
+import { readFileSync, cpSync } from 'fs';
+import path from 'path';
+import { withBasePath } from '../utils/directory';
+import { generate } from '../utils/generate';
+import { getPreferredPackageManager } from '../utils/commands';
+import { runCommandSync } from '../utils/runCommandSync';
+
 
 /**
  * Taken from toolbelt
@@ -34,12 +35,7 @@ const defaultIgnored = [
 
 const devAbortController = new AbortController()
 
-async function storeDev(
-  rootDir: string,
-  tmpDir: string,
-  coreDir: string,
-  port: number
-) {
+async function storeDev(rootDir: string, tmpDir: string, coreDir: string, port: number) {
   const envVars = dotenv.parse(readFileSync(path.join(rootDir, 'vtex.env')))
 
   const packageManager = getPreferredPackageManager()
@@ -53,18 +49,11 @@ async function storeDev(
     cwd: tmpDir,
   })
 
-  const { success } = copyGenerated(
-    path.join(tmpDir, '@generated'),
-    path.join(coreDir, '@generated')
-  )
+  const { success } = copyGenerated(path.join(tmpDir, '@generated'), path.join(coreDir, '@generated'))
 
   if (!success) {
-    console.log(
-      `${chalk.yellow('warn')} - Failed to copy @generated schema back to node_modules, autocomplete and DX might be impacted.`
-    )
-    console.log(
-      `Attempted to copy from ${path.join(tmpDir, '@generated')} to ${path.join(coreDir, '@generated')}`
-    )
+    console.log(`${chalk.yellow('warn')} - Failed to copy @generated schema back to node_modules, autocomplete and DX might be impacted.`)
+    console.log(`Attempted to copy from ${path.join(tmpDir, '@generated')} to ${path.join(coreDir, '@generated')}`)
   }
 
   const devProcess = spawn(`${packageManager} dev-only --port ${port}`, {
@@ -75,7 +64,7 @@ async function storeDev(
     env: {
       ...process.env,
       ...envVars,
-    },
+    }
   })
 
   devProcess.on('close', () => {
@@ -98,12 +87,12 @@ export default class Dev extends Command {
     {
       name: 'account',
       description:
-        'The account for which the Discovery is running. Currently noop.',
+      'The account for which the Discovery is running. Currently noop.',
     },
     {
       name: 'path',
       description:
-        'The path where the FastStore being run is. Defaults to cwd.',
+      'The path where the FastStore being run is. Defaults to cwd.',
     },
     {
       name: 'port',

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,16 +1,15 @@
-import { Command } from '@oclif/core';
-import { spawn } from 'child_process';
-import chalk from 'chalk';
-import chokidar from 'chokidar';
-import dotenv from 'dotenv';
+import { Command } from '@oclif/core'
+import { spawn } from 'child_process'
+import chalk from 'chalk'
+import chokidar from 'chokidar'
+import dotenv from 'dotenv'
 
-import { readFileSync, cpSync } from 'fs';
-import path from 'path';
-import { withBasePath } from '../utils/directory';
-import { generate } from '../utils/generate';
-import { getPreferredPackageManager } from '../utils/commands';
-import { runCommandSync } from '../utils/runCommandSync';
-
+import { readFileSync, cpSync } from 'fs'
+import path from 'path'
+import { withBasePath } from '../utils/directory'
+import { generate } from '../utils/generate'
+import { getPreferredPackageManager } from '../utils/commands'
+import { runCommandSync } from '../utils/runCommandSync'
 
 /**
  * Taken from toolbelt
@@ -35,7 +34,12 @@ const defaultIgnored = [
 
 const devAbortController = new AbortController()
 
-async function storeDev(rootDir: string, tmpDir: string, coreDir: string) {
+async function storeDev(
+  rootDir: string,
+  tmpDir: string,
+  coreDir: string,
+  port: number
+) {
   const envVars = dotenv.parse(readFileSync(path.join(rootDir, 'vtex.env')))
 
   const packageManager = getPreferredPackageManager()
@@ -49,14 +53,21 @@ async function storeDev(rootDir: string, tmpDir: string, coreDir: string) {
     cwd: tmpDir,
   })
 
-  const { success } = copyGenerated(path.join(tmpDir, '@generated'), path.join(coreDir, '@generated'))
+  const { success } = copyGenerated(
+    path.join(tmpDir, '@generated'),
+    path.join(coreDir, '@generated')
+  )
 
   if (!success) {
-    console.log(`${chalk.yellow('warn')} - Failed to copy @generated schema back to node_modules, autocomplete and DX might be impacted.`)
-    console.log(`Attempted to copy from ${path.join(tmpDir, '@generated')} to ${path.join(coreDir, '@generated')}`)
+    console.log(
+      `${chalk.yellow('warn')} - Failed to copy @generated schema back to node_modules, autocomplete and DX might be impacted.`
+    )
+    console.log(
+      `Attempted to copy from ${path.join(tmpDir, '@generated')} to ${path.join(coreDir, '@generated')}`
+    )
   }
 
-  const devProcess = spawn(`${packageManager} dev-only`, {
+  const devProcess = spawn(`${packageManager} dev-only --port ${port}`, {
     shell: true,
     cwd: tmpDir,
     signal: devAbortController.signal,
@@ -64,7 +75,7 @@ async function storeDev(rootDir: string, tmpDir: string, coreDir: string) {
     env: {
       ...process.env,
       ...envVars,
-    }
+    },
   })
 
   devProcess.on('close', () => {
@@ -85,14 +96,25 @@ function copyGenerated(from: string, to: string) {
 export default class Dev extends Command {
   static args = [
     {
+      name: 'account',
+      description:
+        'The account for which the Discovery is running. Currently noop.',
+    },
+    {
       name: 'path',
-      description: 'The path where the FastStore being run is. Defaults to cwd.',
-    }
+      description:
+        'The path where the FastStore being run is. Defaults to cwd.',
+    },
+    {
+      name: 'port',
+      description: 'The port where FastStore should run.',
+    },
   ]
 
   async run() {
     const { args } = await this.parse(Dev)
     const basePath = args.path ?? process.cwd()
+    const port = args.port ?? 3000
 
     const { getRoot, tmpDir, coreDir } = withBasePath(basePath)
 
@@ -118,7 +140,7 @@ export default class Dev extends Command {
 
     await generate({ setup: true, basePath })
 
-    storeDev(getRoot(), tmpDir, coreDir)
+    storeDev(getRoot(), tmpDir, coreDir, port)
 
     return await new Promise((resolve, reject) => {
       watcher

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -18,7 +18,7 @@ export default class Start extends Command {
     },
     {
       name: 'port',
-      description: 'The port where FastStore should run.',
+      description: 'The port where FastStore should run. Defaults to 3000.',
     },
   ]
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -7,14 +7,25 @@ import { getPreferredPackageManager } from '../utils/commands'
 export default class Start extends Command {
   static args = [
     {
+      name: 'account',
+      description:
+        'The account for which the Discovery is running. Currently noop.',
+    },
+    {
       name: 'path',
-      description: 'The path where the FastStore being run is. Defaults to cwd.',
-    }
+      description:
+        'The path where the FastStore being run is. Defaults to cwd.',
+    },
+    {
+      name: 'port',
+      description: 'The port where FastStore should run.',
+    },
   ]
 
   async run() {
     const { args } = await this.parse(Start)
     const basePath = args.path ?? process.cwd()
+    const port = args.port ?? 3000
     const { tmpDir } = withBasePath(basePath)
     const packageManager = getPreferredPackageManager()
 
@@ -24,7 +35,7 @@ export default class Start extends Command {
       )
     }
 
-    return spawn(`${packageManager} run serve`, {
+    return spawn(`${packageManager} run serve -p ${port}`, {
       shell: true,
       cwd: tmpDir,
       stdio: 'inherit',

--- a/packages/cli/src/utils/directory.test.ts
+++ b/packages/cli/src/utils/directory.test.ts
@@ -8,6 +8,12 @@ const pathsToMatch = (expected: string, desired: string) => {
   return expectedResolved === desiredResolved
 }
 
+const originalProcessCwd = process.cwd
+
+beforeEach(() => {
+  process.cwd = originalProcessCwd
+})
+
 describe('withBasePath as the current dir `.`', () => {
   const basePath = '.'
 
@@ -79,8 +85,6 @@ describe('withBasePath as the current dir `.`', () => {
     it('returns the path of the user discovery.config file', () => {
       const { userStoreConfigFile: userStoreConfigFileWithBase } = withBasePath(basePath)
 
-      console.log('userStoreConfigFileWithBase', userStoreConfigFileWithBase);
-
       expect(pathsToMatch(userStoreConfigFileWithBase, './discovery.config.js')).toBe(true)
     })
   })
@@ -99,6 +103,8 @@ describe('withBasePath as an arbitrary dir', () => {
 
   describe('coreDir', () => {
     it('is the faststoreDir + core', () => {
+      const mockedCwd = jest.fn(() => { return './src/__mocks__/store' })
+      process.cwd = mockedCwd
       const { coreDir: coreDirWithBase } = withBasePath(basePath)
 
       expect(pathsToMatch(coreDirWithBase, './src/__mocks__/store/node_modules/@faststore/core')).toBe(true)
@@ -106,6 +112,9 @@ describe('withBasePath as an arbitrary dir', () => {
 
     describe('when is in a monorepo', () => {
       it('can look at its parent until it reaches the monorepo directory', () => {
+        const mockedCwd = jest.fn(() => { return './src/__mocks__/monorepo' })
+        process.cwd = mockedCwd
+
         const { coreDir: coreDirWithBase } = withBasePath(path.join(__dirname, '..', '__mocks__', 'monorepo', 'discovery'))
 
         expect(pathsToMatch(coreDirWithBase, './src/__mocks__/monorepo/node_modules/@faststore/core')).toBe(true)
@@ -171,6 +180,9 @@ describe('withBasePath as an arbitrary dir', () => {
 
   describe('coreCMSDir', () => {
     it('returns the path of the CMS dir on @faststore/core package', () => {
+      const mockedCwd = jest.fn(() => { return './src/__mocks__/store' })
+      process.cwd = mockedCwd
+
       const { coreCMSDir: coreCMSDirWithBase } = withBasePath(basePath)
 
       expect(pathsToMatch(coreCMSDirWithBase, './src/__mocks__/store/node_modules/@faststore/core/cms/faststore')).toBe(true)

--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -12,10 +12,10 @@ export const withBasePath = (basepath: string) => {
     if (basepath.endsWith(tmpFolderName)) {
       // if the current working directory is the build folder (tmp folder), return the starter root
       // this makes sure the semantics of the starter root are consistent with the directories declared below
-      return path.join(basepath, '..')
+      return path.resolve(process.cwd(), path.join(basepath, '..'))
     }
 
-    return basepath
+    return path.resolve(process.cwd(), basepath)
   }
 
   /* 

--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -31,7 +31,7 @@ export const withBasePath = (basepath: string) => {
 
     let attemptedPath
     do {
-      attemptedPath = path.join(basepath, ...parents, coreFromNodeModules)
+      attemptedPath = path.join(resolvedCwd, basepath, ...parents, coreFromNodeModules)
 
       if (fs.existsSync(attemptedPath)) {
         return attemptedPath


### PR DESCRIPTION
## What's the purpose of this pull request?

To work with the Platform CLI, the FastStore CLI commands needs to accept more arguments. I've added such arguments but they are not being used, so this should not affect current behavior in any way.

## How to test it?

Install the version generated by the codesandbox and call all commands :)

### Starters Deploy Preview

[Code](https://github.com/vtex-sites/starter.store/pull/566) | [Store (Vercel)](https://starter-rnshhkjja-faststore.vercel.app/) | [Store (Homebrew)](https://sfj-164c14b--starter.preview.vtex.app/)

## References

[FastStore Platform Spec](https://github.com/vtex/faststore-platform/blob/main/docs/specification.md)

