### PR TITLE
feat: search page with SSR

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -489,56 +489,6 @@ function enableRedirectsMiddleware(basePath: string) {
   }
 }
 
-const GET_SERVER_SIDE_PROPS = `
-  export const getServerSideProps: GetServerSideProps<
-  Props,
-  Record<string, string>,
-  Locator
-> = async (context) => {
-  const { previewData, query, res } = context
-
-  const searchTerm = (query.q as string)?.split('+').join(' ')
-
-  const globalSections = await getGlobalSectionsData(previewData)
-
-  if (storeConfig.cms.data) {
-    const cmsData = JSON.parse(storeConfig.cms.data)
-    const page = cmsData['search'][0]
-
-    if (page) {
-      const pageData = await getPage<SearchContentType>({
-        contentType: 'search',
-        documentId: page.documentId,
-        versionId: page.versionId,
-      })
-
-      return {
-        props: { page: pageData, globalSections, searchTerm },
-      }
-    }
-  }
-
-  const page = await getPage<SearchContentType>({
-    ...(previewData?.contentType === 'search' ? previewData : null),
-    contentType: 'search',
-  })
-
-  res.setHeader(
-    'Cache-Control',
-    'public, s-maxage=300, stale-while-revalidate=31536000'
-  ) // 5 minutes of fresh content and 1 year of stale content
-
-  return {
-    props: {
-      page,
-      globalSections,
-      searchTerm,
-    },
-  }
-}
-`
-
-const GET_STATIC_PROPS_REGEX = /export const getStaticProps: GetStaticProps<[\s\S]*?>\s*= async \(context\) => \{[\s\S]*?\}/
 
 
 function enableSearchSSR(basePath: string) {
@@ -553,19 +503,12 @@ function enableSearchSSR(basePath: string) {
   }
 
   const { tmpDir } = withBasePath(basePath)
-
   const searchPagePath = path.join(tmpDir, 'src', 'pages', 's.tsx')
-
   const searchPageData = String(readFileSync(searchPagePath))
-  let searchPageWithSSR = searchPageData.replace(
-    GET_STATIC_PROPS_REGEX,
-    GET_SERVER_SIDE_PROPS
-  )
 
-  searchPageWithSSR.replace("import type { GetStaticProps } from 'next'", "import type { GetServerSideProps } from 'next'")
+  const searchPageWithSSR = searchPageData.replaceAll('getStaticProps', 'getServerSideProps')
 
   writeFileSync(searchPagePath, searchPageWithSSR)
-
 }
 
 export async function generate(options: GenerateOptions) {

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -489,8 +489,6 @@ function enableRedirectsMiddleware(basePath: string) {
   }
 }
 
-
-
 function enableSearchSSR(basePath: string) {
   const storeConfigPath = getCurrentUserStoreConfigFile(basePath)
 

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -11,7 +11,6 @@ module.exports = {
     search: {
       titleTemplate: '%s: Search results title',
       descriptionTemplate: '%s: Search results description',
-      title: 'Search Results',
     },
   },
 

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -6,7 +6,12 @@ module.exports = {
     author: 'Store Framework',
     plp: {
       titleTemplate: '%s | FastStore PLP',
-      descriptionTemplate: '%s products on FastStore Product Listing Page',
+      descriptionTemplate: '%s products on FastStore Product Listing Page'
+    },
+    search: {
+      titleTemplate: '%s: Search results title',
+      descriptionTemplate: '%s: Search results description',
+      title: 'Search Results',
     },
   },
 
@@ -106,6 +111,6 @@ module.exports = {
     noRobots: false,
     preact: false,
     enableRedirects: false,
-    enableSearchSSR: true,
+    enableSearchSSR: false,
   },
 }

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -106,5 +106,6 @@ module.exports = {
     noRobots: false,
     preact: false,
     enableRedirects: false,
+    enableSearchSSR: true,
   },
 }

