### PR TITLE
fix: removes `useUI()` dependents sections from `LazyLoadingSection`

### DIFF
--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -12,8 +12,6 @@ import SectionBoundary from './SectionBoundary'
 import ViewportObserver from './ViewportObserver'
 import COMPONENTS from './global/Components'
 
-import { useUI } from '@faststore/ui'
-
 interface Props {
   components?: Record<string, ComponentType<any>>
   globalSections?: Array<{ name: string; data: any }>
@@ -55,15 +53,6 @@ export const LazyLoadingSection = ({
   sectionName: string
   children: ReactNode
 }) => {
-  const { cart: displayCart, modal: displayModal } = useUI()
-
-  if (SECTIONS_OUT_OF_VIEWPORT.includes(sectionName)) {
-    const shouldLoad =
-      (sectionName === 'CartSidebar' && displayCart) ||
-      (sectionName === 'RegionModal' && displayModal)
-
-    return shouldLoad ? <>{children}</> : null
-  }
   return (
     <ViewportObserver sectionName={sectionName}>{children}</ViewportObserver>
   )

--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -53,6 +53,10 @@ export const LazyLoadingSection = ({
   sectionName: string
   children: ReactNode
 }) => {
+  if (SECTIONS_OUT_OF_VIEWPORT.includes(sectionName)) {
+    return <>{children}</>
+  }
+
   return (
     <ViewportObserver sectionName={sectionName}>{children}</ViewportObserver>
   )


### PR DESCRIPTION
## What's the purpose of this pull request?

This removes the logic that dynamically loads the sections that depend on the `useUI()` hook: `CartSidebar` and `RegionModal`. We decided to try to load them at another moment (//TODO: create a task for it) instead of on click.

## How to test it?

Try to load the respective sections `CartSidebar` and `RegionModal` using the [preview link](https://sfj-2714681--starter.preview.vtex.app/).
You can see that both sections are being loaded in the initial loading now. Instead of loading after clicking on the respective buttons that trigger the sections.

### Starters Deploy Preview
- https://github.com/vtex-sites/starter.store/pull/639
- preview https://sfj-2714681--starter.preview.vtex.app/
