### PR TITLE
Feat: next/dynamic `ProductShelf` Section and internal components.

### DIFF
--- a/packages/core/src/components/sections/ProductShelf/DefaultComponents.ts
+++ b/packages/core/src/components/sections/ProductShelf/DefaultComponents.ts
@@ -1,6 +1,20 @@
-import { ProductShelf as UIProductShelf } from '@faststore/ui'
-import ProductCard from 'src/components/product/ProductCard'
-import Carousel from 'src/components/ui/Carousel'
+import dynamic from 'next/dynamic'
+const UIProductShelf = dynamic(() =>
+  /* webpackChunkName: "UIProductShelf" */
+  import('@faststore/ui').then((mod) => ({ default: mod.ProductShelf }))
+)
+
+const Carousel = dynamic(
+  () =>
+    /* webpackChunkName: "Carousel" */
+    import('src/components/ui/Carousel')
+)
+
+const ProductCard = dynamic(
+  () =>
+    /* webpackChunkName: "ProductCard" */
+    import('src/components/product/ProductCard')
+)
 
 export const ProductShelfDefaultComponents = {
   ProductShelf: UIProductShelf,

--- a/packages/core/src/components/sections/ProductShelf/DefaultComponents.ts
+++ b/packages/core/src/components/sections/ProductShelf/DefaultComponents.ts
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic'
 const UIProductShelf = dynamic(() =>
   /* webpackChunkName: "UIProductShelf" */
-  import('@faststore/ui').then((mod) => ({ default: mod.ProductShelf }))
+  import('@faststore/ui').then((mod) => mod.ProductShelf)
 )
 
 const Carousel = dynamic(

--- a/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
@@ -1,10 +1,16 @@
+import dynamic from 'next/dynamic'
 import { useEffect, useId, useRef } from 'react'
 
-import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
 import { useViewItemListEvent } from 'src/sdk/analytics/hooks/useViewItemListEvent'
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 import { useProductsQuery } from 'src/sdk/product/useProductsQuery'
 import { textToKebabCase } from 'src/utils/utilities'
+
+const ProductShelfSkeleton = dynamic(
+  () =>
+    /* webpackChunkName: "ProductShelfSkeleton" */
+    import('src/components/skeletons/ProductShelfSkeleton')
+)
 
 type Sort =
   | 'discount_desc'


### PR DESCRIPTION
Depends on 
- https://github.com/vtex/faststore/pull/2558

## What's the purpose of this pull request?

This PR is part of the performance initiative and aims to apply `next/dynamic` to `ProductShelf` internal components.

## How to test it?

The `ProductShelf` should render as before. 

### Starters Deploy Preview

- https://github.com/vtex-sites/starter.store/pull/613

Preview
https://sfj-5f82a4c--starter.preview.vtex.app/

### References
POC PR
- https://github.com/vtex/faststore/pull/2404