### PR TITLE
fix: Reset infinite scroll if search's total pages is less than current state's total pages

### DIFF
--- a/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
@@ -70,7 +70,7 @@ export default function SearchWrapper({
   const stateTotalPages = pages.length
 
   // if the total pages is less than the current state total pages, reset the infinite scroll
-  if (totalPages > 0 && totalPages < stateTotalPages) {
+  if (totalPages > 0 && totalPages !== stateTotalPages) {
     resetInfiniteScroll(0)
   }
 

--- a/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
@@ -70,7 +70,7 @@ export default function SearchWrapper({
   const stateTotalPages = pages.length
 
   // if the total pages is less than the current state total pages, reset the infinite scroll
-  if (totalPages > 0 && totalPages !== stateTotalPages) {
+  if (totalPages > 0 && totalPages < stateTotalPages) {
     resetInfiniteScroll(0)
   }
 

--- a/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
@@ -38,6 +38,8 @@ export default function SearchWrapper({
   const router = useRouter()
   const {
     state: { term, sort, selectedFacets },
+    pages,
+    resetInfiniteScroll,
   } = useSearch()
 
   const { data: pageProductGalleryData, isValidating } = useProductGalleryQuery(
@@ -60,6 +62,16 @@ export default function SearchWrapper({
     })
 
     return <EmptySearch />
+  }
+
+  const totalPages = Math.ceil(
+    pageProductGalleryData.search.products.pageInfo.totalCount / itemsPerPage
+  )
+  const stateTotalPages = pages.length
+
+  // if the total pages is less than the current state total pages, reset the infinite scroll
+  if (totalPages > 0 && totalPages < stateTotalPages) {
+    resetInfiniteScroll(0)
   }
 
   return (

--- a/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
@@ -64,13 +64,14 @@ export default function SearchWrapper({
     return <EmptySearch />
   }
 
-  const totalPages = Math.ceil(
-    pageProductGalleryData.search.products.pageInfo.totalCount / itemsPerPage
-  )
+  const productGalleryProducts = pageProductGalleryData?.search?.products
   const stateTotalPages = pages.length
+  const searchTotalPages = Math.ceil(
+    productGalleryProducts?.pageInfo?.totalCount / itemsPerPage
+  )
 
   // if the total pages is less than the current state total pages, reset the infinite scroll
-  if (totalPages > 0 && totalPages < stateTotalPages) {
+  if (searchTotalPages > 0 && searchTotalPages < stateTotalPages) {
     resetInfiniteScroll(0)
   }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the infinite scroll behavior when a search's total pages is different from the current state's total pages.

Currently, if the current state's total pages are 3, for example, and a product search returns results with only 1 page the previous total pages will be considered, rendering skeletons and pages wrong.

![image](https://github.com/user-attachments/assets/d13e539d-8a7a-4f1f-ade0-3abb6566030e)

## How it works?

It will reset the infinite scroll (always to the first page) if after a product search the total pages number is less than the previous total pages number.

## How to test it?

Navigate to the `Office` PLP, load more than 2 pages then search for `apple` (in the search input). No skeletons or more than 1 page should be rendered.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/644