### PR TITLE
chore: silence the graphql generation debug mode

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,16 +1,15 @@
-import { Command } from '@oclif/core';
-import { spawn } from 'child_process';
-import chalk from 'chalk';
-import chokidar from 'chokidar';
-import dotenv from 'dotenv';
+import { Command } from '@oclif/core'
+import { spawn } from 'child_process'
+import chalk from 'chalk'
+import chokidar from 'chokidar'
+import dotenv from 'dotenv'
 
-import { readFileSync, cpSync } from 'fs';
-import path from 'path';
-import { withBasePath } from '../utils/directory';
-import { generate } from '../utils/generate';
-import { getPreferredPackageManager } from '../utils/commands';
-import { runCommandSync } from '../utils/runCommandSync';
-
+import { readFileSync, cpSync } from 'fs'
+import path from 'path'
+import { withBasePath } from '../utils/directory'
+import { generate } from '../utils/generate'
+import { getPreferredPackageManager } from '../utils/commands'
+import { runCommandSync } from '../utils/runCommandSync'
 
 /**
  * Taken from toolbelt
@@ -35,7 +34,12 @@ const defaultIgnored = [
 
 const devAbortController = new AbortController()
 
-async function storeDev(rootDir: string, tmpDir: string, coreDir: string, port: number) {
+async function storeDev(
+  rootDir: string,
+  tmpDir: string,
+  coreDir: string,
+  port: number
+) {
   const envVars = dotenv.parse(readFileSync(path.join(rootDir, 'vtex.env')))
 
   const packageManager = getPreferredPackageManager()
@@ -45,15 +49,21 @@ async function storeDev(rootDir: string, tmpDir: string, coreDir: string, port: 
     errorMessage:
       'GraphQL was not optimized and TS files were not updated. Changes in the GraphQL layer did not take effect',
     throws: 'error',
-    debug: true,
     cwd: tmpDir,
   })
 
-  const { success } = copyGenerated(path.join(tmpDir, '@generated'), path.join(coreDir, '@generated'))
+  const { success } = copyGenerated(
+    path.join(tmpDir, '@generated'),
+    path.join(coreDir, '@generated')
+  )
 
   if (!success) {
-    console.log(`${chalk.yellow('warn')} - Failed to copy @generated schema back to node_modules, autocomplete and DX might be impacted.`)
-    console.log(`Attempted to copy from ${path.join(tmpDir, '@generated')} to ${path.join(coreDir, '@generated')}`)
+    console.log(
+      `${chalk.yellow('warn')} - Failed to copy @generated schema back to node_modules, autocomplete and DX might be impacted.`
+    )
+    console.log(
+      `Attempted to copy from ${path.join(tmpDir, '@generated')} to ${path.join(coreDir, '@generated')}`
+    )
   }
 
   const devProcess = spawn(`${packageManager} dev-only --port ${port}`, {
@@ -64,7 +74,7 @@ async function storeDev(rootDir: string, tmpDir: string, coreDir: string, port: 
     env: {
       ...process.env,
       ...envVars,
-    }
+    },
   })
 
   devProcess.on('close', () => {
@@ -87,12 +97,12 @@ export default class Dev extends Command {
     {
       name: 'account',
       description:
-      'The account for which the Discovery is running. Currently noop.',
+        'The account for which the Discovery is running. Currently noop.',
     },
     {
       name: 'path',
       description:
-      'The path where the FastStore being run is. Defaults to cwd.',
+        'The path where the FastStore being run is. Defaults to cwd.',
     },
     {
       name: 'port',

--- a/packages/cli/src/commands/generate-graphql.ts
+++ b/packages/cli/src/commands/generate-graphql.ts
@@ -8,15 +8,15 @@ import { getPreferredPackageManager } from '../utils/commands'
 
 export default class GenerateGraphql extends Command {
   static flags = {
-    debug: Flags.boolean({ char: 'd' }),
     core: Flags.boolean({ char: 'c', hidden: true }),
   }
 
   static args = [
     {
       name: 'path',
-      description: 'The path where the FastStore GraphQL customization is. Defaults to cwd.',
-    }
+      description:
+        'The path where the FastStore GraphQL customization is. Defaults to cwd.',
+    },
   ]
 
   async run() {
@@ -25,7 +25,6 @@ export default class GenerateGraphql extends Command {
     const basePath = args.path ?? process.cwd()
     const { tmpDir, coreDir } = withBasePath(basePath)
 
-    const debug = flags.debug ?? false
     const isCore = flags.core ?? false
 
     const packageManager = getPreferredPackageManager()
@@ -44,7 +43,6 @@ export default class GenerateGraphql extends Command {
       cmd: `${packageManager} run generate:schema`,
       errorMessage: `Failed to run '${packageManager} generate:schema'. Please check your setup.`,
       throws: 'error',
-      debug,
       cwd: isCore ? undefined : tmpDir,
     })
 
@@ -53,26 +51,21 @@ export default class GenerateGraphql extends Command {
       errorMessage:
         'GraphQL was not optimized and TS files were not updated. Changes in the GraphQL layer did not take effect',
       throws: 'error',
-      debug,
       cwd: isCore ? undefined : tmpDir,
     })
 
     runCommandSync({
       cmd: `${packageManager} run format:generated`,
-      errorMessage:
-        `Failed to format generated files. '${packageManager} format:generated' thrown errors`,
+      errorMessage: `Failed to format generated files. '${packageManager} format:generated' thrown errors`,
       throws: 'warning',
-      debug,
       cwd: isCore ? undefined : tmpDir,
     })
 
     // The command generate:copy-back expects the DESTINATION var to be present so it can copy the files to the correct directory
     runCommandSync({
       cmd: `DESTINATION=${coreDir} ${packageManager} run generate:copy-back`,
-      errorMessage:
-        `Failed to copy back typings files. '${packageManager} generate:copy-back' thrown errors`,
+      errorMessage: `Failed to copy back typings files. '${packageManager} generate:copy-back' thrown errors`,
       throws: 'warning',
-      debug,
       cwd: isCore ? undefined : tmpDir,
     })
 

--- a/packages/cli/src/utils/dependencies.ts
+++ b/packages/cli/src/utils/dependencies.ts
@@ -1,27 +1,25 @@
-import { getPreferredPackageManager } from "./commands"
-import { runCommandSync } from "./runCommandSync"
+import { getPreferredPackageManager } from './commands'
+import { runCommandSync } from './runCommandSync'
 
-type InstallDependenciesOptions = { 
-    dependencies: string[]
-    cwd: string,
-    errorMessage: string,
+type InstallDependenciesOptions = {
+  dependencies: string[]
+  cwd: string
+  errorMessage: string
 }
 
-export function installDependencies(
- { 
+export function installDependencies({
   dependencies,
-  cwd, 
-  errorMessage 
-}: InstallDependenciesOptions
-) {
-  const packageManager = getPreferredPackageManager() 
+  cwd,
+  errorMessage,
+}: InstallDependenciesOptions) {
+  const packageManager = getPreferredPackageManager()
   const installCommand = packageManager === 'npm' ? 'install' : 'add'
 
   runCommandSync({
     cmd: `${packageManager} ${installCommand} ${dependencies.join(' ')}`,
     errorMessage,
     throws: 'error',
-    debug: false,
     cwd,
   })
 }
+

--- a/packages/cli/src/utils/runCommandSync.ts
+++ b/packages/cli/src/utils/runCommandSync.ts
@@ -48,15 +48,15 @@ export const runCommandSync = ({
   cmd,
   errorMessage,
   throws,
-  debug,
   cwd,
 }: {
   cmd: string
   errorMessage: string
   throws: 'warning' | 'error'
-  debug: boolean
   cwd?: string
 }) => {
+  const debug = process.env.DISCOVERY_DEBUG === 'true' ? true : false
+
   try {
     if (debug) {
       console.log(`[STARTED] ${cmd}`)

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
     "OCLIF_COMPILATION",
     "NODE_ENV",
     "DISABLE_3P_SCRIPTS",
-    "CMS_DATA"
+    "CMS_DATA",
+    "DISCOVERY_DEBUG"
   ],
   "pipeline": {
     "site#build": {


### PR DESCRIPTION
## What's the purpose of this pull request?

FastStore's `dev` command is overly verbose. This PR adds a `DISCOVERY_DEBUG` env variable that toggles the verbosity, which is by default off.

This is still a WIP.

## How it works?

<!--- Tell us the role of the new feature, or component, in its context. Provide details about what you have implemented and screenshots if applicable.  --->

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**

- [ ] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor` and `test`

**PR Description**

- [ ] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [ ] Committed the `yarn.lock` file when there were changes to the packages
