### PR TITLE
feat: add checkbox field error variant

### DIFF
--- a/packages/components/src/molecules/CheckboxField/CheckboxField.tsx
+++ b/packages/components/src/molecules/CheckboxField/CheckboxField.tsx
@@ -7,6 +7,14 @@ export interface CheckboxFieldProps extends CheckboxProps {
    * The text displayed to identify the input checkbox.
    */
   label: string
+  /**
+   * The error message is displayed when an error occurs.
+   */
+  error?: string
+  /**
+   * Control the vertical alignment of the checkbox in relation to the label (center, top, bottom).
+   */
+  alignment?: 'center' | 'top' | 'bottom'
 }
 
 const CheckboxField = forwardRef<HTMLDivElement, CheckboxFieldProps>(
@@ -18,20 +26,38 @@ const CheckboxField = forwardRef<HTMLDivElement, CheckboxFieldProps>(
       value,
       name,
       checked,
+      error,
+      disabled,
+      alignment = 'center',
       ...otherProps
     },
     ref
   ) {
+    const shouldDisplayError = !disabled && error && error !== ''
+
     return (
-      <div ref={ref} data-fs-checkbox-field data-testid={testId}>
+      <div
+        ref={ref}
+        data-testid={testId}
+        data-fs-checkbox-field
+        data-fs-checkbox-field-error={error && error !== ''}
+        data-fs-checkbox-field-alignment={alignment}
+      >
         <Checkbox
           id={id}
           value={value ?? label}
           name={name}
           defaultChecked={checked}
+          disabled={disabled}
           {...otherProps}
         />
-        <Label htmlFor={id}>{label}</Label>
+        <div data-fs-checkbox-field-content>
+          <Label htmlFor={id}>{label}</Label>
+
+          {shouldDisplayError && (
+            <span data-fs-checkbox-field-error-message>{error}</span>
+          )}
+        </div>
       </div>
     )
   }

