### PR TITLE
feat: Send `search.autocomplete.click` IS event (SFS-1815)

### DIFF
--- a/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
+++ b/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
@@ -23,7 +23,7 @@ interface SearchDropdownProps {
   [key: string]: any
 }
 
-function sendAutocompleteClickEvent({
+export function sendAutocompleteClickEvent({
   url,
   term,
   position,

--- a/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
+++ b/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
@@ -13,9 +13,28 @@ import { SearchState } from '@faststore/sdk'
 import { ProductSummary_ProductFragment } from '@generated/graphql'
 import SearchProductItem from 'src/components/search/SearchProductItem'
 import { formatSearchPath } from 'src/sdk/search/formatSearchPath'
+import type {
+  IntelligentSearchAutocompleteClickEvent,
+  IntelligentSearchAutocompleteClickParams,
+} from 'src/sdk/analytics/types'
+
 interface SearchDropdownProps {
   sort: SearchState['sort']
   [key: string]: any
+}
+
+function sendAutocompleteClickEvent({
+  url,
+  term,
+  position,
+  productId,
+}: IntelligentSearchAutocompleteClickParams) {
+  import('@faststore/sdk').then(({ sendAnalyticsEvent }) => {
+    sendAnalyticsEvent<IntelligentSearchAutocompleteClickEvent>({
+      name: 'intelligent_search_autocomplete_click',
+      params: { term, url, productId, position },
+    })
+  })
 }
 
 function SearchDropdown({ sort, ...otherProps }: SearchDropdownProps) {
@@ -38,14 +57,16 @@ function SearchDropdown({ sort, ...otherProps }: SearchDropdownProps) {
                 term: suggestion,
                 sort,
               }),
-              onClick: () =>
+              onClick: () => {
                 onSearchSelection?.(
                   suggestion,
-                  formatSearchPath({
-                    term: suggestion,
-                    sort,
-                  })
-                ),
+                  formatSearchPath({ term: suggestion, sort })
+                )
+                sendAutocompleteClickEvent({
+                  term: suggestion,
+                  url: window.location.href,
+                })
+              },
             }}
           />
         ))}

--- a/packages/core/src/components/search/SearchDropdown/index.ts
+++ b/packages/core/src/components/search/SearchDropdown/index.ts
@@ -1,1 +1,2 @@
 export { default } from './SearchDropdown'
+export { sendAutocompleteClickEvent } from './SearchDropdown'

