### PR TITLE
feat: Adding organization structured data json

### DIFF
--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -107,6 +107,10 @@
                       "type": "string",
                       "default": "VTEX Commerce"
                     },
+                    "id": {
+                      "title": "ID",
+                      "type": "string"
+                    },
                     "url": {
                       "title": "Organization URL",
                       "type": "string",
@@ -134,6 +138,27 @@
                       "title": "Organization phone",
                       "description": "A business phone number. Be sure to include the country code and area code in the phone number",
                       "type": "string"
+                    },
+                    "address": {
+                      "title": "Organization address",
+                      "description": "The address (physical or mailing) of your organization, if applicable.",
+                      "type": "object",
+                      "properties": {
+                        "streetAddress": {
+                          "title": "Street Address",
+                          "description": "The full street address of your postal address.",
+                          "type": "string"
+                        },
+                        "addressLocality": {
+                          "title": "Street Address",
+                          "description": "The city of your postal address.",
+                          "type": "string"
+                        },
+                        "postalCode": {
+                          "title": "Postal Code",
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -104,7 +104,7 @@
                 "organization": {
                   "title": "Organization",
                   "type": "object",
-                  "required": ["name"],
+                  "required": ["name", "url"],
                   "properties": {
                     "name": {
                       "title": "Organization name",

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -129,6 +129,29 @@
                       "description": "A logo that is representative of your organization. Image guidelines: https://developers.google.com/search/docs/appearance/structured-data/organization",
                       "type": "string"
                     },
+                    "image": {
+                      "title": "Organization image/logo object",
+                      "description": "An image that is representative of your organization. Image guidelines: https://developers.google.com/search/docs/appearance/structured-data/organization",
+                      "required": ["url"],
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "title": "Organization image URL",
+                          "description": "The URL of the image. Make sure the url is crawlable and indexable.",
+                          "type": "string"
+                        },
+                        "caption": {
+                          "title": "Organization image caption",
+                          "description": "A short description of the image.",
+                          "type": "string"
+                        },
+                        "id": {
+                          "title": "Organization image ID",
+                          "description": "A unique identifier for the image. E.g.: #logo",
+                          "type": "string"
+                        }
+                      }
+                    },
                     "email": {
                       "title": "Organization email",
                       "description": "The email address to contact your business",
@@ -152,6 +175,11 @@
                         "addressLocality": {
                           "title": "Street Address",
                           "description": "The city of your postal address.",
+                          "type": "string"
+                        },
+                        "addressCountry": {
+                          "title": "Country",
+                          "description": "The country of your postal address. Recommended to be in 2-letter ISO 3166-1 alpha-2 format, for example 'BR','US'.",
                           "type": "string"
                         },
                         "postalCode": {

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -32,7 +32,7 @@
                 },
                 "title": {
                   "title": "Default page title",
-                  "description": "Display this title when no other tile is available",
+                  "description": "Display this title when no other tile is available.",
                   "type": "string",
                   "default": "FastStore Starter"
                 },
@@ -159,7 +159,7 @@
                     },
                     "telephone": {
                       "title": "Organization phone",
-                      "description": "A business phone number. Be sure to include the country code and area code in the phone number",
+                      "description": "A business phone number. Be sure to include the country code and area code in the phone number.",
                       "type": "string"
                     },
                     "address": {
@@ -173,13 +173,13 @@
                           "type": "string"
                         },
                         "addressLocality": {
-                          "title": "Street Address",
+                          "title": "City",
                           "description": "The city of your postal address.",
                           "type": "string"
                         },
                         "addressCountry": {
                           "title": "Country",
-                          "description": "The country of your postal address. Recommended to be in 2-letter ISO 3166-1 alpha-2 format, for example 'BR','US'.",
+                          "description": "The country of your postal address. Recommended to be in 2-letter ISO 3166-1 alpha-2 format, for example 'BR','US'",
                           "type": "string"
                         },
                         "postalCode": {

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -129,7 +129,7 @@
                     "sameAs": {
                       "title": "Organization URLs",
                       "type": "array",
-                      "description": "The URL of a page on another website with additional information about your organization. For example, a URL to your organization's profile page on a social media or review site",
+                      "description": "The URL of a page on another website with additional information about your organization. For example, a URL to your organization's profile page on a social media or review site.",
                       "items": {
                         "type": "string"
                       }
@@ -189,11 +189,12 @@
                         },
                         "addressCountry": {
                           "title": "Country",
-                          "description": "The country of your postal address. Recommended to be in 2-letter ISO 3166-1 alpha-2 format, for example 'BR','US'",
+                          "description": "The country of your postal address. Recommended to be in 2-letter ISO 3166-1 alpha-2 format, for example 'BR','US'.",
                           "type": "string"
                         },
                         "postalCode": {
                           "title": "Postal Code",
+                          "description": "The postal code of your postal address.",
                           "type": "string"
                         }
                       }

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -92,6 +92,51 @@
                   "title": "Canonical url for the page",
                   "type": "string"
                 },
+                "organization": {
+                  "title": "Organization",
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": {
+                      "title": "Organization name",
+                      "type": "string",
+                      "default": "VTEX"
+                    },
+                    "legalName": {
+                      "title": "Organization legal name",
+                      "type": "string",
+                      "default": "VTEX Commerce"
+                    },
+                    "url": {
+                      "title": "Organization URL",
+                      "type": "string",
+                      "default": "https://vtex.com"
+                    },
+                    "sameAs": {
+                      "title": "Organization URLs",
+                      "type": "array",
+                      "description": "The URL of a page on another website with additional information about your organization. For example, a URL to your organization's profile page on a social media or review site",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "logo": {
+                      "title": "Organization logo URL",
+                      "description": "A logo that is representative of your organization. Image guidelines: https://developers.google.com/search/docs/appearance/structured-data/organization",
+                      "type": "string"
+                    },
+                    "email": {
+                      "title": "Organization email",
+                      "description": "The email address to contact your business",
+                      "type": "string"
+                    },
+                    "telephone": {
+                      "title": "Organization phone",
+                      "description": "A business phone number. Be sure to include the country code and area code in the phone number",
+                      "type": "string"
+                    }
+                  }
+                },
                 "name": {
                   "title": "Name",
                   "type": "string"

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -92,6 +92,15 @@
                   "title": "Canonical url for the page",
                   "type": "string"
                 },
+                "name": {
+                  "title": "Name",
+                  "type": "string"
+                },
+                "publisherId": {
+                  "title": "Publisher ID",
+                  "description": "A unique identifier used to reference the publisher. This can be a descriptive value (e.g., `#organization`) or a full URL (e.g., `https://example.com/publisher`).",
+                  "type": "string"
+                },
                 "organization": {
                   "title": "Organization",
                   "type": "object",
@@ -108,7 +117,8 @@
                       "default": "VTEX Commerce"
                     },
                     "id": {
-                      "title": "ID",
+                      "title": "Organization ID",
+                      "description": "A unique reference for the organization. This can be a descriptive value (e.g., #organization) or a full URL (e.g.,https://example.com/organization).",
                       "type": "string"
                     },
                     "url": {
@@ -147,7 +157,7 @@
                         },
                         "id": {
                           "title": "Organization image ID",
-                          "description": "A unique identifier for the image. E.g.: #logo",
+                          "description": "A unique reference for the image. This can be a descriptive value (e.g., #logo) or a full URL (e.g.,https://example.com/logo).",
                           "type": "string"
                         }
                       }
