### PR TITLE
[1.x] fix: Return `price` as offer's `Price` instead of `spotPrice`

### DIFF
--- a/packages/api/src/platforms/vtex/utils/productStock.ts
+++ b/packages/api/src/platforms/vtex/utils/productStock.ts
@@ -3,8 +3,8 @@ import type { CommertialOffer } from '../clients/search/types/ProductSearchResul
 export const inStock = (offer: Pick<CommertialOffer, 'AvailableQuantity'>) =>
   offer.AvailableQuantity > 0
 
-export const price = (offer: Pick<CommertialOffer, 'spotPrice'>) =>
-  offer.spotPrice ?? 0
+export const price = (offer: Pick<CommertialOffer, 'Price'>) => offer.Price ?? 0
+
 export const sellingPrice = (offer: CommertialOffer) => offer.Price ?? 0
 
 export const availability = (available: boolean) =>
@@ -12,8 +12,8 @@ export const availability = (available: boolean) =>
 
 // Smallest Available Spot Price First
 export const bestOfferFirst = (
-  a: Pick<CommertialOffer, 'AvailableQuantity' | 'spotPrice'>,
-  b: Pick<CommertialOffer, 'AvailableQuantity' | 'spotPrice'>
+  a: Pick<CommertialOffer, 'AvailableQuantity' | 'Price'>,
+  b: Pick<CommertialOffer, 'AvailableQuantity' | 'Price'>
 ) => {
   if (inStock(a) && !inStock(b)) {
     return -1

--- a/packages/api/test/vtex.aggregateOffer.test.ts
+++ b/packages/api/test/vtex.aggregateOffer.test.ts
@@ -1,26 +1,26 @@
 import { bestOfferFirst } from '../src/platforms/vtex/utils/productStock'
 import type { CommertialOffer } from '../src/platforms/vtex/clients/search/types/ProductSearchResult'
 
-type TestItem = Pick<CommertialOffer, 'AvailableQuantity' | 'spotPrice'>
+type TestItem = Pick<CommertialOffer, 'AvailableQuantity' | 'Price'>
 
 describe('AggregateOffer', () => {
   it('Should return best offers first', () => {
     const testItems: TestItem[] = [
-      { AvailableQuantity: 1, spotPrice: 10 },
-      { AvailableQuantity: 0, spotPrice: 20 },
-      { AvailableQuantity: 1, spotPrice: 30 },
-      { AvailableQuantity: 0, spotPrice: 10 },
-      { AvailableQuantity: 1, spotPrice: 1 },
+      { AvailableQuantity: 1, Price: 10 },
+      { AvailableQuantity: 0, Price: 20 },
+      { AvailableQuantity: 1, Price: 30 },
+      { AvailableQuantity: 0, Price: 10 },
+      { AvailableQuantity: 1, Price: 1 },
     ]
 
     const sorted = testItems.sort(bestOfferFirst)
 
     expect(sorted).toEqual([
-      { AvailableQuantity: 1, spotPrice: 1 },
-      { AvailableQuantity: 1, spotPrice: 10 },
-      { AvailableQuantity: 1, spotPrice: 30 },
-      { AvailableQuantity: 0, spotPrice: 10 },
-      { AvailableQuantity: 0, spotPrice: 20 },
+      { AvailableQuantity: 1, Price: 1 },
+      { AvailableQuantity: 1, Price: 10 },
+      { AvailableQuantity: 1, Price: 30 },
+      { AvailableQuantity: 0, Price: 10 },
+      { AvailableQuantity: 0, Price: 20 },
     ])
   })
 })


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the price we send to the store.

## How it works?

Currently we send the price as `offer.spotPrice`, but that's wrong. We should follow the Intelligent Search use of prices:
   - "From $100 (`listPrice`) to $90 (`sellingPrice`/`price`), also $80 (`spotPrice`) in _special condition_"

## How to test it?

Check for prices when **unit multiplier is greater than 1**, but also if the prices are shown correctly on PLPs and PDPs.

### Starters Deploy Preview

## References