### PR TITLE
feat: next/dynamic in `BannerText` internal components SFS-1518

### DIFF
--- a/packages/core/src/components/sections/BannerText/DefaultComponents.ts
+++ b/packages/core/src/components/sections/BannerText/DefaultComponents.ts
@@ -1,7 +1,15 @@
-import {
-  BannerText as UIBannerText,
-  BannerTextContent as UIBannerTextContent,
-} from '@faststore/ui'
+import dynamic from 'next/dynamic'
+
+const UIBannerText = dynamic(() =>
+  import(/* webpackChunkName: "UIBannerText" */ '@faststore/ui').then(
+    (mod) => mod.BannerText
+  )
+)
+const UIBannerTextContent = dynamic(() =>
+  import(/* webpackChunkName: "UIBannerTextContent" */ '@faststore/ui').then(
+    (mod) => mod.BannerTextContent
+  )
+)
 
 export const BannerTextDefaultComponents = {
   BannerText: UIBannerText,


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR is part of the performance initiative and aims to apply next/dynamic to BannerText's internal components.

## How to test it?

The pages should render as before, this PR is only to prepare the components for the time that we're gonna render based on the ViewportObserver/LazyLoadingSection.

### Starters Deploy Preview

- https://github.com/vtex-sites/starter.store/pull/608

Preview
https://sfj-fc3bf86--starter.preview.vtex.app/

### References
POC PR
- https://github.com/vtex/faststore/pull/2404