@@ -189,15 +199,6 @@
                       }
                     }
                   }
-                },
-                "name": {
-                  "title": "Name",
-                  "type": "string"
-                },
-                "publisherId": {
-                  "title": "Publisher ID",
-                  "description": "Uses to identifier to reference the publisher. E.g.: #website",
-                  "type": "string"
                 }
               }
             }

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -17,6 +17,19 @@ module.exports = {
       noFollow: true,
       bodyH1: 'Showing results for:',
     },
+    organization: {
+      url: 'https://vtex.com',
+      sameAs: [
+        'https://www.facebook.com/vtex',
+        'https://www.instagram.com/vtex',
+      ],
+      logo: 'https://vtex.com/_next/static/media/vtex-logo.80485bcf.svg',
+      name: 'VTEX',
+      legalName: 'VTEX Commerce',
+      email: 'info@vtex.com',
+      telephone: '',
+      image: '',
+    },
   },
 
   // Theming

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -18,16 +18,23 @@ module.exports = {
       bodyH1: 'Showing results for:',
     },
     organization: {
+      id: '',
       url: 'https://vtex.com',
       sameAs: [
         'https://www.facebook.com/vtex',
         'https://www.instagram.com/vtex',
       ],
       logo: 'https://vtex.com/_next/static/media/vtex-logo.80485bcf.svg',
+      image: 'https://vtex.com/_next/static/media/vtex-logo.80485bcf.svg',
       name: 'VTEX',
       legalName: 'VTEX Commerce',
       email: 'info@vtex.com',
       telephone: '',
+      address: {
+        streetAddress: 'Rue Improbable 99',
+        addressLocality: 'Rio de Janeiro',
+        postalCode: '06473-000',
+      },
     },
   },
 

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -25,7 +25,11 @@ module.exports = {
         'https://www.instagram.com/vtex',
       ],
       logo: 'https://vtex.com/_next/static/media/vtex-logo.80485bcf.svg',
