### PR TITLE
feat: sku matrix packages core

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1618,6 +1618,84 @@
               "default": "Tax included"
             }
           }
+        },
+        "skuMatrix": {
+          "title": "SKUMatrix Configuration",
+          "type": "object",
+          "properties": {
+            "shouldDisplaySKUMatrix": {
+              "title": "Should display SKUMatrix?",
+              "type": "boolean",
+              "default": false
+            },
+            "triggerButtonLabel": {
+              "title": "SKU Matrix Trigger label to be displayed",
+              "type": "string",
+              "default": "Select multiple"
+            },
+            "columns": {
+              "title": "Columns",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "title": "SKU name column label",
+                  "type": "string",
+                  "default": "Name"
+                },
+                "additionalColumns": {
+                  "title": "Additional columns",
+                  "type": "array",
+                  "items": {
+                    "title": "Column",
+                    "type": "object",
+                    "required": ["label", "value"],
+                    "properties": {
+                      "label": {
+                        "title": "Label",
+                        "type": "string"
+                      },
+                      "value": {
+                        "title": "Value",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "availability": {
+                  "title": "Availability column label",
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "title": "Label",
+                      "type": "string",
+                      "default": "Availability"
+                    },
+                    "stockDisplaySettings": {
+                      "title": "Stock display settings",
+                      "description": "Control how the stock status of your products is displayed to customers on your online store.",
+                      "type": "string",
+                      "enum": ["showAvailability", "showStockQuantity"],
+                      "enumNames": [
+                        "Show availability (Available/Out of Stock)",
+                        "Show stock quantity"
+                      ],
+                      "default": "showAvailability"
+                    }
+                  }
+                },
+                "price": {
+                  "title": "Price column label",
+                  "type": "string",
+                  "default": "Price"
+                },
+                "quantitySelector": {
+                  "title": "Quantity selector column label",
+                  "type": "string",
+                  "default": "Quantity"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1633,6 +1633,12 @@
               "type": "string",
               "default": "Select multiple"
             },
+            "separatorButtonsText": {
+              "title": "Separator text",
+              "description": "Text that separates the add to cart button from the SKU Matrix Trigger button.",
+              "type": "string",
+              "default": "Or"
+            },
             "columns": {
               "title": "Columns",
               "type": "object",

--- a/packages/core/src/components/sections/ProductDetails/DefaultComponents.ts
+++ b/packages/core/src/components/sections/ProductDetails/DefaultComponents.ts
@@ -9,13 +9,17 @@ import {
   QuantitySelector as UIQuantitySelector,
   ImageGalleryViewer as UIImageGalleryViewer,
   ImageGallery as UIImageGallery,
+  SKUMatrix as UISKUMatrix,
+  SKUMatrixSidebar as UISKUMatrixSidebar,
+  SKUMatrixTrigger as UISKUMatrixTrigger,
 } from '@faststore/ui'
 
 import LocalImageGallery from 'src/components/ui/ImageGallery'
 import LocalShippingSimulation from 'src/components/ui/ShippingSimulation/ShippingSimulation'
 import { Image } from 'src/components/ui/Image'
 import LocalNotAvailableButton from 'src/components/product/NotAvailableButton'
-import LocalProductDescription from 'src/components/ui/ProductDescription'
+import LocalSKUMatrixSidebar from 'src/components/ui/SKUMatrix/SKUMatrixSidebar'
+import LocalProductDescription from 'src/components/ui/ProductDescription/ProductDescription'
 import { ProductDetailsSettings as LocalProductDetailsSettings } from 'src/components/ui/ProductDetails'
 
 export const ProductDetailsDefaultComponents = {
@@ -29,9 +33,13 @@ export const ProductDetailsDefaultComponents = {
   ShippingSimulation: UIShippingSimulation,
   ImageGallery: UIImageGallery,
   ImageGalleryViewer: UIImageGalleryViewer,
+  SKUMatrix: UISKUMatrix,
+  SKUMatrixTrigger: UISKUMatrixTrigger,
+  SKUMatrixSidebar: UISKUMatrixSidebar,
   __experimentalImageGalleryImage: Image,
   __experimentalImageGallery: LocalImageGallery,
   __experimentalShippingSimulation: LocalShippingSimulation,
+  __experimentalSKUMatrixSidebar: LocalSKUMatrixSidebar,
   __experimentalNotAvailableButton: LocalNotAvailableButton,
   __experimentalProductDescription: LocalProductDescription,
   __experimentalProductDetailsSettings: LocalProductDetailsSettings,

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -121,7 +121,11 @@ function ProductDetails({
     brand,
     isVariantOf,
     description,
-    isVariantOf: { name, productGroupID: productId },
+    isVariantOf: {
+      name,
+      productGroupID: productId,
+      skuVariants: { slugsMap },
+    },
     image: productImages,
     offers: {
       offers: [{ availability, price, listPrice, listPriceWithTaxes, seller }],
@@ -231,23 +235,24 @@ function ProductDetails({
                 taxesConfiguration={taxesConfiguration}
               />
 
-              {skuMatrix?.shouldDisplaySKUMatrix && (
-                <>
-                  <div data-fs-product-details-settings-separator>Or</div>
+              {skuMatrix?.shouldDisplaySKUMatrix &&
+                Object.keys(slugsMap).length > 1 && (
+                  <>
+                    <div data-fs-product-details-settings-separator>Or</div>
 
-                  <SKUMatrix.Component>
-                    <SKUMatrixTrigger.Component disabled={isValidating}>
-                      {skuMatrix.triggerButtonLabel}
-                    </SKUMatrixTrigger.Component>
+                    <SKUMatrix.Component>
+                      <SKUMatrixTrigger.Component disabled={isValidating}>
+                        {skuMatrix.triggerButtonLabel}
+                      </SKUMatrixTrigger.Component>
 
-                    <SKUMatrixSidebar.Component
-                      formatter={useFormattedPrice}
-                      columns={skuMatrix.columns}
-                      overlayProps={{ className: styles.section }}
-                    />
-                  </SKUMatrix.Component>
-                </>
-              )}
+                      <SKUMatrixSidebar.Component
+                        formatter={useFormattedPrice}
+                        columns={skuMatrix.columns}
+                        overlayProps={{ className: styles.section }}
+                      />
+                    </SKUMatrix.Component>
+                  </>
+                )}
             </section>
 
             {!outOfStock && (

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -58,6 +58,7 @@ export interface ProductDetailsProps {
   skuMatrix?: {
     shouldDisplaySKUMatrix?: boolean
     triggerButtonLabel: string
+    separatorButtonsText: string
     columns: {
       name: string
       additionalColumns: Array<{ label: string; value: string }>
@@ -238,7 +239,9 @@ function ProductDetails({
               {skuMatrix?.shouldDisplaySKUMatrix &&
                 Object.keys(slugsMap).length > 1 && (
                   <>
-                    <div data-fs-product-details-settings-separator>Or</div>
+                    <div data-fs-product-details-settings-separator>
+                      {skuMatrix.separatorButtonsText}
+                    </div>
 
                     <SKUMatrix.Component>
                       <SKUMatrixTrigger.Component disabled={isValidating}>

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -60,7 +60,7 @@ export interface ProductDetailsProps {
     triggerButtonLabel: string
     columns: {
       name: string
-      additionalColumns?: Array<{ label: string; value: string }>
+      additionalColumns: Array<{ label: string; value: string }>
       availability: {
         label: string
         stockDisplaySettings: 'showAvailability' | 'showStockQuantity'

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -55,6 +55,20 @@ export interface ProductDetailsProps {
     usePriceWithTaxes?: boolean
     taxesLabel?: string
   }
+  skuMatrix?: {
+    shouldDisplaySKUMatrix?: boolean
+    triggerButtonLabel: string
+    columns: {
+      name: string
+      additionalColumns?: Array<{ label: string; value: string }>
+      availability: {
+        label: string
+        stockDisplaySettings: 'showAvailability' | 'showStockQuantity'
+      }
+      price: number
+      quantitySelector: number
+    }
+  }
 }
 
 function ProductDetails({
@@ -74,6 +88,7 @@ function ProductDetails({
     initiallyExpanded: productDescriptionInitiallyExpanded,
     displayDescription: shouldDisplayProductDescription,
   },
+  skuMatrix,
   notAvailableButton: { title: notAvailableButtonTitle },
   quantitySelector,
   taxesConfiguration,
@@ -81,17 +96,19 @@ function ProductDetails({
   const {
     DiscountBadge,
     ProductTitle,
+    SKUMatrix,
+    SKUMatrixTrigger,
     __experimentalImageGallery: ImageGallery,
     __experimentalShippingSimulation: ShippingSimulation,
     __experimentalNotAvailableButton: NotAvailableButton,
     __experimentalProductDescription: ProductDescription,
     __experimentalProductDetailsSettings: ProductDetailsSettings,
+    __experimentalSKUMatrixSidebar: SKUMatrixSidebar,
   } = useOverrideComponents<'ProductDetails'>()
   const { currency } = useSession()
   const context = usePDP()
   const { product, isValidating } = context?.data
   const [quantity, setQuantity] = useState(1)
-
   if (!product) {
     throw new Error('NotFound')
   }
@@ -213,6 +230,24 @@ function ProductDetails({
                 isValidating={isValidating}
                 taxesConfiguration={taxesConfiguration}
               />
+
+              {skuMatrix?.shouldDisplaySKUMatrix && (
+                <>
+                  <div data-fs-product-details-settings-separator>Or</div>
+
+                  <SKUMatrix.Component>
+                    <SKUMatrixTrigger.Component disabled={isValidating}>
+                      {skuMatrix.triggerButtonLabel}
+                    </SKUMatrixTrigger.Component>
+
+                    <SKUMatrixSidebar.Component
+                      formatter={useFormattedPrice}
+                      columns={skuMatrix.columns}
+                      overlayProps={{ className: styles.section }}
+                    />
+                  </SKUMatrix.Component>
+                </>
+              )}
             </section>
 
             {!outOfStock && (
@@ -277,7 +312,7 @@ export const fragment = gql(`
     isVariantOf {
       name
       productGroupID
-      skuVariants {
+			skuVariants {
         activeVariations
         slugsMap
         availableVariations

--- a/packages/core/src/components/sections/ProductDetails/section.module.scss
+++ b/packages/core/src/components/sections/ProductDetails/section.module.scss
@@ -1,9 +1,13 @@
 @layer components {
   .section {
     // Taxes label
-    --fs-product-details-taxes-label-color        : var(--fs-color-info-text);
-    --fs-product-details-taxes-text-size          : var(--fs-text-size-tiny);
-    --fs-product-details-taxes-text-weight        : var(--fs-text-weight-regular);
+    --fs-product-details-taxes-label-color      : var(--fs-color-info-text);
+    --fs-product-details-taxes-text-size        : var(--fs-text-size-tiny);
+    --fs-product-details-taxes-text-weight      : var(--fs-text-weight-regular);
+
+    // Separator colors
+    --fs-product-details-separator-color        : var(--fs-color-neutral-2);
+    --fs-product-details-separator-color-text   : var(--fs-color-text-light);
 
     margin-top: 0;
 
@@ -29,11 +33,43 @@
     @import "@faststore/ui/src/components/organisms/ShippingSimulation/styles.scss";
     @import "@faststore/ui/src/components/organisms/ImageGallery/styles.scss";
     @import "@faststore/ui/src/components/organisms/ProductDetails/styles.scss";
+    @import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
+    @import "@faststore/ui/src/components/organisms/SKUMatrix/styles.scss";
 
     [data-fs-product-details-taxes-label] {
       font-size: var(--fs-product-details-taxes-text-size);
       font-weight: var(--fs-product-details-taxes-text-weight);
       color: var(--fs-product-details-taxes-label-color);
+    }
+
+    [data-fs-product-details-settings-separator] {
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      color: var(--fs-product-details-separator-color-text);
+
+      &::after {
+        display: inline-block;
+        width: 45%;
+        height: 1px;
+        content: "";
+        background-color: var(--fs-product-details-separator-color);
+      }
+
+      &::before {
+        display: inline-block;
+        width: 45%;
+        height: 1px;
+        content: "";
+        background-color: var(--fs-product-details-separator-color);
+      }
+    }
+
+    [data-fs-sku-matrix] {
+      > [data-fs-button] {
+        width: 100%;
+      }
     }
   }
 }

--- a/packages/core/src/components/ui/SKUMatrix/SKUMatrixSidebar.tsx
+++ b/packages/core/src/components/ui/SKUMatrix/SKUMatrixSidebar.tsx
@@ -1,0 +1,132 @@
+import type { SKUMatrixSidebarProps as UISKUMatrixSidebarProps } from '@faststore/ui'
+import {
+  SKUMatrixSidebar as UISKUMatrixSidebar,
+  useSKUMatrix,
+} from '@faststore/ui'
+import { gql } from '@generated/gql'
+import { useBuyButton } from 'src/sdk/cart/useBuyButton'
+import { usePDP } from 'src/sdk/overrides/PageProvider'
+import { useAllVariantProducts } from 'src/sdk/product/useAllVariantProducts'
+
+interface SKUMatrixProps extends UISKUMatrixSidebarProps {}
+
+function SKUMatrixSidebar(props: SKUMatrixProps) {
+  const {
+    data: { product },
+  } = usePDP()
+
+  const { allVariantProducts, open, setAllVariantProducts } = useSKUMatrix()
+  const { isValidating } = useAllVariantProducts(
+    product.id,
+    open,
+    setAllVariantProducts
+  )
+
+  const {
+    gtin,
+    unitMultiplier,
+    brand,
+    additionalProperty,
+    isVariantOf,
+    offers: {
+      offers: [{ seller }],
+    },
+  } = product
+
+  const buyButtonProps = allVariantProducts
+    .filter((item) => item.selectedCount)
+    .map((item) => {
+      const {
+        offers: {
+          offers: [{ price, priceWithTaxes, listPrice, listPriceWithTaxes }],
+        },
+      } = item
+
+      return {
+        id: item.id,
+        price,
+        priceWithTaxes,
+        listPrice,
+        listPriceWithTaxes,
+        seller,
+        quantity: item.selectedCount,
+        itemOffered: {
+          sku: item.id,
+          name: item.name,
+          gtin,
+          image: [item.image],
+          brand,
+          isVariantOf: {
+            ...isVariantOf,
+            skuVariants: {
+              ...isVariantOf.skuVariants,
+              activeVariations: item.specifications,
+            },
+          },
+          additionalProperty,
+          unitMultiplier,
+        },
+      }
+    })
+
+  const buyProps = useBuyButton(buyButtonProps)
+
+  return (
+    <UISKUMatrixSidebar
+      buyProps={buyProps}
+      title={product.isVariantOf.name ?? ''}
+      loading={isValidating}
+      {...props}
+    />
+  )
+}
+
+export const fragment = gql(`
+  fragment ProductSKUMatrixSidebarFragment_product on StoreProduct {
+    id: productID
+    isVariantOf {
+      name
+      productGroupID
+      skuVariants {
+        activeVariations
+        slugsMap
+        availableVariations
+        allVariantProducts {
+					sku
+          name
+          image {
+            url
+            alternateName
+          }
+          offers {
+            highPrice
+            lowPrice
+            lowPriceWithTaxes
+            offerCount
+            priceCurrency
+            offers {
+              listPrice
+              listPriceWithTaxes
+              sellingPrice
+              priceCurrency
+              price
+              priceWithTaxes
+              priceValidUntil
+              itemCondition
+              availability
+              quantity
+            }
+          }
+          additionalProperty {
+            propertyID
+            value
+            name
+            valueReference
+          }
+        }
+      }
+    }
+  }
+`)
+
+export default SKUMatrixSidebar

--- a/packages/core/src/components/ui/SKUMatrix/SKUMatrixSidebar.tsx
+++ b/packages/core/src/components/ui/SKUMatrix/SKUMatrixSidebar.tsx
@@ -15,10 +15,10 @@ function SKUMatrixSidebar(props: SKUMatrixProps) {
     data: { product },
   } = usePDP()
 
-  const { allVariantProducts, open, setAllVariantProducts } = useSKUMatrix()
+  const { allVariantProducts, isOpen, setAllVariantProducts } = useSKUMatrix()
   const { isValidating } = useAllVariantProducts(
     product.id,
-    open,
+    isOpen,
     setAllVariantProducts
   )
 

--- a/packages/core/src/sdk/cart/useBuyButton.ts
+++ b/packages/core/src/sdk/cart/useBuyButton.ts
@@ -8,11 +8,13 @@ import { useUI } from '@faststore/ui'
 import { useSession } from '../session'
 import { cartStore } from './index'
 
-export const useBuyButton = (item: CartItem | null) => {
+export const useBuyButton = (item: CartItem | CartItem[] | null) => {
   const { openCart } = useUI()
   const {
     currency: { code },
   } = useSession()
+
+  const itemIsArray = Array.isArray(item)
 
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -22,6 +24,33 @@ export const useBuyButton = (item: CartItem | null) => {
         return
       }
 
+      const value = itemIsArray
+        ? item.reduce((sum, item) => (sum += item.price * item.quantity), 0)
+        : item.price * item.quantity
+
+      function generatedItem(item: CartItem) {
+        return {
+          item_id: item.itemOffered.isVariantOf.productGroupID,
+          item_name: item.itemOffered.isVariantOf.name,
+          item_brand: item.itemOffered.brand.name,
+          item_variant: item.itemOffered.sku,
+          quantity: item.quantity,
+          price: item.price,
+          discount: item.listPrice - item.price,
+          currency: code as CurrencyCode,
+          item_variant_name: item.itemOffered.name,
+          product_reference_id: item.itemOffered.gtin,
+        }
+      }
+
+      function getItems() {
+        if (!itemIsArray) {
+          return [generatedItem(item)]
+        }
+
+        return item.map(generatedItem)
+      }
+
       import('@faststore/sdk').then(({ sendAnalyticsEvent }) => {
         sendAnalyticsEvent<AddToCartEvent<AnalyticsItem>>({
           name: 'add_to_cart',
@@ -29,35 +58,27 @@ export const useBuyButton = (item: CartItem | null) => {
             currency: code as CurrencyCode,
             // TODO: In the future, we can explore more robust ways of
             // calculating the value (gift items, discounts, etc.).
-            value: item.price * item.quantity,
-            items: [
-              {
-                item_id: item.itemOffered.isVariantOf.productGroupID,
-                item_name: item.itemOffered.isVariantOf.name,
-                item_brand: item.itemOffered.brand.name,
-                item_variant: item.itemOffered.sku,
-                quantity: item.quantity,
-                price: item.price,
-                discount: item.listPrice - item.price,
-                currency: code as CurrencyCode,
-                item_variant_name: item.itemOffered.name,
-                product_reference_id: item.itemOffered.gtin,
-              },
-            ],
+            value,
+            items: getItems(),
           },
         })
       })
 
-      cartStore.addItem(item)
+      itemIsArray
+        ? item.forEach((value) => cartStore.addItem(value))
+        : cartStore.addItem(item)
+
       openCart()
     },
-    [code, item, openCart]
+    [code, item, openCart, itemIsArray]
   )
 
   return {
     onClick,
     'data-testid': 'buy-button',
-    'data-sku': item?.itemOffered.sku,
-    'data-seller': item?.seller.identifier,
+    'data-sku': itemIsArray ? 'sku-matrix-sidebar' : item?.itemOffered.sku,
+    'data-seller': itemIsArray
+      ? item[0]?.seller.identifier
+      : item?.seller.identifier,
   }
 }

--- a/packages/core/src/typings/overrides.ts
+++ b/packages/core/src/typings/overrides.ts
@@ -39,6 +39,9 @@ import type {
   ShippingSimulationProps,
   SkeletonProps,
   SkuSelectorProps,
+  SKUMatrixProps,
+  SKUMatrixTriggerProps,
+  SKUMatrixSidebarProps,
 } from '@faststore/ui'
 
 import type {
@@ -81,10 +84,10 @@ export type SectionOverride = {
 export type OverrideComponentsForSection<
   Section extends SectionsOverrides[keyof SectionsOverrides]['Section']
 > = {
-    // The first 'extends' condition is used to filter out sections that don't have overrides (typed 'never')
-    [K in keyof SectionsOverrides as SectionsOverrides[K] extends {
-      Section: never
-    }
+// The first 'extends' condition is used to filter out sections that don't have overrides (typed 'never')
+[K in keyof SectionsOverrides as SectionsOverrides[K] extends {
+  Section: never
+}
     ? never
     : // In the second 'extends' condition, we check if the section matches the one we're looking for
     SectionsOverrides[K] extends {
@@ -269,12 +272,25 @@ export type SectionsOverrides = {
         ImageGalleryViewerProps,
         ImageGalleryViewerProps
       >
+      SKUMatrix: ComponentOverrideDefinition<SKUMatrixProps, SKUMatrixProps>
+      SKUMatrixTrigger: ComponentOverrideDefinition<
+        SKUMatrixTriggerProps,
+        SKUMatrixTriggerProps
+      >
+      SKUMatrixSidebar: ComponentOverrideDefinition<
+        SKUMatrixSidebarProps,
+        SKUMatrixSidebarProps
+      >
       __experimentalImageGalleryImage: ComponentOverrideDefinition<any, any>
       __experimentalImageGallery: ComponentOverrideDefinition<any, any>
       __experimentalShippingSimulation: ComponentOverrideDefinition<any, any>
       __experimentalNotAvailableButton: ComponentOverrideDefinition<any, any>
       __experimentalProductDescription: ComponentOverrideDefinition<any, any>
-      __experimentalProductDetailsSettings: ComponentOverrideDefinition<any, any>
+      __experimentalSKUMatrixSidebar: ComponentOverrideDefinition<any, any>
+      __experimentalProductDetailsSettings: ComponentOverrideDefinition<
+        any,
+        any
+      >
     }
   }
   ProductGallery: {


### PR DESCRIPTION
Este PR conta com a implementação do `SKUMatrix` na ProductDetails. 

Dentro do @faststore/core na pasta ui, foi criada uma abstração do `SKUMatrixSidebar`. Toda a lógica de captura dos dados e formatação do mesmo é feita nessa abstração.
Para fazer a requisição dos dados, foi criado uma nova query. Para utiliza-la basta chamar o hook useAllVariantProducts (toda a construção dessa nova query está presente no PR #2504 ). Para consumir esse hook, é necessário passar algumas propriedades, das quais podemos destacar o callBack e enabled.

Dentro dessa abstração do `SKUMatrixSidebar`, deve haver o consumo do contexto do `SKUMatrix`. O contexto que irá controlar todos os estados, como por exemplo, informar ao contexto a lista das variações do produto. Como essa abstração que ficará responsável por fazer a requisição e informar os dados para o contexto, o callBack que é passado no `useAllVariantProducts`, será o método de adicionar os itens que serão exibidos na tabela do `SKUMatrixSidebar`, portanto deve ser atribuído o método `setAllVariantProducts `presente no contexto do `SKUMatrix`, dessa forma, os dados que já serão retornados formatados, serão informados ao contexto e posteriormente, o `SKUMatrixSidebar `vai poder consumir esses dados e exibir em tela.

Falando um pouco sobre o `useBuyButton`, este hook é responsável por adicionar os itens selecionados no carrinho. Anteriormente, o mesmo não aceitava uma lista de itens, logo, foi necessário modifica-lo para que a nova demanda fosse atendida. Como o hook deve consumir algumas informações para posteriormente informar o buyButtonProps (reposável por preparar os dados a serem inseridos no carrinho), ele precisa observar os dados dos produtos a serem adicionados no carrinho. Esses dados, são retornados do contexto do SKUMatrix, por tanto, sempre que existir qualquer tipo de modificação no estado do contexto (por exemplo, uma alteração na quantidade de um SKU dentro da tabela do `SKUMatrixSidebar`), irá refletir no hook do `useBuyButton`, e as propriedades serão geradas corretamente.

Para finalizar, toda a configuração do headless CMS foi desenvolvida nesse PR.


Este PR tem como dependência: #2503 e #2504 


## Printscreens

Headless CMS

![SKU Matrix - Headless CMS](https://github.com/user-attachments/assets/0e234c04-8e85-42d5-9acf-768f041b11ba)