### PR TITLE
chore: update comments on ProductGrid for better clarity

### DIFF
--- a/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
@@ -16,6 +16,9 @@ interface Props {
    * Products listed on the grid.
    */
   products: ClientManyProductsQueryQuery['search']['products']['edges']
+  /**
+   * The page's number that is being rendered.
+   */
   page: number
   /**
    * Quantity of products listed.
@@ -29,7 +32,7 @@ interface Props {
     'showDiscountBadge' | 'bordered' | 'taxesConfiguration' | 'sponsoredLabel'
   >
   /**
-   * Identify the number of firstPage
+   * Determine if the current page is the first page.
    */
   firstPage?: number
 }
@@ -60,6 +63,7 @@ function ProductGrid({
     >
       <UIProductGrid>
         {isGridWithViewportObserver ? (
+          // In mobile, the ProductGrid initially renders the first 2 items, the rest of the items are rendered when they come into the viewport.
           <>
             {products.slice(0, 2).map(({ node: product }, idx) => (
               <UIProductGridItem key={`${product.id}`}>

--- a/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
@@ -83,7 +83,6 @@ function ProductGrid({
                 />
               </UIProductGridItem>
             ))}
-            <></>
             <ViewportObserver sectionName="UIProductGrid-out-viewport">
               {products.slice(2).map(({ node: product }, idx) => (
                 <UIProductGridItem key={`${product.id}`}>


### PR DESCRIPTION
## What's the purpose of this pull request?

- Check the expected behaviours for `ProductGrid` on mobile
- Update comments for better clarity 

## How it works?

In mobile:
Only two items in the `ProductGrid` is being rendered in the first moment.

<img width="800" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/c1569d92-aa98-4def-87ed-a8de6c34310e" />

Also the first two items' image has `fetchpriority="high"`

<img width="800" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/0db2bd08-3651-4434-b5bb-6edc35bcd26e" />

After scrolling, the remaining items are rendered as they come into the viewport.

## How to test it?

1. Run the project locally
2. Test on a mobile device or resize the screen to match a mobile screen size
3. Navigate to a PLP page (Office category) and verify the behaviour described in the previous section

### Starters Deploy Preview

WIP

## References

[SFS-1862](https://vtex-dev.atlassian.net/browse/SFS-1862)


[SFS-1862]: https://vtex-dev.atlassian.net/browse/SFS-1862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