### PR TITLE
fix: Support `releaseId` query string param for Headless CMS previews

### DIFF
--- a/packages/core/src/pages/api/preview.ts
+++ b/packages/core/src/pages/api/preview.ts
@@ -76,8 +76,9 @@ const handler: NextApiHandler = async (req, res) => {
     })
 
     // Redirect to the path from the fetched locator
-    if (previewRedirects[locator.contentType]) {
-      res.redirect(previewRedirects[locator.contentType])
+    const redirects = previewRedirects as Record<string, string>
+    if (redirects[locator.contentType]) {
+      res.redirect(redirects[locator.contentType])
       return
     }
 

--- a/packages/core/src/pages/api/preview.ts
+++ b/packages/core/src/pages/api/preview.ts
@@ -45,7 +45,7 @@ const handler: NextApiHandler = async (req, res) => {
       )
     }
 
-    // Check if querystring params are present
+    // Check if at least one of the querystring params are present
     if (!locator.versionId && !locator.releaseId) {
       throw new StatusError(
         `One of the following querystring params are required: versionId, releaseId`,
@@ -53,7 +53,7 @@ const handler: NextApiHandler = async (req, res) => {
       )
     }
 
-    // Filter undefined keys
+    // Filter undefined key
     Object.keys(locator).forEach(
       (key) => locator[key] === undefined && delete locator[key]
     )

--- a/packages/core/src/pages/api/preview.ts
+++ b/packages/core/src/pages/api/preview.ts
@@ -30,12 +30,18 @@ const pickParam = (req: NextApiRequest, parameter: string) => {
 // TODO: Improve security by disabling CMS preview in production
 const handler: NextApiHandler = async (req, res) => {
   try {
-    const locator: any = {
-      contentType: pickParam(req, 'contentType'),
-      documentId: pickParam(req, 'documentId'),
-      versionId: pickParam(req, 'versionId'),
-      releaseId: pickParam(req, 'releaseId'),
-    }
+    const locator = [
+      'contentType',
+      'documentId',
+      'versionId',
+      'releaseId',
+    ].reduce((acc, param) => {
+      const value = pickParam(req, param)
+
+      if (value !== undefined) acc[param] = value
+
+      return acc
+    }, {} as Record<string, string>)
 
     // Check if required path params are present
     if (!locator.contentType || !locator.documentId) {
@@ -52,11 +58,6 @@ const handler: NextApiHandler = async (req, res) => {
         400
       )
     }
-
-    // Filter undefined key
-    Object.keys(locator).forEach(
-      (key) => locator[key] === undefined && delete locator[key]
-    )
 
     // Fetch CMS to check if the provided `locator` exists
     const page = await clientCMS.getCMSPage(locator as Locator)


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the Headless CMS release preview not working due to missing support for `releaseId` query string param.

## How it works?

With these changes, the function will pick each param, check for missing (required or optional) ones and filter undefined keys (`versionId` or `releaseId`).

## How to test it?

On Admin, check some account with existing Release and try opening the release preview.

### Starters Deploy Preview



## References

[VTEX Headless CMS API doc](https://developers.vtex.com/docs/api-reference/headless-cms-api#get-/_v/cms/api/-projectId-/-content-type-/-document-id-?endpoint=get-/_v/cms/api/-projectId-/-content-type-/-document-id-)