### PR TITLE
fix: NaN when string is inputed on quantity input

### DIFF
--- a/packages/components/src/molecules/QuantitySelector/QuantitySelector.tsx
+++ b/packages/components/src/molecules/QuantitySelector/QuantitySelector.tsx
@@ -140,12 +140,11 @@ const QuantitySelector = ({
         value={useUnitMultiplier ? multipliedUnit : quantity}
         onChange={changeInputValue}
         onBlur={validateBlur}
-        onInput={(event: React.FormEvent<HTMLInputElement>) => {
-          const input = event.currentTarget
-          input.value = isNaN(Number(input.value))
-            ? ''
-            : input.value.replace(/\D/g, '')
-        }}
+        type="number"
+        // onInput={(event: React.FormEvent<HTMLInputElement>) => {
+        //   const input = event.currentTarget
+        //   input.value = input.value.replace(/\D/g, '')
+        // }}
         disabled={disabled}
       />
       <IconButton

--- a/packages/components/src/molecules/QuantitySelector/QuantitySelector.tsx
+++ b/packages/components/src/molecules/QuantitySelector/QuantitySelector.tsx
@@ -142,7 +142,9 @@ const QuantitySelector = ({
         onBlur={validateBlur}
         onInput={(event: React.FormEvent<HTMLInputElement>) => {
           const input = event.currentTarget
-          input.value = input.value.replace(/\D/g, '')
+          input.value = isNaN(Number(input.value))
+            ? ''
+            : input.value.replace(/\D/g, '')
         }}
         disabled={disabled}
       />

--- a/packages/components/src/molecules/QuantitySelector/QuantitySelector.tsx
+++ b/packages/components/src/molecules/QuantitySelector/QuantitySelector.tsx
@@ -113,7 +113,8 @@ const QuantitySelector = ({
   }, [initial])
 
   const changeInputValue = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setQuantity(Number(e.currentTarget.value))
+    const numericValue = e.target.value.replace(/\D/g, '')
+    setQuantity(Number(numericValue))
   }
 
   return (
@@ -139,6 +140,10 @@ const QuantitySelector = ({
         value={useUnitMultiplier ? multipliedUnit : quantity}
         onChange={changeInputValue}
         onBlur={validateBlur}
+        onInput={(event: React.FormEvent<HTMLInputElement>) => {
+          const input = event.currentTarget
+          input.value = input.value.replace(/\D/g, '')
+        }}
         disabled={disabled}
       />
       <IconButton

--- a/packages/components/src/molecules/QuantitySelector/QuantitySelector.tsx
+++ b/packages/components/src/molecules/QuantitySelector/QuantitySelector.tsx
@@ -140,11 +140,10 @@ const QuantitySelector = ({
         value={useUnitMultiplier ? multipliedUnit : quantity}
         onChange={changeInputValue}
         onBlur={validateBlur}
-        type="number"
-        // onInput={(event: React.FormEvent<HTMLInputElement>) => {
-        //   const input = event.currentTarget
-        //   input.value = input.value.replace(/\D/g, '')
-        // }}
+        onInput={(event: React.FormEvent<HTMLInputElement>) => {
+          const input = event.currentTarget
+          input.value = input.value.replace(/\D/g, '')
+        }}
         disabled={disabled}
       />
       <IconButton


### PR DESCRIPTION
## What's the purpose of this pull request?

Resolves the bug that when typing letters in the quantity input a "NaN" error appears

## How it works?

I validated the function to change the input to remove any non-numeric value

## How to test it?

Go to the product page and try to enter a value other than a number in the quantity input

https://newswarovskiargentina-cm2bukmqh008u9fpvz46jty9h-rarbnwb8d.b.vtex.app/5662923-conjunto-stilla-tallas-mixtas-multicolor-bano-tono-oro-rosa-11436/p


## Checklist

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor` and `test`

**PR Description**

- [x] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [x] Committed the `yarn.lock` file when there were changes to the packages
