### PR TITLE
feat: sku matrix packages api

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -609,6 +609,8 @@ export type SkuVariants = {
   /** SKU property values for the current SKU. */
   activeVariations?: Maybe<Scalars['ActiveVariations']>;
   /** All available options for each SKU variant property, indexed by their name. */
+  allVariantProducts?: Maybe<Array<StoreProduct>>;
+  /** All available options for each SKU variant property, indexed by their name. */
   allVariantsByName?: Maybe<Scalars['VariantsByName']>;
   /**
    * Available options for each varying SKU property, taking into account the

--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -608,7 +608,7 @@ export type SkuVariants = {
   __typename?: 'SkuVariants';
   /** SKU property values for the current SKU. */
   activeVariations?: Maybe<Scalars['ActiveVariations']>;
-  /** All available options for each SKU variant property, indexed by their name. */
+  /** All possible variant combinations of the current product. It also includes the data for each variant. */
   allVariantProducts?: Maybe<Array<StoreProduct>>;
   /** All available options for each SKU variant property, indexed by their name. */
   allVariantsByName?: Maybe<Scalars['VariantsByName']>;

--- a/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
+++ b/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
@@ -40,4 +40,5 @@ export const SkuVariants: Record<string, Resolver<Root>> = {
 
     return filteredFormattedVariations
   },
+  allVariantProducts: (root) => root.isVariantOf.items,
 }

