### PR TITLE
Chore: Applies next/dynamic for Toast

### DIFF
--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -5,7 +5,6 @@ import { PropsWithChildren } from 'react'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import { PageContentType, getPage } from 'src/server/cms'
 
-import Toast from 'src/components/common/Toast'
 import RenderSections from './RenderSections'
 
 import { OverriddenDefaultAlert as Alert } from 'src/components/sections/Alert/OverriddenDefaultAlert'
@@ -39,8 +38,6 @@ function GlobalSections({
 }: PropsWithChildren<GlobalSectionsData>) {
   return (
     <RenderSections components={COMPONENTS} {...otherProps}>
-      <Toast />
-
       <main>{children}</main>
     </RenderSections>
   )

--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react'
 
 import { Section } from '@vtex/client-cms'
+import dynamic from 'next/dynamic'
 import SectionBoundary from './SectionBoundary'
 import ViewportObserver from './ViewportObserver'
 
@@ -18,6 +19,11 @@ interface Props {
 }
 
 const SECTIONS_OUT_OF_VIEWPORT = ['CartSidebar', 'RegionModal']
+
+const Toast = dynamic(
+  () => import(/* webpackChunkName: "Toast" */ '../common/Toast'),
+  { ssr: false }
+)
 
 const useDividedSections = (sections: Section[]) => {
   return useMemo(() => {
@@ -102,6 +108,7 @@ function RenderSections({
     <>
       <RenderSectionsBase sections={firstSections} {...otherProps} />
 
+      <Toast />
       {children}
 
       {hasChildren && (

--- a/packages/core/src/components/common/Toast/Toast.tsx
+++ b/packages/core/src/components/common/Toast/Toast.tsx
@@ -1,9 +1,19 @@
 import { useEffect } from 'react'
 
-import { Toast as UIToast, useUI } from '@faststore/ui'
+import dynamic from 'next/dynamic'
+
+import { useUI } from '@faststore/ui'
 import Section from 'src/components/sections/Section/Section'
 import { useCart } from 'src/sdk/cart'
 import styles from './section.module.scss'
+
+const UIToast = dynamic(
+  () =>
+    import(/* webpackChunkName: "UIToast" */ '@faststore/ui').then((module) => {
+      return module.Toast
+    }),
+  { ssr: false }
+)
 
 function Toast() {
   const { toasts, pushToast } = useUI()


### PR DESCRIPTION
## What's the purpose of this pull request?

- Loads `Toast` using dynamic import.
- Imports `Toast` in `RenderSections` instead of `GlobalSections`

**note**: Unlike the [POC](https://github.com/vtex/faststore/pull/2404/files#diff-b45ed72491ecc419d59ca49fa8b4fc7a45deb55758a6a401f3c8401c11114227R113-R120), the Toast component does not use <LazyLoadingSection>. In the PLP, the Toast needs to be imported along with the `QuantitySelector` (within the viewport) to address scenario 2 (refer to item 2 for how to test).

## How it works?

We are aiming to optimize the performance  loading components only when they are needed, rather than at the initial page load.

|starter|preview|
|-|-|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/5525b2e3-0b5e-418e-bd45-8fd63d28f24b">|<img width="500" alt="image" src="https://github.com/user-attachments/assets/29f2f9d7-e4bd-47f6-b528-601cc0a617b0">|


## How to test it?

- Run locally or using this [preview](https://sfj-d0111da--starter.preview.vtex.app/)

1.  In the homepage, you can see the Toast js file being loaded in the network
2. In the PDP, choose any product, and tries to change the quantity  to `11` (type 11 inside the `QuantitySelector`) , you should be able to see the `Toast` with a message.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/b44d727e-340e-4b13-841b-2660f47753e1">


### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/597

## References

[SFS 1514](https://vtex-dev.atlassian.net/browse/SFS-1514)
