### PR TITLE
feat: reviews mutation resolver

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -142,6 +142,19 @@ export type DeliveryIds = {
   warehouseId?: Maybe<Scalars['String']>;
 };
 
+export type ICreateProductReview = {
+  /** Product ID. */
+  productId: Scalars['String'];
+  /** Review rating. */
+  rating: Scalars['Int'];
+  /** Review author name. */
+  reviewerName: Scalars['String'];
+  /** Review content. */
+  text: Scalars['String'];
+  /** Review title. */
+  title: Scalars['String'];
+};
+
 export type IGeoCoordinates = {
   /** The latitude of the geographic coordinates. */
   latitude: Scalars['Float'];
@@ -379,12 +392,19 @@ export type MessageInfo = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  /** Create a new product review. */
+  createProductReview: Scalars['String'];
   /** Subscribes a new person to the newsletter list. */
   subscribeToNewsletter?: Maybe<PersonNewsletter>;
   /** Checks for changes between the cart presented in the UI and the cart stored in the ecommerce platform. If changes are detected, it returns the cart stored on the platform. Otherwise, it returns `null`. */
   validateCart?: Maybe<StoreCart>;
   /** Updates a web session with the specified values. */
   validateSession?: Maybe<StoreSession>;
+};
+
+
+export type MutationCreateProductReviewArgs = {
+  data: ICreateProductReview;
 };
 
 