--- a/packages/api/src/typeDefs/skuVariants.graphql
+++ b/packages/api/src/typeDefs/skuVariants.graphql
@@ -24,6 +24,11 @@ type SkuVariants {
   considered the dominant one.
   """
   availableVariations(dominantVariantName: String): FormattedVariants
+
+  """
+  All available options for each SKU variant property, indexed by their name.
+  """
+  allVariantProducts: [StoreProduct!]
 }
 
 """

--- a/packages/api/src/typeDefs/skuVariants.graphql
+++ b/packages/api/src/typeDefs/skuVariants.graphql
@@ -26,7 +26,7 @@ type SkuVariants {
   availableVariations(dominantVariantName: String): FormattedVariants
 
   """
-  All available options for each SKU variant property, indexed by their name.
+  All possible variant combinations of the current product. It also includes the data for each variant.
   """
   allVariantProducts: [StoreProduct!]
 }

--- a/packages/core/@generated/gql.ts
+++ b/packages/core/@generated/gql.ts
@@ -16,8 +16,10 @@ const documents = {
     types.ProductSummary_ProductFragmentDoc,
   '\n  fragment Filter_facets on StoreFacet {\n    ... on StoreFacetRange {\n      key\n      label\n\n      min {\n        selected\n        absolute\n      }\n\n      max {\n        selected\n        absolute\n      }\n\n      __typename\n    }\n    ... on StoreFacetBoolean {\n      key\n      label\n      values {\n        label\n        value\n        selected\n        quantity\n      }\n\n      __typename\n    }\n  }\n':
     types.Filter_FacetsFragmentDoc,
-  '\n  fragment ProductDetailsFragment_product on StoreProduct {\n    id: productID\n    sku\n    name\n    gtin\n    description\n    unitMultiplier\n    isVariantOf {\n      name\n      productGroupID\n      skuVariants {\n        activeVariations\n        slugsMap\n        availableVariations\n      }\n    }\n\n    image {\n      url\n      alternateName\n    }\n\n    brand {\n      name\n    }\n\n    offers {\n      lowPrice\n      lowPriceWithTaxes\n      offers {\n        availability\n        price\n        priceWithTaxes\n        listPrice\n        listPriceWithTaxes\n        seller {\n          identifier\n        }\n      }\n    }\n\n    additionalProperty {\n      propertyID\n      name\n      value\n      valueReference\n    }\n\n    # Contains necessary info to add this item to cart\n    ...CartProductItem\n  }\n':
+  '\n  fragment ProductDetailsFragment_product on StoreProduct {\n    id: productID\n    sku\n    name\n    gtin\n    description\n    unitMultiplier\n    isVariantOf {\n      name\n      productGroupID\n\t\t\tskuVariants {\n        activeVariations\n        slugsMap\n        availableVariations\n      }\n    }\n\n    image {\n      url\n      alternateName\n    }\n\n    brand {\n      name\n    }\n\n    offers {\n      lowPrice\n      lowPriceWithTaxes\n      offers {\n        availability\n        price\n        priceWithTaxes\n        listPrice\n        listPriceWithTaxes\n        seller {\n          identifier\n        }\n      }\n    }\n\n    additionalProperty {\n      propertyID\n      name\n      value\n      valueReference\n    }\n\n    # Contains necessary info to add this item to cart\n    ...CartProductItem\n  }\n':
     types.ProductDetailsFragment_ProductFragmentDoc,
+  '\n  fragment ProductSKUMatrixSidebarFragment_product on StoreProduct {\n    id: productID\n    isVariantOf {\n      name\n      productGroupID\n      skuVariants {\n        activeVariations\n        slugsMap\n        availableVariations\n        allVariantProducts {\n\t\t\t\t\tsku\n          name\n          image {\n            url\n            alternateName\n          }\n          offers {\n            highPrice\n            lowPrice\n            lowPriceWithTaxes\n            offerCount\n            priceCurrency\n            offers {\n              listPrice\n              listPriceWithTaxes\n              sellingPrice\n              priceCurrency\n              price\n              priceWithTaxes\n              priceValidUntil\n              itemCondition\n              availability\n              quantity\n            }\n          }\n          additionalProperty {\n            propertyID\n            value\n            name\n            valueReference\n          }\n        }\n      }\n    }\n  }\n':
+    types.ProductSkuMatrixSidebarFragment_ProductFragmentDoc,
   '\n  fragment ClientManyProducts on Query {\n    search(\n      first: $first\n      after: $after\n      sort: $sort\n      term: $term\n      selectedFacets: $selectedFacets\n    ) {\n      products {\n        pageInfo {\n          totalCount\n        }\n      }\n    }\n  }\n':
     types.ClientManyProductsFragmentDoc,
   '\n  fragment ClientProduct on Query {\n    product(locator: $locator) {\n      id: productID\n    }\n  }\n':
@@ -42,6 +44,8 @@ const documents = {
     types.ValidateCartMutationDocument,
   '\n  mutation SubscribeToNewsletter($data: IPersonNewsletter!) {\n    subscribeToNewsletter(data: $data) {\n      id\n    }\n  }\n':
     types.SubscribeToNewsletterDocument,
+  '\n  query ClientAllVariantProductsQuery($locator: [IStoreSelectedFacet!]!) {\n      product(locator: $locator) {\n      ...ProductSKUMatrixSidebarFragment_product\n    }\n  }\n':
+    types.ClientAllVariantProductsQueryDocument,
   '\n  query ClientManyProductsQuery(\n    $first: Int!\n    $after: String\n    $sort: StoreSort!\n    $term: String!\n    $selectedFacets: [IStoreSelectedFacet!]!\n  ) {\n    ...ClientManyProducts\n    search(\n      first: $first\n      after: $after\n      sort: $sort\n      term: $term\n      selectedFacets: $selectedFacets\n    ) {\n      products {\n        pageInfo {\n          totalCount\n        }\n        edges {\n          node {\n            ...ProductSummary_product\n          }\n        }\n      }\n    }\n  }\n':
     types.ClientManyProductsQueryDocument,
   '\n  query ClientProductGalleryQuery(\n    $first: Int!\n    $after: String!\n    $sort: StoreSort!\n    $term: String!\n    $selectedFacets: [IStoreSelectedFacet!]!\n  ) {\n    ...ClientProductGallery\n    redirect(term: $term, selectedFacets: $selectedFacets) {\n      url\n    }\n    search(\n      first: $first\n      after: $after\n      sort: $sort\n      term: $term\n      selectedFacets: $selectedFacets\n    ) {\n      products {\n        pageInfo {\n          totalCount\n        }\n      }\n      facets {\n        ...Filter_facets\n      }\n      metadata {\n        ...SearchEvent_metadata\n      }\n    }\n  }\n\n  fragment SearchEvent_metadata on SearchMetadata {\n    isTermMisspelled\n    logicalOperator\n  }\n':
@@ -74,8 +78,14 @@ export function gql(
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function gql(
-  source: '\n  fragment ProductDetailsFragment_product on StoreProduct {\n    id: productID\n    sku\n    name\n    gtin\n    description\n    unitMultiplier\n    isVariantOf {\n      name\n      productGroupID\n      skuVariants {\n        activeVariations\n        slugsMap\n        availableVariations\n      }\n    }\n\n    image {\n      url\n      alternateName\n    }\n\n    brand {\n      name\n    }\n\n    offers {\n      lowPrice\n      lowPriceWithTaxes\n      offers {\n        availability\n        price\n        priceWithTaxes\n        listPrice\n        listPriceWithTaxes\n        seller {\n          identifier\n        }\n      }\n    }\n\n    additionalProperty {\n      propertyID\n      name\n      value\n      valueReference\n    }\n\n    # Contains necessary info to add this item to cart\n    ...CartProductItem\n  }\n'
+  source: '\n  fragment ProductDetailsFragment_product on StoreProduct {\n    id: productID\n    sku\n    name\n    gtin\n    description\n    unitMultiplier\n    isVariantOf {\n      name\n      productGroupID\n\t\t\tskuVariants {\n        activeVariations\n        slugsMap\n        availableVariations\n      }\n    }\n\n    image {\n      url\n      alternateName\n    }\n\n    brand {\n      name\n    }\n\n    offers {\n      lowPrice\n      lowPriceWithTaxes\n      offers {\n        availability\n        price\n        priceWithTaxes\n        listPrice\n        listPriceWithTaxes\n        seller {\n          identifier\n        }\n      }\n    }\n\n    additionalProperty {\n      propertyID\n      name\n      value\n      valueReference\n    }\n\n    # Contains necessary info to add this item to cart\n    ...CartProductItem\n  }\n'
 ): typeof import('./graphql').ProductDetailsFragment_ProductFragmentDoc
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(
+  source: '\n  fragment ProductSKUMatrixSidebarFragment_product on StoreProduct {\n    id: productID\n    isVariantOf {\n      name\n      productGroupID\n      skuVariants {\n        activeVariations\n        slugsMap\n        availableVariations\n        allVariantProducts {\n\t\t\t\t\tsku\n          name\n          image {\n            url\n            alternateName\n          }\n          offers {\n            highPrice\n            lowPrice\n            lowPriceWithTaxes\n            offerCount\n            priceCurrency\n            offers {\n              listPrice\n              listPriceWithTaxes\n              sellingPrice\n              priceCurrency\n              price\n              priceWithTaxes\n              priceValidUntil\n              itemCondition\n              availability\n              quantity\n            }\n          }\n          additionalProperty {\n            propertyID\n            value\n            name\n            valueReference\n          }\n        }\n      }\n    }\n  }\n'
+): typeof import('./graphql').ProductSkuMatrixSidebarFragment_ProductFragmentDoc
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -148,6 +158,12 @@ export function gql(
 export function gql(
   source: '\n  mutation SubscribeToNewsletter($data: IPersonNewsletter!) {\n    subscribeToNewsletter(data: $data) {\n      id\n    }\n  }\n'
 ): typeof import('./graphql').SubscribeToNewsletterDocument
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(
+  source: '\n  query ClientAllVariantProductsQuery($locator: [IStoreSelectedFacet!]!) {\n      product(locator: $locator) {\n      ...ProductSKUMatrixSidebarFragment_product\n    }\n  }\n'
+): typeof import('./graphql').ClientAllVariantProductsQueryDocument
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -597,6 +597,8 @@ export type SkuVariants = {
   /** SKU property values for the current SKU. */
   activeVariations: Maybe<Scalars['ActiveVariations']['output']>
   /** All available options for each SKU variant property, indexed by their name. */
+  allVariantProducts: Maybe<Array<StoreProduct>>
+  /** All available options for each SKU variant property, indexed by their name. */
   allVariantsByName: Maybe<Scalars['VariantsByName']['output']>
   /**
    * Available options for each varying SKU property, taking into account the
@@ -1216,6 +1218,49 @@ export type ProductDetailsFragment_ProductFragment = {
   }>
 }
 
+export type ProductSkuMatrixSidebarFragment_ProductFragment = {
+  id: string
+  isVariantOf: {
+    name: string
+    productGroupID: string
+    skuVariants: {
+      activeVariations: any | null
+      slugsMap: any | null
+      availableVariations: any | null
+      allVariantProducts: Array<{
+        sku: string
+        name: string
+        image: Array<{ url: string; alternateName: string }>
+        offers: {
+          highPrice: number
+          lowPrice: number
+          lowPriceWithTaxes: number
+          offerCount: number
+          priceCurrency: string
+          offers: Array<{
+            listPrice: number
+            listPriceWithTaxes: number
+            sellingPrice: number
+            priceCurrency: string
+            price: number
+            priceWithTaxes: number
+            priceValidUntil: string
+            itemCondition: string
+            availability: string
+            quantity: number
+          }>
+        }
+        additionalProperty: Array<{
+          propertyID: string
+          value: any
+          name: string
+          valueReference: any
+        }>
+      }> | null
+    } | null
+  }
+}
+
 export type ClientManyProductsFragment = {
   search: { products: { pageInfo: { totalCount: number } } }
 }
@@ -1420,6 +1465,55 @@ export type SubscribeToNewsletterMutationVariables = Exact<{
 
 export type SubscribeToNewsletterMutation = {
   subscribeToNewsletter: { id: string } | null
+}
+
+export type ClientAllVariantProductsQueryQueryVariables = Exact<{
+  locator: Array<IStoreSelectedFacet> | IStoreSelectedFacet
+}>
+
+export type ClientAllVariantProductsQueryQuery = {
+  product: {
+    id: string
+    isVariantOf: {
+      name: string
+      productGroupID: string
+      skuVariants: {
+        activeVariations: any | null
+        slugsMap: any | null
+        availableVariations: any | null
+        allVariantProducts: Array<{
+          sku: string
+          name: string
+          image: Array<{ url: string; alternateName: string }>
+          offers: {
+            highPrice: number
+            lowPrice: number
+            lowPriceWithTaxes: number
+            offerCount: number
+            priceCurrency: string
+            offers: Array<{
+              listPrice: number
+              listPriceWithTaxes: number
+              sellingPrice: number
+              priceCurrency: string
+              price: number
+              priceWithTaxes: number
+              priceValidUntil: string
+              itemCondition: string
+              availability: string
+              quantity: number
+            }>
+          }
+          additionalProperty: Array<{
+            propertyID: string
+            value: any
+            name: string
+            valueReference: any
+          }>
+        }> | null
+      } | null
+    }
+  }
 }
 
 export type ClientManyProductsQueryQueryVariables = Exact<{
@@ -1807,11 +1901,6 @@ export const ProductDetailsFragment_ProductFragmentDoc =
   isVariantOf {
     name
     productGroupID
-    skuVariants {
-      activeVariations
-      slugsMap
-      availableVariations
-    }
   }
   image {
     url
@@ -1873,6 +1962,60 @@ export const ProductDetailsFragment_ProductFragmentDoc =
     { fragmentName: 'ProductDetailsFragment_product' }
   ) as unknown as TypedDocumentString<
     ProductDetailsFragment_ProductFragment,
+    unknown
+  >
+export const ProductSkuMatrixSidebarFragment_ProductFragmentDoc =
+  new TypedDocumentString(
+    `
+    fragment ProductSKUMatrixSidebarFragment_product on StoreProduct {
+  id: productID
+  isVariantOf {
+    name
+    productGroupID
+    skuVariants {
+      activeVariations
+      slugsMap
+      availableVariations
+      allVariantProducts {
+        sku
+        name
+        image {
+          url
+          alternateName
+        }
+        offers {
+          highPrice
+          lowPrice
+          lowPriceWithTaxes
+          offerCount
+          priceCurrency
+          offers {
+            listPrice
+            listPriceWithTaxes
+            sellingPrice
+            priceCurrency
+            price
+            priceWithTaxes
+            priceValidUntil
+            itemCondition
+            availability
+            quantity
+          }
+        }
+        additionalProperty {
+          propertyID
+          value
+          name
+          valueReference
+        }
+      }
+    }
+  }
+}
+    `,
+    { fragmentName: 'ProductSKUMatrixSidebarFragment_product' }
+  ) as unknown as TypedDocumentString<
+    ProductSkuMatrixSidebarFragment_ProductFragment,
     unknown
   >
 export const ClientManyProductsFragmentDoc = new TypedDocumentString(
@@ -2060,7 +2203,7 @@ export const ServerCollectionPageQueryDocument = {
 export const ServerProductQueryDocument = {
   __meta__: {
     operationName: 'ServerProductQuery',
-    operationHash: '46103bee661405bde706d72126fdbf9b0a0c9e6e',
+    operationHash: '59d53edc20e918b9ac3b89e52e1eb6343f71db18',
   },
 } as unknown as TypedDocumentString<
   ServerProductQueryQuery,
@@ -2084,6 +2227,15 @@ export const SubscribeToNewsletterDocument = {
   SubscribeToNewsletterMutation,
   SubscribeToNewsletterMutationVariables
 >
+export const ClientAllVariantProductsQueryDocument = {
+  __meta__: {
+    operationName: 'ClientAllVariantProductsQuery',
+    operationHash: '4039e05f01a2fe449e20e8b82170d0ba94b1fbe9',
+  },
+} as unknown as TypedDocumentString<
+  ClientAllVariantProductsQueryQuery,
+  ClientAllVariantProductsQueryQueryVariables
+>
 export const ClientManyProductsQueryDocument = {
   __meta__: {
     operationName: 'ClientManyProductsQuery',
@@ -2105,7 +2257,7 @@ export const ClientProductGalleryQueryDocument = {
 export const ClientProductQueryDocument = {
   __meta__: {
     operationName: 'ClientProductQuery',
-    operationHash: '7d121ef8d4dc99174e64e4429a9b977b8bbebed8',
+    operationHash: '17eebe56abfc90a2e34761d871926a2475c32350',
   },
 } as unknown as TypedDocumentString<
   ClientProductQueryQuery,

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -1901,6 +1901,11 @@ export const ProductDetailsFragment_ProductFragmentDoc =
   isVariantOf {
     name
     productGroupID
+		skuVariants {
+      activeVariations
+      slugsMap
+      availableVariations
+    }
   }
   image {
     url

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -598,7 +598,6 @@ export type SkuVariants = {
   activeVariations: Maybe<Scalars['ActiveVariations']['output']>
   /** All available options for each SKU variant property, indexed by their name. */
   allVariantProducts: Maybe<Array<StoreProduct>>
-  /** All available options for each SKU variant property, indexed by their name. */
   allVariantsByName: Maybe<Scalars['VariantsByName']['output']>
   /**
    * Available options for each varying SKU property, taking into account the

--- a/packages/core/src/sdk/product/useAllVariantProducts.ts
+++ b/packages/core/src/sdk/product/useAllVariantProducts.ts
@@ -1,0 +1,112 @@
+import { useMemo } from 'react'
+
+import { gql } from '@generated'
+import type {
+  ClientAllVariantProductsQueryQuery,
+  ClientProductQueryQueryVariables,
+} from '@generated/graphql'
+
+import { useQuery } from '../graphql/useQuery'
+import { useSession } from '../session'
+
+const query = gql(`
+  query ClientAllVariantProductsQuery($locator: [IStoreSelectedFacet!]!) {
+      product(locator: $locator) {
+      ...ProductSKUMatrixSidebarFragment_product
+    }
+  }
+`)
+
+type FormattedVariantProduct = {
+  id: string
+  name: string
+  image: {
+    url: string
+    alternateName: string
+  }
+  inventory: number
+  selectedCount: number
+  availability: string
+  offers: ClientAllVariantProductsQueryQuery['product']['isVariantOf']['skuVariants']['allVariantProducts'][0]['offers']
+  price: number
+  listPrice: number
+  priceWithTaxes: number
+  listPriceWithTaxes: number
+  specifications: Record<string, string>
+}
+
+export const useAllVariantProducts = <
+  T extends ClientAllVariantProductsQueryQuery
+>(
+  productID: string,
+  enabled: boolean,
+  callBack: (data: FormattedVariantProduct[]) => void,
+  fallbackData?: T
+) => {
+  const { channel, locale } = useSession()
+  const variables = useMemo(() => {
+    if (!channel) {
+      throw new Error(
+        `useAllVariantProducts: 'channel' from session is an empty string.`
+      )
+    }
+
+    return {
+      locator: [
+        { key: 'id', value: productID },
+        { key: 'channel', value: channel },
+        { key: 'locale', value: locale },
+      ],
+    }
+  }, [channel, locale, productID])
+
+  return useQuery<FormattedVariantProduct[], ClientProductQueryQueryVariables>(
+    query,
+    variables,
+    {
+      fallbackData,
+      revalidateOnMount: true,
+      doNotRun: !enabled,
+      onSuccess: (data: ClientAllVariantProductsQueryQuery) => {
+        const formattedData =
+          data.product.isVariantOf.skuVariants.allVariantProducts.map(
+            (item) => {
+              const specifications = item.additionalProperty.reduce<{
+                [key: string]: any
+              }>(
+                (acc, prop) => ({
+                  ...acc,
+                  [prop.name.toLowerCase()]: prop.value,
+                }),
+                {}
+              )
+
+              const outOfStock =
+                item.offers.offers[0].availability ===
+                'https://schema.org/OutOfStock'
+
+              return {
+                id: item.sku,
+                name: item.name,
+                image: {
+                  url: item.image[0].url,
+                  alternateName: item.image[0].alternateName,
+                },
+                inventory: item.offers.offers[0].quantity,
+                availability: outOfStock ? 'outofstock' : 'available',
+                price: item.offers.offers[0].price,
+                listPrice: item.offers.offers[0].listPrice,
+                priceWithTaxes: item.offers.offers[0].priceWithTaxes,
+                listPriceWithTaxes: item.offers.offers[0].listPriceWithTaxes,
+                specifications,
+                offers: item.offers,
+                selectedCount: 0,
+              }
+            }
+          )
+
+        callBack(formattedData.sort((a, b) => a.name.localeCompare(b.name)))
+      },
+    }
+  )
+}

--- a/packages/core/src/sdk/product/useAllVariantProducts.ts
+++ b/packages/core/src/sdk/product/useAllVariantProducts.ts
@@ -40,7 +40,7 @@ export const useAllVariantProducts = <
 >(
   productID: string,
   enabled: boolean,
-  callBack: (data: FormattedVariantProduct[]) => void,
+  processResponse: (data: FormattedVariantProduct[]) => void,
   fallbackData?: T
 ) => {
   const { channel, locale } = useSession()
@@ -105,7 +105,9 @@ export const useAllVariantProducts = <
             }
           )
 
-        callBack(formattedData.sort((a, b) => a.name.localeCompare(b.name)))
+        processResponse(
+          formattedData.sort((a, b) => a.name.localeCompare(b.name))
+        )
       },
     }
   )


### PR DESCRIPTION
Este PR conta com a construção da nova query, que será utilizada pelo SKUMatrix e por toda a geração dos novos tipos. 

Criamos um hook chamado `useAllVariantProducts`, responsável por fazer a request e devolver os dados formatados, conforme esperado pelo `SKUMatrixSidebar`. Para consumir esse hook, é necessário passar algumas propriedades, das quais podemos destacar o **_callBack_** e **_enabled_**.

- **callBack**: é uma função que será executada apenas quando a requisição tiver sucesso e retornar todos os dados. Esse método irá retornar os dados totalmente formatados seguindo o formato pré-estabelecido no componente `SKUMatrixSidebar`

- **enabled**: é um booleano (verdadeiro/falso). Ele irá informar para query se o `SKUMatrixSidebar `está aberto ou não. A requisição só será feita se o slider estiver aberto, caso contrário não, evitando requisição desnecessária

