### PR TITLE
fix: remove debug param validation to insert gtm tag script [bug]

### DIFF
--- a/packages/core/src/components/ThirdPartyScripts/GoogleTagManager.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/GoogleTagManager.tsx
@@ -7,8 +7,7 @@ export const GTM_DEBUG_QUERY_STRING = 'gtm_debug'
 
 const useSnippet = (opts: Props & { partytownScript: boolean }) => `${
   opts.partytownScript ? '!' : ''
-}window.location.search.includes('${GTM_DEBUG_QUERY_STRING}=')&&
-  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+} (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
@@ -47,6 +46,7 @@ function GoogleTagManager(props: Props) {
       <script
         key="gtm"
         type="text/javascript"
+        async
         dangerouslySetInnerHTML={{
           __html: useSnippet({
             ...props,


### PR DESCRIPTION
## What's the purpose of this pull request?

removes the validation of the debug parameter to insert the gtm script

## How it works?

the function that adds the gtm script had a validation if the "debug" parameter is in the route to insert the script, I removed it so that the script is inserted even without this parameter

## How to test it?

Add a gtm id to the faststore config and go to a production page without the debug parameter and check if the events are fired correctly



## Checklist


**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor` and `test`

**PR Description**

- [x] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [x] Committed the `yarn.lock` file when there were changes to the packages
