### PR TITLE
feat: enable lazy loading skip on custom sections

### DIFF
--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -97,7 +97,6 @@ const RenderSectionsBase = ({
     <>
       {sections.map(({ name, data = {} }, index) => {
         const Component = components[name]
-        console.log('Section name:', name, ' - data:', data)
 
         if (!Component) {
           // TODO: add a documentation link to help to do this
@@ -110,12 +109,22 @@ const RenderSectionsBase = ({
 
         return (
           <SectionBoundary key={`cms-section-${name}-${index}`} name={name}>
-            <LazyLoadingSection
-              sectionName={name}
-              isInteractive={isInteractive}
-            >
-              <Component {...data} />
-            </LazyLoadingSection>
+            {data.skipLazyLoadingSection ? (
+              <>
+                {console.log('Skip LazyLoadingSection:', name)}
+                <Component {...data} />
+              </>
+            ) : (
+              <>
+                {console.log('LazyLoadingSection:', name)}
+                <LazyLoadingSection
+                  sectionName={name}
+                  isInteractive={isInteractive}
+                >
+                  <Component {...data} />
+                </LazyLoadingSection>
+              </>
+            )}
           </SectionBoundary>
         )
       })}

--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -97,6 +97,7 @@ const RenderSectionsBase = ({
     <>
       {sections.map(({ name, data = {} }, index) => {
         const Component = components[name]
+        console.log('Section name:', name, ' - data:', data)
 
         if (!Component) {
           // TODO: add a documentation link to help to do this

--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -110,20 +110,14 @@ const RenderSectionsBase = ({
         return (
           <SectionBoundary key={`cms-section-${name}-${index}`} name={name}>
             {data.skipLazyLoadingSection ? (
-              <>
-                {console.log('Skip LazyLoadingSection:', name)}
-                <Component {...data} />
-              </>
+              <Component {...data} />
             ) : (
-              <>
-                {console.log('LazyLoadingSection:', name)}
-                <LazyLoadingSection
-                  sectionName={name}
-                  isInteractive={isInteractive}
-                >
-                  <Component {...data} />
-                </LazyLoadingSection>
-              </>
+              <LazyLoadingSection
+                sectionName={name}
+                isInteractive={isInteractive}
+              >
+                <Component {...data} />
+              </LazyLoadingSection>
             )}
           </SectionBoundary>
         )

--- a/packages/core/src/components/cms/ViewportObserver.tsx
+++ b/packages/core/src/components/cms/ViewportObserver.tsx
@@ -79,7 +79,7 @@ function ViewportObserver({
             height: VIEWPORT_SIZE, // required to make sections out of the viewport to be rendered on demand
             width: '100%',
           }}
-        ></div>
+        />
       )}
 
       {(isVisible || isInteractive) && children}


### PR DESCRIPTION
## What's the purpose of this pull request?

Enable the store to decide if a new custom section will skip lazy loading. 
It's important because otherwise all sections are inside the `LazyLoadingSection` and `ViewportObserver` for performance purposes, which makes the section structure not show on the first HTML - that being said, sometimes it's important to appear on the first HTML for SEO purposes.

## How it works?

If the section has a property called `skipLazyLoadingSection` set to `true` it'll bypass `LazyLoadingSection`.

## How to test it?

I've added a custom section called `Custom H1` in the `playground.store`, this section is composed by a simple h1 that shows the collection name. It's already added to the PLP template on hCMS there, so you can test it through https://sfj-6854f82--playground.preview.vtex.app/just-arrived - a collection page on `playground`.
| | |
| ---- | ---- |
| Custom section with `skipLazyLoadingSection` property | ![image](https://github.com/user-attachments/assets/8f3f2130-8168-4d3a-a65d-d0a406388047) |
| Custom section example | ![image](https://github.com/user-attachments/assets/2ae04efa-42d2-4a82-9d93-a5ae31280ced) |
| Custom section added to PLP template on hCMS | ![image](https://github.com/user-attachments/assets/79144009-a2f5-4fcf-bbb7-63e6f7263659) |
| Custom section structure being shown on the 1st HTML | ![image](https://github.com/user-attachments/assets/b0d9ea7b-5bdf-40da-9d40-601f1bd35cf5) |


### Starters Deploy Preview

https://sfj-6854f82--playground.preview.vtex.app/ ([PR](https://github.com/vtex-sites/playground.store/pull/134))

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SFS-2089)

## Checklist

**Documentation**

- Opened a [doc request](https://vtex.slack.com/archives/C01664JGV43/p1738258909141509) with Mari
