### PR TITLE
feat: enables search seo `noFollow` from config

### DIFF
--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -12,6 +12,7 @@ module.exports = {
       titleTemplate: '%s: Search results title',
       descriptionTemplate: '%s: Search results description',
       noIndex: true,
+      noFollow: true,
     },
   },
 

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -58,6 +58,7 @@ function generateSEOData(storeConfig: StoreConfig, searchTerm?: string) {
   if (!isSSREnabled) {
     return {
       noindex: searchSeo?.noIndex ?? true,
+      nofollow: searchSeo?.noFollow ?? true,
       title: seo.title,
       description: seo.description,
       titleTemplate: seo.titleTemplate,
@@ -81,6 +82,7 @@ function generateSEOData(storeConfig: StoreConfig, searchTerm?: string) {
 
   return {
     noindex: searchSeo?.noIndex ?? true,
+    nofollow: searchSeo?.noFollow ?? true,
     title,
     description,
     titleTemplate,
@@ -110,7 +112,10 @@ function Page({
     return null
   }
 
-  const { noindex, ...seoData } = generateSEOData(storeConfig, searchTerm)
+  const { noindex, nofollow, ...seoData } = generateSEOData(
+    storeConfig,
+    searchTerm
+  )
 
   return (
     <SearchProvider
@@ -119,7 +124,7 @@ function Page({
       {...searchParams}
     >
       {/* SEO */}
-      <NextSeo noindex={noindex} {...seoData} />
+      <NextSeo noindex={noindex} nofollow={nofollow} {...seoData} />
 
       <UISROnly text={seoData.title} />
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to enable the `nofollow` prop from NextSeo from the
discovery.config value.

## How it works?

The default value is true as was previously, but the stores can switch
to false as needed.

## How to test it?

You can switch the value from `discovery.config.js `->
`seo.search.noFollow` and check the value from the meta tag related.

### Starters Deploy Preview

- https://github.com/vtex-sites/starter.store/pull/675

| [nofollow true](https://storeframework-cm652ufll028lmgv665a6xv0g-dgphn5fzx.b.vtex.app/s?q=headphone&fuzzy=0&operator=and&facets=fuzzy%2Coperator&sort=score_desc&page=0) | [nofollow false](https://storeframework-cm652ufll028lmgv665a6xv0g-7mt68ho4g.b.vtex.app/s?q=headphone&fuzzy=0&operator=and&facets=fuzzy%2Coperator&sort=score_desc&page=0) |
|--------|--------|
| <img width="1274" alt="Screenshot 2025-01-30 at 12 08 55" src="https://github.com/user-attachments/assets/0e2a542c-cc97-47c5-a4e1-b8110d47076f" /> | <img width="1297" alt="Screenshot 2025-01-30 at 12 05 31" src="https://github.com/user-attachments/assets/498411b9-86ef-4da4-9e8d-47dfe89f653d" /> | 
