### PR TITLE
feat: add new redirects feature

### DIFF
--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -101,5 +101,6 @@ module.exports = {
     enableCypressExtension: false,
     noRobots: false,
     preact: false,
+    enableRedirects: false,
   },
 }

--- a/packages/core/src/customizations/src/redirects/index.ts
+++ b/packages/core/src/customizations/src/redirects/index.ts
@@ -1,0 +1,7 @@
+interface MatcherArgs {
+  pathname: string
+}
+
+export function matcher(_: MatcherArgs): string | null {
+  return null
+}

--- a/packages/core/src/customizations/src/redirects/index.ts
+++ b/packages/core/src/customizations/src/redirects/index.ts
@@ -2,6 +2,11 @@ interface MatcherArgs {
   pathname: string
 }
 
-export function matcher(_: MatcherArgs): string | null {
+interface MatcherReturn {
+  destination: string
+  permanent?: boolean
+}
+
+export function matcher(_: MatcherArgs): MatcherReturn | null {
   return null
 }

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -25,6 +25,7 @@ import ProductListingPage, {
 import { PageContentType } from 'src/server/cms'
 import { getPLP, PLPContentType } from 'src/server/cms/plp'
 import { getDynamicContent } from 'src/utils/dynamicContent'
+import { getRedirect } from 'src/sdk/redirects'
 
 const LandingPage = dynamic(
   () => import('src/components/templates/LandingPage')
@@ -140,6 +141,16 @@ export const getStaticProps: GetStaticProps<
   const notFound = errors.find(isNotFoundError)
 
   if (notFound) {
+    console.log(slug)
+    const redirect = getRedirect({ pathname: `/${slug}` })
+    if (redirect) {
+      return {
+        redirect: {
+          destination: redirect,
+          permanent: true,
+        },
+      }
+    }
     return {
       notFound: true,
     }

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -22,10 +22,10 @@ import {
 import ProductListingPage, {
   ProductListingPageProps,
 } from 'src/components/templates/ProductListingPage'
+import { getRedirect } from 'src/sdk/redirects'
 import { PageContentType } from 'src/server/cms'
 import { getPLP, PLPContentType } from 'src/server/cms/plp'
 import { getDynamicContent } from 'src/utils/dynamicContent'
-import { getRedirect } from 'src/sdk/redirects'
 
 const LandingPage = dynamic(
   () => import('src/components/templates/LandingPage')
@@ -141,15 +141,18 @@ export const getStaticProps: GetStaticProps<
   const notFound = errors.find(isNotFoundError)
 
   if (notFound) {
-    const redirect = await getRedirect({ pathname: `/${slug}` })
-    if (redirect) {
-      return {
-        redirect: {
-          destination: redirect.location,
-          permanent: true,
-        },
+    if (storeConfig.experimental.enableRedirects) {
+      const redirect = await getRedirect({ pathname: `/${slug}` })
+      if (redirect) {
+        return {
+          redirect: {
+            destination: redirect.location,
+            permanent: true,
+          },
+        }
       }
     }
+
     return {
       notFound: true,
     }

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -141,12 +141,11 @@ export const getStaticProps: GetStaticProps<
   const notFound = errors.find(isNotFoundError)
 
   if (notFound) {
-    console.log(slug)
-    const redirect = getRedirect({ pathname: `/${slug}` })
+    const redirect = await getRedirect({ pathname: `/${slug}` })
     if (redirect) {
       return {
         redirect: {
-          destination: redirect,
+          destination: redirect.location,
           permanent: true,
         },
       }

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -145,10 +145,8 @@ export const getStaticProps: GetStaticProps<
       const redirect = await getRedirect({ pathname: `/${slug}` })
       if (redirect) {
         return {
-          redirect: {
-            destination: redirect.location,
-            permanent: true,
-          },
+          redirect,
+          revalidate: 60 * 5, // 5 minutes
         }
       }
     }

--- a/packages/core/src/sdk/redirects/index.ts
+++ b/packages/core/src/sdk/redirects/index.ts
@@ -5,30 +5,40 @@ type GetRedirectArgs = {
   pathname: string
 }
 
-type GetRedirectResponse = {
+type GetRedirectReturn = {
+  destination: string
+  permanent: boolean
+}
+
+type RewriterResponse = {
   location: string
   status: number
 }
 
+const PERMANENT_STATUS = 308
+
 export async function getRedirect({
   pathname,
-}: GetRedirectArgs): Promise<GetRedirectResponse> {
+}: GetRedirectArgs): Promise<GetRedirectReturn> {
   try {
     const redirectMatch = matcher({ pathname })
     if (redirectMatch) {
       return {
-        location: redirectMatch,
-        status: 301,
+        destination: redirectMatch.destination,
+        permanent: redirectMatch.permanent ?? true,
       }
     }
 
     const response = await fetch(
       `https://${storeConfig.api.storeId}.myvtex.com/redirect-evaluate${pathname}`
     )
-    const rewriterData = (await response.json()) as GetRedirectResponse
+    const rewriterData = (await response.json()) as RewriterResponse
 
     if (rewriterData.location) {
-      return rewriterData
+      return {
+        destination: rewriterData.location,
+        permanent: rewriterData.status === PERMANENT_STATUS,
+      }
     }
     return null
   } catch (err) {

--- a/packages/core/src/sdk/redirects/index.ts
+++ b/packages/core/src/sdk/redirects/index.ts
@@ -9,10 +9,39 @@ type GetRedirectResponse = {
   status: number
 }
 
+const searchRegex = /^\/busca\/([^/]+)/
+
+// Custom function to match the pathname
+function matcher(pathname: string) {
+  const searchMatch = pathname.match(searchRegex)
+  if (searchMatch) {
+    const searchTerm = searchMatch[1].replaceAll('-', '+')
+    return `s/?q=${searchTerm}`
+  }
+  return null
+}
+const pdpRegex = /^\/produto\/([^/]+)\/[^/]+$/
+
+// Custom function to preprocess the pathname
+function preprocessPathname(pathname: string) {
+  const pdpMatch = pathname.match(pdpRegex)
+  return pdpMatch ? `/produto/${pdpMatch[1]}` : pathname
+}
+
 export async function getRedirect({
   pathname,
 }: GetRedirectProps): Promise<GetRedirectResponse> {
   try {
+    const preprocessdPathname = preprocessPathname(pathname)
+    const match = matcher(preprocessdPathname)
+
+    if (match) {
+      return {
+        location: match,
+        status: 301,
+      }
+    }
+
     const response = await fetch(
       `https://secure.vtexfaststore.com/api/io/redirect-evaluate?from=${pathname}&workspace=paladino`
     )

--- a/packages/core/src/sdk/redirects/index.ts
+++ b/packages/core/src/sdk/redirects/index.ts
@@ -1,0 +1,13 @@
+const database: Record<string, string> = {
+  '/produto/7428352752/test-1': '/produto-handmade-plastic-chips-9009169/p',
+  '/produto/7428352752/test-2': '/ergonomic-granite-mouse-57815628/p',
+  '/busca/apple': '/s?q=apple',
+}
+
+type GetRedirectProps = {
+  pathname: string
+}
+
+export function getRedirect({ pathname }: GetRedirectProps) {
+  return database[pathname]
+}

--- a/packages/core/src/sdk/redirects/index.ts
+++ b/packages/core/src/sdk/redirects/index.ts
@@ -1,13 +1,28 @@
-const database: Record<string, string> = {
-  '/produto/7428352752/test-1': '/produto-handmade-plastic-chips-9009169/p',
-  '/produto/7428352752/test-2': '/ergonomic-granite-mouse-57815628/p',
-  '/busca/apple': '/s?q=apple',
-}
+// https://secure.vtexfaststore.com/api/io/redirect-evaluate?from=/produto/1&workspace=paladino
 
 type GetRedirectProps = {
   pathname: string
 }
 
-export function getRedirect({ pathname }: GetRedirectProps) {
-  return database[pathname]
+type GetRedirectResponse = {
+  location: string
+  status: number
+}
+
+export async function getRedirect({
+  pathname,
+}: GetRedirectProps): Promise<GetRedirectResponse> {
+  try {
+    const response = await fetch(
+      `https://secure.vtexfaststore.com/api/io/redirect-evaluate?from=${pathname}&workspace=paladino`
+    )
+    const data = (await response.json()) as GetRedirectResponse
+    if (data.location) {
+      return data
+    }
+    return null
+  } catch (err) {
+    console.error(err)
+    return null
+  }
 }

--- a/packages/core/src/sdk/redirects/index.ts
+++ b/packages/core/src/sdk/redirects/index.ts
@@ -16,7 +16,7 @@ function matcher(pathname: string) {
   const searchMatch = pathname.match(searchRegex)
   if (searchMatch) {
     const searchTerm = searchMatch[1].replaceAll('-', '+')
-    return `s/?q=${searchTerm}`
+    return `/s?q=${searchTerm}`
   }
   return null
 }
@@ -33,8 +33,9 @@ export async function getRedirect({
 }: GetRedirectProps): Promise<GetRedirectResponse> {
   try {
     const preprocessdPathname = preprocessPathname(pathname)
+    console.log({ preprocessdPathname })
     const match = matcher(preprocessdPathname)
-
+    console.log({ match })
     if (match) {
       return {
         location: match,

--- a/packages/core/src/sdk/redirects/index.ts
+++ b/packages/core/src/sdk/redirects/index.ts
@@ -22,11 +22,11 @@ export async function getRedirect({
       }
     }
 
-    // TODO: remove paladino workspace when production URL be ready
     const response = await fetch(
-      `${storeConfig.secureSubdomain}/api/io/redirect-evaluate?from=${pathname}&workspace=paladino`
+      `https://${storeConfig.api.storeId}.myvtex.com/redirect-evaluate${pathname}`
     )
     const rewriterData = (await response.json()) as GetRedirectResponse
+
     if (rewriterData.location) {
       return rewriterData
     }

--- a/packages/core/src/sdk/redirects/index.ts
+++ b/packages/core/src/sdk/redirects/index.ts
@@ -30,7 +30,7 @@ export async function getRedirect({
     }
 
     const response = await fetch(
-      `https://${storeConfig.api.storeId}.myvtex.com/redirect-evaluate${pathname}`
+      `https://${storeConfig.api.storeId}.myvtex.com/_v/public/redirect-evaluate${pathname}`
     )
     const rewriterData = (await response.json()) as RewriterResponse
 


### PR DESCRIPTION
## What's the purpose of this pull request?

The implementation of the redirects feature in FastStore appears as a strategic solution to facilitate the migration of old stores to our platform. 

The idea of ​​this feature is to run the redirect in the **getStaticProps** function when a certain page is not found. In other words, before rendering a **not found (404)** result to the user, we check if there is a redirect associated with the pathname requested by the user.

Since the pathname is not found (404). The redirect flow follows two steps. First it goes through a customization function called **matcher**. If the matcher cannot resolve the redirects, we validate whether a redirect exists in the **rewriter** database.

![Captura de Tela 2024-12-10 às 10 18 24](https://github.com/user-attachments/assets/9f1a6fb0-da7d-46e3-80c0-69380f57eb40)

### Components

- **Matcher**: Optional function that can be implemented via customization. Some pathnames can be resolved via simple logic, without necessarily going to a database to check if there is a redirect registered. [See an example](https://github.com/vtex-sites/starter.store/blob/fad4fde01c0151cf78e1f9de5a378e24afe3f28a/src/redirects/index.ts). 

- **Rewriter**: If the redirect is not resolved via customization, a call will be made to the rewriter api to check if there is a redirect associated with the requested pathname.

[Redirects RFC](https://docs.google.com/document/d/15QxSNexAcDtrryDTR_LXcMmFLg2jnq2linMdp5-Q-r8/edit?usp=sharing)


## How to test it?
https://storeframework.myvtex.com/admin/cms/redirects

![Captura de Tela 2024-12-12 às 10 08 49](https://github.com/user-attachments/assets/c3cb9e59-cc00-4d78-af87-dac91a690cb5)

We can run locally and try to access one of these redirects. 

Example of matcher in starter: https://github.com/vtex-sites/starter.store/pull/626

Example: `/produto/1` 