### PR TITLE
Feat: Adds intersection (ViewportObserver) component

### DIFF
--- a/packages/core/src/components/cms/ViewportObserver.tsx
+++ b/packages/core/src/components/cms/ViewportObserver.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 // Mobile height to prevent sections outside the viewport from being rendered initially.
 // We are using the Moto G Power device measurement as a reference, as used by PageSpeed Insights.
-const VIEWPORT_SIZE = 825
+const VIEWPORT_SIZE = 823
 
 type ViewportObserverProps = {
   /**
@@ -35,17 +35,25 @@ function ViewportObserver({
   const observerCallback = useCallback(
     ([entry]: IntersectionObserverEntry[], obs: IntersectionObserver) => {
       if (entry.isIntersecting) {
-        if (debug) console.log('IN')
+        if (debug) {
+          console.log(`section '${name}' VISIBLE`)
+          document.body.style.border = '2px solid green'
+        }
         setShow(true)
         if (ref.current) {
           obs.unobserve(ref.current)
         }
       } else {
         setShow(false)
-        if (debug) console.log('OUT')
+        if (debug) {
+          console.log(`section '${name}' NOT VISIBLE`)
+          document.body.style.border = '2px solid red'
+          document.body.style.height = `${VIEWPORT_SIZE}px`
+          document.body.style.boxSizing = 'border-box'
+        }
       }
     },
-    []
+    [debug, name]
   )
 
   useEffect(() => {
@@ -69,12 +77,8 @@ function ViewportObserver({
           data-store-section-name={name}
           ref={ref}
           style={{
-            border: debug
-              ? isShow
-                ? '8px solid red'
-                : '8px solid blue'
-              : undefined,
-            backgroundColor: debug ? (isShow ? 'gray' : 'pink') : undefined,
+            border: debug ? '2px solid red' : undefined,
+            backgroundColor: debug ? 'red' : undefined,
             height: VIEWPORT_SIZE, // required to make sections out of the viewport to be rendered on demand
             width: '100%',
           }}

--- a/packages/core/src/components/cms/ViewportObserver.tsx
+++ b/packages/core/src/components/cms/ViewportObserver.tsx
@@ -13,7 +13,7 @@ type ViewportObserverProps = {
   /**
    * Identify the store section
    */
-  name?: string
+  sectionName?: string
   /**
    * Debug/test purposes: enables visual debugging to identify the visibility of the section.
    */
@@ -22,7 +22,7 @@ type ViewportObserverProps = {
   DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
 
 function ViewportObserver({
-  name = '',
+  sectionName = '',
   threshold = 0,
   root = null,
   rootMargin,
@@ -36,7 +36,7 @@ function ViewportObserver({
     ([entry]: IntersectionObserverEntry[], obs: IntersectionObserver) => {
       if (entry.isIntersecting) {
         if (debug) {
-          console.log(`section '${name}' VISIBLE`)
+          console.log(`section '${sectionName}' VISIBLE`)
           document.body.style.border = '2px solid green'
         }
         setVisible(true)
@@ -46,14 +46,14 @@ function ViewportObserver({
       } else {
         setVisible(false)
         if (debug) {
-          console.log(`section '${name}' NOT VISIBLE`)
+          console.log(`section '${sectionName}' NOT VISIBLE`)
           document.body.style.border = '2px solid red'
           document.body.style.height = `${VIEWPORT_SIZE}px`
           document.body.style.boxSizing = 'border-box'
         }
       }
     },
-    [debug, name]
+    [debug, sectionName]
   )
 
   useEffect(() => {
@@ -74,7 +74,7 @@ function ViewportObserver({
     <>
       {!isVisible && (
         <div
-          data-store-section-name={name}
+          data-store-section-name={sectionName}
           ref={ref}
           style={{
             border: debug ? '2px solid red' : undefined,

--- a/packages/core/src/components/cms/ViewportObserver.tsx
+++ b/packages/core/src/components/cms/ViewportObserver.tsx
@@ -5,7 +5,9 @@ import type {
 } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-const viewportSize = 825 // mobile height to prevent sections that are outside the viewport from being rendered initially. We are using Moto G Power devices as a reference.
+// Mobile height to prevent sections outside the viewport from being rendered initially. 
+// We are using the Moto G Power device measurement as a reference because it's the one PageSpeed Insights uses.
+const VIEWPORT_SIZE = 825 
 
 type ViewportObserverProps = {
   /**

--- a/packages/core/src/components/cms/ViewportObserver.tsx
+++ b/packages/core/src/components/cms/ViewportObserver.tsx
@@ -29,7 +29,7 @@ function ViewportObserver({
   children,
   debug = false,
 }: PropsWithChildren<ViewportObserverProps>) {
-  const [isShow, setShow] = useState(false)
+  const [isVisible, setVisible] = useState(false)
   const ref = useRef<HTMLDivElement | null>(null)
 
   const observerCallback = useCallback(
@@ -39,12 +39,12 @@ function ViewportObserver({
           console.log(`section '${name}' VISIBLE`)
           document.body.style.border = '2px solid green'
         }
-        setShow(true)
+        setVisible(true)
         if (ref.current) {
           obs.unobserve(ref.current)
         }
       } else {
-        setShow(false)
+        setVisible(false)
         if (debug) {
           console.log(`section '${name}' NOT VISIBLE`)
           document.body.style.border = '2px solid red'
@@ -72,7 +72,7 @@ function ViewportObserver({
 
   return (
     <>
-      {!isShow && (
+      {!isVisible && (
         <div
           data-store-section-name={name}
           ref={ref}
@@ -85,7 +85,7 @@ function ViewportObserver({
         ></div>
       )}
 
-      {isShow && children}
+      {isVisible && children}
     </>
   )
 }

--- a/packages/core/src/components/cms/ViewportObserver.tsx
+++ b/packages/core/src/components/cms/ViewportObserver.tsx
@@ -1,8 +1,4 @@
-import type {
-  DetailedHTMLProps,
-  HTMLAttributes,
-  PropsWithChildren,
-} from 'react'
+import type { PropsWithChildren } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 // Mobile height to prevent sections outside the viewport from being rendered initially.
@@ -18,8 +14,7 @@ type ViewportObserverProps = {
    * Debug/test purposes: enables visual debugging to identify the visibility of the section.
    */
   debug?: boolean
-} & IntersectionObserverInit &
-  DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
+} & IntersectionObserverInit
 
 function ViewportObserver({
   sectionName = '',

--- a/packages/core/src/components/cms/ViewportObserver.tsx
+++ b/packages/core/src/components/cms/ViewportObserver.tsx
@@ -1,0 +1,69 @@
+import type {
+  DetailedHTMLProps,
+  HTMLAttributes,
+  PropsWithChildren,
+} from 'react'
+import { useEffect, useRef, useState } from 'react'
+
+const viewportSize = 825 // mobile height to prevent sections that are outside the viewport from being rendered initially. We are using Moto G Power devices as a reference.
+
+type ViewportObserverProps = {
+  name?: string
+} & IntersectionObserverInit &
+  DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
+
+function ViewportObserver({
+  name = '',
+  threshold = 0,
+  root = null,
+  rootMargin,
+  children,
+}: PropsWithChildren<ViewportObserverProps>) {
+  const [isShow, setShow] = useState(false)
+  const ref = useRef(null)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry], obs) => {
+        if (entry.isIntersecting) {
+          setShow(true)
+          console.log('IN')
+          if (ref.current) {
+            obs.unobserve(ref.current)
+          }
+        } else {
+          console.log('OUT')
+          setShow(false)
+        }
+      },
+      { root, rootMargin, threshold }
+    )
+
+    if (ref.current) {
+      observer.observe(ref.current)
+    }
+
+    return () => observer.disconnect()
+  }, [root, rootMargin, threshold])
+
+  return (
+    <>
+      {!isShow && (
+        <div
+          data-store-section-name={name}
+          ref={ref}
+          style={{
+            border: isShow ? '5px solid red' : '5px solid blue', // debug
+            backgroundColor: isShow ? 'gray' : 'pink', // debug
+            height: viewportSize, // required to make sections out of the viewport to be rendered on demand
+            width: '100%',
+          }}
+        ></div>
+      )}
+
+      {isShow && children}
+    </>
+  )
+}
+
+export default ViewportObserver

--- a/packages/core/src/components/cms/ViewportObserver.tsx
+++ b/packages/core/src/components/cms/ViewportObserver.tsx
@@ -15,7 +15,7 @@ type ViewportObserverProps = {
    */
   name?: string
   /**
-   * Just for debugging/testing purposes to better see the section in the viewport
+   * Debug/test purposes: enables visual debugging to identify the visibility of the section.
    */
   debug?: boolean
 } & IntersectionObserverInit &

--- a/packages/core/src/components/cms/ViewportObserver.tsx
+++ b/packages/core/src/components/cms/ViewportObserver.tsx
@@ -5,9 +5,9 @@ import type {
 } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-// Mobile height to prevent sections outside the viewport from being rendered initially. 
-// We are using the Moto G Power device measurement as a reference because it's the one PageSpeed Insights uses.
-const VIEWPORT_SIZE = 825 
+// Mobile height to prevent sections outside the viewport from being rendered initially.
+// We are using the Moto G Power device measurement as a reference, as used by PageSpeed Insights.
+const VIEWPORT_SIZE = 825
 
 type ViewportObserverProps = {
   /**
@@ -75,7 +75,7 @@ function ViewportObserver({
                 : '8px solid blue'
               : undefined,
             backgroundColor: debug ? (isShow ? 'gray' : 'pink') : undefined,
-            height: viewportSize, // required to make sections out of the viewport to be rendered on demand
+            height: VIEWPORT_SIZE, // required to make sections out of the viewport to be rendered on demand
             width: '100%',
           }}
         ></div>

--- a/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
@@ -7,6 +7,7 @@ import ProductGridSkeleton from 'src/components/skeletons/ProductGridSkeleton'
 import { ProductCardProps } from '../ProductCard'
 
 import { memo } from 'react'
+import ViewportObserver from 'src/components/cms/ViewportObserver'
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 
 interface Props {
@@ -76,28 +77,29 @@ function ProductGrid({
               </UIProductGridItem>
             ))}
             <></>
-
-            {products.slice(2).map(({ node: product }, idx) => (
-              <UIProductGridItem key={`${product.id}`}>
-                <ProductCard.Component
-                  aspectRatio={aspectRatio}
-                  imgProps={{
-                    width: 150,
-                    height: 150,
-                    sizes: '30vw',
-                    loading: 'lazy',
-                  }}
-                  {...ProductCard.props}
-                  bordered={bordered ?? ProductCard.props.bordered}
-                  showDiscountBadge={
-                    showDiscountBadge ?? ProductCard.props.showDiscountBadge
-                  }
-                  product={product}
-                  index={pageSize * page + idx + 1}
-                  taxesConfiguration={taxesConfiguration}
-                />
-              </UIProductGridItem>
-            ))}
+            <ViewportObserver name="UIProductGrid-out-viewport">
+              {products.slice(2).map(({ node: product }, idx) => (
+                <UIProductGridItem key={`${product.id}`}>
+                  <ProductCard.Component
+                    aspectRatio={aspectRatio}
+                    imgProps={{
+                      width: 150,
+                      height: 150,
+                      sizes: '30vw',
+                      loading: 'lazy',
+                    }}
+                    {...ProductCard.props}
+                    bordered={bordered ?? ProductCard.props.bordered}
+                    showDiscountBadge={
+                      showDiscountBadge ?? ProductCard.props.showDiscountBadge
+                    }
+                    product={product}
+                    index={pageSize * page + idx + 1}
+                    taxesConfiguration={taxesConfiguration}
+                  />
+                </UIProductGridItem>
+              ))}
+            </ViewportObserver>
           </>
         ) : (
           <>

--- a/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
@@ -26,6 +26,10 @@ interface Props {
     ProductCardProps,
     'showDiscountBadge' | 'bordered' | 'taxesConfiguration'
   >
+  /**
+   * Identify the number of firstPage
+   */
+  firstPage?: number
 }
 
 function ProductGrid({
@@ -33,10 +37,14 @@ function ProductGrid({
   page,
   pageSize,
   productCard: { showDiscountBadge, bordered, taxesConfiguration } = {},
+  firstPage,
 }: Props) {
   const { __experimentalProductCard: ProductCard } =
     useOverrideComponents<'ProductGallery'>()
   const aspectRatio = 1
+
+  // TODO: Check if is also isMobile
+  const isFirstPage = firstPage === page
 
   return (
     <ProductGridSkeleton
@@ -44,27 +52,78 @@ function ProductGrid({
       loading={products.length === 0}
     >
       <UIProductGrid>
-        {products.map(({ node: product }, idx) => (
-          <UIProductGridItem key={`${product.id}`}>
-            <ProductCard.Component
-              aspectRatio={aspectRatio}
-              imgProps={{
-                width: 150,
-                height: 150,
-                sizes: '30vw',
-                loading: idx === 0 ? 'eager' : 'lazy',
-              }}
-              {...ProductCard.props}
-              bordered={bordered ?? ProductCard.props.bordered}
-              showDiscountBadge={
-                showDiscountBadge ?? ProductCard.props.showDiscountBadge
-              }
-              product={product}
-              index={pageSize * page + idx + 1}
-              taxesConfiguration={taxesConfiguration}
-            />
-          </UIProductGridItem>
-        ))}
+        {isFirstPage ? (
+          <>
+            {products.slice(0, 2).map(({ node: product }, idx) => (
+              <UIProductGridItem key={`${product.id}`}>
+                <ProductCard.Component
+                  aspectRatio={aspectRatio}
+                  imgProps={{
+                    width: 150,
+                    height: 150,
+                    sizes: '30vw',
+                    loading: 'eager',
+                  }}
+                  {...ProductCard.props}
+                  bordered={bordered ?? ProductCard.props.bordered}
+                  showDiscountBadge={
+                    showDiscountBadge ?? ProductCard.props.showDiscountBadge
+                  }
+                  product={product}
+                  index={pageSize * page + idx + 1}
+                  taxesConfiguration={taxesConfiguration}
+                />
+              </UIProductGridItem>
+            ))}
+            <></>
+
+            {products.slice(2).map(({ node: product }, idx) => (
+              <UIProductGridItem key={`${product.id}`}>
+                <ProductCard.Component
+                  aspectRatio={aspectRatio}
+                  imgProps={{
+                    width: 150,
+                    height: 150,
+                    sizes: '30vw',
+                    loading: 'lazy',
+                  }}
+                  {...ProductCard.props}
+                  bordered={bordered ?? ProductCard.props.bordered}
+                  showDiscountBadge={
+                    showDiscountBadge ?? ProductCard.props.showDiscountBadge
+                  }
+                  product={product}
+                  index={pageSize * page + idx + 1}
+                  taxesConfiguration={taxesConfiguration}
+                />
+              </UIProductGridItem>
+            ))}
+          </>
+        ) : (
+          <>
+            {products.map(({ node: product }, idx) => (
+              <UIProductGridItem key={`${product.id}`}>
+                <ProductCard.Component
+                  aspectRatio={aspectRatio}
+                  imgProps={{
+                    width: 150,
+                    height: 150,
+                    sizes: '30vw',
+                    loading: idx === 0 ? 'eager' : 'lazy',
+                  }}
+                  {...ProductCard.props}
+                  bordered={bordered ?? ProductCard.props.bordered}
+                  showDiscountBadge={
+                    showDiscountBadge ?? ProductCard.props.showDiscountBadge
+                  }
+                  product={product}
+                  index={pageSize * page + idx + 1}
+                  taxesConfiguration={taxesConfiguration}
+                />
+              </UIProductGridItem>
+            ))}
+          </>
+        )}
       </UIProductGrid>
     </ProductGridSkeleton>
   )

--- a/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
@@ -77,7 +77,7 @@ function ProductGrid({
               </UIProductGridItem>
             ))}
             <></>
-            <ViewportObserver name="UIProductGrid-out-viewport">
+            <ViewportObserver sectionName="UIProductGrid-out-viewport">
               {products.slice(2).map(({ node: product }, idx) => (
                 <UIProductGridItem key={`${product.id}`}>
                   <ProductCard.Component

--- a/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
+++ b/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
@@ -12,15 +12,15 @@ import ProductGridSkeleton from 'src/components/skeletons/ProductGridSkeleton'
 import { ProductCardProps } from 'src/components/product/ProductCard'
 import { FilterSliderProps } from 'src/components/search/Filter/FilterSlider'
 import { SortProps } from 'src/components/search/Sort/Sort'
-import { useDelayedFacets } from 'src/sdk/search/useDelayedFacets'
-import { useDelayedPagination } from 'src/sdk/search/useDelayedPagination'
+import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 import {
   PLPContext,
   SearchPageContext,
   usePage,
 } from 'src/sdk/overrides/PageProvider'
 import { useProductsPrefetch } from 'src/sdk/product/useProductsPrefetch'
-import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
+import { useDelayedFacets } from 'src/sdk/search/useDelayedFacets'
+import { useDelayedPagination } from 'src/sdk/search/useDelayedPagination'
 
 const ProductGalleryPage = lazy(() => import('./ProductGalleryPage'))
 const GalleryPageSkeleton = <ProductGridSkeleton loading />
@@ -237,6 +237,7 @@ function ProductGallery({
                   title={title}
                   productCard={productCard}
                   itemsPerPage={itemsPerPage}
+                  firstPage={pages[0]}
                 />
               ))}
             </Suspense>

--- a/packages/core/src/components/ui/ProductGallery/ProductGalleryPage.tsx
+++ b/packages/core/src/components/ui/ProductGallery/ProductGalleryPage.tsx
@@ -1,8 +1,8 @@
 import ProductGrid from 'src/components/product/ProductGrid'
 import Sentinel from 'src/sdk/search/Sentinel'
 
-import { ProductCardProps } from 'src/components/product/ProductCard'
 import { memo } from 'react'
+import { ProductCardProps } from 'src/components/product/ProductCard'
 import { useGalleryPage } from 'src/sdk/product/usePageProductsQuery'
 
 interface Props {
@@ -13,9 +13,16 @@ interface Props {
     'showDiscountBadge' | 'bordered' | 'taxesConfiguration'
   >
   itemsPerPage: number
+  firstPage: number
 }
 
-function ProductGalleryPage({ page, title, productCard, itemsPerPage }: Props) {
+function ProductGalleryPage({
+  page,
+  title,
+  productCard,
+  itemsPerPage,
+  firstPage,
+}: Props) {
   const { data } = useGalleryPage(page)
 
   const products = data?.search?.products?.edges ?? []
@@ -33,6 +40,7 @@ function ProductGalleryPage({ page, title, productCard, itemsPerPage }: Props) {
         page={page}
         pageSize={itemsPerPage}
         productCard={productCard}
+        firstPage={firstPage}
       />
     </>
   )


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR introduces the `ViewportObserver` component, which will be used in future tasks as part of our performance improvement initiative.

## How it works?

We'll primarily use it on mobile devices to prevent sections outside the viewport from being rendered initially. It checks whether a component or section is within the viewport, based on a specified height. We're using Moto G Power devices as the reference for this.

## How to test it?

To facilitate the test for our future tasks, I have added a `debug` mode prop, so we can enable it for testing.
In this case, we can identify if the component is IN or OUT the viewport. **This is only for the initial render.**

1. go to `core/src/components/product/ProductGrid/ProductGrid.tsx`, add `debug` prop to following component:

```
  <ViewportObserver name="UIProductGrid-out-viewport" debug>
```

2. navigate to core, run `yarn dev`

3. go to the PLP, or http://localhost:3000/office?page=0

4. set the browser device to  Moto G Power
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b66c48fe-35de-4062-9265-6ca7801f935e">

5. checking via console.log when the component is IN or OUT
- Only the first row of the ProductGrid is inside the viewport, so you should see `OUT` in the console.log. Scrolling up the next row should appear, and you will be able to see `IN`

<img width="500" alt="image" src="https://github.com/user-attachments/assets/e780ee08-dcaa-4899-8721-4eb12d9d8e7d">

6. checking visually when the component is IN or OUT
- Go to `Network` tab, selects `Slow 4G` as preset, refresh the page
- You will able to see a quick visual feedback (pink rectangle and blue border) in the first ProductCard of the second row.

https://github.com/user-attachments/assets/87f902b6-2e5a-47bd-8b21-3b7897de9bdd

7. checking if the first two ProductCard image is loading=`eager` and the rest `loading=`lazy`

<img width="500" alt="loading-images" src="https://github.com/user-attachments/assets/76d72d87-757c-48b9-9634-c4394a93858b">


### Starters Deploy Preview


## References

https://vtex-dev.atlassian.net/browse/SFS-1507
https://github.com/vtex/faststore/pull/2404

