### PR TITLE
fix: has child items logic on validate cart (bug)

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -110,19 +110,27 @@ const equals = (storeOrder: IStoreOrder, orderForm: OrderForm) => {
 }
 
 function hasChildItem(items: OrderFormItem[], itemId: string) {
-  return items?.some(item => item.parentItemIndex && items[item.parentItemIndex].id === itemId)
+  return items?.some(
+    (item) =>
+      item.parentItemIndex !== null &&
+      item.parentItemIndex !== undefined &&
+      items[item.parentItemIndex]?.id === itemId
+  )
 }
 
 function hasParentItem(items: OrderFormItem[], itemId: string) {
-  return items?.some(item => item.id === itemId && item.parentItemIndex !== null)
+  return items?.some(
+    (item) => item.id === itemId && item.parentItemIndex !== null
+  )
 }
 
 const joinItems = (form: OrderForm) => {
   const itemsById = form.items.reduce(
     (acc, item, idx) => {
-      const id = hasParentItem(form.items, item.id) || hasChildItem(form.items, item.id) ? 
-        `${getId(orderFormItemToOffer(item))}::${idx}` : 
-        getId(orderFormItemToOffer(item))
+      const id =
+        hasParentItem(form.items, item.id) || hasChildItem(form.items, item.id)
+          ? `${getId(orderFormItemToOffer(item))}::${idx}`
+          : getId(orderFormItemToOffer(item))
 
       if (!acc[id]) {
         acc[id] = []
@@ -388,7 +396,10 @@ export const validateCart = async (
       // Update existing items
       const [head, ...tail] = maybeOriginItem
 
-      if(hasParentItem(orderForm.items, head.itemOffered.sku) || hasChildItem(orderForm.items, head.itemOffered.sku)) {
+      if (
+        hasParentItem(orderForm.items, head.itemOffered.sku) ||
+        hasChildItem(orderForm.items, head.itemOffered.sku)
+      ) {
         acc.itemsToUpdate.push(head)
 
         return acc


### PR DESCRIPTION
## What's the purpose of this pull request?

Solves the bug when I have the same item with attachment without necessarily having the same number of attachments

## How it works?

The validation done previously was always returning false, now it returns correctly

## How to test it?

Add products with assembly, but do not add the same total amount of assembly


## Checklist


**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor` and `test`

**PR Description**

- [x] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [x] Committed the `yarn.lock` file when there were changes to the packages
