### PR TITLE
Chore: Fix CLS issues and Navbar dynamic imports 

### DIFF
--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -97,7 +97,7 @@ function Navbar({
   } = useOverrideComponents<'Navbar'>()
   const scrollDirection = useScrollDirection()
   const { openNavbar, navbar: displayNavbar } = useUI()
-  const { isDesktop } = useScreenResize()
+  const { isMobile } = useScreenResize()
 
   const searchMobileRef = useRef<SearchInputRef>(null)
   const [searchExpanded, setSearchExpanded] = useState(false)
@@ -139,10 +139,12 @@ function Navbar({
             </>
           )}
 
-          <SearchInput
-            placeholder={searchInput?.placeholder}
-            sort={searchInput?.sort}
-          />
+          {!isMobile && (
+            <SearchInput
+              placeholder={searchInput?.placeholder}
+              sort={searchInput?.sort}
+            />
+          )}
 
           <NavbarButtons.Component
             searchExpanded={searchExpanded}
@@ -160,16 +162,18 @@ function Navbar({
               />
             )}
 
-            <SearchInput
-              placeholder=""
-              ref={searchMobileRef}
-              testId="store-input-mobile"
-              buttonTestId="store-input-mobile-button"
-              onSearchClick={handlerExpandSearch}
-              sort={searchInput?.sort}
-              hidden={!searchExpanded}
-              aria-hidden={!searchExpanded}
-            />
+            {isMobile && (
+              <SearchInput
+                placeholder=""
+                ref={searchMobileRef}
+                testId="store-input-mobile"
+                buttonTestId="store-input-mobile-button"
+                onSearchClick={handlerExpandSearch}
+                sort={searchInput?.sort}
+                hidden={!searchExpanded}
+                aria-hidden={!searchExpanded}
+              />
+            )}
 
             <ButtonSignIn.Component {...signInButton} />
 
@@ -178,7 +182,7 @@ function Navbar({
         </NavbarRow.Component>
       </NavbarHeader.Component>
 
-      {isDesktop && <NavbarLinks links={links} region={region} />}
+      {!isMobile && <NavbarLinks links={links} region={region} />}
 
       {displayNavbar && (
         <NavbarSlider

--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -175,7 +175,7 @@ function Navbar({
               />
             )}
 
-            <ButtonSignIn.Component {...signInButton} />
+            {!isMobile && <ButtonSignIn.Component {...signInButton} />}
 
             <CartToggle {...cart} />
           </NavbarButtons.Component>

--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -6,7 +6,6 @@ import type { SearchInputRef } from 'src/components/search/SearchInput'
 import SearchInput from 'src/components/search/SearchInput'
 
 import CartToggle from 'src/components/cart/CartToggle'
-import NavbarSlider from 'src/components/navigation/NavbarSlider'
 import Link from 'src/components/ui/Link'
 import Logo from 'src/components/ui/Logo'
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
@@ -22,15 +21,15 @@ const NavbarLinks = dynamic(
     ),
   {
     ssr: false,
-    loading: () => (
-      <div
-        style={{
-          height: 'var(--fs-control-tap-size)',
-          background: 'var(--fs-navbar-bkg-color)',
-        }}
-      ></div>
-    ),
   }
+)
+
+const NavbarSlider = dynamic(
+  () =>
+    /* webpackChunkName: "NavbarSlider" */ import(
+      'src/components/navigation/NavbarSlider'
+    ),
+  { ssr: false }
 )
 
 export interface NavbarProps {

--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -22,6 +22,14 @@ const NavbarLinks = dynamic(
     ),
   {
     ssr: false,
+    loading: () => (
+      <div
+        style={{
+          height: 'var(--fs-control-tap-size)',
+          background: 'var(--fs-navbar-bkg-color)',
+        }}
+      ></div>
+    ),
   }
 )
 

--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -1,18 +1,29 @@
-import { useRef, useState, useCallback } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
-import { useUI, useScrollDirection, Icon as UIIcon } from '@faststore/ui'
+import { Icon as UIIcon, useScrollDirection, useUI } from '@faststore/ui'
 
 import type { SearchInputRef } from 'src/components/search/SearchInput'
 import SearchInput from 'src/components/search/SearchInput'
-import NavbarLinks from 'src/components/navigation/NavbarLinks'
-import NavbarSlider from 'src/components/navigation/NavbarSlider'
+
 import CartToggle from 'src/components/cart/CartToggle'
-import Logo from 'src/components/ui/Logo'
+import NavbarSlider from 'src/components/navigation/NavbarSlider'
 import Link from 'src/components/ui/Link'
+import Logo from 'src/components/ui/Logo'
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 
-import type { NavbarProps as SectionNavbarProps } from '../../sections/Navbar'
+import dynamic from 'next/dynamic'
 import useScreenResize from 'src/sdk/ui/useScreenResize'
+import type { NavbarProps as SectionNavbarProps } from '../../sections/Navbar'
+
+const NavbarLinks = dynamic(
+  () =>
+    /* webpackChunkName: "NavbarLinks" */ import(
+      'src/components/navigation/NavbarLinks'
+    ),
+  {
+    ssr: false,
+  }
+)
 
 export interface NavbarProps {
   /**

--- a/packages/core/src/components/sections/Navbar/DefaultComponents.ts
+++ b/packages/core/src/components/sections/Navbar/DefaultComponents.ts
@@ -1,18 +1,41 @@
 import {
+  IconButton as UIIconButton,
   Navbar as UINavbar,
+  NavbarButtons as UINavbarButtons,
+  NavbarHeader as UINavbarHeader,
   NavbarLinks as UINavbarLinks,
   NavbarLinksList as UINavbarLinksList,
-  NavbarSlider as UINavbarSlider,
-  NavbarSliderHeader as UINavbarSliderHeader,
-  NavbarSliderContent as UINavbarSliderContent,
-  NavbarSliderFooter as UINavbarSliderFooter,
-  NavbarHeader as UINavbarHeader,
   NavbarRow as UINavbarRow,
-  NavbarButtons as UINavbarButtons,
-  IconButton as UIIconButton,
 } from '@faststore/ui'
 
-import { ButtonSignIn } from 'src/components/ui/Button'
+import dynamic from 'next/dynamic'
+
+const ButtonSignIn = dynamic(() =>
+  import(
+    /* webpackChunkName: "ButtonSignIn" */ 'src/components/ui/Button'
+  ).then((module) => module.ButtonSignIn)
+)
+
+const UINavbarSlider = dynamic(() =>
+  import(/* webpackChunkName: "UINavbarSlider" */ '@faststore/ui').then(
+    (module) => module.NavbarSlider
+  )
+)
+const UINavbarSliderHeader = dynamic(() =>
+  import(/* webpackChunkName: "UINavbarSliderHeader" */ '@faststore/ui').then(
+    (module) => module.NavbarSliderHeader
+  )
+)
+const UINavbarSliderContent = dynamic(() =>
+  import(/* webpackChunkName: "UINavbarSliderContent" */ '@faststore/ui').then(
+    (module) => module.NavbarSliderContent
+  )
+)
+const UINavbarSliderFooter = dynamic(() =>
+  import(/* webpackChunkName: "UINavbarSliderFooter" */ '@faststore/ui').then(
+    (module) => module.NavbarSliderFooter
+  )
+)
 
 export const NavbarDefaultComponents = {
   Navbar: UINavbar,

--- a/packages/core/src/components/sections/Navbar/section.module.scss
+++ b/packages/core/src/components/sections/Navbar/section.module.scss
@@ -23,5 +23,12 @@
     @import "@faststore/ui/src/components/molecules/SearchTop/styles.scss";
     @import "@faststore/ui/src/components/organisms/SearchInput/styles.scss";
     @import "@faststore/ui/src/components/organisms/Navbar/styles.scss";
+
+    // Sets Navbar height on desktop to avoid CLS issue - Cumulative Layout Shift
+    --fs-navbar-height-desktop: 4.5rem;
+
+    @include media(">=notebook") {
+      height: var(--fs-navbar-height-desktop);
+    }
   }
 }

--- a/packages/core/src/components/sections/RegionBar/RegionBar.tsx
+++ b/packages/core/src/components/sections/RegionBar/RegionBar.tsx
@@ -1,9 +1,8 @@
+import { getOverridableSection } from '../../..//sdk/overrides/getOverriddenSection'
 import RegionBar, { RegionBarProps } from '../../region/RegionBar/RegionBar'
 import Section from '../Section/Section'
-import styles from './section.module.scss'
 import { RegionBarDefaultComponents } from './DefaultComponents'
-import { getOverridableSection } from '../../..//sdk/overrides/getOverriddenSection'
-import useScreenResize from 'src/sdk/ui/useScreenResize'
+import styles from './section.module.scss'
 
 type RegionBarSectionProps = {
   /**
@@ -29,14 +28,10 @@ type RegionBarSectionProps = {
 }
 
 function RegionBarSection({ ...otherProps }: RegionBarSectionProps) {
-  const { isMobile } = useScreenResize()
-
   return (
-    isMobile && (
-      <Section className={`${styles.section} section-region-bar`}>
-        <RegionBar {...otherProps} />
-      </Section>
-    )
+    <Section className={`${styles.section} section-region-bar display-mobile`}>
+      <RegionBar {...otherProps} />
+    </Section>
   )
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

- Fix CLS (Cumulative Layout Shift) for `RegionBar` (it was introduced when we change to use `isMobile` hook to render the section, although using the `display-mobile` won't remove the component from the dom, I opted to put it back to avoid the CLS)

|Mobile| Desktop|
|-|-|
![CLS-Mobile](https://github.com/user-attachments/assets/d737bcd7-54e4-44cd-a532-33d95471a156)|![CLS-Desk](https://github.com/user-attachments/assets/b669d5aa-b402-49ee-ae16-2d34feed14b6)

- Uses dynamic import to `Navlinks` 
- Uses `useScreenResize` hook on `Navbar` component to avoid components duplication and render depending on the device
- Uses dynamic import for `NavbarSlider` internal components

## How it works?

- Mobile

|Starter | CLS fixes + navbar improvements|
|-|-|
<img width="1018" alt="mob-starter" src="https://github.com/user-attachments/assets/2d9f6d2a-51dc-4341-8aa0-670d6a20281b">|<img width="1031" alt="mob-perf" src="https://github.com/user-attachments/assets/d7a3e426-39b7-40a4-9871-b90e5c3fb577">|

- Desktop

|Starter | CLS fixes + navbar improvements|
|-|-|
|<img width="1008" alt="desk-starter" src="https://github.com/user-attachments/assets/68c8da9d-839e-415b-b4c0-39fd4e423019">|<img width="1011" alt="desk-perf" src="https://github.com/user-attachments/assets/956a19aa-bd92-4acf-a163-348cc94938d1">|


## How to test it?

Use this preview link for tests: https://sfj-1842eea--starter.preview.vtex.app

1. Everything should be working as before
2. Check if the layout shift in the RegionBar is still happening
3. Try testing the link in https://pagespeed.web.dev/

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/587