--- a/packages/components/src/molecules/CheckboxField/CheckboxField.tsx
+++ b/packages/components/src/molecules/CheckboxField/CheckboxField.tsx
@@ -52,7 +52,9 @@ const CheckboxField = forwardRef<HTMLDivElement, CheckboxFieldProps>(
           {...otherProps}
         />
         <div data-fs-checkbox-field-content>
-          <Label htmlFor={id}>{label}</Label>
+          <Label data-fs-checkbox-field-label htmlFor={id}>
+            {label}
+          </Label>
 
           {shouldDisplayError && (
             <span data-fs-checkbox-field-error-message>{error}</span>

--- a/packages/ui/src/components/molecules/CheckboxField/styles.scss
+++ b/packages/ui/src/components/molecules/CheckboxField/styles.scss
@@ -6,6 +6,12 @@
   // Default properties
   --fs-checkbox-field-gap: var(--fs-spacing-1);
 
+  // Label
+  --fs-checkbox-field-label-color: var(--fs-color-text-light);
+  --fs-checkbox-field-label-size: var(--fs-text-size-1);
+  --fs-checkbox-field-label-weight: var(--fs-text-weight-regular);
+  --fs-checkbox-field-label-line-height: 1.42;
+
   /* Error tokens */
   --fs-checkbox-field-error-message-size: var(--fs-text-size-legend);
   --fs-checkbox-field-error-message-line-height: 1.1;
@@ -23,6 +29,13 @@
   [data-fs-checkbox-field-content] {
     display: flex;
     flex-direction: column;
+  }
+
+  [data-fs-checkbox-field-label] {
+    color: var(--fs-checkbox-field-label-color);
+    font-size: var(--fs-checkbox-field-label-size);
+    font-weight: var(--fs-checkbox-field-label-weight);
+    line-height: var(--fs-checkbox-field-label-line-height);
   }
 
   // --------------------------------------------------------

--- a/packages/ui/src/components/molecules/CheckboxField/styles.scss
+++ b/packages/ui/src/components/molecules/CheckboxField/styles.scss
@@ -4,9 +4,51 @@
   // --------------------------------------------------------
 
   // Default properties
-  --fs-checkbox-field-gap : var(--fs-spacing-1);
+  --fs-checkbox-field-gap: var(--fs-spacing-1);
+
+  /* Error tokens */
+  --fs-checkbox-field-error-message-size: var(--fs-text-size-legend);
+  --fs-checkbox-field-error-message-line-height: 1.1;
+  --fs-checkbox-field-error-message-margin-top: var(--fs-spacing-0);
+  --fs-checkbox-field-error-message-color: var(--fs-color-danger-text);
+  --fs-checkbox-field-error-border-color: var(--fs-color-danger-border);
 
   display: flex;
-  align-items: center;
   column-gap: var(--fs-checkbox-field-gap);
-};
+
+  [data-fs-checkbox] {
+    flex-shrink: 0;
+  }
+
+  [data-fs-checkbox-field-content] {
+    display: flex;
+    flex-direction: column;
+  }
+
+  // --------------------------------------------------------
+  // Variants Styles
+  // --------------------------------------------------------
+
+  &[data-fs-checkbox-field-alignment='center'] {
+    align-items: center;
+  }
+  &[data-fs-checkbox-field-alignment='top'] {
+    align-items: flex-start;
+  }
+  &[data-fs-checkbox-field-alignment='bottom'] {
+    align-items: flex-end;
+  }
+
+  &[data-fs-checkbox-field-error='true'] {
+    [data-fs-checkbox-field-error-message] {
+      margin-top: var(--fs-checkbox-field-error-message-margin-top);
+      font-size: var(--fs-checkbox-field-error-message-size);
+      line-height: var(--fs-checkbox-field-error-message-line-height);
+      color: var(--fs-checkbox-field-error-message-color);
+    }
+
+    [data-fs-checkbox]:not(:disabled) {
+      border-color: var(--fs-checkbox-field-error-border-color);
+    }
+  }
+}

--- a/packages/ui/src/components/molecules/CheckboxField/styles.scss
+++ b/packages/ui/src/components/molecules/CheckboxField/styles.scss
@@ -4,20 +4,20 @@
   // --------------------------------------------------------
 
   // Default properties
-  --fs-checkbox-field-gap: var(--fs-spacing-1);
+  --fs-checkbox-field-gap                                         : var(--fs-spacing-1);
 
   // Label
-  --fs-checkbox-field-label-color: var(--fs-color-text-light);
-  --fs-checkbox-field-label-size: var(--fs-text-size-1);
-  --fs-checkbox-field-label-weight: var(--fs-text-weight-regular);
-  --fs-checkbox-field-label-line-height: 1.42;
+  --fs-checkbox-field-label-color                                 : var(--fs-color-text-light);
+  --fs-checkbox-field-label-size                                  : var(--fs-text-size-1);
+  --fs-checkbox-field-label-weight                                : var(--fs-text-weight-regular);
+  --fs-checkbox-field-label-line-height                           : 1.42;
 
   /* Error tokens */
-  --fs-checkbox-field-error-message-size: var(--fs-text-size-legend);
-  --fs-checkbox-field-error-message-line-height: 1.1;
-  --fs-checkbox-field-error-message-margin-top: var(--fs-spacing-0);
-  --fs-checkbox-field-error-message-color: var(--fs-color-danger-text);
-  --fs-checkbox-field-error-border-color: var(--fs-color-danger-border);
+  --fs-checkbox-field-error-message-size                          : var(--fs-text-size-legend);
+  --fs-checkbox-field-error-message-line-height                   : 1.1;
+  --fs-checkbox-field-error-message-margin-top                    : var(--fs-spacing-0);
+  --fs-checkbox-field-error-message-color                         : var(--fs-color-danger-text);
+  --fs-checkbox-field-error-border-color                          : var(--fs-color-danger-border);
 
   display: flex;
   column-gap: var(--fs-checkbox-field-gap);


### PR DESCRIPTION
## What's the purpose of this pull request?

This pull request adds styles and an error text for the CheckboxField component. Additionally, it adjusts the styles of the CheckboxField label. This new styling will be used in the modal for adding a review to a product in the new Reviews and Ratings section.

## How it works?

I added the `error` and `alignment` props to the `CheckboxField` component. The `alignment` prop is used to vertically align the checkbox, with the default value set to `center`. 

Additionally, the `label` was not previously styled, so I added styles to it based on the Figma to ensure the label is displayed correctly.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

[Preview](https://starter-git-chore-add-checkbox-cli-vtex.vercel.app/review-and-ratings-playground)

## References

[JIRA TASK: SFS-2073](https://vtex-dev.atlassian.net/browse/SFS-2073)

[Figma](https://www.figma.com/design/YXU6IX2htN2yg7udpCumZv/Reviews-%26-Ratings?node-id=131-65865&t=iOanfcOwmDa4bolf-4)

![image](https://github.com/user-attachments/assets/8d1e12e2-01c2-4878-88fe-cf0b9208e1b4)
