### PR TITLE
[1.x] chore: Replace `isomorphic-unfetch` with `node-fetch`

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,7 +31,7 @@
     "@rollup/plugin-graphql": "^1.0.0",
     "dataloader": "^2.1.0",
     "fast-deep-equal": "^3.1.3",
-    "isomorphic-unfetch": "^3.1.0",
+    "node-fetch": "^2.7.0",
     "p-limit": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/api/src/platforms/vtex/clients/fetch.ts
+++ b/packages/api/src/platforms/vtex/clients/fetch.ts
@@ -1,4 +1,4 @@
-import fetch from 'isomorphic-unfetch'
+import fetch, { RequestInfo, RequestInit } from 'node-fetch'
 import packageJson from '../../../../package.json'
 
 const USER_AGENT = `${packageJson.name}@${packageJson.version}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -18214,14 +18214,6 @@ isomorphic-fetch@^3.0.0:
     node-fetch "^2.6.1"
     whatwg-fetch "^3.4.1"
 
-isomorphic-unfetch@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz"
-  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
-  dependencies:
-    node-fetch "^2.6.1"
-    unfetch "^4.2.0"
-
 isomorphic-ws@4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz"
@@ -20646,6 +20638,13 @@ node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to replace the `isomorphic-unfetch` lib with `node-fetch` towards supporting the use of `Host` header.

## How it works?

Everything should work as before.

## How to test it?

Check if all the requests are behaving correctly.

### Starters Deploy Preview

https://github.com/vtex-sites/nextjs.store/pull/414