### PR TITLE
feat: add tooltip component

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -148,6 +148,8 @@ export { default as RatingField } from './molecules/RatingField'
 export type { RatingFieldProps } from './molecules/RatingField'
 export { default as RegionBar } from './molecules/RegionBar'
 export type { RegionBarProps } from './molecules/RegionBar'
+export { default as Tooltip } from './molecules/Tooltip'
+export type { TooltipProps } from './molecules/Tooltip'
 
 export { default as SearchProvider } from './molecules/SearchProvider'
 export type { SearchProviderContextValue } from './molecules/SearchProvider'

--- a/packages/components/src/molecules/Tooltip/Tooltip.tsx
+++ b/packages/components/src/molecules/Tooltip/Tooltip.tsx
@@ -33,32 +33,26 @@ export interface TooltipProps
    * Text/content of the tooltip.
    */
   content: ReactNode
-
   /**
    * Defines the side or side-alignment (e.g., "top", "right-end") of the tooltip.
    */
   placement?: Placement
-
   /**
    * If the tooltip can be closed by a button.
    */
   dismissable?: boolean
-
   /**
    * (Optional) Called when the dismiss button is clicked.
    */
   onDismiss?: MouseEventHandler<HTMLButtonElement>
-
   /**
    * Element that activates the tooltip on hover/focus.
    */
   children: ReactNode
-
   /**
-   * For testing (Cypress, Jest, etc.).
+   * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */
   testId?: string
-
   /**
    * Maximum width of the tooltip.
    */

--- a/packages/components/src/molecules/Tooltip/Tooltip.tsx
+++ b/packages/components/src/molecules/Tooltip/Tooltip.tsx
@@ -3,7 +3,7 @@ import React, {
   type MouseEventHandler,
   useState,
   forwardRef,
-  HTMLAttributes,
+  type HTMLAttributes,
 } from 'react'
 import Icon from '../../atoms/Icon'
 import IconButton from '../IconButton'

