### PR TITLE
feat: enables search page seo `noIndex` from config

### DIFF
--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -11,6 +11,7 @@ module.exports = {
     search: {
       titleTemplate: '%s: Search results title',
       descriptionTemplate: '%s: Search results description',
+      noIndex: true,
     },
   },
 

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -57,6 +57,7 @@ function generateSEOData(storeConfig: StoreConfig, searchTerm?: string) {
   // default behavior without SSR
   if (!isSSREnabled) {
     return {
+      noindex: searchSeo?.noIndex ?? true,
       title: seo.title,
       description: seo.description,
       titleTemplate: seo.titleTemplate,
@@ -79,6 +80,7 @@ function generateSEOData(storeConfig: StoreConfig, searchTerm?: string) {
     : undefined
 
   return {
+    noindex: searchSeo?.noIndex ?? true,
     title,
     description,
     titleTemplate,
@@ -117,7 +119,7 @@ function Page({
       {...searchParams}
     >
       {/* SEO */}
-      <NextSeo noindex {...seoData} />
+      <NextSeo {...seoData} />
 
       <UISROnly text={seoData.title} />
 

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -110,7 +110,7 @@ function Page({
     return null
   }
 
-  const seoData = generateSEOData(storeConfig, searchTerm)
+  const { noindex, ...seoData } = generateSEOData(storeConfig, searchTerm)
 
   return (
     <SearchProvider
@@ -119,7 +119,7 @@ function Page({
       {...searchParams}
     >
       {/* SEO */}
-      <NextSeo {...seoData} />
+      <NextSeo noindex={noindex} {...seoData} />
 
       <UISROnly text={seoData.title} />
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to enable the `noindex` prop from NextSeo from the discovery.config value. 

## How it works?

The default value is true as was previously, but the stores can switch to false as needed.

## How to test it?

You can switch the value from `discovery.config.js `-> `seo.search.noIndex` and check the value from the meta tag related.

Preview with noindex true
https://storeframework-cm652ufll028lmgv665a6xv0g-8keew9na7.b.vtex.app/s?q=headphone&fuzzy=0&operator=and&facets=fuzzy%2Coperator&sort=score_desc&page=0

Preview with noindex false
https://storeframework-cm652ufll028lmgv665a6xv0g-kqsnuywde.b.vtex.app/s?q=headphone&fuzzy=0&operator=and&facets=fuzzy%2Coperator&sort=score_desc&page=0


### Starters Deploy Preview

- https://github.com/vtex-sites/starter.store/pull/667

| [Preview with noindex true](https://storeframework-cm652ufll028lmgv665a6xv0g-8keew9na7.b.vtex.app/s?q=headphone&fuzzy=0&operator=and&facets=fuzzy%2Coperator&sort=score_desc&page=0) | [Preview with noindex false](https://storeframework-cm652ufll028lmgv665a6xv0g-kqsnuywde.b.vtex.app/s?q=headphone&fuzzy=0&operator=and&facets=fuzzy%2Coperator&sort=score_desc&page=0) |
|--------|--------|
| <img width="1261" alt="Screenshot 2025-01-29 at 17 43 16" src="https://github.com/user-attachments/assets/9c8d5623-c646-489c-91bc-c6a9645dc876" />| <img width="1257" alt="Screenshot 2025-01-29 at 17 47 09" src="https://github.com/user-attachments/assets/2f46ea18-cfb8-4184-87e6-2cfd0e8ca6b4" />| 