--- a/packages/api/src/platforms/errors.ts
+++ b/packages/api/src/platforms/errors.ts
@@ -1,4 +1,8 @@
-type ErrorType = 'BadRequestError' | 'NotFoundError' | 'RedirectError'
+type ErrorType =
+  | 'BadRequestError'
+  | 'NotFoundError'
+  | 'RedirectError'
+  | 'NotAuthorizedError'
 
 interface Extension {
   type: ErrorType
@@ -24,6 +28,12 @@ export class BadRequestError extends FastStoreError {
 export class NotFoundError extends FastStoreError {
   constructor(message?: string) {
     super({ status: 404, type: 'NotFoundError' }, message)
+  }
+}
+
+export class NotAuthorizedError extends FastStoreError {
+  constructor(message?: string) {
+    super({ status: 401, type: 'NotAuthorizedError' }, message)
   }
 }
 

--- a/packages/api/src/platforms/vtex/resolvers/createProductReview.ts
+++ b/packages/api/src/platforms/vtex/resolvers/createProductReview.ts
@@ -1,0 +1,13 @@
+import type { Context } from '..'
+import type { MutationCreateProductReviewArgs } from '../../../__generated__/schema'
+
+export const createProductReview = async (
+  _: any,
+  { data }: MutationCreateProductReviewArgs,
+  { clients: { commerce } }: Context
+): Promise<string> => {
+  return commerce.reviews.create({
+    ...data,
+    approved: true,
+  })
+}

--- a/packages/api/src/platforms/vtex/resolvers/createProductReview.ts
+++ b/packages/api/src/platforms/vtex/resolvers/createProductReview.ts
@@ -6,7 +6,7 @@ export const createProductReview = async (
   { data }: MutationCreateProductReviewArgs,
   { clients: { commerce } }: Context
 ): Promise<string> => {
-  return commerce.reviews.create({
+  return await commerce.reviews.create({
     ...data,
     approved: true,
   })

--- a/packages/api/src/platforms/vtex/resolvers/mutation.ts
+++ b/packages/api/src/platforms/vtex/resolvers/mutation.ts
@@ -1,9 +1,11 @@
 import { subscribeToNewsletter } from './subscribeToNewsletter'
 import { validateCart } from './validateCart'
 import { validateSession } from './validateSession'
+import { createProductReview } from './createProductReview'
 
 export const Mutation = {
   validateCart,
   validateSession,
   subscribeToNewsletter,
+  createProductReview,
 }

--- a/packages/api/src/platforms/vtex/utils/cookies.ts
+++ b/packages/api/src/platforms/vtex/utils/cookies.ts
@@ -124,3 +124,16 @@ export const updatesCookieValueByKey = (
   // add new storage cookie to the original list of cookies
   return `${existingCookies};${storageCookieKey}=${storageCookieValue}`
 }
+
+export function getCookieFromRequestHeaders(
+  ctx: ContextForCookies,
+  cookieKey: string
+): string | undefined {
+  const compoundKey = `${cookieKey}=`
+
+  return new Headers(ctx.headers)
+    .get('cookie')
+    ?.split('; ')
+    .find((x) => x.startsWith(compoundKey))
+    ?.replace(compoundKey, '')
+}

--- a/packages/api/src/typeDefs/mutation.graphql
+++ b/packages/api/src/typeDefs/mutation.graphql
@@ -11,4 +11,8 @@ type Mutation {
   Subscribes a new person to the newsletter list.
   """
   subscribeToNewsletter(data: IPersonNewsletter!): PersonNewsletter
+  """
+  Create a new product review.
+  """
+  createProductReview(data: ICreateProductReview!): String!
 }

--- a/packages/api/src/typeDefs/productReview.graphql
+++ b/packages/api/src/typeDefs/productReview.graphql
@@ -82,3 +82,26 @@ enum StoreProductListReviewsSort {
   """
   rating_asc
 }
+
+input ICreateProductReview {
+  """
+  Product ID.
+  """
+  productId: String!
+  """
+  Review rating.
+  """
+  rating: Int!
+  """
+  Review title.
+  """
+  title: String!
+  """
+  Review content.
+  """
+  text: String!
+  """
+  Review author name.
+  """
+  reviewerName: String!
+}

--- a/packages/api/test/schema.test.ts
+++ b/packages/api/test/schema.test.ts
@@ -56,6 +56,7 @@ const TYPES = [
   'PickupAddress',
   'MessageInfo',
   'MessageFields',
+  'ICreateProductReview',
 ]
 
 const QUERIES = [
@@ -70,7 +71,12 @@ const QUERIES = [
   'reviews',
 ]
 
-const MUTATIONS = ['validateCart', 'validateSession', 'subscribeToNewsletter']
+const MUTATIONS = [
+  'validateCart',
+  'validateSession',
+  'subscribeToNewsletter',
+  'createProductReview',
+]
 
 let schema: GraphQLSchema
 

--- a/packages/core/test/server/index.test.ts
+++ b/packages/core/test/server/index.test.ts
@@ -60,6 +60,7 @@ const TYPES = [
   'PickupAddress',
   'MessageInfo',
   'MessageFields',
+  'ICreateProductReview',
 ]
 
 const QUERIES = [
@@ -74,7 +75,12 @@ const QUERIES = [
   'reviews',
 ]
 
-const MUTATIONS = ['validateCart', 'validateSession', 'subscribeToNewsletter']
+const MUTATIONS = [
+  'validateCart',
+  'validateSession',
+  'subscribeToNewsletter',
+  'createProductReview',
+]
 
 describe('FastStore GraphQL Layer', () => {
   describe('@faststore/api', () => {


### PR DESCRIPTION
>⚠️ THIS PR DEPENDS ON [PR#2647](https://github.com/vtex/faststore/pull/2647) ⚠️

## What's the purpose of this pull request?

To add a reviews mutation resolver on graphQL for allowing a new review to be created

## How it works?

It defines a few new types and adds a new mutation resolver called: `createProductReview`

## How to test it?

run the api graphql server locally with the following command:
```bash
yarn dev:server
```
and make a query call

## References

[JIRA TASK: SFS-2095](https://vtex-dev.atlassian.net/browse/SFS-2095)
[API Reviews Docs](https://developers.vtex.com/docs/api-reference/reviews-and-ratings-api#post-/reviews-and-ratings/api/review) 

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Description**

- [ ] Adds graphQL types
- [ ] Creates a new mutation resolver for `Reviews`