--- a/packages/core/src/components/search/SearchProductItem/SearchProductItem.tsx
+++ b/packages/core/src/components/search/SearchProductItem/SearchProductItem.tsx
@@ -8,7 +8,25 @@ import {
 import { Image } from 'src/components/ui/Image'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import { useProductLink } from 'src/sdk/product/useProductLink'
+import type {
+  IntelligentSearchAutocompleteClickEvent,
+  IntelligentSearchAutocompleteClickParams,
+} from 'src/sdk/analytics/types'
 import type { ProductSummary_ProductFragment } from '@generated/graphql'
+
+function sendAutocompleteClickEvent({
+  url,
+  term,
+  position,
+  productId,
+}: IntelligentSearchAutocompleteClickParams) {
+  import('@faststore/sdk').then(({ sendAnalyticsEvent }) => {
+    sendAnalyticsEvent<IntelligentSearchAutocompleteClickEvent>({
+      name: 'intelligent_search_autocomplete_click',
+      params: { term, url, productId, position },
+    })
+  })
+}
 
 type SearchProductItemProps = {
   /**
@@ -50,6 +68,12 @@ function SearchProductItem({
     onClick: () => {
       onClick()
       onSearchSelection?.(name, href)
+      sendAutocompleteClickEvent({
+        url: href,
+        term: name,
+        position: index,
+        productId: product.isVariantOf.productGroupID ?? product.sku,
+      })
     },
     ...baseLinkProps,
   }

--- a/packages/core/src/components/search/SearchProductItem/SearchProductItem.tsx
+++ b/packages/core/src/components/search/SearchProductItem/SearchProductItem.tsx
@@ -8,25 +8,8 @@ import {
 import { Image } from 'src/components/ui/Image'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import { useProductLink } from 'src/sdk/product/useProductLink'
-import type {
-  IntelligentSearchAutocompleteClickEvent,
-  IntelligentSearchAutocompleteClickParams,
-} from 'src/sdk/analytics/types'
+import { sendAutocompleteClickEvent } from '../SearchDropdown'
 import type { ProductSummary_ProductFragment } from '@generated/graphql'
-
-function sendAutocompleteClickEvent({
-  url,
-  term,
-  position,
-  productId,
-}: IntelligentSearchAutocompleteClickParams) {
-  import('@faststore/sdk').then(({ sendAnalyticsEvent }) => {
-    sendAnalyticsEvent<IntelligentSearchAutocompleteClickEvent>({
-      name: 'intelligent_search_autocomplete_click',
-      params: { term, url, productId, position },
-    })
-  })
-}
 
 type SearchProductItemProps = {
   /**

--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -3,6 +3,7 @@
  */
 import type { AnalyticsEvent } from '@faststore/sdk'
 import type {
+  IntelligentSearchAutocompleteClickEvent,
   IntelligentSearchAutocompleteQueryEvent,
   IntelligentSearchQueryEvent,
   SearchSelectItemEvent,
@@ -76,6 +77,13 @@ type SearchEvent =
       url: string
       type: 'search.autocomplete.query'
     }
+  | {
+      text: string
+      url?: string
+      position?: number
+      productId?: string
+      type: 'search.autocomplete.click'
+    }
 
 const sendEvent = (options: SearchEvent & { url?: string }) =>
   fetch(`https://sp.vtex.com/event-api/v1/${config.api.storeId}/event`, {
@@ -101,6 +109,7 @@ const handleEvent = (
     | SearchSelectItemEvent
     | IntelligentSearchQueryEvent
     | IntelligentSearchAutocompleteQueryEvent
+    | IntelligentSearchAutocompleteClickEvent
 ) => {
   switch (event.name) {
     case 'search_select_item': {
@@ -151,6 +160,18 @@ const handleEvent = (
         match: event.params.totalCount,
         operator: event.params.logicalOperator,
         locale: event.params.locale,
+      })
+
+      break
+    }
+
+    case 'intelligent_search_autocomplete_click': {
+      sendEvent({
+        text: event.params.term,
+        url: event.params.url ?? '',
+        productId: event.params.productId ?? '',
+        ...(event.params.position && { position: event.params.position }),
+        type: 'search.autocomplete.click',
       })
 
       break

--- a/packages/core/src/sdk/analytics/types.ts
+++ b/packages/core/src/sdk/analytics/types.ts
@@ -48,3 +48,15 @@ export interface IntelligentSearchAutocompleteQueryEvent {
   name: 'intelligent_search_autocomplete_query'
   params: IntelligentSearchAutocompleteQueryParams
 }
+
+export interface IntelligentSearchAutocompleteClickParams {
+  term: string
+  url?: string
+  position?: number
+  productId?: string
+}
+
+export interface IntelligentSearchAutocompleteClickEvent {
+  name: 'intelligent_search_autocomplete_click'
+  params: IntelligentSearchAutocompleteClickParams
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add the sending of `search.autocomplete.click` event when searching and clicking on autocompleted terms or suggested products.

## How it works?

When searching and clicking on both autocompleted term or suggested product, a function called `sendAutocompleteClickEvent` will be called and will send the IS event.

## How to test it?

Use the search input to search for "app" and if you click on an autocompleted term or a suggested product, a `search.autocomplete.click` event should be sent in the `Network` tab.

### Starters Deploy Preview

vtex-sites/starter.store#623

## References

Check the `Search Click` object in [IS Events API](https://developers.vtex.com/docs/api-reference/intelligent-search-events-api-headless#post-/event).