### PR TITLE
ci: create a job to validate the PR  title

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,7 @@
 **PR Title and Commit Messages**
 
 - [ ] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
-  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor` and `test`
+  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`
 
 **PR Description**
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,5 +21,14 @@ jobs:
             eslint-config
             lighthouse
             graphql-utils
+          types: |
+            fix
+            feat
+            chore
+            docs
+            style
+            refactor
+            test
+            ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: "Lint PR"
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened, edited, synchronize]
 
 jobs:
   main:
@@ -10,5 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
+        with:
+          scopes: |
+            core
+            ui
+            api
+            components
+            sdk
+            shared
+            eslint-config
+            lighthouse
+            graphql-utils
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,14 @@
+name: "Lint PR"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What's the purpose of this pull request?

Create a workflow with a job to validate PR title. The title should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. 

Available types:
```
 - fix
 - feat
 - chore
 - docs
 - style
 - refactor
 - test
 - ci
```


## How it works?
![Captura de Tela 2024-12-03 às 14 35 33](https://github.com/user-attachments/assets/b9fa7903-71c3-415e-9c4b-2f4c5ddea05b)


## How to test it?

Change the title of this PR and refresh the page. When I update the title, I need to refresh the page to see the job running again. It looks like a visual issue.


