### PR TITLE
feat: add ads label product card

### DIFF
--- a/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
+++ b/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
@@ -68,7 +68,7 @@ export interface ProductCardContentProps extends HTMLAttributes<HTMLElement> {
   /**
    * Specifies if the displayed product is sponsored.
    */
-  isSponsored?: boolean
+  sponsored?: boolean
   /**
    * Specifies the sponsored label, if advertisement is applicable.
    */
@@ -91,7 +91,7 @@ const ProductCardContent = forwardRef<HTMLElement, ProductCardContentProps>(
       children,
       includeTaxes = false,
       includeTaxesLabel = 'Tax included',
-      isSponsored = false,
+      sponsored = false,
       sponsoredLabel = 'Sponsored',
       ...otherProps
     },
@@ -108,7 +108,7 @@ const ProductCardContent = forwardRef<HTMLElement, ProductCardContentProps>(
         data-testid={testId}
         {...otherProps}
       >
-        {isSponsored && (
+        {sponsored && (
           <span data-fs-product-card-sponsored-label>{sponsoredLabel}</span>
         )}
         <div data-fs-product-card-heading>

--- a/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
+++ b/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
@@ -62,7 +62,7 @@ export interface ProductCardContentProps extends HTMLAttributes<HTMLElement> {
    */
   includeTaxes?: boolean
   /**
-   * Label to determine if the price includes taxes.
+   * Specifies the include taxes label, if taxes are included.
    */
   includeTaxesLabel?: string
   /**
@@ -70,7 +70,7 @@ export interface ProductCardContentProps extends HTMLAttributes<HTMLElement> {
    */
   isSponsored?: boolean
   /**
-   * Label to indicate if the product is sponsored.
+   * Specifies the sponsored label, if advertisement is applicable.
    */
   sponsoredLabel?: string
 }

--- a/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
+++ b/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
@@ -91,7 +91,7 @@ const ProductCardContent = forwardRef<HTMLElement, ProductCardContentProps>(
       children,
       includeTaxes = false,
       includeTaxesLabel = 'Tax included',
-      isSponsored = true,
+      isSponsored = false,
       sponsoredLabel = 'Sponsored',
       ...otherProps
     },

--- a/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
+++ b/packages/components/src/molecules/ProductCard/ProductCardContent.tsx
@@ -65,6 +65,14 @@ export interface ProductCardContentProps extends HTMLAttributes<HTMLElement> {
    * Label to determine if the price includes taxes.
    */
   includeTaxesLabel?: string
+  /**
+   * Specifies if the displayed product is sponsored.
+   */
+  isSponsored?: boolean
+  /**
+   * Label to indicate if the product is sponsored.
+   */
+  sponsoredLabel?: string
 }
 
 const ProductCardContent = forwardRef<HTMLElement, ProductCardContentProps>(
@@ -82,7 +90,9 @@ const ProductCardContent = forwardRef<HTMLElement, ProductCardContentProps>(
       onButtonClick,
       children,
       includeTaxes = false,
-      includeTaxesLabel = "Tax included",
+      includeTaxesLabel = 'Tax included',
+      isSponsored = true,
+      sponsoredLabel = 'Sponsored',
       ...otherProps
     },
     ref
@@ -98,6 +108,9 @@ const ProductCardContent = forwardRef<HTMLElement, ProductCardContentProps>(
         data-testid={testId}
         {...otherProps}
       >
+        {isSponsored && (
+          <span data-fs-product-card-sponsored-label>{sponsoredLabel}</span>
+        )}
         <div data-fs-product-card-heading>
           <h3 data-fs-product-card-title>
             <Link {...linkProps} title={title}>
@@ -113,9 +126,7 @@ const ProductCardContent = forwardRef<HTMLElement, ProductCardContentProps>(
             />
           )}
           {includeTaxes && (
-            <Label data-fs-product-card-taxes-label>
-              {includeTaxesLabel}
-            </Label>
+            <Label data-fs-product-card-taxes-label>{includeTaxesLabel}</Label>
           )}
           {ratingValue && (
             <Rating value={ratingValue} icon={<Icon name="Star" />} />

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1776,6 +1776,11 @@
                   "default": "Tax included"
                 }
               }
+            },
+            "sponsoredLabel": {
+              "title": "Sponsored Label",
+              "type": "string",
+              "default": "Sponsored"
             }
           }
         },

--- a/packages/core/src/components/product/ProductCard/ProductCard.tsx
+++ b/packages/core/src/components/product/ProductCard/ProductCard.tsx
@@ -51,12 +51,16 @@ export interface ProductCardProps {
    */
   showDiscountBadge?: boolean
   /**
-   * Define taxes configuration, if taxes should be considered
+   * Define taxes configuration, if taxes should be considered.
    */
   taxesConfiguration?: {
     usePriceWithTaxes?: boolean
     taxesLabel?: string
   }
+  /**
+   * Specifies the sponsored label, if advertisement is applicable.
+   */
+  sponsoredLabel?: string
 }
 
 function ProductCard({
@@ -71,6 +75,7 @@ function ProductCard({
   onButtonClick,
   showDiscountBadge = true,
   taxesConfiguration,
+  sponsoredLabel,
   ...otherProps
 }: ProductCardProps) {
   const {
@@ -148,6 +153,8 @@ function ProductCard({
         showDiscountBadge={hasDiscount && showDiscountBadge}
         includeTaxes={taxesConfiguration?.usePriceWithTaxes}
         includeTaxesLabel={taxesConfiguration?.taxesLabel}
+        isSponsored={!!advertisement}
+        sponsoredLabel={sponsoredLabel}
       />
     </UIProductCard>
   )

--- a/packages/core/src/components/product/ProductCard/ProductCard.tsx
+++ b/packages/core/src/components/product/ProductCard/ProductCard.tsx
@@ -153,7 +153,7 @@ function ProductCard({
         showDiscountBadge={hasDiscount && showDiscountBadge}
         includeTaxes={taxesConfiguration?.usePriceWithTaxes}
         includeTaxesLabel={taxesConfiguration?.taxesLabel}
-        isSponsored={!!advertisement}
+        sponsored={!!advertisement}
         sponsoredLabel={sponsoredLabel}
       />
     </UIProductCard>

--- a/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
@@ -25,7 +25,7 @@ interface Props {
    */
   productCard?: Pick<
     ProductCardProps,
-    'showDiscountBadge' | 'bordered' | 'taxesConfiguration'
+    'showDiscountBadge' | 'bordered' | 'taxesConfiguration' | 'sponsoredLabel'
   >
   /**
    * Identify the number of firstPage
@@ -37,7 +37,12 @@ function ProductGrid({
   products,
   page,
   pageSize,
-  productCard: { showDiscountBadge, bordered, taxesConfiguration } = {},
+  productCard: {
+    showDiscountBadge,
+    bordered,
+    taxesConfiguration,
+    sponsoredLabel,
+  } = {},
   firstPage,
 }: Props) {
   const { __experimentalProductCard: ProductCard } =
@@ -73,6 +78,7 @@ function ProductGrid({
                   product={product}
                   index={pageSize * page + idx + 1}
                   taxesConfiguration={taxesConfiguration}
+                  sponsoredLabel={sponsoredLabel}
                 />
               </UIProductGridItem>
             ))}
@@ -96,6 +102,7 @@ function ProductGrid({
                     product={product}
                     index={pageSize * page + idx + 1}
                     taxesConfiguration={taxesConfiguration}
+                    sponsoredLabel={sponsoredLabel}
                   />
                 </UIProductGridItem>
               ))}
@@ -121,6 +128,7 @@ function ProductGrid({
                   product={product}
                   index={pageSize * page + idx + 1}
                   taxesConfiguration={taxesConfiguration}
+                  sponsoredLabel={product.sponsoredLabel}
                 />
               </UIProductGridItem>
             ))}

--- a/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
@@ -128,7 +128,7 @@ function ProductGrid({
                   product={product}
                   index={pageSize * page + idx + 1}
                   taxesConfiguration={taxesConfiguration}
-                  sponsoredLabel={product.sponsoredLabel}
+                  sponsoredLabel={sponsoredLabel}
                 />
               </UIProductGridItem>
             ))}

--- a/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
+++ b/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
@@ -59,7 +59,7 @@ export interface ProductGalleryProps {
   sortBySelector?: SortProps
   productCard?: Pick<
     ProductCardProps,
-    'showDiscountBadge' | 'bordered' | 'taxesConfiguration'
+    'showDiscountBadge' | 'bordered' | 'taxesConfiguration' | 'sponsoredLabel'
   >
 }
 

--- a/packages/core/src/components/ui/ProductGallery/ProductGalleryPage.tsx
+++ b/packages/core/src/components/ui/ProductGallery/ProductGalleryPage.tsx
@@ -10,7 +10,7 @@ interface Props {
   title: string
   productCard?: Pick<
     ProductCardProps,
-    'showDiscountBadge' | 'bordered' | 'taxesConfiguration'
+    'showDiscountBadge' | 'bordered' | 'taxesConfiguration' | 'sponsoredLabel'
   >
   itemsPerPage: number
   firstPage: number

--- a/packages/ui/src/components/molecules/ProductCard/styles.scss
+++ b/packages/ui/src/components/molecules/ProductCard/styles.scss
@@ -54,6 +54,10 @@
   --fs-product-card-wide-bkg-color           : var(--fs-color-neutral-bkg);
   --fs-product-card-wide-min-width           : 9rem;
 
+  // Sponsored Label
+  --fs-product-card-sponsored-label-size     : var(--fs-text-size-tiny);
+  --fs-product-card-sponsored-label-color    : var(--fs-color-text-light);
+
   // --------------------------------------------------------
   // Structural Styles
   // --------------------------------------------------------
@@ -136,6 +140,12 @@
         content: "";
       }
     }
+  }
+
+  [data-fs-product-card-sponsored-label] {
+    font-size: var(--fs-product-card-sponsored-label-size);
+    color: var(--fs-product-card-sponsored-label-color);
+    line-height: 1.33;
   }
 
   [data-fs-product-card-title] {


### PR DESCRIPTION
## What's the purpose of this pull request?

Enable Ad label indicator in `ProductCard`. 

Since products are duplicated in the Product Gallery, it's important to clearly indicate which products are sponsored. This will help prevent users from finding the duplication confusing. Additionally, we want to provide an easier way to customize the sponsored label. To achieve this, we're adding the label to the ProductCard and enable text customization via the CMS.

|Before|After|
|-|-|
![no-label](https://github.com/user-attachments/assets/0429bf10-7954-4a17-a827-1225970c3f95)|![label](https://github.com/user-attachments/assets/a6e95a6b-f3ad-4fb5-8e40-f2e5f6adf4db)

TODO: 

- [ ] Run cms sync in the main account to reflect the `sections.json` changes.
- [ ] Update `ProductCard` component doc with new tokens related to sponsored-label - I'll create a ticket when merging this PR
- [x] Verifying with IS team if sponsored products should be included in the count parameter (it's a bug or feature) - current scenario setting the query with `count=12` its returning 13 products.  [thread](https://vtex.slack.com/archives/C03L3CRCDC4/p1733413820077979?thread_ts=1733356825.821979&cid=C03L3CRCDC4)


## How it works?

Changing the label via CMS, the default text is `Sponsored`

|Admin|Store|
|-|-|
![admin-cms](https://github.com/user-attachments/assets/e9cfa44d-c543-477f-9f37-88b026120fa9)|![faststore-label](https://github.com/user-attachments/assets/837e8098-bb9c-4bfb-bb88-1feb2d21a03d)

## How to test it?

1. Run the store locally
2. On `discovery.config.js`file, update `showSponsored` setting. 

```
 // Platform specific configs for API
  api: {
    ...
    showSponsored: true,
  }
```

3. Change via CMS, you can use my test account [fannyads](https://fannyads--storeframework.myvtex.com/admin/new-cms/faststore/)
   - On the Product List Page: Look for Product Card Configuration, and update the `Sponsored Label` input.
   - Update the text and save. Use the [CMS mode preview](https://developers.vtex.com/docs/guides/faststore/headless-cms-previewing-changes-in-development-mode) to visualize the change in the store.
   - You should be able to see the Label with the text.

### Starters Deploy Preview

[Preview Link - PLP](https://sfj-2e9ae6b--starter.preview.vtex.app/office?category-1=office&fuzzy=0&operator=and&facets=category-1%2Cfuzzy%2Coperator&sort=score_desc&page=0)
[Test PR](https://github.com/vtex-sites/starter.store/pull/628)

## References

[Jira ticket](https://vtex-dev.atlassian.net/jira/software/c/projects/SFS/boards/1051?selectedIssue=SFS-1607)
[Ad Network (Beta)](https://help.vtex.com/pt/tutorial/vtex-ad-network-beta--2cgqXcBuJmXN2livQvClur)