--- a/packages/core/src/experimental/searchServerSideFunctions/getServerSideProps.ts
+++ b/packages/core/src/experimental/searchServerSideFunctions/getServerSideProps.ts
@@ -1,0 +1,51 @@
+import { GetServerSideProps } from 'next'
+import { SearchPageProps } from './getStaticProps'
+
+import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'
+import { SearchContentType, getPage } from 'src/server/cms'
+import { Locator } from '@vtex/client-cms'
+import storeConfig from 'discovery.config'
+
+export const getServerSideProps: GetServerSideProps<
+  SearchPageProps,
+  Record<string, string>,
+  Locator
+> = async (context) => {
+  const { previewData, query, res } = context
+  const searchTerm = (query.q as string)?.split('+').join(' ')
+
+  const globalSections = await getGlobalSectionsData(previewData)
+
+  if (storeConfig.cms.data) {
+    const cmsData = JSON.parse(storeConfig.cms.data)
+    const page = cmsData['search'][0]
+    if (page) {
+      const pageData = await getPage<SearchContentType>({
+        contentType: 'search',
+        documentId: page.documentId,
+        versionId: page.versionId,
+      })
+      return {
+        props: { page: pageData, globalSections, searchTerm },
+      }
+    }
+  }
+
+  const page = await getPage<SearchContentType>({
+    ...(previewData?.contentType === 'search' ? previewData : null),
+    contentType: 'search',
+  })
+
+  res.setHeader(
+    'Cache-Control',
+    'public, s-maxage=300, stale-while-revalidate=31536000'
+  ) // 5 minutes of fresh content and 1 year of stale content
+
+  return {
+    props: {
+      page,
+      globalSections,
+      searchTerm,
+    },
+  }
+}

