### PR TITLE
Feat: Improve Dropdown Component

### DIFF
--- a/apps/site/middleware.ts
+++ b/apps/site/middleware.ts
@@ -1,21 +1,21 @@
 import { NextResponse, NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const { pathname } = new URL(request.url)
-  if (pathname.startsWith('/docs')) {
-    return NextResponse.redirect(
-      `https://developers.vtex.com/docs/guides/faststore${pathname.replace(
-        '/docs',
-        ''
-      )}`
-    )
-  }
-  if (pathname.startsWith('/components')) {
-    return NextResponse.redirect(
-      `https://developers.vtex.com/docs/guides/faststore${pathname
-        .replace('/components', '')
-        .replace(/\/([^\/]*)\//, '/$1-')}`
-    )
-  }
+  // const { pathname } = new URL(request.url)
+  // if (pathname.startsWith('/docs')) {
+  //   return NextResponse.redirect(
+  //     `https://developers.vtex.com/docs/guides/faststore${pathname.replace(
+  //       '/docs',
+  //       ''
+  //     )}`
+  //   )
+  // }
+  // if (pathname.startsWith('/components')) {
+  //   return NextResponse.redirect(
+  //     `https://developers.vtex.com/docs/guides/faststore${pathname
+  //       .replace('/components', '')
+  //       .replace(/\/([^\/]*)\//, '/$1-')}`
+  //   )
+  // }
   return NextResponse.next()
 }

--- a/apps/site/pages/components/molecules/dropdown.mdx
+++ b/apps/site/pages/components/molecules/dropdown.mdx
@@ -240,10 +240,10 @@ export const ControlledDropdown = () => {
     <Dropdown isOpen={isOpen} onDismiss={() => {setIsOpen(false)}}>
       <DropdownButton onClick={()=> setIsOpen(true)}>Controlled Dropdown</DropdownButton>
       <DropdownMenu>
-        <DropdownItem>A - Dropdown item as child</DropdownItem>
-        <DropdownItem>B - Dropdown item as child</DropdownItem>
-        <DropdownItem>C - Dropdown item as child</DropdownItem>
-        <DropdownItem>D - Dropdown item as child</DropdownItem>
+        <DropdownItem>A - Dropdown item</DropdownItem>
+        <DropdownItem>B - Dropdown item</DropdownItem>
+        <DropdownItem>C - Dropdown item</DropdownItem>
+        <DropdownItem>D - Dropdown item</DropdownItem>
       </DropdownMenu>
     </Dropdown>
   )
