### PR TITLE
feat: enable preact experimental feature

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "degit": "^2.8.4",
     "dotenv": "^16.4.5",
     "fs-extra": "^10.1.0",
-    "ora": "^8.1.0",
+    "ora": "5.4.1",
     "path": "^0.12.7"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
     "degit": "^2.8.4",
     "dotenv": "^16.4.5",
     "fs-extra": "^10.1.0",
+    "ora": "^8.1.0",
     "path": "^0.12.7"
   },
   "devDependencies": {

--- a/packages/cli/src/utils/dependencies.ts
+++ b/packages/cli/src/utils/dependencies.ts
@@ -2,6 +2,7 @@ import chalk from "chalk"
 import { getPreferredPackageManager } from "./commands"
 import { execSync } from "node:child_process"
 
+
 type InstallDependenciesOptions = { 
     dependencies: string[]
     cwd: string,
@@ -10,15 +11,24 @@ type InstallDependenciesOptions = {
 }
 
 export function installDependencies(
- { dependencies,
-  cwd, successMessage }: InstallDependenciesOptions
+ { 
+  dependencies,
+  cwd, 
+  successMessage,
+  errorMessage 
+}: InstallDependenciesOptions
 ) {
-
-  const packageManager = getPreferredPackageManager() 
-  const installCommand = packageManager === 'npm' ? 'install' : 'add'
-  execSync(`${packageManager} ${installCommand} ${dependencies.join(' ')}`, {
-    cwd,
-  })
-
-  console.log(`${chalk.green('success')} - ${successMessage}`)
+  try {
+    const packageManager = getPreferredPackageManager() 
+    const installCommand = packageManager === 'npm' ? 'install' : 'add'
+    execSync(`${packageManager} ${installCommand} ${dependencies.join(' ')}`, {
+      cwd,
+    })
+  
+    console.log(`${chalk.green('success')} - ${successMessage}`)
+  }catch (err) {
+    console.log(`${chalk.red('error')} - ${errorMessage}`)
+    process.exit(1)
+  }
+ 
 }

--- a/packages/cli/src/utils/dependencies.ts
+++ b/packages/cli/src/utils/dependencies.ts
@@ -1,34 +1,28 @@
-import chalk from "chalk"
 import { getPreferredPackageManager } from "./commands"
-import { execSync } from "node:child_process"
+import { runCommandSync } from "./runCommandSync"
 
 
 type InstallDependenciesOptions = { 
     dependencies: string[]
     cwd: string,
     errorMessage: string,
-    successMessage: string,
 }
 
 export function installDependencies(
  { 
   dependencies,
   cwd, 
-  successMessage,
   errorMessage 
 }: InstallDependenciesOptions
 ) {
-  try {
-    const packageManager = getPreferredPackageManager() 
-    const installCommand = packageManager === 'npm' ? 'install' : 'add'
-    execSync(`${packageManager} ${installCommand} ${dependencies.join(' ')}`, {
-      cwd,
-    })
-  
-    console.log(`${chalk.green('success')} - ${successMessage}`)
-  }catch (err) {
-    console.log(`${chalk.red('error')} - ${errorMessage}`)
-    process.exit(1)
-  }
- 
+  const packageManager = getPreferredPackageManager() 
+  const installCommand = packageManager === 'npm' ? 'install' : 'add'
+
+  runCommandSync({
+    cmd: `${packageManager} ${installCommand} ${dependencies.join(' ')}`,
+    errorMessage,
+    throws: 'error',
+    debug: false,
+    cwd,
+  })
 }

--- a/packages/cli/src/utils/dependencies.ts
+++ b/packages/cli/src/utils/dependencies.ts
@@ -1,7 +1,6 @@
 import { getPreferredPackageManager } from "./commands"
 import { runCommandSync } from "./runCommandSync"
 
-
 type InstallDependenciesOptions = { 
     dependencies: string[]
     cwd: string,

--- a/packages/cli/src/utils/dependencies.ts
+++ b/packages/cli/src/utils/dependencies.ts
@@ -1,0 +1,35 @@
+import chalk from "chalk"
+import { getPreferredPackageManager } from "./commands"
+import { runCommandSync } from "./runCommandSync"
+
+type InstallDependenciesOptions = { 
+    dependencies: string[]
+    cwd: string,
+    errorMessage: string,
+    successMessage: string,
+}
+
+const installCommandByPackageManager: Record<string, string> = { 
+  yarn: 'add',
+  npm: 'install',
+  pnpm: 'add'
+}
+
+export function installDependencies(
+ { dependencies,
+  cwd, errorMessage, successMessage }: InstallDependenciesOptions
+) {
+
+  const packageManager = getPreferredPackageManager() 
+  const installCommand = installCommandByPackageManager[packageManager]
+
+  runCommandSync({
+    cwd,
+    cmd: `${packageManager} ${installCommand} ${dependencies.join(' ')}`,
+    errorMessage,
+    debug: true,
+    throws: 'error'
+  })
+
+  console.log(`${chalk.green('success')} - ${successMessage}`)
+}

--- a/packages/cli/src/utils/dependencies.ts
+++ b/packages/cli/src/utils/dependencies.ts
@@ -27,7 +27,7 @@ export function installDependencies(
     cwd,
     cmd: `${packageManager} ${installCommand} ${dependencies.join(' ')}`,
     errorMessage,
-    debug: true,
+    debug: false,
     throws: 'error'
   })
 

--- a/packages/cli/src/utils/dependencies.ts
+++ b/packages/cli/src/utils/dependencies.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk"
 import { getPreferredPackageManager } from "./commands"
-import { runCommandSync } from "./runCommandSync"
+import { execSync } from "node:child_process"
 
 type InstallDependenciesOptions = { 
     dependencies: string[]
@@ -9,26 +9,15 @@ type InstallDependenciesOptions = {
     successMessage: string,
 }
 
-const installCommandByPackageManager: Record<string, string> = { 
-  yarn: 'add',
-  npm: 'install',
-  pnpm: 'add'
-}
-
 export function installDependencies(
  { dependencies,
-  cwd, errorMessage, successMessage }: InstallDependenciesOptions
+  cwd, successMessage }: InstallDependenciesOptions
 ) {
 
   const packageManager = getPreferredPackageManager() 
-  const installCommand = installCommandByPackageManager[packageManager]
-
-  runCommandSync({
+  const installCommand = packageManager === 'npm' ? 'install' : 'add'
+  execSync(`${packageManager} ${installCommand} ${dependencies.join(' ')}`, {
     cwd,
-    cmd: `${packageManager} ${installCommand} ${dependencies.join(' ')}`,
-    errorMessage,
-    debug: false,
-    throws: 'error'
   })
 
   console.log(`${chalk.green('success')} - ${successMessage}`)

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -406,13 +406,12 @@ function validateAndInstallMissingDependencies(basePath: string) {
     })
 
     if(dependenciesToInstall.length > 0) {
-      const spinner = ora(`Installing missing dependencies ${dependenciesToInstall.join(' ')}...`).start()
+      const spinner = ora(`Installing ${feature} missing dependencies\n`).start()
 
       installDependencies({
         dependencies: dependenciesToInstall,
         cwd: userDir,
         errorMessage: `failed to install ${feature} dependencies`,
-        successMessage: `${feature} dependencies installed`,
       })
 
       spinner.stop()

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -13,6 +13,7 @@ import {
 import path from 'path'
 
 import { withBasePath } from './directory'
+import { installDependencies } from './dependencies'
 
 interface GenerateOptions {
   setup?: boolean
@@ -376,10 +377,33 @@ function checkDependencies(basePath: string, packagesToCheck: string[]) {
   })
 }
 
+async function installRequiredDependencies(basePath: string) {
+  const { userDir, userStoreConfigFile } = withBasePath(basePath)
+  console.log(userDir, userStoreConfigFile)
+  if (!existsSync(userStoreConfigFile)) {
+    return 
+  }
+
+  const userStoreConfig = await import(path.resolve(userStoreConfigFile))
+
+  if(userStoreConfig.experimental.preact) {
+    installDependencies({
+      dependencies: ['preact@10.23.1', 'preact-render-to-string@6.5.8'],
+      cwd: userDir,
+      errorMessage: 'Failed to install Preact dependencies',
+      successMessage: 'Preact dependencies installed',
+    })
+  }
+}
+
+
 export async function generate(options: GenerateOptions) {
   const { basePath, setup = false } = options
 
   let setupPromise: Promise<unknown> | null = null
+
+
+  await installRequiredDependencies(basePath)
 
   if (setup) {
     setupPromise = Promise.all([

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -100,5 +100,6 @@ module.exports = {
     cypressVersion: 12,
     enableCypressExtension: false,
     noRobots: false,
+    preact: false,
   },
 }

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -48,8 +48,6 @@ const nextConfig = {
 
     if (storeConfig.experimental.preact && !isServer && !dev) {
       Object.assign(config.resolve.alias, {
-        // 'react/jsx-runtime.js': 'preact/compat/jsx-runtime',
-
         react: 'preact/compat',
 
         'react-dom/test-utils': 'preact/test-utils',

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -46,6 +46,18 @@ const nextConfig = {
       config.optimization.splitChunks.maxInitialRequests = 1
     }
 
+    if (storeConfig.experimental.preact && !isServer && !dev) {
+      Object.assign(config.resolve.alias, {
+        // 'react/jsx-runtime.js': 'preact/compat/jsx-runtime',
+
+        react: 'preact/compat',
+
+        'react-dom/test-utils': 'preact/test-utils',
+
+        'react-dom': 'preact/compat',
+      })
+    }
+
     return config
   },
   redirects: storeConfig.redirects,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5751,7 +5751,7 @@ chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@5.3.0, chalk@^5.3.0:
+chalk@5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
@@ -5988,13 +5988,6 @@ cli-cursor@^4.0.0:
   integrity sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==
   dependencies:
     restore-cursor "^4.0.0"
-
-cli-cursor@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
-  integrity sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==
-  dependencies:
-    restore-cursor "^5.0.0"
 
 cli-progress@^3.10.0:
   version "3.11.2"
@@ -10537,11 +10530,6 @@ is-interactive@^1.0.0:
   resolved "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
-is-interactive@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-2.0.0.tgz#40c57614593826da1100ade6059778d597f16e90"
-  integrity sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==
-
 is-lambda@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz"
@@ -10783,16 +10771,6 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
-
-is-unicode-supported@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz#d824984b616c292a2e198207d4a609983842f714"
-  integrity sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==
-
-is-unicode-supported@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz#09f0ab0de6d3744d48d265ebb98f65d11f2a9b3a"
-  integrity sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==
 
 is-upper-case@^2.0.2:
   version "2.0.2"
@@ -12202,14 +12180,6 @@ log-symbols@^4.0.0, log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
-log-symbols@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-6.0.0.tgz#bb95e5f05322651cac30c0feb6404f9f2a8a9439"
-  integrity sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==
-  dependencies:
-    chalk "^5.3.0"
-    is-unicode-supported "^1.3.0"
-
 log-update@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz"
@@ -13256,11 +13226,6 @@ mimic-fn@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz"
   integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
-
-mimic-function@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
-  integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
@@ -14378,13 +14343,6 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
-onetime@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
-  integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
-  dependencies:
-    mimic-function "^5.0.0"
-
 open@^7.1.0:
   version "7.4.2"
   resolved "https://registry.npmjs.org/open/-/open-7.4.2.tgz"
@@ -14428,7 +14386,7 @@ ora@5.3.0:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
-ora@^5.4.1:
+ora@5.4.1, ora@^5.4.1:
   version "5.4.1"
   resolved "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz"
   integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
@@ -14442,21 +14400,6 @@ ora@^5.4.1:
     log-symbols "^4.1.0"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
-
-ora@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-8.1.0.tgz#c3db2f9f83a2bec9e8ab71fe3b9ae234d65ca3a8"
-  integrity sha512-GQEkNkH/GHOhPFXcqZs3IDahXEQcQxsSjEkK4KvEEST4t7eNzoMjxTzef+EZ+JluDEV+Raoi3WQ2CflnRdSVnQ==
-  dependencies:
-    chalk "^5.3.0"
-    cli-cursor "^5.0.0"
-    cli-spinners "^2.9.2"
-    is-interactive "^2.0.0"
-    is-unicode-supported "^2.0.0"
-    log-symbols "^6.0.0"
-    stdin-discarder "^0.2.2"
-    string-width "^7.2.0"
-    strip-ansi "^7.1.0"
 
 os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -15946,14 +15889,6 @@ restore-cursor@^4.0.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
-restore-cursor@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
-  integrity sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==
-  dependencies:
-    onetime "^7.0.0"
-    signal-exit "^4.1.0"
-
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz"
@@ -16729,11 +16664,6 @@ statuses@2.0.1:
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stdin-discarder@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.2.2.tgz#390037f44c4ae1a1ae535c5fe38dc3aba8d997be"
-  integrity sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==
-
 stop-iteration-iterator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz"
@@ -16820,15 +16750,6 @@ string-width@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/string-width/-/string-width-7.0.0.tgz"
   integrity sha512-GPQHj7row82Hjo9hKZieKcHIhaAIKOJvFSIZXuCU9OASVZrMNUaZuz++SPVrBjnLsnk4k+z9f2EIypgxf2vNFw==
-  dependencies:
-    emoji-regex "^10.3.0"
-    get-east-asian-width "^1.0.0"
-    strip-ansi "^7.1.0"
-
-string-width@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
-  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
   dependencies:
     emoji-regex "^10.3.0"
     get-east-asian-width "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5751,7 +5751,7 @@ chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@5.3.0:
+chalk@5.3.0, chalk@^5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
@@ -5988,6 +5988,13 @@ cli-cursor@^4.0.0:
   integrity sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==
   dependencies:
     restore-cursor "^4.0.0"
+
+cli-cursor@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
+  integrity sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==
+  dependencies:
+    restore-cursor "^5.0.0"
 
 cli-progress@^3.10.0:
   version "3.11.2"
@@ -10530,6 +10537,11 @@ is-interactive@^1.0.0:
   resolved "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
+is-interactive@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-2.0.0.tgz#40c57614593826da1100ade6059778d597f16e90"
+  integrity sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==
+
 is-lambda@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz"
@@ -10771,6 +10783,16 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-unicode-supported@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz#d824984b616c292a2e198207d4a609983842f714"
+  integrity sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==
+
+is-unicode-supported@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz#09f0ab0de6d3744d48d265ebb98f65d11f2a9b3a"
+  integrity sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==
 
 is-upper-case@^2.0.2:
   version "2.0.2"
@@ -12180,6 +12202,14 @@ log-symbols@^4.0.0, log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
+log-symbols@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-6.0.0.tgz#bb95e5f05322651cac30c0feb6404f9f2a8a9439"
+  integrity sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==
+  dependencies:
+    chalk "^5.3.0"
+    is-unicode-supported "^1.3.0"
+
 log-update@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz"
@@ -13226,6 +13256,11 @@ mimic-fn@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz"
   integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
+
+mimic-function@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
+  integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
@@ -14343,6 +14378,13 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
+onetime@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
+  integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
+  dependencies:
+    mimic-function "^5.0.0"
+
 open@^7.1.0:
   version "7.4.2"
   resolved "https://registry.npmjs.org/open/-/open-7.4.2.tgz"
@@ -14400,6 +14442,21 @@ ora@^5.4.1:
     log-symbols "^4.1.0"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
+
+ora@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-8.1.0.tgz#c3db2f9f83a2bec9e8ab71fe3b9ae234d65ca3a8"
+  integrity sha512-GQEkNkH/GHOhPFXcqZs3IDahXEQcQxsSjEkK4KvEEST4t7eNzoMjxTzef+EZ+JluDEV+Raoi3WQ2CflnRdSVnQ==
+  dependencies:
+    chalk "^5.3.0"
+    cli-cursor "^5.0.0"
+    cli-spinners "^2.9.2"
+    is-interactive "^2.0.0"
+    is-unicode-supported "^2.0.0"
+    log-symbols "^6.0.0"
+    stdin-discarder "^0.2.2"
+    string-width "^7.2.0"
+    strip-ansi "^7.1.0"
 
 os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -15889,6 +15946,14 @@ restore-cursor@^4.0.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+restore-cursor@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
+  integrity sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==
+  dependencies:
+    onetime "^7.0.0"
+    signal-exit "^4.1.0"
+
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz"
@@ -16664,6 +16729,11 @@ statuses@2.0.1:
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
+stdin-discarder@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.2.2.tgz#390037f44c4ae1a1ae535c5fe38dc3aba8d997be"
+  integrity sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==
+
 stop-iteration-iterator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz"
@@ -16750,6 +16820,15 @@ string-width@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/string-width/-/string-width-7.0.0.tgz"
   integrity sha512-GPQHj7row82Hjo9hKZieKcHIhaAIKOJvFSIZXuCU9OASVZrMNUaZuz++SPVrBjnLsnk4k+z9f2EIypgxf2vNFw==
+  dependencies:
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
+
+string-width@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
   dependencies:
     emoji-regex "^10.3.0"
     get-east-asian-width "^1.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to experimentally allow the store to enable the use of preact instead of react, keeping react as the default behavior. The objective is to reduce the size of the package used in the project and thus improve performance.

### React build output
<img width="1030" alt="Captura de Tela 2024-10-09 às 11 05 43" src="https://github.com/user-attachments/assets/f89c9b77-2b9d-4c0b-b04b-7490e72b143d">

### Preact build output
<img width="1181" alt="Captura de Tela 2024-10-09 às 11 02 52" src="https://github.com/user-attachments/assets/3b932f02-5d2b-42b5-901a-a0c9d3c816bb">

## How it works?

When **preact** is enabled, all necessary **preact** dependencies are installed and preact settings are also added to `next.config`.

<img width="701" alt="Captura de Tela 2024-10-09 às 12 15 04" src="https://github.com/user-attachments/assets/70e89085-17f4-4825-b26c-2ddd52f9d59a">

## How to test it?

### Validating CLI feature
- Install this preview version of CLI in the starter
- Enable preact in `discovery.config.js` 
```
experimental: {
    nodeVersion: 18,
    cypressVersion: 12,
    preact: true
  }
```
- Run `yarn dev` or `yarn build`
- Validate if all necessary **preact** dependencies are installed

### Validate performance
- Validate if the build size improves when running `yarn build`
- Validate if the store is working. 


