### PR TITLE
chore: Updates `website` structured data

### DIFF
--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -96,7 +96,7 @@
                   "title": "Name",
                   "type": "string"
                 },
-                "publisherId":{
+                "publisherId": {
                   "title": "Publisher ID",
                   "description": "Uses to identifier to reference the publisher. E.g.: #website",
                   "type": "string"

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -91,6 +91,15 @@
                 "canonical": {
                   "title": "Canonical url for the page",
                   "type": "string"
+                },
+                "name": {
+                  "title": "Name",
+                  "type": "string"
+                },
+                "publisherId":{
+                  "title": "Publisher ID",
+                  "description": "Uses to identifier to reference the publisher. E.g.: #website",
+                  "type": "string"
                 }
               }
             }

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -4,6 +4,8 @@ module.exports = {
     description: 'Fast Demo Store',
     titleTemplate: '%s | FastStore',
     author: 'Store Framework',
+    name: 'FastStore',
+    publisherId: '',
     plp: {
       titleTemplate: '%s | FastStore PLP',
       descriptionTemplate: '%s products on FastStore Product Listing Page',

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -49,7 +49,7 @@ function Page({
         }}
       />
       <SiteLinksSearchBoxJsonLd
-        type='WebSite'
+        type="WebSite"
         name={settings?.seo?.name ?? storeConfig.seo.name}
         url={storeConfig.storeUrl}
         potentialActions={[

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -30,6 +30,8 @@ function Page({
     data: serverData,
   }
 
+  const publisherId = settings?.seo?.publisherId ?? storeConfig.seo.publisherId
+
   return (
     <>
       {/* SEO */}
@@ -47,6 +49,8 @@ function Page({
         }}
       />
       <SiteLinksSearchBoxJsonLd
+        type='WebSite'
+        name={settings?.seo?.name ?? storeConfig.seo.name}
         url={storeConfig.storeUrl}
         potentialActions={[
           {
@@ -54,6 +58,7 @@ function Page({
             queryInput: 'search_term_string',
           },
         ]}
+        {...(publisherId && { publisher: { '@id': publisherId } })}
       />
 
       {/*

--- a/packages/core/src/server/cms/index.ts
+++ b/packages/core/src/server/cms/index.ts
@@ -30,6 +30,8 @@ export type PageContentType = ContentData & {
       title: string
       description: string
       canonical?: string
+      name?: string
+      publisherId?: string
     }
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds `name` and `publisher` properties to website schema

## How it works?

Allow adding the following [WebSite](https://schema.org/WebSite) schema proprieties:

- name: website name.
- publisher: the publisher of the creative work. (We are allowing a publisherId `@id` to identifier reference to the publisher. E.g.: #website)

Users can add data either through the headless CMS interface or by editing the `discovery.config.js` file.

> Note: Data from the headless CMS takes precedence over data from `discovery.config.js`.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/42586134-1c67-4807-9c68-7aca82fe6254" />


## How to test it?

1. Go to [preview](https://starter-git-test-seo-website-update-vtex.vercel.app/) link, inspect and look for `WebSite`
<img width="877" alt="image" src="https://github.com/user-attachments/assets/4a54bce5-a70e-46c1-a74f-5cb2f0afc3e4" />

2. Copy the generated script and paste [here](https://validator.schema.org) to check if is a valid schema:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/49b33b02-305c-4478-aa4c-24d9bfd02454" />

OR

1. Test in `storeframework` account, go to CMS admin, changes the fields values -> Save and Publish.
2. Wait for the new preview link and do the same process mention above (look for `WebSite ` and validate the schema)

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/677

## References

https://developers.google.com/search/blog/2024/10/sitelinks-search-box
https://developers.google.com/search/docs/appearance/site-names#website