@@ -263,10 +263,10 @@ export const ControlledDropdown = () => {
         <Dropdown isOpen={isOpen} onDismiss={() => {setIsOpen(false)}}>
           <DropdownButton>Controlled Dropdown</DropdownButton>
           <DropdownMenu>
-            <DropdownItem>A - Dropdown item as child</DropdownItem>
-            <DropdownItem>B - Dropdown item as child</DropdownItem>
-            <DropdownItem>C - Dropdown item as child</DropdownItem>
-            <DropdownItem>D - Dropdown item as child</DropdownItem>
+            <DropdownItem>A - Dropdown item</DropdownItem>
+            <DropdownItem>B - Dropdown item</DropdownItem>
+            <DropdownItem>C - Dropdown item</DropdownItem>
+            <DropdownItem>D - Dropdown item</DropdownItem>
           </DropdownMenu>
         </Dropdown>
     </OverviewSection>

--- a/apps/site/pages/components/molecules/dropdown.mdx
+++ b/apps/site/pages/components/molecules/dropdown.mdx
@@ -29,6 +29,7 @@ import { OverviewSection } from 'site/components/OverviewSection'
 import path from 'path'
 import { useSSG } from 'nextra/ssg'
 import { getComponentPropsFrom } from 'site/components/utilities/propsSection'
+import { useState } from 'react'
 
 export const getStaticProps = () => {
   const dropdownPath = path.resolve(__filename)
@@ -84,25 +85,38 @@ Displays a set of actions/items to the user, usually used to show a menu of opti
 
 ## Overview
 
-<Tabs items={['Example', 'Code']} defaultIndex="0">
-  <Tab>
-    <OverviewSection>
-      <Dropdown>
-        <DropdownButton icon={<Icon name="CaretDown" />}>
-          {'Dropdown'}
+export const ControlledDropdown = () => {
+  const [isOpen, setIsOpen] = useState(true)
+  return (
+      <Dropdown isOpen={isOpen} onDismiss={() => {console.log("Dismiss"); setIsOpen(false)}}>
+        <DropdownButton asChild>
+          <button onClick={() => setIsOpen(old => !old)}>{'Dropdown'}</button>
         </DropdownButton>
         <DropdownMenu>
           <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
-            {'Dropdown Item 1'}
+          <Icon name="ArrowElbowDownRight" />
+                <input type="checkbox" id="scales" name="scales" />
+    <label for="scales">Scales</label>
+            
           </DropdownItem>
           <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
-            {'Dropdown Item 2'}
+            {'B - Dropdown Item 2'}
           </DropdownItem>
           <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
-            {'Dropdown Item 3'}
+            {'C - Dropdown Item 3'}
+          </DropdownItem>
+                    <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
+            {'B - Dropdown Item 3'}
           </DropdownItem>
         </DropdownMenu>
       </Dropdown>
+  )
+}
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <ControlledDropdown />
       <Dropdown>
         <DropdownButton icon={<Icon name="CaretDown" />}>
           {'Dropdown Small'}

--- a/apps/site/pages/components/molecules/dropdown.mdx
+++ b/apps/site/pages/components/molecules/dropdown.mdx
@@ -90,15 +90,15 @@ Displays a set of actions/items to the user, usually used to show a menu of opti
     <OverviewSection>
       <Dropdown>
         <DropdownButton icon={<Icon name="CaretDown" />}>Dropdown</DropdownButton>
-        <DropdownMenu>
+        <DropdownMenu size="regular" align="left">
           <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
-            Dropdown Item 1
+            {'Dropdown Item 1'}
           </DropdownItem>
           <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
-            Dropdown Item 2
+            {'Dropdown Item 2'}
           </DropdownItem>
           <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
-            Dropdown Item 3
+            {'Dropdown Item 3'}
           </DropdownItem>
         </DropdownMenu>
       </Dropdown>
@@ -106,7 +106,7 @@ Displays a set of actions/items to the user, usually used to show a menu of opti
         <DropdownButton icon={<Icon name="CaretDown" />}>
           {'Dropdown Small'}
         </DropdownButton>
-        <DropdownMenu size="small">
+        <DropdownMenu size="small"  align="center">
           <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
             {'Dropdown Item 1'}
           </DropdownItem>
@@ -237,23 +237,13 @@ Follow the instructions in the [Importing FastStore UI component styles](/docs/c
 export const ControlledDropdown = () => {
   const [isOpen, setIsOpen] = useState(false)
   return (
-    <Dropdown isOpen={isOpen} onDismiss={() => {console.log("Dismiss"); setIsOpen(false)}}>
-      <DropdownButton asChild>
-        <button onClick={() => setIsOpen(old => !old)}>{'Controlled Dropdown with trigger as child'}</button>
-      </DropdownButton>
-      <DropdownMenu style={{ backgroundColor: "white"}}>
-        <DropdownItem  asChild>
-          <button>A - Dropdown item as child</button>
-        </DropdownItem>
-        <DropdownItem  asChild>
-          <button>B - Dropdown item as child</button>
-        </DropdownItem>
-        <DropdownItem  asChild>
-          <button>C - Dropdown item as child</button>
-        </DropdownItem>
-        <DropdownItem  asChild>
-          <button>D - Dropdown item as child</button>
-        </DropdownItem>
+    <Dropdown isOpen={isOpen} onDismiss={() => {setIsOpen(false)}}>
+      <DropdownButton onClick={()=> setIsOpen(true)}>Controlled Dropdown</DropdownButton>
+      <DropdownMenu>
+        <DropdownItem>A - Dropdown item as child</DropdownItem>
+        <DropdownItem>B - Dropdown item as child</DropdownItem>
+        <DropdownItem>C - Dropdown item as child</DropdownItem>
+        <DropdownItem>D - Dropdown item as child</DropdownItem>
       </DropdownMenu>
     </Dropdown>
   )
@@ -268,30 +258,70 @@ export const ControlledDropdown = () => {
   <Tab>
     ```tsx
     <OverviewSection>
-      export const ControlledDropdown = () => {
-        const [isOpen, setIsOpen] = useState(true)
-        return (
-            <Dropdown isOpen={isOpen} onDismiss={() => {console.log("Dismiss"); setIsOpen(false)}}>
-              <DropdownButton asChild>
-                <button onClick={() => setIsOpen(old => !old)}>{'Controlled Dropdown with trigger as child'}</button>
-              </DropdownButton>
-              <DropdownMenu style={{ backgroundColor: "white"}}>
-                <DropdownItem  asChild>
-                  <button>A - Dropdown item as child</button>
-                </DropdownItem>
-                <DropdownItem  asChild>
-                  <button>B - Dropdown item as child</button>
-                </DropdownItem>
-                <DropdownItem  asChild>
-                  <button>C - Dropdown item as child</button>
-                </DropdownItem>
-                <DropdownItem  asChild>
-                  <button>D - Dropdown item as child</button>
-                </DropdownItem>
-              </DropdownMenu>
-            </Dropdown>
-        )
-      }
+      const [isOpen, setIsOpen] = useState(false)
+      return (
+        <Dropdown isOpen={isOpen} onDismiss={() => {setIsOpen(false)}}>
+          <DropdownButton>Controlled Dropdown</DropdownButton>
+          <DropdownMenu>
+            <DropdownItem>A - Dropdown item as child</DropdownItem>
+            <DropdownItem>B - Dropdown item as child</DropdownItem>
+            <DropdownItem>C - Dropdown item as child</DropdownItem>
+            <DropdownItem>D - Dropdown item as child</DropdownItem>
+          </DropdownMenu>
+        </Dropdown>
+    </OverviewSection>
+    ```
+  </Tab>
+</Tabs>
+
+#### As Child
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <Dropdown>
+        <DropdownButton asChild>
+          <button>{'Dropdown with trigger as child'}</button>
+        </DropdownButton>
+        <DropdownMenu style={{ backgroundColor: "white"}}>
+          <DropdownItem  asChild>
+            <button>A - Dropdown item as child</button>
+          </DropdownItem>
+          <DropdownItem  asChild>
+            <button>B - Dropdown item as child</button>
+          </DropdownItem>
+          <DropdownItem  asChild>
+            <button>C - Dropdown item as child</button>
+          </DropdownItem>
+          <DropdownItem  asChild>
+            <button>D - Dropdown item as child</button>
+          </DropdownItem>
+        </DropdownMenu>
+      </Dropdown>
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <OverviewSection>
+      <Dropdown>
+        <DropdownButton asChild>
+          <button>{'Dropdown with trigger as child'}</button>
+        </DropdownButton>
+        <DropdownMenu style={{ backgroundColor: "white"}}>
+          <DropdownItem  asChild>
+            <button>A - Dropdown item as child</button>
+          </DropdownItem>
+          <DropdownItem  asChild>
+            <button>B - Dropdown item as child</button>
+          </DropdownItem>
+          <DropdownItem  asChild>
+            <button>C - Dropdown item as child</button>
+          </DropdownItem>
+          <DropdownItem  asChild>
+            <button>D - Dropdown item as child</button>
+          </DropdownItem>
+        </DropdownMenu>
+      </Dropdown>
     </OverviewSection>
     ```
   </Tab>

--- a/apps/site/pages/components/molecules/dropdown.mdx
+++ b/apps/site/pages/components/molecules/dropdown.mdx
@@ -85,38 +85,23 @@ Displays a set of actions/items to the user, usually used to show a menu of opti
 
 ## Overview
 
-export const ControlledDropdown = () => {
-  const [isOpen, setIsOpen] = useState(true)
-  return (
-      <Dropdown isOpen={isOpen} onDismiss={() => {console.log("Dismiss"); setIsOpen(false)}}>
-        <DropdownButton asChild>
-          <button onClick={() => setIsOpen(old => !old)}>{'Dropdown'}</button>
-        </DropdownButton>
-        <DropdownMenu>
-          <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
-          <Icon name="ArrowElbowDownRight" />
-                <input type="checkbox" id="scales" name="scales" />
-    <label for="scales">Scales</label>
-            
-          </DropdownItem>
-          <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
-            {'B - Dropdown Item 2'}
-          </DropdownItem>
-          <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
-            {'C - Dropdown Item 3'}
-          </DropdownItem>
-                    <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
-            {'B - Dropdown Item 3'}
-          </DropdownItem>
-        </DropdownMenu>
-      </Dropdown>
-  )
-}
-
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
     <OverviewSection>
-      <ControlledDropdown />
+      <Dropdown>
+        <DropdownButton icon={<Icon name="CaretDown" />}>Dropdown</DropdownButton>
+        <DropdownMenu>
+          <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
+            Dropdown Item 1
+          </DropdownItem>
+          <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
+            Dropdown Item 2
+          </DropdownItem>
+          <DropdownItem icon={<Icon name="ArrowElbowDownRight" />}>
+            Dropdown Item 3
+          </DropdownItem>
+        </DropdownMenu>
+      </Dropdown>
       <Dropdown>
         <DropdownButton icon={<Icon name="CaretDown" />}>
           {'Dropdown Small'}
@@ -200,6 +185,8 @@ Follow the instructions in the [Importing FastStore UI component styles](/docs/c
 
 ## Usage
 
+#### Default
+
 <Tabs items={['Example', 'Code']} defaultIndex="0">
   <Tab>
     <OverviewSection>
@@ -240,6 +227,71 @@ Follow the instructions in the [Importing FastStore UI component styles](/docs/c
           </DropdownItem>
         </DropdownMenu>
       </Dropdown>
+    </OverviewSection>
+    ```
+  </Tab>
+</Tabs>
+
+#### Controlled
+
+export const ControlledDropdown = () => {
+  const [isOpen, setIsOpen] = useState(false)
+  return (
+    <Dropdown isOpen={isOpen} onDismiss={() => {console.log("Dismiss"); setIsOpen(false)}}>
+      <DropdownButton asChild>
+        <button onClick={() => setIsOpen(old => !old)}>{'Controlled Dropdown with trigger as child'}</button>
+      </DropdownButton>
+      <DropdownMenu style={{ backgroundColor: "white"}}>
+        <DropdownItem  asChild>
+          <button>A - Dropdown item as child</button>
+        </DropdownItem>
+        <DropdownItem  asChild>
+          <button>B - Dropdown item as child</button>
+        </DropdownItem>
+        <DropdownItem  asChild>
+          <button>C - Dropdown item as child</button>
+        </DropdownItem>
+        <DropdownItem  asChild>
+          <button>D - Dropdown item as child</button>
+        </DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
+  )
+}
+
+<Tabs items={['Example', 'Code']} defaultIndex="0">
+  <Tab>
+    <OverviewSection>
+      <ControlledDropdown/>
+    </OverviewSection>
+  </Tab>
+  <Tab>
+    ```tsx
+    <OverviewSection>
+      export const ControlledDropdown = () => {
+        const [isOpen, setIsOpen] = useState(true)
+        return (
+            <Dropdown isOpen={isOpen} onDismiss={() => {console.log("Dismiss"); setIsOpen(false)}}>
+              <DropdownButton asChild>
+                <button onClick={() => setIsOpen(old => !old)}>{'Controlled Dropdown with trigger as child'}</button>
+              </DropdownButton>
+              <DropdownMenu style={{ backgroundColor: "white"}}>
+                <DropdownItem  asChild>
+                  <button>A - Dropdown item as child</button>
+                </DropdownItem>
+                <DropdownItem  asChild>
+                  <button>B - Dropdown item as child</button>
+                </DropdownItem>
+                <DropdownItem  asChild>
+                  <button>C - Dropdown item as child</button>
+                </DropdownItem>
+                <DropdownItem  asChild>
+                  <button>D - Dropdown item as child</button>
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+        )
+      }
     </OverviewSection>
     ```
   </Tab>

--- a/packages/components/src/atoms/Button/index.ts
+++ b/packages/components/src/atoms/Button/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Button'
-export type { ButtonProps, Variant, Size, IconPosition } from './Button'
+export type { ButtonProps, Variant as ButtonVariant, Size as ButtonSize, IconPosition as ButtonIconPosition } from './Button'

--- a/packages/components/src/atoms/Button/index.ts
+++ b/packages/components/src/atoms/Button/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Button'
-export type { ButtonProps } from './Button'
+export type { ButtonProps, Variant, Size, IconPosition } from './Button'

--- a/packages/components/src/molecules/Dropdown/Dropdown.tsx
+++ b/packages/components/src/molecules/Dropdown/Dropdown.tsx
@@ -51,23 +51,19 @@ const Dropdown = ({
     })
   }, [onDismiss])
 
-  const addDropdownTriggerRef = useCallback(<T extends HTMLElement = HTMLElement>(ref: T) => {
-    dropdownTriggerRef.current = ref
-  }, [])
+  const addDropdownTriggerRef = useCallback(
+    <T extends HTMLElement = HTMLElement>(ref: T) => {
+      dropdownTriggerRef.current = ref
+    },
+    []
+  )
 
   useEffect(() => {
     setIsOpenInternal(isOpenControlled ?? false)
   }, [isOpenControlled])
 
   useEffect(() => {
-    if(isOpen) {
-      dropdownItemsRef?.current[0]?.focus()
-      document.body.style.overflow = 'hidden'
-
-      return
-    }
-
-    document.body.style.overflow = 'auto'
+    isOpen && dropdownItemsRef?.current[0]?.focus()
   }, [isOpen])
 
   useEffect(() => {

--- a/packages/components/src/molecules/Dropdown/Dropdown.tsx
+++ b/packages/components/src/molecules/Dropdown/Dropdown.tsx
@@ -60,7 +60,14 @@ const Dropdown = ({
   }, [isOpenControlled])
 
   useEffect(() => {
-    isOpen && dropdownItemsRef?.current[0]?.focus()
+    if(isOpen) {
+      dropdownItemsRef?.current[0]?.focus()
+      document.body.style.overflow = 'hidden'
+
+      return
+    }
+
+    document.body.style.overflow = 'auto'
   }, [isOpen])
 
   useEffect(() => {

--- a/packages/components/src/molecules/Dropdown/Dropdown.tsx
+++ b/packages/components/src/molecules/Dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react'
 import React, { useRef, useMemo, useState, useEffect, useCallback } from 'react'
 
-import DropdownContext, { DropdownItemElement, DropdownTriggerElement } from '../Dropdown/contexts/DropdownContext'
+import DropdownContext from '../Dropdown/contexts/DropdownContext'
 
 export interface DropdownProps {
   /**
@@ -25,9 +25,9 @@ const Dropdown = ({
   id = 'fs-dropdown',
 }: PropsWithChildren<DropdownProps>) => {
   const [isOpenInternal, setIsOpenInternal] = useState(false)
-  const dropdownItemsRef = useRef<DropdownItemElement[]>([])
+  const dropdownItemsRef = useRef<HTMLElement[]>([])
   const selectedDropdownItemIndexRef = useRef(0)
-  const dropdownTriggerRef = useRef<DropdownTriggerElement | null>(null)
+  const dropdownTriggerRef = useRef<HTMLElement | null>(null)
 
   const isOpen = isOpenControlled ?? isOpenInternal
 

--- a/packages/components/src/molecules/Dropdown/Dropdown.tsx
+++ b/packages/components/src/molecules/Dropdown/Dropdown.tsx
@@ -60,8 +60,8 @@ const Dropdown = ({
   }, [isOpenControlled])
 
   useEffect(() => {
-    isOpenInternal && dropdownItemsRef?.current[0]?.focus()
-  }, [isOpenInternal])
+    isOpen && dropdownItemsRef?.current[0]?.focus()
+  }, [isOpen])
 
   useEffect(() => {
     let firstClick = true

--- a/packages/components/src/molecules/Dropdown/DropdownButton.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownButton.tsx
@@ -1,15 +1,33 @@
-import React, { cloneElement, forwardRef } from 'react'
-import Button, { ButtonProps } from '../../atoms/Button'
+import React, { cloneElement, forwardRef, ReactNode } from 'react'
+import Button, { ButtonProps, IconPosition } from '../../atoms/Button'
 import { useDropdownTrigger } from './hooks/useDropdownTrigger'
 
 export interface DropdownButtonProps
-  extends Omit<ButtonProps, 'variant' | 'inverse'> {
+  extends Omit<ButtonProps, 'variant' | 'inverse' | 'icon' | 'iconPosition' > {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
   testId?: string
   /** Replace the default rendered element with the one passed as a child, merging their props and behavior. */
   asChild?: boolean
+  /**
+   * Boolean that represents a loading state.
+   */
+  loading?: boolean
+  /**
+   * Specifies a label for loading state.
+   */
+  loadingLabel?: string
+  /**
+   * @deprecated
+   * A React component that will be rendered as an icon.
+   */
+  icon?: ReactNode
+  /**
+   * @deprecated
+   * Specifies where the icon should be positioned
+   */
+  iconPosition?: IconPosition
 }
 
 const DropdownButton = forwardRef<HTMLButtonElement, DropdownButtonProps>(

--- a/packages/components/src/molecules/Dropdown/DropdownButton.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownButton.tsx
@@ -1,9 +1,9 @@
 import React, { cloneElement, forwardRef, ReactNode } from 'react'
-import Button, { ButtonProps, IconPosition } from '../../atoms/Button'
+import Button, { ButtonProps, ButtonIconPosition } from '../../atoms/Button'
 import { useDropdownTrigger } from './hooks/useDropdownTrigger'
 
 export interface DropdownButtonProps
-  extends Omit<ButtonProps, 'variant' | 'inverse' | 'icon' | 'iconPosition' > {
+  extends Omit<ButtonProps, 'variant' | 'inverse' | 'icon' | 'iconPosition'> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
@@ -29,7 +29,7 @@ export interface DropdownButtonProps
    * @deprecated
    * Specifies where the icon should be positioned
    */
-  iconPosition?: IconPosition
+  iconPosition?: ButtonIconPosition
 }
 
 const DropdownButton = forwardRef<HTMLButtonElement, DropdownButtonProps>(
@@ -40,8 +40,8 @@ const DropdownButton = forwardRef<HTMLButtonElement, DropdownButtonProps>(
     const triggerProps = useDropdownTrigger({ triggerRef })
 
     const asChildrenTrigger = React.isValidElement(children)
-    ? cloneElement(children, { ...triggerProps, ...children.props })
-    : children;
+      ? cloneElement(children, { ...triggerProps, ...children.props })
+      : children
 
     return (
       <>

--- a/packages/components/src/molecules/Dropdown/DropdownButton.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownButton.tsx
@@ -1,7 +1,6 @@
-import React, { forwardRef, useImperativeHandle, AriaAttributes } from 'react'
+import React, { cloneElement, forwardRef } from 'react'
 import Button, { ButtonProps } from '../../atoms/Button'
-
-import { useDropdown } from './hooks/useDropdown'
+import { useDropdownTrigger } from './hooks/useDropdownTrigger'
 
 export interface DropdownButtonProps
   extends Omit<ButtonProps, 'variant' | 'inverse'> {
@@ -9,43 +8,37 @@ export interface DropdownButtonProps
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
   testId?: string
-  /**
-   * For accessibility purposes, add an ARIA label to the element when it doesn't have a label.
-   */
-  'aria-label'?: AriaAttributes['aria-label']
+
+  asChild?: boolean
 }
 
 const DropdownButton = forwardRef<HTMLButtonElement, DropdownButtonProps>(
   function DropdownButton(
-    {
-      testId = 'fs-dropdown-button',
-      'aria-label': ariaLabel,
-       children,
-      ...otherProps
-    },
-    ref
+    { testId = 'fs-dropdown-button', children, asChild = false, ...otherProps },
+    triggerRef
   ) {
-    const { toggle, dropdownButtonRef, isOpen, id } = useDropdown()
+    const triggerProps = useDropdownTrigger({ triggerRef })
 
-    useImperativeHandle(ref, () => dropdownButtonRef!.current!, [
-      dropdownButtonRef,
-    ])
+    const asChildrenTrigger = React.isValidElement(children)
+    ? cloneElement(children, { ...triggerProps, ...children.props })
+    : children;
 
     return (
-      <Button
-        data-fs-dropdown-button
-        onClick={toggle}
-        data-testid={testId}
-        ref={dropdownButtonRef}
-        aria-label={ariaLabel}
-        aria-expanded={isOpen}
-        aria-haspopup="menu"
-        aria-controls={id}
-        variant="tertiary"
-        {...otherProps}
-      >
-        {children}
-      </Button>
+      <>
+        {asChild ? (
+          asChildrenTrigger
+        ) : (
+          <Button
+            data-fs-dropdown-button
+            data-testid={testId}
+            variant="tertiary"
+            {...triggerProps}
+            {...otherProps}
+          >
+            {children}
+          </Button>
+        )}
+      </>
     )
   }
 )

--- a/packages/components/src/molecules/Dropdown/DropdownButton.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownButton.tsx
@@ -8,7 +8,9 @@ export interface DropdownButtonProps
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
   testId?: string
-  /** Replace the default rendered element with the one passed as a child, merging their props and behavior. */
+  /**
+   * Replace the default rendered element with the provided child element, merging their props and behavior.
+   */
   asChild?: boolean
   /**
    * Boolean that represents a loading state.

--- a/packages/components/src/molecules/Dropdown/DropdownButton.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownButton.tsx
@@ -8,7 +8,7 @@ export interface DropdownButtonProps
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
   testId?: string
-
+  /** Replace the default rendered element with the one passed as a child, merging their props and behavior. */
   asChild?: boolean
 }
 

--- a/packages/components/src/molecules/Dropdown/DropdownItem.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownItem.tsx
@@ -1,7 +1,7 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
-import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import React, { forwardRef } from 'react'
 
-import { useDropdown } from './hooks/useDropdown'
+import { useDropdownItem } from './hooks/useDropdownItem'
 
 export interface DropdownItemProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -20,48 +20,13 @@ const DropdownItem = forwardRef<HTMLButtonElement, DropdownItemProps>(
     { children, icon, onClick, testId = 'fs-dropdown-item', ...otherProps },
     ref
   ) {
-    const { dropdownItemsRef, selectedDropdownItemIndexRef, close } =
-      useDropdown()
-
-    const [dropdownItemIndex, setDropdownItemIndex] = useState(0)
-    const dropdownItemRef = useRef<HTMLButtonElement>()
-
-    const addToRefs = (el: HTMLButtonElement) => {
-      if (el && !dropdownItemsRef?.current.includes(el)) {
-        dropdownItemsRef?.current.push(el)
-        setDropdownItemIndex(
-          dropdownItemsRef?.current.findIndex((element) => element === el) ?? 0
-        )
-      }
-
-      dropdownItemRef.current = el
-    }
-
-    const onFocusItem = () => {
-      selectedDropdownItemIndexRef!.current = dropdownItemIndex
-      dropdownItemsRef?.current[selectedDropdownItemIndexRef!.current]?.focus()
-    }
-
-    const handleOnClickItem = (
-      event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-    ) => {
-      onClick?.(event)
-      close?.()
-    }
-
-    useImperativeHandle(ref, () => dropdownItemRef.current!, [])
+    const itemProps = useDropdownItem({ ref, onClick })
 
     return (
       <button
         data-fs-dropdown-item
         data-testid={testId}
-        ref={addToRefs}
-        onFocus={onFocusItem}
-        onMouseEnter={onFocusItem}
-        onClick={handleOnClickItem}
-        role="menuitem"
-        tabIndex={-1}
-        data-index={dropdownItemIndex}
+        {...itemProps}
         {...otherProps}
       >
         {!!icon && icon}

--- a/packages/components/src/molecules/Dropdown/DropdownItem.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownItem.tsx
@@ -1,5 +1,5 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
-import React, { forwardRef } from 'react'
+import React, { cloneElement, forwardRef } from 'react'
 
 import { useDropdownItem } from './hooks/useDropdownItem'
 
@@ -13,25 +13,39 @@ export interface DropdownItemProps
    * A React component that will be rendered as an icon.
    */
   icon?: ReactNode
+
+  asChild?: boolean
+
+  dismissOnClick?: boolean
 }
 
 const DropdownItem = forwardRef<HTMLButtonElement, DropdownItemProps>(
   function Button(
-    { children, icon, onClick, testId = 'fs-dropdown-item', ...otherProps },
+    { children, asChild, icon, onClick, dismissOnClick = true, testId = 'fs-dropdown-item', ...otherProps },
     ref
   ) {
-    const itemProps = useDropdownItem({ ref, onClick })
+    const itemProps = useDropdownItem({ ref, onClick, dismissOnClick })
+
+    const asChildrenItem = React.isValidElement(children)
+    ? cloneElement(children, { ...itemProps, ...children.props })
+    : children;
 
     return (
-      <button
-        data-fs-dropdown-item
-        data-testid={testId}
-        {...itemProps}
-        {...otherProps}
-      >
-        {!!icon && icon}
-        {children}
-      </button>
+      <>
+      {asChild ? (
+        asChildrenItem
+      ) : (
+        <button
+          data-fs-dropdown-item
+          data-testid={testId}
+          {...itemProps}
+          {...otherProps}
+        >
+          {!!icon && icon}
+          {children}
+        </button>
+        )}
+      </>
     )
   }
 )

--- a/packages/components/src/molecules/Dropdown/DropdownItem.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownItem.tsx
@@ -14,41 +14,49 @@ export interface DropdownItemProps
    * A React component that will be rendered as an icon.
    */
   icon?: ReactNode
-  /** 
-   * Replace the default rendered element with the one passed as a child, merging their props and behavior. 
+  /**
+   * Replace the default rendered element with the one passed as a child, merging their props and behavior.
    * */
   asChild?: boolean
   /**
-   *  Emit onDismiss eventwhen the component is clicked.
+   * Emit onDismiss event when the component is clicked.
    */
   dismissOnClick?: boolean
 }
 
 const DropdownItem = forwardRef<HTMLButtonElement, DropdownItemProps>(
   function Button(
-    { children, asChild, icon, onClick, dismissOnClick = true, testId = 'fs-dropdown-item', ...otherProps },
+    {
+      children,
+      asChild,
+      icon,
+      onClick,
+      dismissOnClick = true,
+      testId = 'fs-dropdown-item',
+      ...otherProps
+    },
     ref
   ) {
     const itemProps = useDropdownItem({ ref, onClick, dismissOnClick })
 
     const asChildrenItem = React.isValidElement(children)
-    ? cloneElement(children, { ...itemProps, ...children.props })
-    : children;
+      ? cloneElement(children, { ...itemProps, ...children.props })
+      : children
 
     return (
       <>
-      {asChild ? (
-        asChildrenItem
-      ) : (
-        <button
-          data-fs-dropdown-item
-          data-testid={testId}
-          {...itemProps}
-          {...otherProps}
-        >
-          {!!icon && icon}
-          {children}
-        </button>
+        {asChild ? (
+          asChildrenItem
+        ) : (
+          <button
+            data-fs-dropdown-item
+            data-testid={testId}
+            {...itemProps}
+            {...otherProps}
+          >
+            {!!icon && icon}
+            {children}
+          </button>
         )}
       </>
     )

--- a/packages/components/src/molecules/Dropdown/DropdownItem.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownItem.tsx
@@ -10,6 +10,7 @@ export interface DropdownItemProps
    */
   testId?: string
   /**
+   * @deprecated
    * A React component that will be rendered as an icon.
    */
   icon?: ReactNode

--- a/packages/components/src/molecules/Dropdown/DropdownItem.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownItem.tsx
@@ -13,9 +13,13 @@ export interface DropdownItemProps
    * A React component that will be rendered as an icon.
    */
   icon?: ReactNode
-
+  /** 
+   * Replace the default rendered element with the one passed as a child, merging their props and behavior. 
+   * */
   asChild?: boolean
-
+  /**
+   *  Emit onDismiss eventwhen the component is clicked.
+   */
   dismissOnClick?: boolean
 }
 

--- a/packages/components/src/molecules/Dropdown/DropdownMenu.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownMenu.tsx
@@ -29,7 +29,7 @@ export interface DropdownMenuProps extends ModalContentProps {
    */
   onDismiss?: (event: MouseEvent | KeyboardEvent) => void
 
-   /**
+  /**
    * Specifies the size variant.
    */
   size?: 'small' | 'regular'
@@ -50,8 +50,14 @@ const DropdownMenu = ({
   style,
   ...otherProps
 }: PropsWithChildren<DropdownMenuProps>) => {
-  const { isOpen, close, dropdownItemsRef, selectedDropdownItemIndexRef, dropdownButtonRef, id } =
-    useDropdown()
+  const {
+    isOpen,
+    close,
+    dropdownItemsRef,
+    selectedDropdownItemIndexRef,
+    dropdownTriggerRef,
+    id,
+  } = useDropdown()
 
   const dropdownPosition = useDropdownPosition()
 
@@ -89,25 +95,58 @@ const DropdownMenu = ({
 
   const handleEscapePress = () => {
     close?.()
-    dropdownButtonRef?.current?.focus()
+    dropdownTriggerRef?.current?.focus()
   }
 
+  const handleKeyNavigatePress = (key: string) => {
+    const dropdownItems = dropdownItemsRef?.current ?? [];
+    const selectedIndex = selectedDropdownItemIndexRef!.current;
+  
+    const rearrangedDropdownItems = [
+      ...dropdownItems.slice(selectedIndex + 1),
+      ...dropdownItems.slice(0, selectedIndex + 1),
+    ];
+  
+    const matchItem = rearrangedDropdownItems.find(
+      (item) => item.textContent?.[0].toLowerCase() === key.toLowerCase()
+    );
+  
+    if (matchItem) {
+      selectedDropdownItemIndexRef!.current = dropdownItems.indexOf(matchItem);
+      matchItem.focus();
+    }
+  };
+  
+
   const handleBackdropKeyDown = (event: KeyboardEvent) => {
-    if (event.defaultPrevented || event.key === 'Enter') {
+    console.log(event.keyCode)
+    if (event.defaultPrevented || event.key === 'Enter' || event.keyCode === 32) {
       return
     }
+    
 
     event.preventDefault()
 
-    event.key === 'Escape' && handleEscapePress()
-
-    event.key === 'ArrowDown' && handleDownPress()
-
-    event.key === 'ArrowUp' && handleUpPress()
-
-    event.key === 'Home' && handleHomePress()
-
-    event.key === 'End' && handleEndPress()
+    switch (event.key) {
+      case 'Escape':
+        handleEscapePress()
+        break
+      case 'ArrowDown':
+        handleDownPress()
+        break
+      case 'ArrowUp':
+        handleUpPress()
+        break
+      case 'Home':
+        handleHomePress()
+        break
+      case 'End':
+        handleEndPress()
+        break
+      default:
+        handleKeyNavigatePress(event.key)
+        break
+    }
 
     event.stopPropagation()
   }

--- a/packages/components/src/molecules/Dropdown/DropdownMenu.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownMenu.tsx
@@ -22,17 +22,19 @@ export interface DropdownMenuProps extends ModalContentProps {
    * @see aria-labelledby https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby
    */
   'aria-labelledby'?: AriaAttributes['aria-label']
-
   /**
    * This function is called whenever the user hits "Escape" or clicks outside
    * the dialog.
    */
   onDismiss?: (event: MouseEvent | KeyboardEvent) => void
-
   /**
    * Specifies the size variant.
    */
   size?: 'small' | 'regular'
+  /**
+   * Alignment for the dropdown
+   */
+  align?: 'left' | 'right' | 'center'
 
   children: ReactNode[] | ReactNode
 }
@@ -47,6 +49,7 @@ const DropdownMenu = ({
   children,
   testId = 'fs-dropdown-menu',
   size = 'regular',
+  align = 'left',
   style,
   ...otherProps
 }: PropsWithChildren<DropdownMenuProps>) => {
@@ -59,7 +62,7 @@ const DropdownMenu = ({
     id,
   } = useDropdown()
 
-  const { loading: loadingPosition, ...dropdownPosition } = useDropdownPosition()
+  const { loading: loadingPosition, ...dropdownPosition } = useDropdownPosition(align)
 
   const childrenLength = React.Children.toArray(children).length
 

--- a/packages/components/src/molecules/Dropdown/DropdownMenu.tsx
+++ b/packages/components/src/molecules/Dropdown/DropdownMenu.tsx
@@ -59,7 +59,7 @@ const DropdownMenu = ({
     id,
   } = useDropdown()
 
-  const dropdownPosition = useDropdownPosition()
+  const { loading: loadingPosition, ...dropdownPosition } = useDropdownPosition()
 
   const childrenLength = React.Children.toArray(children).length
 
@@ -108,7 +108,7 @@ const DropdownMenu = ({
     ];
   
     const matchItem = rearrangedDropdownItems.find(
-      (item) => item.textContent?.[0].toLowerCase() === key.toLowerCase()
+      (item) => item.textContent?.[0]?.toLowerCase() === key.toLowerCase()
     );
   
     if (matchItem) {
@@ -119,11 +119,9 @@ const DropdownMenu = ({
   
 
   const handleBackdropKeyDown = (event: KeyboardEvent) => {
-    console.log(event.keyCode)
-    if (event.defaultPrevented || event.key === 'Enter' || event.keyCode === 32) {
+    if (event.defaultPrevented || event.key === 'Enter' || event.key === ' ') {
       return
     }
-    
 
     event.preventDefault()
 
@@ -157,7 +155,7 @@ const DropdownMenu = ({
     return null
   }
 
-  return isOpen
+  return (isOpen && !loadingPosition)
     ? createPortal(
         <div
           role="presentation"

--- a/packages/components/src/molecules/Dropdown/contexts/DropdownContext.ts
+++ b/packages/components/src/molecules/Dropdown/contexts/DropdownContext.ts
@@ -38,6 +38,9 @@ export type DropdownContextState<
    */
   id: string
 
+  /**
+   * Associates the dropdown trigger element's ref for managing its position and interaction events.
+   */
   addDropdownTriggerRef?(ref: T | null): void
 }
 

--- a/packages/components/src/molecules/Dropdown/contexts/DropdownContext.ts
+++ b/packages/components/src/molecules/Dropdown/contexts/DropdownContext.ts
@@ -1,6 +1,18 @@
 import { createContext } from 'react'
 
-export type DropdownContextState = {
+export type DropdownTriggerElement = {
+  focus(): void
+  getBoundingClientRect(): DOMRect
+} & Element
+
+export type DropdownItemElement = {
+  focus(): void
+} & Element
+
+export type DropdownContextState<
+  T extends DropdownTriggerElement = DropdownTriggerElement,
+  E extends DropdownItemElement = DropdownItemElement,
+> = {
   /**
    * Control de Dropdown state as Opened (true) or Closed (false).
    */
@@ -8,7 +20,7 @@ export type DropdownContextState = {
   /**
    * Reference to DropdownButton, used to calculate a position for the DropdownMenu.
    */
-  dropdownButtonRef: React.RefObject<HTMLButtonElement> | null
+  dropdownTriggerRef: React.MutableRefObject<T | null> | null
   /**
    * Reference to a selected DropdownItem, used to manipulate focus.
    */
@@ -16,11 +28,7 @@ export type DropdownContextState = {
   /**
    * Array of References to dropdownItems in a DropdownMenu.
    */
-  dropdownItemsRef: React.MutableRefObject<HTMLButtonElement[]> | null
-  /**
-   * Close DropdownMenu event inherited from Modal.
-   */
-  onDismiss?(): void
+  dropdownItemsRef: React.MutableRefObject<E[]> | null
   /**
    * Function responsible for close the DropdownMenu in this context.
    */
@@ -38,11 +46,13 @@ export type DropdownContextState = {
    * Identifier to be used in aria-controls
    */
   id: string
+
+  addDropdownTriggerRef?(ref: T | null): void
 }
 
 const defaultState: DropdownContextState = {
   isOpen: false,
-  dropdownButtonRef: null,
+  dropdownTriggerRef: null,
   selectedDropdownItemIndexRef: null,
   dropdownItemsRef: null,
   id: 'fs-dropdown',

--- a/packages/components/src/molecules/Dropdown/contexts/DropdownContext.ts
+++ b/packages/components/src/molecules/Dropdown/contexts/DropdownContext.ts
@@ -32,12 +32,10 @@ export type DropdownContextState<
    * Function responsible for switch the the DropdownMenu state in this context.
    */
   toggle?(): void
-
   /**
    * Identifier to be used in aria-controls
    */
   id: string
-
   /**
    * Associates the dropdown trigger element's ref for managing its position and interaction events.
    */

--- a/packages/components/src/molecules/Dropdown/contexts/DropdownContext.ts
+++ b/packages/components/src/molecules/Dropdown/contexts/DropdownContext.ts
@@ -1,17 +1,8 @@
 import { createContext } from 'react'
 
-export type DropdownTriggerElement = {
-  focus(): void
-  getBoundingClientRect(): DOMRect
-} & Element
-
-export type DropdownItemElement = {
-  focus(): void
-} & Element
-
 export type DropdownContextState<
-  T extends DropdownTriggerElement = DropdownTriggerElement,
-  E extends DropdownItemElement = DropdownItemElement,
+  T extends HTMLElement = HTMLElement,
+  E extends HTMLElement = HTMLElement,
 > = {
   /**
    * Control de Dropdown state as Opened (true) or Closed (false).

--- a/packages/components/src/molecules/Dropdown/hooks/useDropdown.ts
+++ b/packages/components/src/molecules/Dropdown/hooks/useDropdown.ts
@@ -1,14 +1,14 @@
 import { useContext } from 'react'
 
-import type { DropdownContextState, DropdownItemElement, DropdownTriggerElement } from '../contexts/DropdownContext'
+import type { DropdownContextState } from '../contexts/DropdownContext'
 import DropdownContext from '../contexts/DropdownContext'
 
 /**
  * Hook to use the Dropdown context.
  * @returns Dropdown context.
  */
-export const useDropdown = <T extends DropdownTriggerElement = DropdownTriggerElement, E extends DropdownItemElement = DropdownItemElement>() => {
-  const context = useContext<DropdownContextState<DropdownTriggerElement, DropdownItemElement>>(DropdownContext)
+export const useDropdown = <T extends HTMLElement = HTMLElement, E extends HTMLElement = HTMLElement>() => {
+  const context = useContext<DropdownContextState<HTMLElement, HTMLElement>>(DropdownContext)
 
   if (context === undefined) {
     throw new Error('Do not use useDropdown hook outside the Dropdown context.')

--- a/packages/components/src/molecules/Dropdown/hooks/useDropdown.ts
+++ b/packages/components/src/molecules/Dropdown/hooks/useDropdown.ts
@@ -1,18 +1,18 @@
 import { useContext } from 'react'
 
-import type { DropdownContextState } from '../contexts/DropdownContext'
+import type { DropdownContextState, DropdownItemElement, DropdownTriggerElement } from '../contexts/DropdownContext'
 import DropdownContext from '../contexts/DropdownContext'
 
 /**
  * Hook to use the Dropdown context.
  * @returns Dropdown context.
  */
-export const useDropdown = () => {
-  const context = useContext<DropdownContextState>(DropdownContext)
+export const useDropdown = <T extends DropdownTriggerElement = DropdownTriggerElement, E extends DropdownItemElement = DropdownItemElement>() => {
+  const context = useContext<DropdownContextState<DropdownTriggerElement, DropdownItemElement>>(DropdownContext)
 
   if (context === undefined) {
     throw new Error('Do not use useDropdown hook outside the Dropdown context.')
   }
 
-  return context
+  return context as DropdownContextState<T, E>
 }

--- a/packages/components/src/molecules/Dropdown/hooks/useDropdownItem.ts
+++ b/packages/components/src/molecules/Dropdown/hooks/useDropdownItem.ts
@@ -1,0 +1,63 @@
+import React, { useImperativeHandle, useRef, useState } from 'react'
+
+import { DropdownItemElement } from '../contexts/DropdownContext'
+import { useDropdown } from './useDropdown'
+
+export type UseDropdownItemProps<
+  E extends DropdownItemElement = DropdownItemElement,
+> = {
+  ref: React.ForwardedRef<E>
+  onClick?: React.MouseEventHandler<E>
+}
+
+export const useDropdownItem = <
+  E extends DropdownItemElement = DropdownItemElement,
+>({
+  ref,
+  onClick,
+}: UseDropdownItemProps<E>) => {
+  const { dropdownItemsRef, selectedDropdownItemIndexRef, 
+    // close 
+  } = useDropdown<
+    never,
+    E
+  >()
+
+  const [dropdownItemIndex, setDropdownItemIndex] = useState(0)
+  const dropdownItemRef = useRef<E>()
+
+  const addToRefs = (el: E) => {
+    if (el && !dropdownItemsRef?.current.includes(el)) {
+      dropdownItemsRef?.current.push(el)
+      setDropdownItemIndex(
+        dropdownItemsRef?.current.findIndex((element) => element === el) ?? 0
+      )
+    }
+
+    dropdownItemRef.current = el
+  }
+
+  const onFocusItem = () => {
+    selectedDropdownItemIndexRef!.current = dropdownItemIndex
+    dropdownItemsRef?.current[selectedDropdownItemIndexRef!.current]?.focus()
+  }
+
+  const handleOnClickItem = (
+    event: React.MouseEvent<E, MouseEvent>
+  ) => {
+    onClick?.(event)
+    // close?.()
+  }
+
+  useImperativeHandle(ref, () => dropdownItemRef.current!, [])
+
+  return {
+    ref: addToRefs,
+    onFocus: onFocusItem,
+    onMouseEnter: onFocusItem,
+    onClick: handleOnClickItem,
+    role: 'menuitem',
+    tabIndex: -1,
+    'data-index': dropdownItemIndex,
+  }
+}

--- a/packages/components/src/molecules/Dropdown/hooks/useDropdownItem.ts
+++ b/packages/components/src/molecules/Dropdown/hooks/useDropdownItem.ts
@@ -2,24 +2,18 @@ import React, { useImperativeHandle, useRef, useState } from 'react'
 
 import { useDropdown } from './useDropdown'
 
-export type UseDropdownItemProps<
-  E extends HTMLElement = HTMLElement,
-> = {
+export type UseDropdownItemProps<E extends HTMLElement = HTMLElement> = {
   ref: React.ForwardedRef<E>
   onClick?: React.MouseEventHandler<E>
   dismissOnClick?: boolean
 }
 
-export const useDropdownItem = <
-  E extends HTMLElement = HTMLElement,
->({
+export const useDropdownItem = <E extends HTMLElement = HTMLElement>({
   ref,
   onClick,
-  dismissOnClick = true
+  dismissOnClick = true,
 }: UseDropdownItemProps<E>) => {
-  const { dropdownItemsRef, selectedDropdownItemIndexRef, 
-    close 
-  } = useDropdown<
+  const { dropdownItemsRef, selectedDropdownItemIndexRef, close } = useDropdown<
     never,
     E
   >()
@@ -39,13 +33,11 @@ export const useDropdownItem = <
   }
 
   const onFocusItem = () => {
-    selectedDropdownItemIndexRef!.current = dropdownItemIndex;
-    (dropdownItemsRef?.current[selectedDropdownItemIndexRef!.current])?.focus()
+    selectedDropdownItemIndexRef!.current = dropdownItemIndex
+    dropdownItemsRef?.current[selectedDropdownItemIndexRef!.current]?.focus()
   }
 
-  const handleOnClickItem = (
-    event: React.MouseEvent<E, MouseEvent>
-  ) => {
+  const handleOnClickItem = (event: React.MouseEvent<E, MouseEvent>) => {
     onClick?.(event)
     dismissOnClick && close?.()
   }

--- a/packages/components/src/molecules/Dropdown/hooks/useDropdownItem.ts
+++ b/packages/components/src/molecules/Dropdown/hooks/useDropdownItem.ts
@@ -1,17 +1,16 @@
 import React, { useImperativeHandle, useRef, useState } from 'react'
 
-import { DropdownItemElement } from '../contexts/DropdownContext'
 import { useDropdown } from './useDropdown'
 
 export type UseDropdownItemProps<
-  E extends DropdownItemElement = DropdownItemElement,
+  E extends HTMLElement = HTMLElement,
 > = {
   ref: React.ForwardedRef<E>
   onClick?: React.MouseEventHandler<E>
 }
 
 export const useDropdownItem = <
-  E extends DropdownItemElement = DropdownItemElement,
+  E extends HTMLElement = HTMLElement,
 >({
   ref,
   onClick,
@@ -38,8 +37,8 @@ export const useDropdownItem = <
   }
 
   const onFocusItem = () => {
-    selectedDropdownItemIndexRef!.current = dropdownItemIndex
-    dropdownItemsRef?.current[selectedDropdownItemIndexRef!.current]?.focus()
+    selectedDropdownItemIndexRef!.current = dropdownItemIndex;
+    (dropdownItemsRef?.current[selectedDropdownItemIndexRef!.current])?.focus()
   }
 
   const handleOnClickItem = (

--- a/packages/components/src/molecules/Dropdown/hooks/useDropdownItem.ts
+++ b/packages/components/src/molecules/Dropdown/hooks/useDropdownItem.ts
@@ -7,6 +7,7 @@ export type UseDropdownItemProps<
 > = {
   ref: React.ForwardedRef<E>
   onClick?: React.MouseEventHandler<E>
+  dismissOnClick?: boolean
 }
 
 export const useDropdownItem = <
@@ -14,9 +15,10 @@ export const useDropdownItem = <
 >({
   ref,
   onClick,
+  dismissOnClick = true
 }: UseDropdownItemProps<E>) => {
   const { dropdownItemsRef, selectedDropdownItemIndexRef, 
-    // close 
+    close 
   } = useDropdown<
     never,
     E
@@ -45,7 +47,7 @@ export const useDropdownItem = <
     event: React.MouseEvent<E, MouseEvent>
   ) => {
     onClick?.(event)
-    // close?.()
+    dismissOnClick && close?.()
   }
 
   useImperativeHandle(ref, () => dropdownItemRef.current!, [])

--- a/packages/components/src/molecules/Dropdown/hooks/useDropdownPosition.ts
+++ b/packages/components/src/molecules/Dropdown/hooks/useDropdownPosition.ts
@@ -3,18 +3,20 @@ import { useDropdown } from './useDropdown'
 
 type DropdownPosition = {
   loading: boolean
-} & Pick<React.CSSProperties, 'position' | 'top' | 'left'>
+} & Pick<React.CSSProperties, 'position' | 'top' | 'left' | 'right' | 'transform'>
 
 /**
  * Hook used to find the DropdownMenu position in relation to DropdownButton
  * @returns Style with positions.
  */
-export const useDropdownPosition = (): DropdownPosition => {
+export const useDropdownPosition = (align: 'left' | 'center' | 'right' = 'left'): DropdownPosition => {
   const { dropdownTriggerRef, isOpen } = useDropdown()
 
   const [positionProps, setPositionProps] = useState({
     top: 0,
-    left: 0,
+    left: 0 as React.CSSProperties['left'],
+    right: 'auto',
+    transform: 'none',
     loading: true
   })
 
@@ -23,10 +25,13 @@ export const useDropdownPosition = (): DropdownPosition => {
       // Necessary to use this component in SSR
       const isBrowser = typeof window !== 'undefined'
 
-      const buttonRect = dropdownTriggerRef?.current?.getBoundingClientRect()
+      if (!dropdownTriggerRef?.current) return
+
+      const buttonRect = dropdownTriggerRef.current.getBoundingClientRect()
       const topLevel = buttonRect?.top ?? 0
       const topOffset = buttonRect?.height ?? 0
       const leftLevel = buttonRect?.left ?? 0
+      const buttonWidth = buttonRect?.width ?? 0
 
       // The scroll properties fix the position of DropdownMenu when the scroll is activated.
       const scrollTop = isBrowser ? document?.documentElement?.scrollTop : 0
@@ -34,27 +39,38 @@ export const useDropdownPosition = (): DropdownPosition => {
 
       const topPosition = topLevel + topOffset + scrollTop
 
-      const leftPosition = leftLevel + scrollLeft
+      let leftPosition: React.CSSProperties['left'] = leftLevel + scrollLeft
+      let rightPosition = 'auto'
+      let transform = 'none'
+
+      if (align === 'right') {
+        rightPosition = `${document.documentElement.clientWidth - leftLevel - buttonWidth}px`
+        leftPosition = 'auto'
+      } else if (align === 'center') {
+        leftPosition = leftLevel + (buttonWidth / 2) + scrollLeft
+        transform = 'translateX(-50%)'
+      }
 
       setPositionProps({
         top: topPosition,
         left: leftPosition,
+        right: rightPosition,
+        transform,
         loading: false
       })
     }
 
-      if (isOpen) {
-        // Update the position of the menu
-        updateMenuPosition()
-        window.addEventListener('resize', updateMenuPosition)
-      }
-
-      // Cleanup listener on unmount or close
-      return () => {
-        window.removeEventListener('resize', updateMenuPosition)
-      }
+    if (isOpen) {
+      // Update the position of the menu
+      updateMenuPosition()
+      window.addEventListener('resize', updateMenuPosition)
     }
-  , [dropdownTriggerRef, isOpen])
+
+    // Cleanup listener on unmount or close
+    return () => {
+      window.removeEventListener('resize', updateMenuPosition)
+    }
+  }, [dropdownTriggerRef, isOpen, align])
 
   return { ...positionProps, position: 'absolute' as const }
 }

--- a/packages/components/src/molecules/Dropdown/hooks/useDropdownPosition.ts
+++ b/packages/components/src/molecules/Dropdown/hooks/useDropdownPosition.ts
@@ -1,33 +1,60 @@
+import { useEffect, useState } from 'react'
 import { useDropdown } from './useDropdown'
 
-type DropdownPosition = Pick<React.CSSProperties, 'position' | 'top' | 'left'>
+type DropdownPosition = {
+  loading: boolean
+} & Pick<React.CSSProperties, 'position' | 'top' | 'left'>
 
 /**
  * Hook used to find the DropdownMenu position in relation to DropdownButton
  * @returns Style with positions.
  */
 export const useDropdownPosition = (): DropdownPosition => {
-  const { dropdownTriggerRef } = useDropdown()
+  const { dropdownTriggerRef, isOpen } = useDropdown()
 
-  // Necessary to use this component in SSR
-  const isBrowser = typeof window !== 'undefined'
+  const [positionProps, setPositionProps] = useState({
+    top: 0,
+    left: 0,
+    loading: true
+  })
 
-  const buttonRect = dropdownTriggerRef?.current?.getBoundingClientRect()
-  const topLevel = buttonRect?.top ?? 0
-  const topOffset = buttonRect?.height ?? 0
-  const leftLevel = buttonRect?.left ?? 0
+  useEffect(() => {
+    const updateMenuPosition = () => {
+      // Necessary to use this component in SSR
+      const isBrowser = typeof window !== 'undefined'
 
-  // The scroll properties fix the position of DropdownMenu when the scroll is activated.
-  const scrollTop = isBrowser ? document?.documentElement?.scrollTop : 0
-  const scrollLeft = isBrowser ? document?.documentElement?.scrollLeft : 0
+      const buttonRect = dropdownTriggerRef?.current?.getBoundingClientRect()
+      const topLevel = buttonRect?.top ?? 0
+      const topOffset = buttonRect?.height ?? 0
+      const leftLevel = buttonRect?.left ?? 0
 
-  const topPosition = topLevel + topOffset + scrollTop
+      // The scroll properties fix the position of DropdownMenu when the scroll is activated.
+      const scrollTop = isBrowser ? document?.documentElement?.scrollTop : 0
+      const scrollLeft = isBrowser ? document?.documentElement?.scrollLeft : 0
 
-  const leftPosition = leftLevel + scrollLeft
+      const topPosition = topLevel + topOffset + scrollTop
 
-  return {
-    position: 'absolute',
-    top: topPosition,
-    left: leftPosition,
-  }
+      const leftPosition = leftLevel + scrollLeft
+
+      setPositionProps({
+        top: topPosition,
+        left: leftPosition,
+        loading: false
+      })
+    }
+
+      if (isOpen) {
+        // Update the position of the menu
+        updateMenuPosition()
+        window.addEventListener('resize', updateMenuPosition)
+      }
+
+      // Cleanup listener on unmount or close
+      return () => {
+        window.removeEventListener('resize', updateMenuPosition)
+      }
+    }
+  , [dropdownTriggerRef, isOpen])
+
+  return { ...positionProps, position: 'absolute' as const }
 }

--- a/packages/components/src/molecules/Dropdown/hooks/useDropdownPosition.ts
+++ b/packages/components/src/molecules/Dropdown/hooks/useDropdownPosition.ts
@@ -7,12 +7,12 @@ type DropdownPosition = Pick<React.CSSProperties, 'position' | 'top' | 'left'>
  * @returns Style with positions.
  */
 export const useDropdownPosition = (): DropdownPosition => {
-  const { dropdownButtonRef } = useDropdown()
+  const { dropdownTriggerRef } = useDropdown()
 
   // Necessary to use this component in SSR
   const isBrowser = typeof window !== 'undefined'
 
-  const buttonRect = dropdownButtonRef?.current?.getBoundingClientRect()
+  const buttonRect = dropdownTriggerRef?.current?.getBoundingClientRect()
   const topLevel = buttonRect?.top ?? 0
   const topOffset = buttonRect?.height ?? 0
   const leftLevel = buttonRect?.left ?? 0

--- a/packages/components/src/molecules/Dropdown/hooks/useDropdownTrigger.ts
+++ b/packages/components/src/molecules/Dropdown/hooks/useDropdownTrigger.ts
@@ -1,13 +1,12 @@
-import { DropdownTriggerElement } from '../contexts/DropdownContext'
 import { useDropdown } from './useDropdown'
 import React, { useImperativeHandle } from 'react'
 
-type UseDropdownTriggerProps<T extends DropdownTriggerElement = DropdownTriggerElement> = {
+type UseDropdownTriggerProps<T extends HTMLElement = HTMLElement> = {
   triggerRef: React.ForwardedRef<T>
   label?: string
 }
 
-export const useDropdownTrigger = <T extends DropdownTriggerElement = DropdownTriggerElement>({
+export const useDropdownTrigger = <T extends HTMLElement = HTMLElement>({
   triggerRef,
 }: UseDropdownTriggerProps<T>) => {
   const { toggle, dropdownTriggerRef, addDropdownTriggerRef, isOpen, id } =

--- a/packages/components/src/molecules/Dropdown/hooks/useDropdownTrigger.ts
+++ b/packages/components/src/molecules/Dropdown/hooks/useDropdownTrigger.ts
@@ -1,0 +1,27 @@
+import { DropdownTriggerElement } from '../contexts/DropdownContext'
+import { useDropdown } from './useDropdown'
+import React, { useImperativeHandle } from 'react'
+
+type UseDropdownTriggerProps<T extends DropdownTriggerElement = DropdownTriggerElement> = {
+  triggerRef: React.ForwardedRef<T>
+  label?: string
+}
+
+export const useDropdownTrigger = <T extends DropdownTriggerElement = DropdownTriggerElement>({
+  triggerRef,
+}: UseDropdownTriggerProps<T>) => {
+  const { toggle, dropdownTriggerRef, addDropdownTriggerRef, isOpen, id } =
+    useDropdown<T>()
+
+  useImperativeHandle(triggerRef, () => dropdownTriggerRef!.current!, [
+    dropdownTriggerRef,
+  ])
+
+  return {
+    onClick: toggle,
+    ref: addDropdownTriggerRef,
+    'aria-expanded': isOpen,
+    'aria-controls': id,
+    'aria-haspopup': 'menu' as const,
+  }
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

<!--- Considering the context, what is the problem we'll solve? Where in VTEX's big picture our issue fits in? Write a tweet about the context and the problem itself. --->

Improve the Dropdown by adding new options and expanding its usability. In this PR, properties like `asChild`, `alignment`, and `dismissOnClick` have been added. There are no breaking changes, but properties related to icons in `DropdownButton` and `DropdownMenuItem` were marked as deprecated, as these functionalities can now be configured directly within the component content.

## How does it work?

### New Hooks
As part of the refactor of the `DropdownButton` and `DropdownMenuItem` components, new hooks were created that encapsulate logic, enabling new components to be created with a fresh structure while maintaining functionality. The new hooks are `useDropdownItem` and `useDropdownTrigger`.

### Alignment Property
A new property called `align` has been added to the `DropdownMenu`. This property allows the `DropdownMenu` to align with the `DropdownButton` based on the desired alignment: right, left, or center.

| right     | center | left     |
|----------|--------|------------|
| <img width="179" alt="Screenshot 2024-10-07 at 23 24 07" src="https://github.com/user-attachments/assets/53d6c21f-3c1e-434a-8493-e477b5efefd9">     | <img width="178" alt="Screenshot 2024-10-07 at 23 23 31" src="https://github.com/user-attachments/assets/30151d85-b1b7-4d88-92de-d0a90029477d">    | <img width="182" alt="Screenshot 2024-10-07 at 23 24 35" src="https://github.com/user-attachments/assets/61634f68-d76a-4f47-93b7-3046aa5d80d8">     |

### Adjustments to the `useDropdownPosition` Hook
Some adjustments have been made to the `useDropdownPosition` hook. It now observes changes in window resizing, fixing the alignment bug for the Dropdown.

### Controlled Component
New functionality has been added to allow the Dropdown to be controlled externally, enabling it to be manipulated through external states. Example:

```jsx
      const [isOpen, setIsOpen] = useState(false)
      return (
        <Dropdown isOpen={isOpen} onDismiss={() => {setIsOpen(false)}}>
          <DropdownButton>Controlled Dropdown</DropdownButton>
          <DropdownMenu>
            <DropdownItem>A - Dropdown item as child</DropdownItem>
            <DropdownItem>B - Dropdown item as child</DropdownItem>
            <DropdownItem>C - Dropdown item as child</DropdownItem>
            <DropdownItem>D - Dropdown item as child</DropdownItem>
          </DropdownMenu>
        </Dropdown>
```

The usage of the controlled Dropdown can be seen in the preview at: [#controlled](https://faststore-site-git-feat-improve-dropdowneat-faststore.vercel.app/components/molecules/dropdown#controlled)

### asChild Property
Based on libraries like Radix, the DropdownButton and DropdownMenuItem components now include the asChild property. This allows replacing the default rendered components with custom child elements, while maintaining behavior through prop passing. Example:

```jsx
      <Dropdown>
        <DropdownButton asChild>
          <button>{'Dropdown with trigger as child'}</button>
        </DropdownButton>
        <DropdownMenu style={{ backgroundColor: "white"}}>
          <DropdownItem asChild>
            <button>A - Dropdown item as child</button>
          </DropdownItem>
          <DropdownItem asChild>
            <button>B - Dropdown item as child</button>
          </DropdownItem>
          <DropdownItem asChild>
            <button>C - Dropdown item as child</button>
          </DropdownItem>
          <DropdownItem asChild>
            <button>D - Dropdown item as child</button>
          </DropdownItem>
        </DropdownMenu>
      </Dropdown>
```

The usage of the asChild property can be seen in the preview at: [#as-child](https://faststore-site-git-feat-improve-dropdowneat-faststore.vercel.app/components/molecules/dropdown#as-child)

How to test it?
You can test it by visiting the documentation at: https://faststore-site-git-feat-improve-dropdowneat-faststore.vercel.app/components/molecules/dropdown

References
[Dropdown Menu](https://www.radix-ui.com/primitives/docs/components/dropdown-menu)
[B2BTEAM-1895](https://vtex-dev.atlassian.net/browse/B2BTEAM-1895)

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: feat, fix, chore, docs, style, refactor and test

**PR Description**

- [x] Added a label according to the PR goal - breaking change, bug, contributing, performance, documentation..

**Dependencies**

- [ ] Committed the yarn.lock file when there were changes to the packages


[B2BTEAM-1895]: https://vtex-dev.atlassian.net/browse/B2BTEAM-1895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