### PR TITLE
chore: increases ui package size

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,7 +40,7 @@
   "size-limit": [
     {
       "path": "dist/cjs/index.js",
-      "limit": "45 KB"
+      "limit": "50 KB"
     },
     {
       "path": "dist/esm/index.js",


### PR DESCRIPTION
## What's the purpose of this pull request?

Due https://github.com/vtex/faststore/pull/2588
The build should not fail because of package size limit