--- a/packages/components/src/molecules/Tooltip/Tooltip.tsx
+++ b/packages/components/src/molecules/Tooltip/Tooltip.tsx
@@ -114,7 +114,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
 
   return (
     <div
-      data-fs-tooltip-wrapper
+      data-fs-tooltip
       onMouseEnter={toggleOpen}
       onMouseLeave={() => setOpen(false)}
       onFocus={toggleOpen}
@@ -130,7 +130,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
       {open && !dismissed && (
         <div
           ref={ref}
-          data-fs-tooltip
+          data-fs-tooltip-wrapper
           data-fs-tooltip-placement={placement}
           data-fs-tooltip-dismissible={dismissible}
           role="tooltip"

--- a/packages/components/src/molecules/Tooltip/Tooltip.tsx
+++ b/packages/components/src/molecules/Tooltip/Tooltip.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react'
 import Icon from '../../atoms/Icon'
 import IconButton from '../IconButton'
+
 /**
  * Specifies tooltip position.
  */

--- a/packages/components/src/molecules/Tooltip/Tooltip.tsx
+++ b/packages/components/src/molecules/Tooltip/Tooltip.tsx
@@ -1,0 +1,136 @@
+import React, {
+  type ReactNode,
+  type MouseEventHandler,
+  useState,
+  forwardRef,
+  HTMLAttributes,
+} from 'react'
+import Icon from '../../atoms/Icon'
+import IconButton from '../IconButton'
+/**
+ * Possible sides for the tooltip.
+ */
+export type Side = 'top' | 'right' | 'bottom' | 'left'
+
+/**
+ * Possible alignments for the tooltip.
+ */
+export type Alignment = 'start' | 'end'
+
+/**
+ * Example: "top", "top-start", "top-end", etc.
+ */
+export type AlignedPlacement = `${Side}-${Alignment}`
+
+/**
+ * Type that combines pure side (e.g., "top") or side + alignment (e.g., "top-start").
+ */
+export type Placement = Side | AlignedPlacement
+
+export interface TooltipProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'content'> {
+  /**
+   * Text/content of the tooltip.
+   */
+  content: ReactNode
+
+  /**
+   * Defines the side or side-alignment (e.g., "top", "right-end") of the tooltip.
+   */
+  placement?: Placement
+
+  /**
+   * If the tooltip can be closed by a button.
+   */
+  dismissable?: boolean
+
+  /**
+   * (Optional) Called when the dismiss button is clicked.
+   */
+  onDismiss?: MouseEventHandler<HTMLButtonElement>
+
+  /**
+   * Element that activates the tooltip on hover/focus.
+   */
+  children: ReactNode
+
+  /**
+   * For testing (Cypress, Jest, etc.).
+   */
+  testId?: string
+
+  /**
+   * Maximum width of the tooltip.
+   */
+  maxWidth?: number
+}
+
+const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
+  {
+    content,
+    placement = 'top',
+    dismissable = false,
+    onDismiss,
+    children,
+    testId = 'fs-tooltip',
+    maxWidth = 300,
+    ...otherProps
+  },
+  ref
+) {
+  const [open, setOpen] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+
+  const handleDismiss: MouseEventHandler<HTMLButtonElement> = (ev) => {
+    onDismiss?.(ev)
+    setOpen(false)
+    setDismissed(true)
+  }
+
+  const toggleOpen = () => {
+    if (dismissed) {
+      setDismissed(false)
+    }
+    setOpen(true)
+  }
+
+  return (
+    <div
+      data-fs-tooltip-wrapper
+      onMouseEnter={toggleOpen}
+      onMouseLeave={() => setOpen(false)}
+      onFocus={toggleOpen}
+      onBlur={() => setOpen(false)}
+      data-testid={testId}
+    >
+      {children}
+
+      {open && !dismissed && (
+        <div
+          ref={ref}
+          data-fs-tooltip
+          data-fs-tooltip-position={placement}
+          data-fs-tooltip-dismissable={dismissable}
+          style={{ maxWidth }}
+          {...otherProps}
+        >
+          <div data-fs-tooltip-content>{content}</div>
+          {dismissable && (
+            <IconButton
+              size="small"
+              variant="tertiary"
+              inverse
+              icon={<Icon name="X" width={20} height={20} />}
+              aria-label="Dismiss tooltip"
+              data-fs-tooltip-dismiss-button
+              onClick={handleDismiss}
+            />
+          )}
+          <div data-fs-tooltip-indicator aria-hidden="true" />
+        </div>
+      )}
+    </div>
+  )
+})
+
+export default Tooltip

--- a/packages/components/src/molecules/Tooltip/Tooltip.tsx
+++ b/packages/components/src/molecules/Tooltip/Tooltip.tsx
@@ -8,12 +8,12 @@ import React, {
 import Icon from '../../atoms/Icon'
 import IconButton from '../IconButton'
 /**
- * Possible sides for the tooltip.
+ * Specifies tooltip position.
  */
 export type Side = 'top' | 'right' | 'bottom' | 'left'
 
 /**
- * Possible alignments for the tooltip.
+ * Specifies tooltip alignment.
  */
 export type Alignment = 'start' | 'end'
 
@@ -23,7 +23,7 @@ export type Alignment = 'start' | 'end'
 export type AlignedPlacement = `${Side}-${Alignment}`
 
 /**
- * Type that combines pure side (e.g., "top") or side + alignment (e.g., "top-start").
+ * Combines pure side (e.g., "top") or side + alignment (e.g., "top-start").
  */
 export type Placement = Side | AlignedPlacement
 
@@ -42,7 +42,7 @@ export interface TooltipProps
    */
   dismissible?: boolean
   /**
-   * (Optional) Called when the dismiss button is clicked.
+   * Called when the dismiss button is clicked.
    */
   onDismiss?: MouseEventHandler<HTMLButtonElement>
   /**

--- a/packages/components/src/molecules/Tooltip/Tooltip.tsx
+++ b/packages/components/src/molecules/Tooltip/Tooltip.tsx
@@ -40,7 +40,7 @@ export interface TooltipProps
   /**
    * If the tooltip can be closed by a button.
    */
-  dismissable?: boolean
+  dismissible?: boolean
   /**
    * (Optional) Called when the dismiss button is clicked.
    */
@@ -63,7 +63,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
   {
     content,
     placement = 'top',
-    dismissable = false,
+    dismissible = false,
     onDismiss,
     children,
     testId = 'fs-tooltip',
@@ -104,12 +104,12 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
           ref={ref}
           data-fs-tooltip
           data-fs-tooltip-position={placement}
-          data-fs-tooltip-dismissable={dismissable}
+          data-fs-tooltip-dismissible={dismissible}
           style={{ maxWidth }}
           {...otherProps}
         >
           <div data-fs-tooltip-content>{content}</div>
-          {dismissable && (
+          {dismissible && (
             <IconButton
               size="small"
               variant="tertiary"

--- a/packages/components/src/molecules/Tooltip/index.ts
+++ b/packages/components/src/molecules/Tooltip/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Tooltip'
+export { TooltipProps } from './Tooltip'

--- a/packages/ui/src/components/molecules/Tooltip/styles.scss
+++ b/packages/ui/src/components/molecules/Tooltip/styles.scss
@@ -1,5 +1,6 @@
 [data-fs-tooltip-wrapper] {
   position: relative;
+  display: inline-flex;
 
   [data-fs-tooltip] {
     // --------------------------------------------------------

--- a/packages/ui/src/components/molecules/Tooltip/styles.scss
+++ b/packages/ui/src/components/molecules/Tooltip/styles.scss
@@ -1,9 +1,9 @@
-[data-fs-tooltip-wrapper] {
+[data-fs-tooltip] {
   position: relative;
   display: inline-flex;
   width: fit-content;
 
-  [data-fs-tooltip] {
+  [data-fs-tooltip-wrapper] {
     // --------------------------------------------------------
     // Design Tokens for Tooltip
     // --------------------------------------------------------

--- a/packages/ui/src/components/molecules/Tooltip/styles.scss
+++ b/packages/ui/src/components/molecules/Tooltip/styles.scss
@@ -1,6 +1,7 @@
 [data-fs-tooltip-wrapper] {
   position: relative;
   display: inline-flex;
+  width: fit-content;
 
   [data-fs-tooltip] {
     // --------------------------------------------------------
@@ -70,170 +71,170 @@
   // --------------------------------------------------------
 
   /* TOP */
-  [data-fs-tooltip-position^="top"] {
+  [data-fs-tooltip-placement^="top-center"] {
     bottom: 100%;
     transform: translateY(calc(-1 * var(--fs-tooltip-indicator-translate)));
   }
 
-  [data-fs-tooltip-position^="top"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement^="top-center"] [data-fs-tooltip-indicator] {
     top: 100%;
     border-top-color: var(--fs-tooltip-background);
   }
 
   /* TOP-CENTER */
-  [data-fs-tooltip-position="top"] {
+  [data-fs-tooltip-placement="top-center"] {
     left: 50%;
     transform:
       translateX(-50%)
       translateY(calc(-1 * var(--fs-tooltip-indicator-translate)));
   }
 
-  [data-fs-tooltip-position="top"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="top-center"] [data-fs-tooltip-indicator] {
     left: 50%;
     transform: translateX(-50%);
   }
 
   /* TOP-START */
-  [data-fs-tooltip-position="top-start"] {
+  [data-fs-tooltip-placement="top-start"] {
     left: 0;
   }
 
-  [data-fs-tooltip-position="top-start"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="top-start"] [data-fs-tooltip-indicator] {
     left: var(--fs-spacing-3);
   }
 
   /* TOP-END */
-  [data-fs-tooltip-position="top-end"] {
+  [data-fs-tooltip-placement="top-end"] {
     right: 0;
   }
 
-  [data-fs-tooltip-position="top-end"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="top-end"] [data-fs-tooltip-indicator] {
     right: var(--fs-spacing-3);
   }
 
   /* RIGHT */
-  [data-fs-tooltip-position^="right"] {
+  [data-fs-tooltip-placement^="right-center"] {
     left: 100%;
     transform: translateX(var(--fs-tooltip-indicator-translate));
   }
 
-  [data-fs-tooltip-position^="right"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement^="right-center"] [data-fs-tooltip-indicator] {
     right: 100%;
     border-right-color: var(--fs-tooltip-background);
   }
 
   /* RIGHT-CENTER */
-  [data-fs-tooltip-position="right"] {
+  [data-fs-tooltip-placement="right-center"] {
     top: 50%;
     transform:
       translateY(-50%)
       translateX(var(--fs-tooltip-indicator-translate));
   }
 
-  [data-fs-tooltip-position="right"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="right-center"] [data-fs-tooltip-indicator] {
     top: 50%;
     transform: translateY(-50%);
   }
 
   /* RIGHT-START */
-  [data-fs-tooltip-position="right-start"] {
+  [data-fs-tooltip-placement="right-start"] {
     top: 0;
   }
 
-  [data-fs-tooltip-position="right-start"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="right-start"] [data-fs-tooltip-indicator] {
     top: var(--fs-spacing-3);
   }
 
   /* RIGHT-END */
-  [data-fs-tooltip-position="right-end"] {
+  [data-fs-tooltip-placement="right-end"] {
     bottom: 0;
   }
 
-  [data-fs-tooltip-position="right-end"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="right-end"] [data-fs-tooltip-indicator] {
     bottom: var(--fs-spacing-3);
   }
 
   /* BOTTOM */
-  [data-fs-tooltip-position^="bottom"] {
+  [data-fs-tooltip-placement^="bottom-center"] {
     top: 100%;
     transform: translateY(var(--fs-tooltip-indicator-translate));
   }
 
-  [data-fs-tooltip-position^="bottom"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement^="bottom-center"] [data-fs-tooltip-indicator] {
     bottom: 100%;
     border-bottom-color: var(--fs-tooltip-background);
   }
 
   /* BOTTOM-CENTER */
-  [data-fs-tooltip-position="bottom"] {
+  [data-fs-tooltip-placement="bottom-center"] {
     left: 50%;
     transform:
       translateX(-50%)
       translateY(var(--fs-tooltip-indicator-translate));
   }
 
-  [data-fs-tooltip-position="bottom"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="bottom-center"] [data-fs-tooltip-indicator] {
     left: 50%;
     transform: translateX(-50%);
   }
 
   /* BOTTOM-START */
-  [data-fs-tooltip-position="bottom-start"] {
+  [data-fs-tooltip-placement="bottom-start"] {
     left: 0;
   }
 
-  [data-fs-tooltip-position="bottom-start"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="bottom-start"] [data-fs-tooltip-indicator] {
     left: var(--fs-spacing-3);
   }
 
   /* BOTTOM-END */
-  [data-fs-tooltip-position="bottom-end"] {
+  [data-fs-tooltip-placement="bottom-end"] {
     right: 0;
   }
 
-  [data-fs-tooltip-position="bottom-end"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="bottom-end"] [data-fs-tooltip-indicator] {
     right: var(--fs-spacing-3);
   }
 
   /* LEFT */
-  [data-fs-tooltip-position^="left"] {
+  [data-fs-tooltip-placement^="left-center"] {
     right: 100%;
     transform: translateX(calc(-1 * var(--fs-tooltip-indicator-translate)));
   }
 
-  [data-fs-tooltip-position^="left"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement^="left-center"] [data-fs-tooltip-indicator] {
     left: 100%;
     border-left-color: var(--fs-tooltip-background);
   }
 
   /* LEFT-CENTER */
-  [data-fs-tooltip-position="left"] {
+  [data-fs-tooltip-placement="left-center"] {
     top: 50%;
     transform:
       translateY(-50%)
       translateX(calc(-1 * var(--fs-tooltip-indicator-translate)));
   }
 
-  [data-fs-tooltip-position="left"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="left-center"] [data-fs-tooltip-indicator] {
     top: 50%;
     transform: translateY(-50%);
   }
 
   /* LEFT-START */
-  [data-fs-tooltip-position="left-start"] {
+  [data-fs-tooltip-placement="left-start"] {
     top: 0;
   }
 
-  [data-fs-tooltip-position="left-start"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="left-start"] [data-fs-tooltip-indicator] {
     top: var(--fs-spacing-3);
   }
 
   /* LEFT-END */
-  [data-fs-tooltip-position="left-end"] {
+  [data-fs-tooltip-placement="left-end"] {
     bottom: 0;
   }
 
-  [data-fs-tooltip-position="left-end"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement="left-end"] [data-fs-tooltip-indicator] {
     bottom: var(--fs-spacing-3);
   }
 }

--- a/packages/ui/src/components/molecules/Tooltip/styles.scss
+++ b/packages/ui/src/components/molecules/Tooltip/styles.scss
@@ -1,34 +1,36 @@
 [data-fs-tooltip] {
+  // --------------------------------------------------------
+  // Design Tokens for Tooltip
+  // --------------------------------------------------------
+
+  // Default properties
+  --fs-button-height                                : var(--fs-control-tap-size);
+  --fs-tooltip-z-index                              : var(--fs-z-index-high);
+  --fs-tooltip-background                           : var(--fs-color-neutral-6);
+  --fs-tooltip-text-color                           : var(--fs-color-text-inverse);
+  --fs-tooltip-border-radius                        : var(--fs-border-radius);
+  --fs-tooltip-padding                              : var(--fs-spacing-2);
+  --fs-tooltip-gap                                  : var(--fs-spacing-1);
+
+  --fs-tooltip-transition-property                  : opacity;
+  --fs-tooltip-transition-timing                    : var(--fs-transition-timing);
+  --fs-tooltip-transition-function                  : var(--fs-transition-function);
+
+  // Indicator
+  --fs-tooltip-indicator-size                       : var(--fs-spacing-1);
+  --fs-tooltip-indicator-distance-edge              : var(--fs-spacing-3);
+  --fs-tooltip-indicator-distance-base              : var(--fs-spacing-1);
+  --fs-tooltip-indicator-translate                  : calc(var(--fs-tooltip-indicator-size) + var(--fs-tooltip-indicator-distance-base));
+
+  // --------------------------------------------------------
+  // Structural Styles
+  // --------------------------------------------------------
+
   position: relative;
   display: inline-flex;
   width: fit-content;
 
   [data-fs-tooltip-wrapper] {
-    // --------------------------------------------------------
-    // Design Tokens for Tooltip
-    // --------------------------------------------------------
-
-    // Default properties
-    --fs-tooltip-z-index                                                   : var(--fs-z-index-high);
-    --fs-tooltip-background                                                : var(--fs-color-neutral-6);
-    --fs-tooltip-text-color                                                : var(--fs-color-text-inverse);
-    --fs-tooltip-border-radius                                             : var(--fs-border-radius);
-    --fs-tooltip-padding                                                   : var(--fs-spacing-2);
-    --fs-tooltip-gap                                                       : var(--fs-spacing-1);
-    --fs-tooltip-transition-property                                       : opacity;
-    --fs-tooltip-transition-timing                                         : var(--fs-transition-timing);
-    --fs-tooltip-transition-function                                       : var(--fs-transition-function);
-
-    // Indicator
-    --fs-tooltip-indicator-size                                            : var(--fs-spacing-1);
-    --fs-tooltip-indicator-distance-edge                                   : var(--fs-spacing-3);
-    --fs-tooltip-indicator-distance-base                                   : var(--fs-spacing-1);
-    --fs-tooltip-indicator-translate                                       : calc(var(--fs-tooltip-indicator-size) + var(--fs-tooltip-indicator-distance-base));
-
-    // --------------------------------------------------------
-    // Structural Styles
-    // --------------------------------------------------------
-
     position: absolute;
     z-index: var(--fs-tooltip-z-index);
     display: flex;

--- a/packages/ui/src/components/molecules/Tooltip/styles.scss
+++ b/packages/ui/src/components/molecules/Tooltip/styles.scss
@@ -8,24 +8,21 @@
     // --------------------------------------------------------
 
     // Default properties
-    --fs-tooltip-z-index: var(--fs-z-index-high);
-    --fs-tooltip-background: var(--fs-color-neutral-6);
-    --fs-tooltip-text-color: var(--fs-color-text-inverse);
-    --fs-tooltip-border-radius: var(--fs-border-radius);
-    --fs-tooltip-padding: var(--fs-spacing-2);
-    --fs-tooltip-gap: var(--fs-spacing-1);
-    --fs-tooltip-transition-property: opacity;
-    --fs-tooltip-transition-timing: var(--fs-transition-timing);
-    --fs-tooltip-transition-function: var(--fs-transition-function);
+    --fs-tooltip-z-index                                                   : var(--fs-z-index-high);
+    --fs-tooltip-background                                                : var(--fs-color-neutral-6);
+    --fs-tooltip-text-color                                                : var(--fs-color-text-inverse);
+    --fs-tooltip-border-radius                                             : var(--fs-border-radius);
+    --fs-tooltip-padding                                                   : var(--fs-spacing-2);
+    --fs-tooltip-gap                                                       : var(--fs-spacing-1);
+    --fs-tooltip-transition-property                                       : opacity;
+    --fs-tooltip-transition-timing                                         : var(--fs-transition-timing);
+    --fs-tooltip-transition-function                                       : var(--fs-transition-function);
 
     // Indicator
-    --fs-tooltip-indicator-size: var(--fs-spacing-1);
-    --fs-tooltip-indicator-distance-edge: var(--fs-spacing-3);
-    --fs-tooltip-indicator-distance-base: var(--fs-spacing-1);
-    --fs-tooltip-indicator-translate: calc(
-      var(--fs-tooltip-indicator-size) +
-        var(--fs-tooltip-indicator-distance-base)
-    );
+    --fs-tooltip-indicator-size                                            : var(--fs-spacing-1);
+    --fs-tooltip-indicator-distance-edge                                   : var(--fs-spacing-3);
+    --fs-tooltip-indicator-distance-base                                   : var(--fs-spacing-1);
+    --fs-tooltip-indicator-translate                                       : calc(var(--fs-tooltip-indicator-size) + var(--fs-tooltip-indicator-distance-base));
 
     // --------------------------------------------------------
     // Structural Styles
@@ -33,25 +30,24 @@
 
     position: absolute;
     z-index: var(--fs-tooltip-z-index);
-
-    background-color: var(--fs-tooltip-background);
-    color: var(--fs-tooltip-text-color);
-    border-radius: var(--fs-tooltip-border-radius);
-    padding: var(--fs-tooltip-padding);
-    opacity: 1;
-    transition: var(--fs-tooltip-transition-property)
-      var(--fs-tooltip-transition-timing) var(--fs-tooltip-transition-function);
-
     display: flex;
     gap: var(--fs-tooltip-gap);
     align-items: flex-start;
+    padding: var(--fs-tooltip-padding);
+    color: var(--fs-tooltip-text-color);
+    background-color: var(--fs-tooltip-background);
+    border-radius: var(--fs-tooltip-border-radius);
+    opacity: 1;
+    transition:
+      var(--fs-tooltip-transition-property)
+      var(--fs-tooltip-transition-timing) var(--fs-tooltip-transition-function);
   }
 
   [data-fs-tooltip-content] {
+    width: max-content;
     font-size: var(--fs-text-size-0);
     font-weight: var(--fs-text-weight-medium);
     line-height: 16px;
-    width: max-content;
   }
 
   [data-fs-tooltip-dismiss-button] {
@@ -74,150 +70,170 @@
   // --------------------------------------------------------
 
   /* TOP */
-  [data-fs-tooltip-position^='top'] {
+  [data-fs-tooltip-position^="top"] {
     bottom: 100%;
     transform: translateY(calc(-1 * var(--fs-tooltip-indicator-translate)));
   }
-  [data-fs-tooltip-position^='top'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position^="top"] [data-fs-tooltip-indicator] {
     top: 100%;
     border-top-color: var(--fs-tooltip-background);
   }
 
   /* TOP-CENTER */
-  [data-fs-tooltip-position='top'] {
+  [data-fs-tooltip-position="top"] {
     left: 50%;
-    transform: translateX(-50%)
+    transform:
+      translateX(-50%)
       translateY(calc(-1 * var(--fs-tooltip-indicator-translate)));
   }
-  [data-fs-tooltip-position='top'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="top"] [data-fs-tooltip-indicator] {
     left: 50%;
     transform: translateX(-50%);
   }
 
   /* TOP-START */
-  [data-fs-tooltip-position='top-start'] {
+  [data-fs-tooltip-position="top-start"] {
     left: 0;
   }
-  [data-fs-tooltip-position='top-start'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="top-start"] [data-fs-tooltip-indicator] {
     left: var(--fs-spacing-3);
   }
 
   /* TOP-END */
-  [data-fs-tooltip-position='top-end'] {
+  [data-fs-tooltip-position="top-end"] {
     right: 0;
   }
-  [data-fs-tooltip-position='top-end'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="top-end"] [data-fs-tooltip-indicator] {
     right: var(--fs-spacing-3);
   }
 
   /* RIGHT */
-  [data-fs-tooltip-position^='right'] {
+  [data-fs-tooltip-position^="right"] {
     left: 100%;
     transform: translateX(var(--fs-tooltip-indicator-translate));
   }
-  [data-fs-tooltip-position^='right'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position^="right"] [data-fs-tooltip-indicator] {
     right: 100%;
     border-right-color: var(--fs-tooltip-background);
   }
 
-  /* RIGHT-CENTER*/
-  [data-fs-tooltip-position='right'] {
+  /* RIGHT-CENTER */
+  [data-fs-tooltip-position="right"] {
     top: 50%;
-    transform: translateY(-50%)
+    transform:
+      translateY(-50%)
       translateX(var(--fs-tooltip-indicator-translate));
   }
-  [data-fs-tooltip-position='right'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="right"] [data-fs-tooltip-indicator] {
     top: 50%;
     transform: translateY(-50%);
   }
 
   /* RIGHT-START */
-  [data-fs-tooltip-position='right-start'] {
+  [data-fs-tooltip-position="right-start"] {
     top: 0;
   }
-  [data-fs-tooltip-position='right-start'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="right-start"] [data-fs-tooltip-indicator] {
     top: var(--fs-spacing-3);
   }
 
   /* RIGHT-END */
-  [data-fs-tooltip-position='right-end'] {
+  [data-fs-tooltip-position="right-end"] {
     bottom: 0;
   }
-  [data-fs-tooltip-position='right-end'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="right-end"] [data-fs-tooltip-indicator] {
     bottom: var(--fs-spacing-3);
   }
 
   /* BOTTOM */
-  [data-fs-tooltip-position^='bottom'] {
+  [data-fs-tooltip-position^="bottom"] {
     top: 100%;
     transform: translateY(var(--fs-tooltip-indicator-translate));
   }
-  [data-fs-tooltip-position^='bottom'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position^="bottom"] [data-fs-tooltip-indicator] {
     bottom: 100%;
     border-bottom-color: var(--fs-tooltip-background);
   }
 
-  /* BOTTOM-CENTER*/
-  [data-fs-tooltip-position='bottom'] {
+  /* BOTTOM-CENTER */
+  [data-fs-tooltip-position="bottom"] {
     left: 50%;
-    transform: translateX(-50%)
+    transform:
+      translateX(-50%)
       translateY(var(--fs-tooltip-indicator-translate));
   }
-  [data-fs-tooltip-position='bottom'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="bottom"] [data-fs-tooltip-indicator] {
     left: 50%;
     transform: translateX(-50%);
   }
 
   /* BOTTOM-START */
-  [data-fs-tooltip-position='bottom-start'] {
+  [data-fs-tooltip-position="bottom-start"] {
     left: 0;
   }
-  [data-fs-tooltip-position='bottom-start'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="bottom-start"] [data-fs-tooltip-indicator] {
     left: var(--fs-spacing-3);
   }
 
   /* BOTTOM-END */
-  [data-fs-tooltip-position='bottom-end'] {
+  [data-fs-tooltip-position="bottom-end"] {
     right: 0;
   }
-  [data-fs-tooltip-position='bottom-end'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="bottom-end"] [data-fs-tooltip-indicator] {
     right: var(--fs-spacing-3);
   }
 
   /* LEFT */
-  [data-fs-tooltip-position^='left'] {
+  [data-fs-tooltip-position^="left"] {
     right: 100%;
     transform: translateX(calc(-1 * var(--fs-tooltip-indicator-translate)));
   }
-  [data-fs-tooltip-position^='left'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position^="left"] [data-fs-tooltip-indicator] {
     left: 100%;
     border-left-color: var(--fs-tooltip-background);
   }
 
-  /* LEFT-CENTER*/
-  [data-fs-tooltip-position='left'] {
+  /* LEFT-CENTER */
+  [data-fs-tooltip-position="left"] {
     top: 50%;
-    transform: translateY(-50%)
+    transform:
+      translateY(-50%)
       translateX(calc(-1 * var(--fs-tooltip-indicator-translate)));
   }
-  [data-fs-tooltip-position='left'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="left"] [data-fs-tooltip-indicator] {
     top: 50%;
     transform: translateY(-50%);
   }
 
   /* LEFT-START */
-  [data-fs-tooltip-position='left-start'] {
+  [data-fs-tooltip-position="left-start"] {
     top: 0;
   }
-  [data-fs-tooltip-position='left-start'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="left-start"] [data-fs-tooltip-indicator] {
     top: var(--fs-spacing-3);
   }
 
   /* LEFT-END */
-  [data-fs-tooltip-position='left-end'] {
+  [data-fs-tooltip-position="left-end"] {
     bottom: 0;
   }
-  [data-fs-tooltip-position='left-end'] [data-fs-tooltip-indicator] {
+
+  [data-fs-tooltip-position="left-end"] [data-fs-tooltip-indicator] {
     bottom: var(--fs-spacing-3);
   }
 }

--- a/packages/ui/src/components/molecules/Tooltip/styles.scss
+++ b/packages/ui/src/components/molecules/Tooltip/styles.scss
@@ -1,0 +1,222 @@
+[data-fs-tooltip-wrapper] {
+  position: relative;
+
+  [data-fs-tooltip] {
+    // --------------------------------------------------------
+    // Design Tokens for Tooltip
+    // --------------------------------------------------------
+
+    // Default properties
+    --fs-tooltip-z-index: var(--fs-z-index-high);
+    --fs-tooltip-background: var(--fs-color-neutral-6);
+    --fs-tooltip-text-color: var(--fs-color-text-inverse);
+    --fs-tooltip-border-radius: var(--fs-border-radius);
+    --fs-tooltip-padding: var(--fs-spacing-2);
+    --fs-tooltip-gap: var(--fs-spacing-1);
+    --fs-tooltip-transition-property: opacity;
+    --fs-tooltip-transition-timing: var(--fs-transition-timing);
+    --fs-tooltip-transition-function: var(--fs-transition-function);
+
+    // Indicator
+    --fs-tooltip-indicator-size: var(--fs-spacing-1);
+    --fs-tooltip-indicator-distance-edge: var(--fs-spacing-3);
+    --fs-tooltip-indicator-distance-base: var(--fs-spacing-1);
+    --fs-tooltip-indicator-translate: calc(
+      var(--fs-tooltip-indicator-size) +
+        var(--fs-tooltip-indicator-distance-base)
+    );
+
+    // --------------------------------------------------------
+    // Structural Styles
+    // --------------------------------------------------------
+
+    position: absolute;
+    z-index: var(--fs-tooltip-z-index);
+
+    background-color: var(--fs-tooltip-background);
+    color: var(--fs-tooltip-text-color);
+    border-radius: var(--fs-tooltip-border-radius);
+    padding: var(--fs-tooltip-padding);
+    opacity: 1;
+    transition: var(--fs-tooltip-transition-property)
+      var(--fs-tooltip-transition-timing) var(--fs-tooltip-transition-function);
+
+    display: flex;
+    gap: var(--fs-tooltip-gap);
+    align-items: flex-start;
+  }
+
+  [data-fs-tooltip-content] {
+    font-size: var(--fs-text-size-0);
+    font-weight: var(--fs-text-weight-medium);
+    line-height: 16px;
+    width: max-content;
+  }
+
+  [data-fs-tooltip-dismiss-button] {
+    flex-shrink: 0;
+    width: var(--fs-control-tap-size-smallest);
+    height: var(--fs-control-tap-size-smallest);
+    min-height: var(--fs-control-tap-size-smallest);
+    padding: 0;
+  }
+
+  [data-fs-tooltip-indicator] {
+    position: absolute;
+    width: 0;
+    height: 0;
+    border: var(--fs-tooltip-indicator-size) solid transparent;
+  }
+
+  // --------------------------------------------------------
+  // Variants Styles
+  // --------------------------------------------------------
+
+  /* TOP */
+  [data-fs-tooltip-position^='top'] {
+    bottom: 100%;
+    transform: translateY(calc(-1 * var(--fs-tooltip-indicator-translate)));
+  }
+  [data-fs-tooltip-position^='top'] [data-fs-tooltip-indicator] {
+    top: 100%;
+    border-top-color: var(--fs-tooltip-background);
+  }
+
+  /* TOP-CENTER */
+  [data-fs-tooltip-position='top'] {
+    left: 50%;
+    transform: translateX(-50%)
+      translateY(calc(-1 * var(--fs-tooltip-indicator-translate)));
+  }
+  [data-fs-tooltip-position='top'] [data-fs-tooltip-indicator] {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  /* TOP-START */
+  [data-fs-tooltip-position='top-start'] {
+    left: 0;
+  }
+  [data-fs-tooltip-position='top-start'] [data-fs-tooltip-indicator] {
+    left: var(--fs-spacing-3);
+  }
+
+  /* TOP-END */
+  [data-fs-tooltip-position='top-end'] {
+    right: 0;
+  }
+  [data-fs-tooltip-position='top-end'] [data-fs-tooltip-indicator] {
+    right: var(--fs-spacing-3);
+  }
+
+  /* RIGHT */
+  [data-fs-tooltip-position^='right'] {
+    left: 100%;
+    transform: translateX(var(--fs-tooltip-indicator-translate));
+  }
+  [data-fs-tooltip-position^='right'] [data-fs-tooltip-indicator] {
+    right: 100%;
+    border-right-color: var(--fs-tooltip-background);
+  }
+
+  /* RIGHT-CENTER*/
+  [data-fs-tooltip-position='right'] {
+    top: 50%;
+    transform: translateY(-50%)
+      translateX(var(--fs-tooltip-indicator-translate));
+  }
+  [data-fs-tooltip-position='right'] [data-fs-tooltip-indicator] {
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  /* RIGHT-START */
+  [data-fs-tooltip-position='right-start'] {
+    top: 0;
+  }
+  [data-fs-tooltip-position='right-start'] [data-fs-tooltip-indicator] {
+    top: var(--fs-spacing-3);
+  }
+
+  /* RIGHT-END */
+  [data-fs-tooltip-position='right-end'] {
+    bottom: 0;
+  }
+  [data-fs-tooltip-position='right-end'] [data-fs-tooltip-indicator] {
+    bottom: var(--fs-spacing-3);
+  }
+
+  /* BOTTOM */
+  [data-fs-tooltip-position^='bottom'] {
+    top: 100%;
+    transform: translateY(var(--fs-tooltip-indicator-translate));
+  }
+  [data-fs-tooltip-position^='bottom'] [data-fs-tooltip-indicator] {
+    bottom: 100%;
+    border-bottom-color: var(--fs-tooltip-background);
+  }
+
+  /* BOTTOM-CENTER*/
+  [data-fs-tooltip-position='bottom'] {
+    left: 50%;
+    transform: translateX(-50%)
+      translateY(var(--fs-tooltip-indicator-translate));
+  }
+  [data-fs-tooltip-position='bottom'] [data-fs-tooltip-indicator] {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  /* BOTTOM-START */
+  [data-fs-tooltip-position='bottom-start'] {
+    left: 0;
+  }
+  [data-fs-tooltip-position='bottom-start'] [data-fs-tooltip-indicator] {
+    left: var(--fs-spacing-3);
+  }
+
+  /* BOTTOM-END */
+  [data-fs-tooltip-position='bottom-end'] {
+    right: 0;
+  }
+  [data-fs-tooltip-position='bottom-end'] [data-fs-tooltip-indicator] {
+    right: var(--fs-spacing-3);
+  }
+
+  /* LEFT */
+  [data-fs-tooltip-position^='left'] {
+    right: 100%;
+    transform: translateX(calc(-1 * var(--fs-tooltip-indicator-translate)));
+  }
+  [data-fs-tooltip-position^='left'] [data-fs-tooltip-indicator] {
+    left: 100%;
+    border-left-color: var(--fs-tooltip-background);
+  }
+
+  /* LEFT-CENTER*/
+  [data-fs-tooltip-position='left'] {
+    top: 50%;
+    transform: translateY(-50%)
+      translateX(calc(-1 * var(--fs-tooltip-indicator-translate)));
+  }
+  [data-fs-tooltip-position='left'] [data-fs-tooltip-indicator] {
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  /* LEFT-START */
+  [data-fs-tooltip-position='left-start'] {
+    top: 0;
+  }
+  [data-fs-tooltip-position='left-start'] [data-fs-tooltip-indicator] {
+    top: var(--fs-spacing-3);
+  }
+
+  /* LEFT-END */
+  [data-fs-tooltip-position='left-end'] {
+    bottom: 0;
+  }
+  [data-fs-tooltip-position='left-end'] [data-fs-tooltip-indicator] {
+    bottom: var(--fs-spacing-3);
+  }
+}

--- a/packages/ui/src/styles/components.scss
+++ b/packages/ui/src/styles/components.scss
@@ -57,6 +57,7 @@
 @import "../components/molecules/Toast/styles";
 @import "../components/molecules/Toggle/styles";
 @import "../components/molecules/ToggleField/styles";
+@import "../components/molecules/Tooltip/styles";
 
 // Organisms
 @import "../components/organisms/BannerText/styles";


### PR DESCRIPTION
## What's the purpose of this pull request?

This pull request adds the Tooltip atom component. This component will be used in the ReviewCard for displaying reviews of a product in the new Reviews and Ratings section.

## How does it work?

This PR introduces a new molecule component, `Tooltip`, which allows customization of its behavior and appearance. The component includes default values for some of its props: `placement` is `"top"`, `dismissable` is `false`, and `maxWidth` is `300`. 

When `dismissable` is enabled, the tooltip uses an `IconButton` for the dismiss action.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

[Preview](https://starter-git-chore-add-tooltip-cli-vtex.vercel.app/review-and-ratings-playground)

## References

[JIRA TASK: SFS-2070](https://vtex-dev.atlassian.net/browse/SFS-2070)

[Figma](https://www.figma.com/design/YXU6IX2htN2yg7udpCumZv/Reviews-%26-Ratings?node-id=131-64437&t=0rv1XYm6XsgBeDwA-4)

![image](https://github.com/user-attachments/assets/128e8aad-df02-4738-9d58-c4a2e68c14dd)