--- a/packages/core/src/experimental/searchServerSideFunctions/getServerSideProps.ts
+++ b/packages/core/src/experimental/searchServerSideFunctions/getServerSideProps.ts
@@ -38,7 +38,7 @@ export const getServerSideProps: GetServerSideProps<
 
   res.setHeader(
     'Cache-Control',
-    'public, s-maxage=300, stale-while-revalidate=31536000'
+    'public, s-maxage=300, stale-while-revalidate=31536000, stale-if-error=31536000'
   ) // 5 minutes of fresh content and 1 year of stale content
 
   return {

--- a/packages/core/src/experimental/searchServerSideFunctions/getStaticProps.ts
+++ b/packages/core/src/experimental/searchServerSideFunctions/getStaticProps.ts
@@ -1,0 +1,53 @@
+import { GetStaticProps } from 'next'
+import {
+  getGlobalSectionsData,
+  GlobalSectionsData,
+} from 'src/components/cms/GlobalSections'
+import { SearchContentType, getPage } from 'src/server/cms'
+import { Locator } from '@vtex/client-cms'
+import storeConfig from 'discovery.config'
+
+export type SearchPageProps = {
+  page: SearchContentType
+  globalSections: GlobalSectionsData
+  searchTerm?: string
+}
+
+export const getStaticProps: GetStaticProps<
+  SearchPageProps,
+  Record<string, string>,
+  Locator
+> = async (context) => {
+  const { previewData } = context
+
+  const globalSections = await getGlobalSectionsData(previewData)
+
+  if (storeConfig.cms.data) {
+    const cmsData = JSON.parse(storeConfig.cms.data)
+    const page = cmsData['search'][0]
+
+    if (page) {
+      const pageData = await getPage<SearchContentType>({
+        contentType: 'search',
+        documentId: page.documentId,
+        versionId: page.versionId,
+      })
+
+      return {
+        props: { page: pageData, globalSections },
+      }
+    }
+  }
+
+  const page = await getPage<SearchContentType>({
+    ...(previewData?.contentType === 'search' ? previewData : null),
+    contentType: 'search',
+  })
+
+  return {
+    props: {
+      page,
+      globalSections,
+    },
+  }
+}

--- a/packages/core/src/experimental/searchServerSideFunctions/getStaticProps.ts
+++ b/packages/core/src/experimental/searchServerSideFunctions/getStaticProps.ts
@@ -13,6 +13,10 @@ export type SearchPageProps = {
   searchTerm?: string
 }
 
+/* 
+  Depending on the value of the storeConfig.experimental.enableSearchSSR flag, the function used will be getServerSideProps (./getServerSideProps). 
+  Our CLI that does this process of converting from getStaticProps to getServerSideProps.
+*/
 export const getStaticProps: GetStaticProps<
   SearchPageProps,
   Record<string, string>,

--- a/packages/core/src/experimental/searchServerSideFunctions/index.ts
+++ b/packages/core/src/experimental/searchServerSideFunctions/index.ts
@@ -1,0 +1,2 @@
+export * from './getServerSideProps'
+export * from './getStaticProps'

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -137,7 +137,7 @@ function Page({
         searchContentType={searchContentType}
         serverData={{
           title: seoData.title,
-          searchTerm: searchParams.term ?? undefined,
+          searchTerm: searchTerm ?? searchParams.term ?? undefined,
         }}
         globalSections={globalSections.sections}
       />

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -1,4 +1,3 @@
-import type { GetStaticProps } from 'next'
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
@@ -14,20 +13,13 @@ import { SROnly as UISROnly } from '@faststore/ui'
 import { ITEMS_PER_PAGE } from 'src/constants'
 import { useApplySearchState } from 'src/sdk/search/state'
 
-import { Locator } from '@vtex/client-cms'
 import storeConfig from 'discovery.config'
-import {
-  getGlobalSectionsData,
-  GlobalSectionsData,
-} from 'src/components/cms/GlobalSections'
-import { SearchWrapper } from 'src/components/templates/SearchPage'
-import { getPage, SearchContentType } from 'src/server/cms'
 
-type Props = {
-  page: SearchContentType
-  globalSections: GlobalSectionsData
-  searchTerm?: string
-}
+import { SearchWrapper } from 'src/components/templates/SearchPage'
+import {
+  getStaticProps,
+  SearchPageProps,
+} from 'src/experimental/searchServerSideFunctions'
 
 export interface SearchPageContextType {
   title: string
@@ -55,7 +47,11 @@ const useSearchParams = ({
   }, [asPath, defaultSort])
 }
 
-function Page({ page: searchContentType, globalSections, searchTerm }: Props) {
+function Page({
+  page: searchContentType,
+  globalSections,
+  searchTerm,
+}: SearchPageProps) {
   const { settings } = searchContentType
   const applySearchState = useApplySearchState()
   const searchParams = useSearchParams({
@@ -129,43 +125,6 @@ function Page({ page: searchContentType, globalSections, searchTerm }: Props) {
   )
 }
 
-export const getStaticProps: GetStaticProps<
-  Props,
-  Record<string, string>,
-  Locator
-> = async (context) => {
-  const { previewData } = context
-
-  const globalSections = await getGlobalSectionsData(previewData)
-
-  if (storeConfig.cms.data) {
-    const cmsData = JSON.parse(storeConfig.cms.data)
-    const page = cmsData['search'][0]
-
-    if (page) {
-      const pageData = await getPage<SearchContentType>({
-        contentType: 'search',
-        documentId: page.documentId,
-        versionId: page.versionId,
-      })
-
-      return {
-        props: { page: pageData, globalSections },
-      }
-    }
-  }
-
-  const page = await getPage<SearchContentType>({
-    ...(previewData?.contentType === 'search' ? previewData : null),
-    contentType: 'search',
-  })
-
-  return {
-    props: {
-      page,
-      globalSections,
-    },
-  }
-}
+export { getStaticProps }
 
 export default Page

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -61,7 +61,7 @@ function Page({ page: searchContentType, globalSections, searchTerm }: Props) {
   const searchParams = useSearchParams({
     sort: settings?.productGallery?.sortBySelection as SearchState['sort'],
   })
-  console.log({ searchTerm })
+
   const title = 'Search Results'
   const { description, titleTemplate } = storeConfig.seo
   const itemsPerPage = settings?.productGallery?.itemsPerPage ?? ITEMS_PER_PAGE
@@ -120,9 +120,10 @@ export const getServerSideProps: GetServerSideProps<
   Record<string, string>,
   Locator
 > = async (context) => {
-  const { previewData, query } = context
+  const { previewData, query, res } = context
 
-  const searchTerm = query.q as string
+  const searchTerm = (query.q as string)?.split('+').join(' ')
+
   const globalSections = await getGlobalSectionsData(previewData)
 
   if (storeConfig.cms.data) {
@@ -146,6 +147,11 @@ export const getServerSideProps: GetServerSideProps<
     ...(previewData?.contentType === 'search' ? previewData : null),
     contentType: 'search',
   })
+
+  res.setHeader(
+    'Cache-Control',
+    'public, s-maxage=300, stale-while-revalidate=31536000'
+  ) // 5 minutes of fresh content and 1 year of stale content
 
   return {
     props: {

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -1,4 +1,4 @@
-import type { GetStaticProps } from 'next'
+import type { GetServerSideProps } from 'next'
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
@@ -26,6 +26,7 @@ import { getPage, SearchContentType } from 'src/server/cms'
 type Props = {
   page: SearchContentType
   globalSections: GlobalSectionsData
+  searchTerm: string
 }
 
 export interface SearchPageContextType {
@@ -54,13 +55,13 @@ const useSearchParams = ({
   }, [asPath, defaultSort])
 }
 
-function Page({ page: searchContentType, globalSections }: Props) {
+function Page({ page: searchContentType, globalSections, searchTerm }: Props) {
   const { settings } = searchContentType
   const applySearchState = useApplySearchState()
   const searchParams = useSearchParams({
     sort: settings?.productGallery?.sortBySelection as SearchState['sort'],
   })
-
+  console.log({ searchTerm })
   const title = 'Search Results'
   const { description, titleTemplate } = storeConfig.seo
   const itemsPerPage = settings?.productGallery?.itemsPerPage ?? ITEMS_PER_PAGE
@@ -78,8 +79,8 @@ function Page({ page: searchContentType, globalSections }: Props) {
       {/* SEO */}
       <NextSeo
         noindex
-        title={title}
-        description={description}
+        title={`${searchTerm}`}
+        description={`${searchTerm}: em promoção que você procura? Na Americanas você encontra as melhores ofertas de produtos com entrega rápida. Vem!`}
         titleTemplate={titleTemplate}
         openGraph={{
           type: 'website',
@@ -114,11 +115,14 @@ function Page({ page: searchContentType, globalSections }: Props) {
   )
 }
 
-export const getStaticProps: GetStaticProps<
+export const getServerSideProps: GetServerSideProps<
   Props,
   Record<string, string>,
   Locator
-> = async ({ previewData }) => {
+> = async (context) => {
+  const { previewData, query } = context
+
+  const searchTerm = query.q as string
   const globalSections = await getGlobalSectionsData(previewData)
 
   if (storeConfig.cms.data) {
@@ -133,7 +137,7 @@ export const getStaticProps: GetStaticProps<
       })
 
       return {
-        props: { page: pageData, globalSections },
+        props: { page: pageData, globalSections, searchTerm },
       }
     }
   }
@@ -147,6 +151,7 @@ export const getStaticProps: GetStaticProps<
     props: {
       page,
       globalSections,
+      searchTerm,
     },
   }
 }

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -75,7 +75,7 @@ function generateSEOData(storeConfig: StoreConfig, searchTerm?: string) {
     : seo.description
 
   const canonical = searchTerm
-    ? `${storeConfig.storeUrl}?s=${searchTerm}`
+    ? `${storeConfig.storeUrl}/s?q=${searchTerm}`
     : undefined
 
   return {

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -26,7 +26,7 @@ import { getPage, SearchContentType } from 'src/server/cms'
 type Props = {
   page: SearchContentType
   globalSections: GlobalSectionsData
-  searchTerm: string
+  searchTerm?: string
 }
 
 export interface SearchPageContextType {
@@ -70,6 +70,14 @@ function Page({ page: searchContentType, globalSections, searchTerm }: Props) {
     return null
   }
 
+  const isSSREnabled = storeConfig.experimental.enableSearchSSR
+
+  const currentSearchTerm = isSSREnabled ? searchTerm : searchParams.term
+  const currentTitle = isSSREnabled ? searchTerm : title
+  const currentDescription = isSSREnabled
+    ? `${searchTerm}: em promoção que você procura? Na Americanas você encontra as melhores ofertas de produtos com entrega rápida. Vem!`
+    : description
+
   return (
     <SearchProvider
       onChange={applySearchState}
@@ -79,17 +87,17 @@ function Page({ page: searchContentType, globalSections, searchTerm }: Props) {
       {/* SEO */}
       <NextSeo
         noindex
-        title={`${searchTerm}`}
-        description={`${searchTerm}: em promoção que você procura? Na Americanas você encontra as melhores ofertas de produtos com entrega rápida. Vem!`}
+        title={currentTitle}
+        description={currentDescription}
         titleTemplate={titleTemplate}
         openGraph={{
           type: 'website',
-          title,
-          description,
+          title: currentTitle,
+          description: currentDescription,
         }}
       />
 
-      <UISROnly text={title} />
+      <UISROnly text={currentTitle} />
 
       {/*
           WARNING: Do not import or render components from any
@@ -107,7 +115,7 @@ function Page({ page: searchContentType, globalSections, searchTerm }: Props) {
         searchContentType={searchContentType}
         serverData={{
           title,
-          searchTerm: searchParams.term ?? undefined,
+          searchTerm: currentSearchTerm ?? undefined,
         }}
         globalSections={globalSections.sections}
       />


### PR DESCRIPTION
# (Don't merge!)

## What's the purpose of this pull request?

This POC is an alternative to indexing search pages using [server side rendering](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props). As the search page is dynamic and we need to set the title and description based on the search term, we chose to use server side rendering as it is the most suitable for this type of situation.

### Nextjs reference: 
**Like SSG,[ Server-Side Rendering](https://nextjs.org/docs/basic-features/pages#server-side-rendering) (SSR) is pre-rendered, which also makes it great for SEO. Instead of being generated at build time, as in SSG, SSR's HTML is generated at request time. This is great for when you have pages that are very dynamic.**
https://nextjs.org/learn-pages-router/seo/rendering-and-ranking/rendering-strategies

## How it works?

We use the getServerSideProps function instead of getStaticProps. We added a cache header to the response so that it is possible to cache the return in a CDN.




## How to test it?
Click on: https://storeframework-cm652ufll028lmgv665a6xv0g-polemunmz.b.vtex.app/s?q=headphone



