### PR TITLE
feat: adjust rating styles

### DIFF
--- a/packages/components/src/molecules/Rating/Rating.tsx
+++ b/packages/components/src/molecules/Rating/Rating.tsx
@@ -30,6 +30,10 @@ export interface RatingProps
    * Function to be triggered when Rating option change. This should only be used if you and an actionable rating list.
    */
   onChange?: (value: number) => void
+  /**
+   * Specifies that the actionable rating should be disabled.
+   */
+  disabled?: boolean
 }
 
 export interface RatingItemProps {
@@ -45,6 +49,7 @@ const Rating = forwardRef<HTMLUListElement, RatingProps>(function Rating(
     value = 0,
     icon,
     onChange,
+    disabled,
     ...otherProps
   },
   ref
@@ -94,6 +99,7 @@ const Rating = forwardRef<HTMLUListElement, RatingProps>(function Rating(
                 }}
                 onMouseEnter={() => setHover(tempIndex)}
                 onMouseLeave={() => setHover(value)}
+                disabled={disabled}
               />
             ) : (
               <>

--- a/packages/ui/src/components/molecules/Rating/styles.scss
+++ b/packages/ui/src/components/molecules/Rating/styles.scss
@@ -4,20 +4,20 @@
   // --------------------------------------------------------
 
   // Default properties
-  --fs-rating-gap: var(--fs-spacing-0);
-  --fs-rating-color: var(--fs-color-main-2);
-  --fs-rating-color-empty: var(--fs-color-neutral-4);
+  --fs-rating-gap                              : var(--fs-spacing-0);
+  --fs-rating-color                            : var(--fs-color-main-2);
+  --fs-rating-color-empty                      : var(--fs-color-neutral-4);
 
   // Icon
-  --fs-rating-icon-width: var(--fs-spacing-3);
-  --fs-rating-icon-height: var(--fs-rating-icon-width);
+  --fs-rating-icon-width                       : var(--fs-spacing-3);
+  --fs-rating-icon-height                      : var(--fs-rating-icon-width);
 
   // Actionable
-  --fs-rating-actionable-gap: 0;
-  --fs-rating-actionable-icon-width: var(--fs-rating-icon-width);
-  --fs-rating-actionable-icon-height: var(--fs-rating-actionable-icon-width);
-  --fs-rating-actionable-icon-color: var(--fs-rating-color-empty);
-  --fs-rating-actionable-icon-color-selected: var(--fs-rating-color);
+  --fs-rating-actionable-gap                   : 0;
+  --fs-rating-actionable-icon-width            : var(--fs-rating-icon-width);
+  --fs-rating-actionable-icon-height           : var(--fs-rating-actionable-icon-width);
+  --fs-rating-actionable-icon-color            : var(--fs-rating-color-empty);
+  --fs-rating-actionable-icon-color-selected   : var(--fs-rating-color);
 
   // --------------------------------------------------------
   // Structural Styles

--- a/packages/ui/src/components/molecules/Rating/styles.scss
+++ b/packages/ui/src/components/molecules/Rating/styles.scss
@@ -5,7 +5,8 @@
 
   // Default properties
   --fs-rating-gap: var(--fs-spacing-0);
-  --fs-rating-color: var(--fs-color-text);
+  --fs-rating-color: var(--fs-color-main-2);
+  --fs-rating-color-empty: var(--fs-color-neutral-4);
 
   // Icon
   --fs-rating-icon-width: var(--fs-spacing-3);
@@ -15,8 +16,8 @@
   --fs-rating-actionable-gap: 0;
   --fs-rating-actionable-icon-width: var(--fs-rating-icon-width);
   --fs-rating-actionable-icon-height: var(--fs-rating-actionable-icon-width);
-  --fs-rating-actionable-color: var(--fs-color-neutral-4);
-  --fs-rating-actionable-color-selected: var(--fs-color-main-2);
+  --fs-rating-actionable-color: var(--fs-rating-color-empty);
+  --fs-rating-actionable-color-selected: var(--fs-rating-color);
 
   // --------------------------------------------------------
   // Structural Styles
@@ -58,6 +59,7 @@
 
   [data-fs-rating-item] {
     position: relative;
+    fill: var(--fs-rating-color);
   }
 
   //  --------------------------------------------------------
@@ -65,6 +67,7 @@
   // --------------------------------------------------------
 
   [data-fs-rating-item='empty'] svg[data-fs-icon] {
+    color: var(--fs-rating-color-empty);
     fill: none;
   }
 

--- a/packages/ui/src/components/molecules/Rating/styles.scss
+++ b/packages/ui/src/components/molecules/Rating/styles.scss
@@ -16,8 +16,8 @@
   --fs-rating-actionable-gap: 0;
   --fs-rating-actionable-icon-width: var(--fs-rating-icon-width);
   --fs-rating-actionable-icon-height: var(--fs-rating-actionable-icon-width);
-  --fs-rating-actionable-color: var(--fs-rating-color-empty);
-  --fs-rating-actionable-color-selected: var(--fs-rating-color);
+  --fs-rating-actionable-icon-color: var(--fs-rating-color-empty);
+  --fs-rating-actionable-icon-color-selected: var(--fs-rating-color);
 
   // --------------------------------------------------------
   // Structural Styles
@@ -25,23 +25,25 @@
   display: flex;
 
   [data-fs-icon] {
-    color: var(--fs-rating-color);
     width: var(--fs-rating-icon-width);
     height: var(--fs-rating-icon-height);
+    color: var(--fs-rating-color);
   }
 
   [data-fs-rating-button] {
-    &[disabled] {
-      [data-fs-button-wrapper] {
-        background: transparent !important;
-        opacity: 0.5;
+    color: unset;
+
+    &[disabled] [data-fs-button-wrapper] {
+      background-color: transparent;
+
+      &:hover {
+        background-color: transparent;
       }
     }
 
-    color: unset;
-    &[data-fs-button-variant='tertiary']:hover,
-    &[data-fs-button-variant='tertiary']:focus,
-    &[data-fs-button-variant='tertiary']:active {
+    &[data-fs-button-variant="tertiary"]:hover,
+    &[data-fs-button-variant="tertiary"]:focus,
+    &[data-fs-button-variant="tertiary"]:active {
       color: unset;
     }
   }
@@ -66,31 +68,31 @@
   // Variants Styles
   // --------------------------------------------------------
 
-  [data-fs-rating-item='empty'] svg[data-fs-icon] {
+  [data-fs-rating-item="empty"] svg[data-fs-icon] {
     color: var(--fs-rating-color-empty);
     fill: none;
   }
 
-  [data-fs-rating-item='partial'] [data-fs-rating-icon-wrapper] {
+  [data-fs-rating-item="partial"] [data-fs-rating-icon-wrapper] {
     width: calc(var(--fs-rating-icon-width) / 2);
   }
 
-  &:not([data-fs-rating-actionable='true']) {
+  &:not([data-fs-rating-actionable="true"]) {
     column-gap: var(--fs-rating-gap);
   }
 
-  &[data-fs-rating-actionable='true'] {
+  &[data-fs-rating-actionable="true"] {
     column-gap: var(--fs-rating-actionable-gap);
 
-    [data-fs-rating-item='full'] svg[data-fs-icon] {
-      color: var(--fs-rating-actionable-color-selected);
-      fill: var(--fs-rating-actionable-color-selected);
+    [data-fs-rating-item="full"] svg[data-fs-icon] {
+      color: var(--fs-rating-actionable-icon-color-selected);
+      fill: var(--fs-rating-actionable-icon-color-selected);
     }
 
     [data-fs-icon] {
-      color: var(--fs-rating-actionable-color);
       width: var(--fs-rating-actionable-icon-width);
       height: var(--fs-rating-actionable-icon-height);
+      color: var(--fs-rating-actionable-icon-color);
     }
   }
 }

--- a/packages/ui/src/components/molecules/Rating/styles.scss
+++ b/packages/ui/src/components/molecules/Rating/styles.scss
@@ -30,6 +30,13 @@
   }
 
   [data-fs-rating-button] {
+    &[disabled] {
+      [data-fs-button-wrapper] {
+        background: transparent !important;
+        opacity: 0.5;
+      }
+    }
+
     color: unset;
     &[data-fs-button-variant='tertiary']:hover,
     &[data-fs-button-variant='tertiary']:focus,

--- a/packages/ui/src/components/molecules/Rating/styles.scss
+++ b/packages/ui/src/components/molecules/Rating/styles.scss
@@ -4,22 +4,23 @@
   // --------------------------------------------------------
 
   // Default properties
-  --fs-rating-gap                     : var(--fs-spacing-0);
-  --fs-rating-color                   : var(--fs-color-text);
+  --fs-rating-gap: var(--fs-spacing-0);
+  --fs-rating-color: var(--fs-color-text);
 
   // Icon
-  --fs-rating-icon-width              : var(--fs-spacing-3);
-  --fs-rating-icon-height             : var(--fs-rating-icon-width);
+  --fs-rating-icon-width: var(--fs-spacing-3);
+  --fs-rating-icon-height: var(--fs-rating-icon-width);
 
   // Actionable
-  --fs-rating-actionable-gap          : 0;
-  --fs-rating-actionable-icon-width   : var(--fs-rating-icon-width);
-  --fs-rating-actionable-icon-height  : var(--fs-rating-actionable-icon-width);
+  --fs-rating-actionable-gap: 0;
+  --fs-rating-actionable-icon-width: var(--fs-rating-icon-width);
+  --fs-rating-actionable-icon-height: var(--fs-rating-actionable-icon-width);
+  --fs-rating-actionable-color: var(--fs-color-neutral-4);
+  --fs-rating-actionable-color-selected: var(--fs-color-main-2);
 
   // --------------------------------------------------------
   // Structural Styles
   // --------------------------------------------------------
-
   display: flex;
 
   [data-fs-icon] {
@@ -30,9 +31,11 @@
 
   [data-fs-rating-button] {
     color: unset;
-    &[data-fs-button-variant=tertiary]:hover,
-    &[data-fs-button-variant=tertiary]:focus,
-    &[data-fs-button-variant=tertiary]:active { color: unset; }
+    &[data-fs-button-variant='tertiary']:hover,
+    &[data-fs-button-variant='tertiary']:focus,
+    &[data-fs-button-variant='tertiary']:active {
+      color: unset;
+    }
   }
 
   [data-fs-rating-icon-wrapper] {
@@ -42,34 +45,42 @@
     overflow: hidden;
   }
 
-  svg[data-fs-rating-icon-outline] { 
-    fill: none; 
+  svg[data-fs-rating-icon-outline] {
+    fill: none;
   }
 
-  [data-fs-rating-item] { position: relative; }
+  [data-fs-rating-item] {
+    position: relative;
+  }
 
   //  --------------------------------------------------------
   // Variants Styles
   // --------------------------------------------------------
 
-  [data-fs-rating-item="empty"] svg[data-fs-icon] {
+  [data-fs-rating-item='empty'] svg[data-fs-icon] {
     fill: none;
   }
 
-  [data-fs-rating-item="partial"] [data-fs-rating-icon-wrapper] {
+  [data-fs-rating-item='partial'] [data-fs-rating-icon-wrapper] {
     width: calc(var(--fs-rating-icon-width) / 2);
   }
 
-  &:not([data-fs-rating-actionable="true"]) {
+  &:not([data-fs-rating-actionable='true']) {
     column-gap: var(--fs-rating-gap);
   }
 
-  &[data-fs-rating-actionable="true"] {
+  &[data-fs-rating-actionable='true'] {
     column-gap: var(--fs-rating-actionable-gap);
+
+    [data-fs-rating-item='full'] svg[data-fs-icon] {
+      color: var(--fs-rating-actionable-color-selected);
+      fill: var(--fs-rating-actionable-color-selected);
+    }
+
     [data-fs-icon] {
+      color: var(--fs-rating-actionable-color);
       width: var(--fs-rating-actionable-icon-width);
       height: var(--fs-rating-actionable-icon-height);
     }
   }
-
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This pull request introduces adjustments to the **Rating component** for the new **Reviews & Ratings** section. 

## How it works?

It updates the colors for both the default and actionable versions, using `main-2` for active stars and `neutral-4` for empty stars.
Additionally, it includes the addition of a `disabled` style for the actionable rating.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

[Preview](https://starter-git-feat-rating-field-vtex.vercel.app/review-and-ratings-playground)

## References

[JIRA TASK: SFS-2077](https://vtex-dev.atlassian.net/browse/SFS-2077)

[Figma](https://www.figma.com/design/YXU6IX2htN2yg7udpCumZv/Reviews-%26-Ratings?node-id=131-49445&t=97j1KIeA0brteiq8-4)

Default

![image](https://github.com/user-attachments/assets/53cff9ef-b54a-4ea6-9ea0-1d1d574ce04c)

Actionable

![image](https://github.com/user-attachments/assets/ae6395cb-2bc8-4dff-94a3-c99f0eb7c5ac)