-      image: 'https://vtex.com/_next/static/media/vtex-logo.80485bcf.svg',
+      image: {
+        url: 'https://vtex.com/_next/static/media/vtex-logo.80485bcf.svg',
+        caption: 'FastStore',
+        id: '',
+      },
       name: 'VTEX',
       legalName: 'VTEX Commerce',
       email: 'info@vtex.com',
@@ -34,6 +38,7 @@ module.exports = {
         streetAddress: 'Rue Improbable 99',
         addressLocality: 'Rio de Janeiro',
         postalCode: '06473-000',
+        addressCountry: 'BR',
       },
     },
     plp: {

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -6,17 +6,6 @@ module.exports = {
     author: 'Store Framework',
     name: 'FastStore',
     publisherId: '',
-    plp: {
-      titleTemplate: '%s | FastStore PLP',
-      descriptionTemplate: '%s products on FastStore Product Listing Page',
-    },
-    search: {
-      titleTemplate: '%s: Search results title',
-      descriptionTemplate: '%s: Search results description',
-      noIndex: true,
-      noFollow: true,
-      bodyH1: 'Showing results for:',
-    },
     organization: {
       id: '',
       url: 'https://vtex.com',
@@ -44,6 +33,13 @@ module.exports = {
     plp: {
       titleTemplate: '%s | FastStore PLP',
       descriptionTemplate: '%s products on FastStore Product Listing Page',
+    },
+    search: {
+      titleTemplate: '%s: Search results title',
+      descriptionTemplate: '%s: Search results description',
+      noIndex: true,
+      noFollow: true,
+      bodyH1: 'Showing results for:',
     },
   },
 

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -28,7 +28,6 @@ module.exports = {
       legalName: 'VTEX Commerce',
       email: 'info@vtex.com',
       telephone: '',
-      image: '',
     },
   },
 

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -6,30 +6,6 @@ module.exports = {
     author: 'Store Framework',
     name: 'FastStore',
     publisherId: '',
-    organization: {
-      id: '',
-      url: 'https://vtex.com',
-      sameAs: [
-        'https://www.facebook.com/vtex',
-        'https://www.instagram.com/vtex',
-      ],
-      logo: 'https://vtex.com/_next/static/media/vtex-logo.80485bcf.svg',
-      image: {
-        url: 'https://vtex.com/_next/static/media/vtex-logo.80485bcf.svg',
-        caption: 'FastStore',
-        id: '',
-      },
-      name: 'VTEX',
-      legalName: 'VTEX Commerce',
-      email: 'info@vtex.com',
-      telephone: '',
-      address: {
-        streetAddress: 'Rue Improbable 99',
-        addressLocality: 'Rio de Janeiro',
-        postalCode: '06473-000',
-        addressCountry: 'BR',
-      },
-    },
     plp: {
       titleTemplate: '%s | FastStore PLP',
       descriptionTemplate: '%s products on FastStore Product Listing Page',

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -36,6 +36,10 @@ module.exports = {
         postalCode: '06473-000',
       },
     },
+    plp: {
+      titleTemplate: '%s | FastStore PLP',
+      descriptionTemplate: '%s products on FastStore Product Listing Page',
+    },
   },
 
   // Theming

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -63,6 +63,7 @@ function Page({
 
       <OrganizationJsonLd
         type="Organization"
+        id={settings?.seo?.organization?.id ?? storeConfig.storeUrl}
         url={settings?.seo?.organization?.url ?? storeConfig.storeUrl}
         sameAs={
           settings?.seo?.organization?.sameAs ??
@@ -70,6 +71,10 @@ function Page({
         }
         logo={
           settings?.seo?.organization?.logo ?? storeConfig.seo.organization.logo
+        }
+        image={
+          settings?.seo?.organization?.image ??
+          storeConfig.seo.organization.image
         }
         name={
           settings?.seo?.organization?.name ?? storeConfig.seo.organization.name
@@ -86,6 +91,18 @@ function Page({
           settings?.seo?.organization?.telephone ??
           storeConfig.seo.organization.telephone
         }
+        address={{
+          '@type': 'PostalAddress',
+          streetAddress:
+            settings?.seo?.organization?.address?.streetAddress ??
+            storeConfig.seo.organization.address.streetAddress,
+          addressLocality:
+            settings?.seo?.organization?.address?.addressLocality ??
+            storeConfig.seo.organization.address.addressLocality,
+          postalCode:
+            settings?.seo?.organization?.address?.postalCode ??
+            storeConfig.seo.organization.address.postalCode,
+        }}
       />
 
       {/*

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -63,57 +63,62 @@ function Page({
 
       <OrganizationJsonLd
         type="Organization"
-        id={settings?.seo?.organization?.id ?? storeConfig.seo.organization.id}
-        url={settings?.seo?.organization?.url ?? storeConfig.storeUrl}
-        sameAs={
-          settings?.seo?.organization?.sameAs ??
-          storeConfig.seo.organization.sameAs
-        }
-        logo={
-          settings?.seo?.organization?.logo ?? storeConfig.seo.organization.logo
-        }
-        image={{
-          type: 'ImageObject',
-          url:
-            settings?.seo?.organization?.image?.url ??
-            storeConfig.seo.organization.image.url,
-          caption:
-            settings?.seo?.organization?.image.caption ??
-            storeConfig.seo.organization.image.caption,
-          id:
-            settings?.seo?.organization?.image?.id ??
-            storeConfig.seo.organization.image.id,
-        }}
-        name={
-          settings?.seo?.organization?.name ?? storeConfig.seo.organization.name
-        }
-        legalName={
-          settings?.seo?.organization?.legalName ??
-          storeConfig.seo.organization.legalName
-        }
-        email={
-          settings?.seo?.organization?.email ??
-          storeConfig.seo.organization.email
-        }
-        telephone={
-          settings?.seo?.organization?.telephone ??
-          storeConfig.seo.organization.telephone
-        }
-        address={{
-          type: 'PostalAddress',
-          streetAddress:
-            settings?.seo?.organization?.address?.streetAddress ??
-            storeConfig.seo.organization.address.streetAddress,
-          addressLocality:
-            settings?.seo?.organization?.address?.addressLocality ??
-            storeConfig.seo.organization.address.addressLocality,
-          postalCode:
-            settings?.seo?.organization?.address?.postalCode ??
-            storeConfig.seo.organization.address.postalCode,
-          addressCountry:
-            settings?.seo?.organization?.address?.addressCountry ??
-            storeConfig.seo.organization.address.addressCountry,
-        }}
+        {...(settings?.seo?.organization?.id && {
+          id: settings.seo.organization.id,
+        })}
+        {...(settings?.seo?.organization?.url && {
+          url: settings.seo.organization.url,
+        })}
+        {...(settings?.seo?.organization?.sameAs?.length && {
+          sameAs: settings.seo.organization.sameAs,
+        })}
+        {...(settings?.seo?.organization?.logo && {
+          logo: settings.seo.organization.logo,
+        })}
+        {...(settings?.seo?.organization?.name && {
+          name: settings.seo.organization.name,
+        })}
+        {...(settings?.seo?.organization?.legalName && {
+          legalName: settings.seo.organization.legalName,
+        })}
+        {...(settings?.seo?.organization?.email && {
+          email: settings.seo.organization.email,
+        })}
+        {...(settings?.seo?.organization?.telephone && {
+          telephone: settings.seo.organization.telephone,
+        })}
+        {...(settings?.seo?.organization?.image && {
+          image: {
+            type: 'ImageObject',
+            ...(settings.seo.organization.image.url && {
+              url: settings.seo.organization.image.url,
+            }),
+            ...(settings.seo.organization.image.caption && {
+              caption: settings.seo.organization.image.caption,
+            }),
+            ...(settings.seo.organization.image.id && {
+              id: settings.seo.organization.image.id,
+            }),
+          },
+        })}
+        {...(settings?.seo?.organization?.address && {
+          address: {
+            type: 'PostalAddress',
+            ...(settings.seo.organization.address.streetAddress && {
+              streetAddress: settings.seo.organization.address.streetAddress,
+            }),
+            ...(settings.seo.organization.address.addressLocality && {
+              addressLocality:
+                settings.seo.organization.address.addressLocality,
+            }),
+            ...(settings.seo.organization.address.postalCode && {
+              postalCode: settings.seo.organization.address.postalCode,
+            }),
+            ...(settings.seo.organization.address.addressCountry && {
+              addressCountry: settings.seo.organization.address.addressCountry,
+            }),
+          },
+        })}
       />
 
       {/*

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import type { Locator } from '@vtex/client-cms'
 import type { GetStaticProps } from 'next'
-import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
+import { NextSeo, OrganizationJsonLd, SiteLinksSearchBoxJsonLd } from 'next-seo'
 
 import RenderSections from 'src/components/cms/RenderSections'
 import type { PageContentType } from 'src/server/cms'
@@ -59,6 +59,19 @@ function Page({
           },
         ]}
         {...(publisherId && { publisher: { '@id': publisherId } })}
+      />
+
+      <OrganizationJsonLd
+        type="Organization"
+        id="https://www.purpule-fox.io/#corporation"
+        logo="https://www.example.com/photos/logo.jpg"
+        legalName="GO - Companhia FastStore"
+        name="FastStore"
+        email="sac@faststore.com"
+        telephone="4003-2000"
+        sameAs={['https://www.facebook.com/faststore']}
+        url="https://www.vtexfaststore.com"
+        image="#logo"
       />
 
       {/*

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -72,10 +72,18 @@ function Page({
         logo={
           settings?.seo?.organization?.logo ?? storeConfig.seo.organization.logo
         }
-        image={
-          settings?.seo?.organization?.image ??
-          storeConfig.seo.organization.image
-        }
+        image={{
+          type: 'ImageObject',
+          url:
+            settings?.seo?.organization?.image?.url ??
+            storeConfig.seo.organization.image.url,
+          caption:
+            settings?.seo?.organization?.image.caption ??
+            storeConfig.seo.organization.image.caption,
+          id:
+            settings?.seo?.organization?.image?.id ??
+            storeConfig.seo.organization.image.id,
+        }}
         name={
           settings?.seo?.organization?.name ?? storeConfig.seo.organization.name
         }
@@ -92,7 +100,7 @@ function Page({
           storeConfig.seo.organization.telephone
         }
         address={{
-          '@type': 'PostalAddress',
+          type: 'PostalAddress',
           streetAddress:
             settings?.seo?.organization?.address?.streetAddress ??
             storeConfig.seo.organization.address.streetAddress,
@@ -102,6 +110,9 @@ function Page({
           postalCode:
             settings?.seo?.organization?.address?.postalCode ??
             storeConfig.seo.organization.address.postalCode,
+          addressCountry:
+            settings?.seo?.organization?.address?.addressCountry ??
+            storeConfig.seo.organization.address.addressCountry,
         }}
       />
 

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -31,6 +31,14 @@ function Page({
   }
 
   const publisherId = settings?.seo?.publisherId ?? storeConfig.seo.publisherId
+  const orgAddress = settings?.seo?.organization?.address
+
+  const address =
+    orgAddress && Boolean(Object.values(orgAddress).find(Boolean))
+      ? Object.fromEntries(
+          Object.entries(orgAddress).filter(([, value]) => Boolean(value))
+        )
+      : null
 
   return (
     <>
@@ -102,25 +110,7 @@ function Page({
               }),
             },
           })}
-          {...(settings?.seo?.organization?.address && {
-            address: {
-              type: 'PostalAddress',
-              ...(settings.seo.organization.address.streetAddress && {
-                streetAddress: settings.seo.organization.address.streetAddress,
-              }),
-              ...(settings.seo.organization.address.addressLocality && {
-                addressLocality:
-                  settings.seo.organization.address.addressLocality,
-              }),
-              ...(settings.seo.organization.address.postalCode && {
-                postalCode: settings.seo.organization.address.postalCode,
-              }),
-              ...(settings.seo.organization.address.addressCountry && {
-                addressCountry:
-                  settings.seo.organization.address.addressCountry,
-              }),
-            },
-          })}
+          {...(address && { address })}
         />
       )}
 

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -63,7 +63,7 @@ function Page({
 
       <OrganizationJsonLd
         type="Organization"
-        id={settings?.seo?.organization?.id ?? storeConfig.storeUrl}
+        id={settings?.seo?.organization?.id ?? storeConfig.seo.organization.id}
         url={settings?.seo?.organization?.url ?? storeConfig.storeUrl}
         sameAs={
           settings?.seo?.organization?.sameAs ??

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -63,13 +63,29 @@ function Page({
 
       <OrganizationJsonLd
         type="Organization"
-        url={storeConfig.seo.organization.url}
-        sameAs={storeConfig.seo.organization.sameAs}
-        logo={storeConfig.seo.organization.logo}
-        name={storeConfig.seo.organization.name}
-        legalName={storeConfig.seo.organization.legalName}
-        email={storeConfig.seo.organization.email}
-        telephone={storeConfig.seo.organization.telephone}
+        url={settings?.seo?.organization?.url ?? storeConfig.storeUrl}
+        sameAs={
+          settings?.seo?.organization?.sameAs ??
+          storeConfig.seo.organization.sameAs
+        }
+        logo={
+          settings?.seo?.organization?.logo ?? storeConfig.seo.organization.logo
+        }
+        name={
+          settings?.seo?.organization?.name ?? storeConfig.seo.organization.name
+        }
+        legalName={
+          settings?.seo?.organization?.legalName ??
+          storeConfig.seo.organization.legalName
+        }
+        email={
+          settings?.seo?.organization?.email ??
+          storeConfig.seo.organization.email
+        }
+        telephone={
+          settings?.seo?.organization?.telephone ??
+          storeConfig.seo.organization.telephone
+        }
       />
 
       {/*

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -61,65 +61,68 @@ function Page({
         {...(publisherId && { publisher: { '@id': publisherId } })}
       />
 
-      <OrganizationJsonLd
-        type="Organization"
-        {...(settings?.seo?.organization?.id && {
-          id: settings.seo.organization.id,
-        })}
-        {...(settings?.seo?.organization?.url && {
-          url: settings.seo.organization.url,
-        })}
-        {...(settings?.seo?.organization?.sameAs?.length && {
-          sameAs: settings.seo.organization.sameAs,
-        })}
-        {...(settings?.seo?.organization?.logo && {
-          logo: settings.seo.organization.logo,
-        })}
-        {...(settings?.seo?.organization?.name && {
-          name: settings.seo.organization.name,
-        })}
-        {...(settings?.seo?.organization?.legalName && {
-          legalName: settings.seo.organization.legalName,
-        })}
-        {...(settings?.seo?.organization?.email && {
-          email: settings.seo.organization.email,
-        })}
-        {...(settings?.seo?.organization?.telephone && {
-          telephone: settings.seo.organization.telephone,
-        })}
-        {...(settings?.seo?.organization?.image && {
-          image: {
-            type: 'ImageObject',
-            ...(settings.seo.organization.image.url && {
-              url: settings.seo.organization.image.url,
-            }),
-            ...(settings.seo.organization.image.caption && {
-              caption: settings.seo.organization.image.caption,
-            }),
-            ...(settings.seo.organization.image.id && {
-              id: settings.seo.organization.image.id,
-            }),
-          },
-        })}
-        {...(settings?.seo?.organization?.address && {
-          address: {
-            type: 'PostalAddress',
-            ...(settings.seo.organization.address.streetAddress && {
-              streetAddress: settings.seo.organization.address.streetAddress,
-            }),
-            ...(settings.seo.organization.address.addressLocality && {
-              addressLocality:
-                settings.seo.organization.address.addressLocality,
-            }),
-            ...(settings.seo.organization.address.postalCode && {
-              postalCode: settings.seo.organization.address.postalCode,
-            }),
-            ...(settings.seo.organization.address.addressCountry && {
-              addressCountry: settings.seo.organization.address.addressCountry,
-            }),
-          },
-        })}
-      />
+      {settings?.seo?.organization && (
+        <OrganizationJsonLd
+          type="Organization"
+          {...(settings?.seo?.organization?.id && {
+            id: settings.seo.organization.id,
+          })}
+          {...(settings?.seo?.organization?.url && {
+            url: settings.seo.organization.url,
+          })}
+          {...(settings?.seo?.organization?.sameAs?.length && {
+            sameAs: settings.seo.organization.sameAs,
+          })}
+          {...(settings?.seo?.organization?.logo && {
+            logo: settings.seo.organization.logo,
+          })}
+          {...(settings?.seo?.organization?.name && {
+            name: settings.seo.organization.name,
+          })}
+          {...(settings?.seo?.organization?.legalName && {
+            legalName: settings.seo.organization.legalName,
+          })}
+          {...(settings?.seo?.organization?.email && {
+            email: settings.seo.organization.email,
+          })}
+          {...(settings?.seo?.organization?.telephone && {
+            telephone: settings.seo.organization.telephone,
+          })}
+          {...(settings?.seo?.organization?.image && {
+            image: {
+              type: 'ImageObject',
+              ...(settings.seo.organization.image.url && {
+                url: settings.seo.organization.image.url,
+              }),
+              ...(settings.seo.organization.image.caption && {
+                caption: settings.seo.organization.image.caption,
+              }),
+              ...(settings.seo.organization.image.id && {
+                id: settings.seo.organization.image.id,
+              }),
+            },
+          })}
+          {...(settings?.seo?.organization?.address && {
+            address: {
+              type: 'PostalAddress',
+              ...(settings.seo.organization.address.streetAddress && {
+                streetAddress: settings.seo.organization.address.streetAddress,
+              }),
+              ...(settings.seo.organization.address.addressLocality && {
+                addressLocality:
+                  settings.seo.organization.address.addressLocality,
+              }),
+              ...(settings.seo.organization.address.postalCode && {
+                postalCode: settings.seo.organization.address.postalCode,
+              }),
+              ...(settings.seo.organization.address.addressCountry && {
+                addressCountry:
+                  settings.seo.organization.address.addressCountry,
+              }),
+            },
+          })}
+        />
+      )}
 
       {/*
         WARNING: Do not import or render components from any

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -63,15 +63,14 @@ function Page({
 
       <OrganizationJsonLd
         type="Organization"
-        id="https://www.purpule-fox.io/#corporation"
-        logo="https://www.example.com/photos/logo.jpg"
-        legalName="GO - Companhia FastStore"
-        name="FastStore"
-        email="sac@faststore.com"
-        telephone="4003-2000"
-        sameAs={['https://www.facebook.com/faststore']}
-        url="https://www.vtexfaststore.com"
-        image="#logo"
+        url={storeConfig.seo.organization.url}
+        sameAs={storeConfig.seo.organization.sameAs}
+        logo={storeConfig.seo.organization.logo}
+        name={storeConfig.seo.organization.name}
+        legalName={storeConfig.seo.organization.legalName}
+        email={storeConfig.seo.organization.email}
+        telephone={storeConfig.seo.organization.telephone}
+        image={storeConfig.seo.organization.image}
       />
 
       {/*

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -70,7 +70,6 @@ function Page({
         legalName={storeConfig.seo.organization.legalName}
         email={storeConfig.seo.organization.email}
         telephone={storeConfig.seo.organization.telephone}
-        image={storeConfig.seo.organization.image}
       />
 
       {/*

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -31,14 +31,18 @@ function Page({
   }
 
   const publisherId = settings?.seo?.publisherId ?? storeConfig.seo.publisherId
-  const orgAddress = settings?.seo?.organization?.address
 
-  const address =
-    orgAddress && Boolean(Object.values(orgAddress).find(Boolean))
-      ? Object.fromEntries(
-          Object.entries(orgAddress).filter(([, value]) => Boolean(value))
-        )
-      : null
+  const organizationAddress = Object.entries(
+    settings?.seo?.organization?.address ?? {}
+  ).reduce(
+    (acc, [key, value]) => {
+      if (value) {
+        acc[key] = value
+      }
+      return acc
+    },
+    {} as Record<string, string>
+  )
 
   return (
     <>
@@ -110,7 +114,9 @@ function Page({
               }),
             },
           })}
-          {...(address && { address })}
+          {...(Object.keys(organizationAddress).length !== 0 && {
+            address: organizationAddress,
+          })}
         />
       )}
 

--- a/packages/core/src/server/cms/index.ts
+++ b/packages/core/src/server/cms/index.ts
@@ -33,13 +33,20 @@ export type PageContentType = ContentData & {
       name?: string
       publisherId?: string
       organization: {
+        id?: string
         url?: string
         sameAs?: string[]
         logo?: string
+        image?: string
         name: string
         legalName?: string
         email?: string
         telephone?: string
+        address?: {
+          streetAddress?: string
+          addressLocality?: string
+          postalCode?: string
+        }
       }
     }
   }

--- a/packages/core/src/server/cms/index.ts
+++ b/packages/core/src/server/cms/index.ts
@@ -32,6 +32,15 @@ export type PageContentType = ContentData & {
       canonical?: string
       name?: string
       publisherId?: string
+      organization: {
+        url?: string
+        sameAs?: string[]
+        logo?: string
+        name: string
+        legalName?: string
+        email?: string
+        telephone?: string
+      }
     }
   }
 }

--- a/packages/core/src/server/cms/index.ts
+++ b/packages/core/src/server/cms/index.ts
@@ -37,7 +37,11 @@ export type PageContentType = ContentData & {
         url?: string
         sameAs?: string[]
         logo?: string
-        image?: string
+        image?: {
+          url: string
+          caption: string
+          id: string
+        }
         name: string
         legalName?: string
         email?: string
@@ -46,6 +50,7 @@ export type PageContentType = ContentData & {
           streetAddress?: string
           addressLocality?: string
           postalCode?: string
+          addressCountry?: string
         }
       }
     }


### PR DESCRIPTION
## What's the purpose of this pull request?

- Adding [Organization](https://developers.google.com/search/docs/appearance/structured-data/organization) structured data in homepage

> Adding organization structured data to your home page can help Google better understand your organization's administrative details and disambiguate your organization in search results.

## How it works?

Allow adding the following [Organization](https://schema.org/Organization) schema proprieties:

- url: the URL of the website of your organization. This helps Google uniquely identify your organization.
- sameAs: The URL of a page on another website with additional information about your organization, if applicable. For example, a URL to your organization's profile page on a social media or review site. You can provide multiple sameAs URLs.
- logo: A logo url that is representative of your organization, if applicable. (image [guidelines](https://developers.google.com/search/docs/appearance/structured-data/organization))
- image: An image that is representative of your organization. This could also be the same as the logo. Add a ImageObject (provide image url and caption)
- name: The name of your organization.
- legalName: The registered, legal name of your Organization.
- email: The email address to contact your business, if applicable.
- telephone: A business phone number meant to be the primary contact method for customers, if applicable.
- address: The address (physical or mailing) of your organization, if applicable.


> Note: Users can add Organization data through the headless CMS interface.

### Headless CMS
<img width="636" alt="image" src="https://github.com/user-attachments/assets/a73765d6-2b21-4593-9d63-e684eed8285c" />

TODO: Run cms sync in default acc.

## How to test it?

1. Go to [preview](https://starter-llg52ur11-vtex.vercel.app/) link, inspect and look for `Organization`

<img width="500" alt="image" src="https://github.com/user-attachments/assets/6fff3dad-6e4b-4e3d-9f45-0ad22ea7afc3" />

2. Copy the generated script and paste [here - google rich test](https://search.google.com/test/rich-results?utm_campaign=devsite&utm_medium=jsonld&utm_source=merchant) to test the valid schema:

<img width="1607" alt="image" src="https://github.com/user-attachments/assets/d9de0173-add6-4154-9746-ef50b30236ba" />

OR

1. Test in `storeframework` account, go to CMS admin, changes the fields values -> Save and Publish.
2. Wait for the new preview link and do the same process mention above (look for `organization` and validate the schema)

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/655

## References

- [Google rich test](https://search.google.com/test/rich-results?utm_campaign=devsite&utm_medium=jsonld&utm_source=merchant)
- [Schema.org](https://schema.org/Organization)
