### PR TITLE
feat: split the global sections in own file

### DIFF
--- a/packages/core/src/components/cms/global/Components.ts
+++ b/packages/core/src/components/cms/global/Components.ts
@@ -1,0 +1,40 @@
+import dynamic from 'next/dynamic'
+import { ComponentType } from 'react'
+
+import { OverriddenDefaultAlert as Alert } from 'src/components/sections/Alert/OverriddenDefaultAlert'
+import { OverriddenDefaultNavbar as Navbar } from 'src/components/sections/Navbar/OverriddenDefaultNavbar'
+import { OverriddenDefaultRegionBar as RegionBar } from 'src/components/sections/RegionBar/OverriddenDefaultRegionBar'
+
+import CUSTOM_COMPONENTS from 'src/customizations/src/components'
+
+const CartSidebar = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "CartSidebar" */ 'src/components/cart/CartSidebar'
+    ),
+  { ssr: false }
+)
+const RegionModal = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "RegionModal" */ 'src/components/region/RegionModal'
+    ),
+  { ssr: false }
+)
+const Footer = dynamic(
+  () =>
+    import(/* webpackChunkName: "Footer" */ 'src/components/sections/Footer'),
+  { ssr: false }
+)
+
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  Alert,
+  Navbar,
+  RegionBar,
+  CartSidebar, // out of viewport
+  RegionModal, // out of viewport
+  Footer,
+  ...CUSTOM_COMPONENTS,
+}
+
+export default COMPONENTS

--- a/packages/core/src/components/cms/global/Components.ts
+++ b/packages/core/src/components/cms/global/Components.ts
@@ -33,7 +33,7 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
   RegionBar,
   CartSidebar, // out of viewport
   RegionModal, // out of viewport
-  Footer,
+  Footer, // out of viewport
   ...CUSTOM_COMPONENTS,
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR is part of the performance initiative and aims to split the global sections into its own file.

Let's initially separate the components of each page type into their own files; this will help organize the import of components by page type (in other tasks) and opens up the possibility of only importing customized components based on the page type in the future, instead of all components, as we currently do. 

The idea is to stop using the `GlobalSections` component in the tree of each page, but since we are not doing this for all pages yet, we’ll keep it temporarily. We will only remove the use of this component on the homepage (in another task). Once we’ve done this for all pages, we can remove this component entirely, but we will keep the function `getGlobalSectionsData`. (packages/core/src/components/cms/GlobalSections.tsx). Global sections will now be imported into the sections file of each page and passed directly to `RenderSections`.


### Starters Deploy Preview

- https://github.com/vtex-sites/starter.store/pull/610

Preview
https://sfj-923b60d--starter.preview.vtex.app/

### References
POC PR
- https://github.com/vtex/faststore/pull/2404