### PR TITLE
feat: add preact support for projects with legacy store config

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -393,14 +393,31 @@ function updateNextConfig(basePath: string) {
   writeFileSync(nextConfigPath, nextConfigData)
 }
 
-function validateAndInstallMissingDependencies(basePath: string) {
-  const { userDir, userStoreConfigFile } = withBasePath(basePath)
+// returns new (discovery.config.js) or legacy (faststore.config.js) store config file
+function getCurrentUserStoreConfigFile(basePath: string) {
+  const { userStoreConfigFile, userLegacyStoreConfigFile } = withBasePath(basePath)
 
-  if (!existsSync(userStoreConfigFile)) {
+  if (existsSync(userStoreConfigFile)) {
+    return userStoreConfigFile
+  }
+
+  if (existsSync(userLegacyStoreConfigFile)) {
+    return userLegacyStoreConfigFile
+  }
+
+  return null
+}
+
+function validateAndInstallMissingDependencies(basePath: string) {
+  const { userDir } = withBasePath(basePath)
+
+  const currentUserStoreConfigFile = getCurrentUserStoreConfigFile(basePath) 
+
+  if (!currentUserStoreConfigFile) {
     return
   }
 
-  const userStoreConfig = require(userStoreConfigFile)
+  const userStoreConfig = require(currentUserStoreConfigFile)
   const userPackageJson = require(path.join(userDir, 'package.json'))
 
   const missingDependencies: Array<{


### PR DESCRIPTION
## What's the purpose of this pull request?
feat: add preact support for projects with legacy store config  (faststore.config.js)

## How it works?
I created a function that returns new (discovery.config.js) or legacy (faststore.config.js) store config file

## How to test it?

Enable preact flag using `faststore.config.js` and `discovery.config.js`. Both should work.

Check the documentation for more details: https://developers.vtex.com/docs/guides/faststore/managing-performance-improving-store-performance-with-preact 
### Result

![Captura de Tela 2024-11-26 às 09 54 16](https://github.com/user-attachments/assets/37791f54-7398-4cf7-b271-e6b4d002a322)


