### PR TITLE
chore: add deps and deps-dev scopes to PR title validation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,7 @@ jobs:
             eslint-config
             lighthouse
             graphql-utils
+            deps
           types: |
             fix
             feat

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,7 @@ jobs:
             lighthouse
             graphql-utils
             deps
+            deps-dev
           types: |
             fix
             feat


### PR DESCRIPTION
## What's the purpose of this pull request?

Add the `deps` and `deps-dev` scopes to the PR title validation, so it can be used on the dependabot PRs that updates the deps versions.

## How it works?

Adding this new scope [this](https://github.com/vtex/faststore/actions/runs/12278625904/job/34260726276?pr=2589) type of error won't happen on dependabot PRs:
![Screenshot 2024-12-20 at 11 19 02](https://github.com/user-attachments/assets/86d39ff7-9be9-42b7-a486-70feb79e2d3b)

The `deps-dev` scope is for updates on devDependencies.

## References

- https://github.com/vtex/faststore/pull/2580
