### PR TITLE
fix: don't move .next directory if it is in the correct place

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -93,7 +93,13 @@ async function copyResources(basePath: string) {
   if (process.env.BUILD_CONTEXT === 'vercel') {
     const toDir = process.cwd()
 
-    await copyResource(`${tmpDir}/.next`, `${toDir}/.faststore/.next`)
+    // Because of how copyResource works (delete the target directory if it exists),
+    // if we're moving something to the same place it is it will break.
+    const nextOutputDirectory = `${tmpDir}/.next`
+    const expectedOutputDirectory = `${toDir}/.faststore/.next`
+    if (nextOutputDirectory !== expectedOutputDirectory) {
+      await copyResource(nextOutputDirectory, expectedOutputDirectory)
+    }
     await copyResource(`${tmpDir}/public`, `${toDir}/public`)
   } else {
     await copyResource(`${tmpDir}/.next`, `${userDir}/.next`)


### PR DESCRIPTION
## What's the purpose of this pull request?

To fix the build of accounts using the discovery-only repo.

## How it works?

Instead of blindly moving `.faststore/.next` to the same place, we first check if we're trying to move it to the same place. If it is, we just skipping copy altogether.

## How to test it?

Do the onboarding and change the repo to use this preview URL.

### Starters Deploy Preview

TBD