### PR TITLE
fix(sdk): page view event trigger

### DIFF
--- a/packages/core/src/sdk/analytics/hooks/usePageViewEvent.ts
+++ b/packages/core/src/sdk/analytics/hooks/usePageViewEvent.ts
@@ -19,11 +19,7 @@ export const usePageViewEvent = () => {
   const router = useRouter()
 
   useEffect(() => {
-    router.events.on('routeChangeComplete', sendPageViewEvent)
-
-    return () => {
-      router.events.off('routeChangeComplete', sendPageViewEvent)
-    }
+    sendPageViewEvent()
   }, [router, sendPageViewEvent])
 
   return { sendPageViewEvent }


### PR DESCRIPTION
## What's the purpose of this pull request?

Change the moment in which the page_view event is sent. It was previously being sent only during a page change, so it wasn't sent on the initialization of the page.

## How it works?

Instead of watching the `routeChangeComplete` route event, now it sends the page_view event when the page is loaded.

## How to test it?

Check on the starter preview that the store is working as expected.
The real impact of this change will be tested in the next PR, in which the RC events will start to be sent.

### Starters Deploy Preview

https://sfj-59f6820--starter.preview.vtex.app/ ([PR](https://github.com/vtex-sites/starter.store/pull/631))

## References

- [GA page view](https://developers.google.com/analytics/devguides/collection/ga4/views)
- [Jira task](https://vtex-dev.atlassian.net/browse/SFS-1798)
- [Slack thread](https://vtex.slack.com/archives/C03L3CRCDC4/p1733837843137469)
