### PR TITLE
feat: Add plugins apis support

### DIFF
--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -1,22 +1,22 @@
-import path from 'path'
-import fs from 'node:fs'
+import path from "path";
+import fs from "node:fs";
 
 export const withBasePath = (basepath: string) => {
-  const tmpFolderName = '.faststore'
+  const tmpFolderName = ".faststore";
 
   const getRoot = () => {
     if (process.env.OCLIF_COMPILATION) {
-      return ''
+      return "";
     }
 
     if (basepath.endsWith(tmpFolderName)) {
       // if the current working directory is the build folder (tmp folder), return the starter root
       // this makes sure the semantics of the starter root are consistent with the directories declared below
-      return path.resolve(process.cwd(), path.join(basepath, '..'))
+      return path.resolve(process.cwd(), path.join(basepath, ".."));
     }
 
-    return path.resolve(process.cwd(), basepath)
-  }
+    return path.resolve(process.cwd(), basepath);
+  };
 
   /*
    * This will loop from the basepath until the process.cwd() looking for node_modules/@faststore/core
@@ -25,76 +25,77 @@ export const withBasePath = (basepath: string) => {
    */
   const getCorePackagePath = () => {
     const packageFromNodeModules = path.join(
-      'node_modules',
-      '@faststore',
-      'core'
-    )
-    const resolvedCwd = path.resolve(process.cwd())
+      "node_modules",
+      "@faststore",
+      "core",
+    );
+    const resolvedCwd = path.resolve(process.cwd());
 
-    const parents: string[] = []
+    const parents: string[] = [];
 
-    let attemptedPath
+    let attemptedPath;
     do {
       attemptedPath = path.join(
         resolvedCwd,
         basepath,
         ...parents,
-        packageFromNodeModules
-      )
+        packageFromNodeModules,
+      );
 
       if (fs.existsSync(attemptedPath)) {
-        return attemptedPath
+        return attemptedPath;
       }
 
-      parents.push('..')
+      parents.push("..");
     } while (
       path.resolve(attemptedPath) !== resolvedCwd ||
-      path.resolve(attemptedPath) !== '/'
-    )
+      path.resolve(attemptedPath) !== "/"
+    );
 
-    throw `Could not find @node_modules on ${basepath} or any of its parents until ${attemptedPath}`
-  }
+    throw `Could not find @node_modules on ${basepath} or any of its parents until ${attemptedPath}`;
+  };
 
-  const tmpDir = path.join(getRoot(), tmpFolderName)
-  const userSrcDir = path.join(getRoot(), 'src')
+  const tmpDir = path.join(getRoot(), tmpFolderName);
+  const userSrcDir = path.join(getRoot(), "src");
   const getPackagePath = (...packagePath: string[]) =>
-    path.join(getRoot(), 'node_modules', ...packagePath)
+    path.join(getRoot(), "node_modules", ...packagePath);
 
   return {
     getRoot,
     getPackagePath,
     userDir: getRoot(),
     userSrcDir,
-    userThemesFileDir: path.join(userSrcDir, 'themes'),
-    userCMSDir: path.join(getRoot(), 'cms', 'faststore'),
-    userLegacyStoreConfigFile: path.join(getRoot(), 'faststore.config.js'),
-    userStoreConfigFile: path.join(getRoot(), 'discovery.config.js'),
+    userThemesFileDir: path.join(userSrcDir, "themes"),
+    userCMSDir: path.join(getRoot(), "cms", "faststore"),
+    userLegacyStoreConfigFile: path.join(getRoot(), "faststore.config.js"),
+    userStoreConfigFile: path.join(getRoot(), "discovery.config.js"),
 
-    tmpSeoConfig: path.join(tmpDir, 'next-seo.config.ts'),
+    tmpSeoConfig: path.join(tmpDir, "next-seo.config.ts"),
     tmpFolderName,
     tmpDir,
-    tmpCustomizationsSrcDir: path.join(tmpDir, 'src', 'customizations', 'src'),
+    tmpCustomizationsSrcDir: path.join(tmpDir, "src", "customizations", "src"),
     tmpThemesCustomizationsFile: path.join(
       tmpDir,
-      'src',
-      'customizations',
-      'src',
-      'themes',
-      'index.scss'
+      "src",
+      "customizations",
+      "src",
+      "themes",
+      "index.scss",
     ),
-    tmpThemesPluginsFile: path.join(tmpDir, 'src', 'plugins', 'index.scss'),
-    tmpCMSDir: path.join(tmpDir, 'cms', 'faststore'),
-    tmpCMSWebhookUrlsFile: path.join(tmpDir, 'cms-webhook-urls.json'),
-    tmpPagesDir: path.join(tmpDir, 'src', 'pages'),
-    tmpPluginsDir: path.join(tmpDir, 'src', 'plugins'),
+    tmpThemesPluginsFile: path.join(tmpDir, "src", "plugins", "index.scss"),
+    tmpCMSDir: path.join(tmpDir, "cms", "faststore"),
+    tmpCMSWebhookUrlsFile: path.join(tmpDir, "cms-webhook-urls.json"),
+    tmpPagesDir: path.join(tmpDir, "src", "pages"),
+    tmpApiDir: path.join(tmpDir, "src", "pages", "api"),
+    tmpPluginsDir: path.join(tmpDir, "src", "plugins"),
     tmpStoreConfigFile: path.join(
       tmpDir,
-      'src',
-      'customizations',
-      'discovery.config.js'
+      "src",
+      "customizations",
+      "discovery.config.js",
     ),
 
     coreDir: getCorePackagePath(),
-    coreCMSDir: path.join(getCorePackagePath(), 'cms', 'faststore'),
-  }
-}
+    coreCMSDir: path.join(getCorePackagePath(), "cms", "faststore"),
+  };
+};

--- a/packages/cli/src/utils/directory.ts
+++ b/packages/cli/src/utils/directory.ts
@@ -1,22 +1,22 @@
-import path from "path";
-import fs from "node:fs";
+import path from 'path'
+import fs from 'node:fs'
 
 export const withBasePath = (basepath: string) => {
-  const tmpFolderName = ".faststore";
+  const tmpFolderName = '.faststore'
 
   const getRoot = () => {
     if (process.env.OCLIF_COMPILATION) {
-      return "";
+      return ''
     }
 
     if (basepath.endsWith(tmpFolderName)) {
       // if the current working directory is the build folder (tmp folder), return the starter root
       // this makes sure the semantics of the starter root are consistent with the directories declared below
-      return path.resolve(process.cwd(), path.join(basepath, ".."));
+      return path.resolve(process.cwd(), path.join(basepath, '..'))
     }
 
-    return path.resolve(process.cwd(), basepath);
-  };
+    return path.resolve(process.cwd(), basepath)
+  }
 
   /*
    * This will loop from the basepath until the process.cwd() looking for node_modules/@faststore/core
@@ -25,77 +25,77 @@ export const withBasePath = (basepath: string) => {
    */
   const getCorePackagePath = () => {
     const packageFromNodeModules = path.join(
-      "node_modules",
-      "@faststore",
-      "core",
-    );
-    const resolvedCwd = path.resolve(process.cwd());
+      'node_modules',
+      '@faststore',
+      'core'
+    )
+    const resolvedCwd = path.resolve(process.cwd())
 
-    const parents: string[] = [];
+    const parents: string[] = []
 
-    let attemptedPath;
+    let attemptedPath
     do {
       attemptedPath = path.join(
         resolvedCwd,
         basepath,
         ...parents,
-        packageFromNodeModules,
-      );
+        packageFromNodeModules
+      )
 
       if (fs.existsSync(attemptedPath)) {
-        return attemptedPath;
+        return attemptedPath
       }
 
-      parents.push("..");
+      parents.push('..')
     } while (
       path.resolve(attemptedPath) !== resolvedCwd ||
-      path.resolve(attemptedPath) !== "/"
-    );
+      path.resolve(attemptedPath) !== '/'
+    )
 
-    throw `Could not find @node_modules on ${basepath} or any of its parents until ${attemptedPath}`;
-  };
+    throw `Could not find @node_modules on ${basepath} or any of its parents until ${attemptedPath}`
+  }
 
-  const tmpDir = path.join(getRoot(), tmpFolderName);
-  const userSrcDir = path.join(getRoot(), "src");
+  const tmpDir = path.join(getRoot(), tmpFolderName)
+  const userSrcDir = path.join(getRoot(), 'src')
   const getPackagePath = (...packagePath: string[]) =>
-    path.join(getRoot(), "node_modules", ...packagePath);
+    path.join(getRoot(), 'node_modules', ...packagePath)
 
   return {
     getRoot,
     getPackagePath,
     userDir: getRoot(),
     userSrcDir,
-    userThemesFileDir: path.join(userSrcDir, "themes"),
-    userCMSDir: path.join(getRoot(), "cms", "faststore"),
-    userLegacyStoreConfigFile: path.join(getRoot(), "faststore.config.js"),
-    userStoreConfigFile: path.join(getRoot(), "discovery.config.js"),
+    userThemesFileDir: path.join(userSrcDir, 'themes'),
+    userCMSDir: path.join(getRoot(), 'cms', 'faststore'),
+    userLegacyStoreConfigFile: path.join(getRoot(), 'faststore.config.js'),
+    userStoreConfigFile: path.join(getRoot(), 'discovery.config.js'),
 
-    tmpSeoConfig: path.join(tmpDir, "next-seo.config.ts"),
+    tmpSeoConfig: path.join(tmpDir, 'next-seo.config.ts'),
     tmpFolderName,
     tmpDir,
-    tmpCustomizationsSrcDir: path.join(tmpDir, "src", "customizations", "src"),
+    tmpCustomizationsSrcDir: path.join(tmpDir, 'src', 'customizations', 'src'),
     tmpThemesCustomizationsFile: path.join(
       tmpDir,
-      "src",
-      "customizations",
-      "src",
-      "themes",
-      "index.scss",
+      'src',
+      'customizations',
+      'src',
+      'themes',
+      'index.scss'
     ),
-    tmpThemesPluginsFile: path.join(tmpDir, "src", "plugins", "index.scss"),
-    tmpCMSDir: path.join(tmpDir, "cms", "faststore"),
-    tmpCMSWebhookUrlsFile: path.join(tmpDir, "cms-webhook-urls.json"),
-    tmpPagesDir: path.join(tmpDir, "src", "pages"),
-    tmpApiDir: path.join(tmpDir, "src", "pages", "api"),
-    tmpPluginsDir: path.join(tmpDir, "src", "plugins"),
+    tmpThemesPluginsFile: path.join(tmpDir, 'src', 'plugins', 'index.scss'),
+    tmpCMSDir: path.join(tmpDir, 'cms', 'faststore'),
+    tmpCMSWebhookUrlsFile: path.join(tmpDir, 'cms-webhook-urls.json'),
+    tmpPagesDir: path.join(tmpDir, 'src', 'pages'),
+    tmpApiDir: path.join(tmpDir, 'src', 'pages', 'api'),
+    tmpPluginsDir: path.join(tmpDir, 'src', 'plugins'),
     tmpStoreConfigFile: path.join(
       tmpDir,
-      "src",
-      "customizations",
-      "discovery.config.js",
+      'src',
+      'customizations',
+      'discovery.config.js'
     ),
 
     coreDir: getCorePackagePath(),
-    coreCMSDir: path.join(getCorePackagePath(), "cms", "faststore"),
-  };
-};
+    coreCMSDir: path.join(getCorePackagePath(), 'cms', 'faststore'),
+  }
+}

--- a/packages/cli/src/utils/plugins.ts
+++ b/packages/cli/src/utils/plugins.ts
@@ -4,120 +4,125 @@ import {
   mkdirSync,
   readdirSync,
   writeFileSync,
-} from 'fs-extra'
-import { withBasePath } from './directory'
-import path from 'path'
-import { logger } from './logger'
+} from "fs-extra";
+import { withBasePath } from "./directory";
+import path from "path";
+import { logger } from "./logger";
 
 export type PageConfig = {
-  path: string
-  appLayout: boolean
-  name: string
-}
+  path: string;
+  appLayout: boolean;
+  name: string;
+};
+
+export type APIConfig = {
+  path: string;
+};
 
 export type PluginConfig = {
-  pages?: { [pageName: string]: Partial<PageConfig> }
-}
+  pages?: { [pageName: string]: Partial<PageConfig> };
+  apis?: { [pageName: string]: Partial<APIConfig> };
+};
 
 export type Plugin =
   | string
   | {
-      [pluginName: string]: PluginConfig
-    }
+      [pluginName: string]: PluginConfig;
+    };
 
-const PLUGIN_CONFIG_FILE = 'plugin.config.js'
+const PLUGIN_CONFIG_FILE = "plugin.config.js";
 
 const sanitizePluginName = (pluginName: string, pascalCase = false) => {
-  const sanitized = pluginName.split('/')[1]
+  const sanitized = pluginName.split("/")[1];
 
   if (pascalCase) {
     return sanitized
       .toLowerCase()
-      .split('-')
+      .split("-")
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join('')
+      .join("");
   }
 
-  return sanitized
-}
+  return sanitized;
+};
 
 export const getPluginName = (plugin: Plugin) => {
-  if (typeof plugin === 'string') {
-    return plugin
+  if (typeof plugin === "string") {
+    return plugin;
   }
 
-  return Object.keys(plugin)[0]
-}
+  return Object.keys(plugin)[0];
+};
 
 const getPluginCustomConfig = (plugin: Plugin) => {
-  if (typeof plugin === 'string') {
-    return {}
+  if (typeof plugin === "string") {
+    return {};
   }
 
-  return plugin[getPluginName(plugin)]
-}
+  return plugin[getPluginName(plugin)];
+};
 
 const getPluginSrcPath = async (basePath: string, pluginName: string) => {
-  const { getPackagePath } = withBasePath(basePath)
-  return getPackagePath(pluginName, 'src')
-}
+  const { getPackagePath } = withBasePath(basePath);
+  return getPackagePath(pluginName, "src");
+};
 
 export const getPluginsList = async (basePath: string): Promise<Plugin[]> => {
-  const { tmpStoreConfigFile } = withBasePath(basePath)
+  const { tmpStoreConfigFile } = withBasePath(basePath);
 
   try {
-    const { plugins = [] } = await import(tmpStoreConfigFile)
-    return plugins
+    const { plugins = [] } = await import(tmpStoreConfigFile);
+    return plugins;
   } catch (error) {
-    logger.error(`Could not load plugins from store config`)
+    logger.error(`Could not load plugins from store config`);
   }
 
-  return []
-}
+  return [];
+};
 
 const copyPluginsSrc = async (basePath: string, plugins: Plugin[]) => {
-  const { tmpPluginsDir } = withBasePath(basePath)
+  const { tmpPluginsDir } = withBasePath(basePath);
 
-  logger.log('Copying plugins files')
+  logger.log("Copying plugins files");
 
   plugins.forEach(async (plugin) => {
-    const pluginName = getPluginName(plugin)
+    const pluginName = getPluginName(plugin);
     const pluginSrcPath = await getPluginSrcPath(
       basePath,
       getPluginName(pluginName)
-    )
+    );
     const pluginDestPath = path.join(
       tmpPluginsDir,
       sanitizePluginName(pluginName)
-    )
+    );
 
-    copySync(pluginSrcPath, pluginDestPath)
-    logger.log(`Copied ${pluginName} files`)
-  })
-}
+    copySync(pluginSrcPath, pluginDestPath);
+    logger.log(`Copied ${pluginName} files`);
+  });
+};
 
 const copyPluginPublicFiles = async (basePath: string, plugins: Plugin[]) => {
-  const { tmpDir, getPackagePath } = withBasePath(basePath)
+  const { tmpDir, getPackagePath } = withBasePath(basePath);
 
-  logger.log('Copying plugin public files')
+  logger.log("Copying plugin public files");
 
   plugins.forEach(async (plugin) => {
-    const pluginName = getPluginName(plugin)
-    const pluginPath = getPackagePath(getPluginName(pluginName))
+    const pluginName = getPluginName(plugin);
+    const pluginPath = getPackagePath(getPluginName(pluginName));
 
     try {
       if (existsSync(`${pluginPath}/public`)) {
         copySync(`${pluginPath}/public`, `${tmpDir}/public`, {
           dereference: true,
           overwrite: true,
-        })
-        logger.log(`Plugin public files copied`)
+        });
+        logger.log(`Plugin public files copied`);
       }
     } catch (e) {
-      logger.error(e)
+      logger.error(e);
     }
-  })
-}
+  });
+};
 
 const getPluginPageFileContent = (
   pluginName: string,
@@ -126,23 +131,23 @@ const getPluginPageFileContent = (
 ) => `
 // GENERATED FILE
 // @ts-nocheck
-import * as page from 'src/plugins/${pluginName}/pages/${pageName}';
+import * as page from 'src/plugins/${pluginName}/pages/${pageName}'
 ${appLayout ? `import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'` : ``}
 ${appLayout ? `import RenderSections from 'src/components/cms/RenderSections'` : ``}
 
-export async function getServerSideProps(${appLayout ? '{ previewData, ...otherProps }' : 'otherProps'}) {
+export async function getServerSideProps(${appLayout ? "{ previewData, ...otherProps }" : "otherProps"}) {
   const noop = async function() {}
   const loaderData = await (page.loader || noop)(otherProps)
 ${appLayout ? `const { sections = [] } = await getGlobalSectionsData(previewData)` : ``}
 
-  return { 
-    props: { 
-        data: loaderData, 
-        ${appLayout ? 'globalSections: sections' : ``}
-    } 
+  return {
+    props: {
+        data: loaderData,
+        ${appLayout ? "globalSections: sections" : ``}
+    }
   }
 }
-export default function Page(props) { 
+export default function Page(props) {
   ${
     appLayout
       ? `return <RenderSections globalSections={props.globalSections}>
@@ -151,146 +156,195 @@ export default function Page(props) {
       : `return page.default(props.data)`
   }
 }
-      `
+      `;
 
 const generatePluginPages = async (basePath: string, plugins: Plugin[]) => {
-  const { tmpPagesDir, getPackagePath } = withBasePath(basePath)
+  const { tmpPagesDir, getPackagePath } = withBasePath(basePath);
 
-  logger.log('Generating plugin pages')
+  logger.log("Generating plugin pages");
 
   plugins.forEach(async (plugin) => {
-    const pluginName = getPluginName(plugin)
-    const pluginConfigPath = getPackagePath(pluginName, PLUGIN_CONFIG_FILE)
+    const pluginName = getPluginName(plugin);
+    const pluginConfigPath = getPackagePath(pluginName, PLUGIN_CONFIG_FILE);
 
-    const pluginConfig = await import(pluginConfigPath)
+    const pluginConfig = await import(pluginConfigPath);
 
-    const { pages: pagesCustom } = getPluginCustomConfig(plugin)
+    const { pages: pagesCustom } = getPluginCustomConfig(plugin);
 
     const pagesConfig: Record<string, PageConfig> = {
       ...(pluginConfig.pages ?? {}),
       ...pagesCustom,
-    }
+    };
 
-    const pages = Object.keys(pagesConfig)
+    const pages = Object.keys(pagesConfig);
 
     pages.forEach(async (pageName) => {
-      const paths = pagesConfig[pageName].path.split('/')
+      const paths = pagesConfig[pageName].path.split("/");
 
-      const pageFile = paths.pop()
-      const pagePaths = paths
+      const pageFile = paths.pop();
+      const pagePaths = paths;
 
-      const pagePath = path.join(tmpPagesDir, ...pagePaths, pageFile + '.tsx')
+      const pagePath = path.join(tmpPagesDir, ...pagePaths, pageFile + ".tsx");
 
       const fileContent = getPluginPageFileContent(
         sanitizePluginName(pluginName),
         pageName,
         pagesConfig[pageName].appLayout
-      )
+      );
 
-      mkdirSync(path.dirname(pagePath), { recursive: true })
-      writeFileSync(pagePath, fileContent)
-    })
-  })
-}
+      mkdirSync(path.dirname(pagePath), { recursive: true });
+      writeFileSync(pagePath, fileContent);
+    });
+  });
+};
 
 export async function addPluginsSections(basePath: string, plugins: Plugin[]) {
-  const { tmpPluginsDir, getPackagePath } = withBasePath(basePath)
+  const { tmpPluginsDir, getPackagePath } = withBasePath(basePath);
 
-  logger.log('Adding plugin sections')
+  logger.log("Adding plugin sections");
 
   const indexPluginsOverrides = plugins
     .filter((plugin) =>
       existsSync(
-        getPackagePath(getPluginName(plugin), 'src', 'components', 'index.ts')
+        getPackagePath(getPluginName(plugin), "src", "components", "index.ts")
       )
     )
     .map((plugin) => {
       const pluginReference =
-        sanitizePluginName(getPluginName(plugin), true) + 'Components'
+        sanitizePluginName(getPluginName(plugin), true) + "Components";
 
       return {
         import: `import { default as ${pluginReference} } from 'src/plugins/${sanitizePluginName(getPluginName(plugin))}/components'`,
         pluginReference,
-      }
-    })
+      };
+    });
 
   const pluginsImportFileContent = `
-  ${indexPluginsOverrides.map((plugin) => plugin.import).join('\n')}
+  ${indexPluginsOverrides.map((plugin) => plugin.import).join("\n")}
 
   export default {
-    ${indexPluginsOverrides.map((plugin) => `...${plugin.pluginReference}`).join(',\n')}
+    ${indexPluginsOverrides.map((plugin) => `...${plugin.pluginReference}`).join(",\n")}
   }
-  `
+  `;
 
-  const sectionPath = path.join(tmpPluginsDir, 'index.ts')
-  writeFileSync(sectionPath, pluginsImportFileContent)
-  logger.log('Writing plugins overrides')
-  logger.log(sectionPath)
-  logger.log(pluginsImportFileContent)
+  const sectionPath = path.join(tmpPluginsDir, "index.ts");
+  writeFileSync(sectionPath, pluginsImportFileContent);
+  logger.log("Writing plugins overrides");
+  logger.log(sectionPath);
+  logger.log(pluginsImportFileContent);
 }
 
 export async function addPluginsOverrides(basePath: string, plugins: Plugin[]) {
-  const { tmpPluginsDir, getPackagePath } = withBasePath(basePath)
+  const { tmpPluginsDir, getPackagePath } = withBasePath(basePath);
 
-  logger.log('Adding plugin overrides')
+  logger.log("Adding plugin overrides");
 
   plugins
     .map((plugin) => ({
       pluginName: getPluginName(plugin),
       pluginOverridesPath: getPackagePath(
         getPluginName(plugin),
-        'src',
-        'components',
-        'overrides'
+        "src",
+        "components",
+        "overrides"
       ),
     }))
     .filter(({ pluginOverridesPath }) => existsSync(pluginOverridesPath))
     .reverse()
     .forEach(({ pluginName, pluginOverridesPath }) => {
-      const overrideFilesAlreadyCopied: string[] = []
+      const overrideFilesAlreadyCopied: string[] = [];
 
-      const sanitizedPluginName = sanitizePluginName(pluginName)
+      const sanitizedPluginName = sanitizePluginName(pluginName);
 
-      const overrideFiles = readdirSync(pluginOverridesPath)
+      const overrideFiles = readdirSync(pluginOverridesPath);
 
       overrideFiles
         .filter((file) => !overrideFilesAlreadyCopied.includes(file))
         .forEach((overrideFileName) => {
-          const overrideFileContent = `export { override } from 'src/plugins/${sanitizedPluginName}/components/overrides/${overrideFileName.split('.')[0]}'`
+          const overrideFileContent = `export { override } from 'src/plugins/${sanitizedPluginName}/components/overrides/${overrideFileName.split(".")[0]}'`;
 
           writeFileSync(
-            path.join(tmpPluginsDir, 'overrides', overrideFileName),
+            path.join(tmpPluginsDir, "overrides", overrideFileName),
             overrideFileContent
-          )
-          overrideFilesAlreadyCopied.push(overrideFileName)
-        })
-    })
+          );
+          overrideFilesAlreadyCopied.push(overrideFileName);
+        });
+    });
 }
 
 const addPluginsTheme = async (basePath: string, plugins: Plugin[]) => {
-  const { getPackagePath, tmpThemesPluginsFile } = withBasePath(basePath)
+  const { getPackagePath, tmpThemesPluginsFile } = withBasePath(basePath);
 
   const pluginImportsContent = plugins
     .filter((plugin) =>
       existsSync(
-        getPackagePath(getPluginName(plugin), 'src', 'themes', 'index.scss')
+        getPackagePath(getPluginName(plugin), "src", "themes", "index.scss")
       )
     )
-    .map(
-      (plugin) => `@import "${getPluginName(plugin)}/src/themes/index.scss";`
-    )
-    .join('\n')
+    .map((plugin) => `@import "${getPluginName(plugin)}/src/themes/index.scss"`)
+    .join("\n");
 
-  writeFileSync(tmpThemesPluginsFile, pluginImportsContent)
+  writeFileSync(tmpThemesPluginsFile, pluginImportsContent);
+};
+
+const getPluginAPIFileContent = (pluginName: string, apiName: string) => `
+// GENERATED FILE
+// @ts-nocheck
+import apiHandle from 'src/plugins/${pluginName}/apis/${apiName}'
+import { NextApiRequest, NextApiResponse } from "next/types"
+
+export default function handle(req: NextApiRequest, res: NextApiResponse) {
+  return apiHandle(req, res)
 }
+`;
+
+const generatePluginApis = async (basePath: string, plugins: Plugin[]) => {
+  const { tmpApiDir, getPackagePath } = withBasePath(basePath);
+
+  logger.log("Generating plugin APIs");
+
+  plugins.forEach(async (plugin) => {
+    const pluginName = getPluginName(plugin);
+    const pluginConfigPath = getPackagePath(pluginName, PLUGIN_CONFIG_FILE);
+
+    const pluginConfig = await import(pluginConfigPath);
+
+    const { apis: apisCustom } = getPluginCustomConfig(plugin);
+
+    const apisConfig: Record<string, APIConfig> = {
+      ...(pluginConfig.apis ?? {}),
+      ...apisCustom,
+    };
+
+    const apis = Object.keys(apisConfig);
+
+    apis.forEach(async (apiName) => {
+      const paths = apisConfig[apiName].path.split("/");
+
+      const apiFile = paths.pop();
+      const apiPaths = paths;
+
+      const apiPath = path.join(tmpApiDir, ...apiPaths, apiFile + ".ts");
+
+      const fileContent = getPluginAPIFileContent(
+        sanitizePluginName(pluginName),
+        apiName
+      );
+
+      mkdirSync(path.dirname(apiPath), { recursive: true });
+      writeFileSync(apiPath, fileContent);
+    });
+  });
+};
 
 export const installPlugins = async (basePath: string) => {
-  const plugins = await getPluginsList(basePath)
+  const plugins = await getPluginsList(basePath);
 
-  copyPluginsSrc(basePath, plugins)
-  copyPluginPublicFiles(basePath, plugins)
-  generatePluginPages(basePath, plugins)
-  addPluginsSections(basePath, plugins)
-  addPluginsOverrides(basePath, plugins)
-  addPluginsTheme(basePath, plugins)
-}
+  copyPluginsSrc(basePath, plugins);
+  copyPluginPublicFiles(basePath, plugins);
+  generatePluginPages(basePath, plugins);
+  generatePluginApis(basePath, plugins);
+  addPluginsSections(basePath, plugins);
+  addPluginsOverrides(basePath, plugins);
+  addPluginsTheme(basePath, plugins);
+};

--- a/packages/cli/src/utils/plugins.ts
+++ b/packages/cli/src/utils/plugins.ts
@@ -4,125 +4,125 @@ import {
   mkdirSync,
   readdirSync,
   writeFileSync,
-} from "fs-extra";
-import { withBasePath } from "./directory";
-import path from "path";
-import { logger } from "./logger";
+} from 'fs-extra'
+import { withBasePath } from './directory'
+import path from 'path'
+import { logger } from './logger'
 
 export type PageConfig = {
-  path: string;
-  appLayout: boolean;
-  name: string;
-};
+  path: string
+  appLayout: boolean
+  name: string
+}
 
 export type APIConfig = {
-  path: string;
-};
+  path: string
+}
 
 export type PluginConfig = {
-  pages?: { [pageName: string]: Partial<PageConfig> };
-  apis?: { [pageName: string]: Partial<APIConfig> };
-};
+  pages?: { [pageName: string]: Partial<PageConfig> }
+  apis?: { [pageName: string]: Partial<APIConfig> }
+}
 
 export type Plugin =
   | string
   | {
-      [pluginName: string]: PluginConfig;
-    };
+      [pluginName: string]: PluginConfig
+    }
 
-const PLUGIN_CONFIG_FILE = "plugin.config.js";
+const PLUGIN_CONFIG_FILE = 'plugin.config.js'
 
 const sanitizePluginName = (pluginName: string, pascalCase = false) => {
-  const sanitized = pluginName.split("/")[1];
+  const sanitized = pluginName.split('/')[1]
 
   if (pascalCase) {
     return sanitized
       .toLowerCase()
-      .split("-")
+      .split('-')
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join("");
+      .join('')
   }
 
-  return sanitized;
-};
+  return sanitized
+}
 
 export const getPluginName = (plugin: Plugin) => {
-  if (typeof plugin === "string") {
-    return plugin;
+  if (typeof plugin === 'string') {
+    return plugin
   }
 
-  return Object.keys(plugin)[0];
-};
+  return Object.keys(plugin)[0]
+}
 
 const getPluginCustomConfig = (plugin: Plugin) => {
-  if (typeof plugin === "string") {
-    return {};
+  if (typeof plugin === 'string') {
+    return {}
   }
 
-  return plugin[getPluginName(plugin)];
-};
+  return plugin[getPluginName(plugin)]
+}
 
 const getPluginSrcPath = async (basePath: string, pluginName: string) => {
-  const { getPackagePath } = withBasePath(basePath);
-  return getPackagePath(pluginName, "src");
-};
+  const { getPackagePath } = withBasePath(basePath)
+  return getPackagePath(pluginName, 'src')
+}
 
 export const getPluginsList = async (basePath: string): Promise<Plugin[]> => {
-  const { tmpStoreConfigFile } = withBasePath(basePath);
+  const { tmpStoreConfigFile } = withBasePath(basePath)
 
   try {
-    const { plugins = [] } = await import(tmpStoreConfigFile);
-    return plugins;
+    const { plugins = [] } = await import(tmpStoreConfigFile)
+    return plugins
   } catch (error) {
-    logger.error(`Could not load plugins from store config`);
+    logger.error(`Could not load plugins from store config`)
   }
 
-  return [];
-};
+  return []
+}
 
 const copyPluginsSrc = async (basePath: string, plugins: Plugin[]) => {
-  const { tmpPluginsDir } = withBasePath(basePath);
+  const { tmpPluginsDir } = withBasePath(basePath)
 
-  logger.log("Copying plugins files");
+  logger.log('Copying plugins files')
 
   plugins.forEach(async (plugin) => {
-    const pluginName = getPluginName(plugin);
+    const pluginName = getPluginName(plugin)
     const pluginSrcPath = await getPluginSrcPath(
       basePath,
       getPluginName(pluginName)
-    );
+    )
     const pluginDestPath = path.join(
       tmpPluginsDir,
       sanitizePluginName(pluginName)
-    );
+    )
 
-    copySync(pluginSrcPath, pluginDestPath);
-    logger.log(`Copied ${pluginName} files`);
-  });
-};
+    copySync(pluginSrcPath, pluginDestPath)
+    logger.log(`Copied ${pluginName} files`)
+  })
+}
 
 const copyPluginPublicFiles = async (basePath: string, plugins: Plugin[]) => {
-  const { tmpDir, getPackagePath } = withBasePath(basePath);
+  const { tmpDir, getPackagePath } = withBasePath(basePath)
 
-  logger.log("Copying plugin public files");
+  logger.log('Copying plugin public files')
 
   plugins.forEach(async (plugin) => {
-    const pluginName = getPluginName(plugin);
-    const pluginPath = getPackagePath(getPluginName(pluginName));
+    const pluginName = getPluginName(plugin)
+    const pluginPath = getPackagePath(getPluginName(pluginName))
 
     try {
       if (existsSync(`${pluginPath}/public`)) {
         copySync(`${pluginPath}/public`, `${tmpDir}/public`, {
           dereference: true,
           overwrite: true,
-        });
-        logger.log(`Plugin public files copied`);
+        })
+        logger.log(`Plugin public files copied`)
       }
     } catch (e) {
-      logger.error(e);
+      logger.error(e)
     }
-  });
-};
+  })
+}
 
 const getPluginPageFileContent = (
   pluginName: string,
@@ -135,7 +135,7 @@ import * as page from 'src/plugins/${pluginName}/pages/${pageName}'
 ${appLayout ? `import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'` : ``}
 ${appLayout ? `import RenderSections from 'src/components/cms/RenderSections'` : ``}
 
-export async function getServerSideProps(${appLayout ? "{ previewData, ...otherProps }" : "otherProps"}) {
+export async function getServerSideProps(${appLayout ? '{ previewData, ...otherProps }' : 'otherProps'}) {
   const noop = async function() {}
   const loaderData = await (page.loader || noop)(otherProps)
 ${appLayout ? `const { sections = [] } = await getGlobalSectionsData(previewData)` : ``}
@@ -143,7 +143,7 @@ ${appLayout ? `const { sections = [] } = await getGlobalSectionsData(previewData
   return {
     props: {
         data: loaderData,
-        ${appLayout ? "globalSections: sections" : ``}
+        ${appLayout ? 'globalSections: sections' : ``}
     }
   }
 }
@@ -156,136 +156,136 @@ export default function Page(props) {
       : `return page.default(props.data)`
   }
 }
-      `;
+      `
 
 const generatePluginPages = async (basePath: string, plugins: Plugin[]) => {
-  const { tmpPagesDir, getPackagePath } = withBasePath(basePath);
+  const { tmpPagesDir, getPackagePath } = withBasePath(basePath)
 
-  logger.log("Generating plugin pages");
+  logger.log('Generating plugin pages')
 
   plugins.forEach(async (plugin) => {
-    const pluginName = getPluginName(plugin);
-    const pluginConfigPath = getPackagePath(pluginName, PLUGIN_CONFIG_FILE);
+    const pluginName = getPluginName(plugin)
+    const pluginConfigPath = getPackagePath(pluginName, PLUGIN_CONFIG_FILE)
 
-    const pluginConfig = await import(pluginConfigPath);
+    const pluginConfig = await import(pluginConfigPath)
 
-    const { pages: pagesCustom } = getPluginCustomConfig(plugin);
+    const { pages: pagesCustom } = getPluginCustomConfig(plugin)
 
     const pagesConfig: Record<string, PageConfig> = {
       ...(pluginConfig.pages ?? {}),
       ...pagesCustom,
-    };
+    }
 
-    const pages = Object.keys(pagesConfig);
+    const pages = Object.keys(pagesConfig)
 
     pages.forEach(async (pageName) => {
-      const paths = pagesConfig[pageName].path.split("/");
+      const paths = pagesConfig[pageName].path.split('/')
 
-      const pageFile = paths.pop();
-      const pagePaths = paths;
+      const pageFile = paths.pop()
+      const pagePaths = paths
 
-      const pagePath = path.join(tmpPagesDir, ...pagePaths, pageFile + ".tsx");
+      const pagePath = path.join(tmpPagesDir, ...pagePaths, pageFile + '.tsx')
 
       const fileContent = getPluginPageFileContent(
         sanitizePluginName(pluginName),
         pageName,
         pagesConfig[pageName].appLayout
-      );
+      )
 
-      mkdirSync(path.dirname(pagePath), { recursive: true });
-      writeFileSync(pagePath, fileContent);
-    });
-  });
-};
+      mkdirSync(path.dirname(pagePath), { recursive: true })
+      writeFileSync(pagePath, fileContent)
+    })
+  })
+}
 
 export async function addPluginsSections(basePath: string, plugins: Plugin[]) {
-  const { tmpPluginsDir, getPackagePath } = withBasePath(basePath);
+  const { tmpPluginsDir, getPackagePath } = withBasePath(basePath)
 
-  logger.log("Adding plugin sections");
+  logger.log('Adding plugin sections')
 
   const indexPluginsOverrides = plugins
     .filter((plugin) =>
       existsSync(
-        getPackagePath(getPluginName(plugin), "src", "components", "index.ts")
+        getPackagePath(getPluginName(plugin), 'src', 'components', 'index.ts')
       )
     )
     .map((plugin) => {
       const pluginReference =
-        sanitizePluginName(getPluginName(plugin), true) + "Components";
+        sanitizePluginName(getPluginName(plugin), true) + 'Components'
 
       return {
         import: `import { default as ${pluginReference} } from 'src/plugins/${sanitizePluginName(getPluginName(plugin))}/components'`,
         pluginReference,
-      };
-    });
+      }
+    })
 
   const pluginsImportFileContent = `
-  ${indexPluginsOverrides.map((plugin) => plugin.import).join("\n")}
+  ${indexPluginsOverrides.map((plugin) => plugin.import).join('\n')}
 
   export default {
-    ${indexPluginsOverrides.map((plugin) => `...${plugin.pluginReference}`).join(",\n")}
+    ${indexPluginsOverrides.map((plugin) => `...${plugin.pluginReference}`).join(',\n')}
   }
-  `;
+  `
 
-  const sectionPath = path.join(tmpPluginsDir, "index.ts");
-  writeFileSync(sectionPath, pluginsImportFileContent);
-  logger.log("Writing plugins overrides");
-  logger.log(sectionPath);
-  logger.log(pluginsImportFileContent);
+  const sectionPath = path.join(tmpPluginsDir, 'index.ts')
+  writeFileSync(sectionPath, pluginsImportFileContent)
+  logger.log('Writing plugins overrides')
+  logger.log(sectionPath)
+  logger.log(pluginsImportFileContent)
 }
 
 export async function addPluginsOverrides(basePath: string, plugins: Plugin[]) {
-  const { tmpPluginsDir, getPackagePath } = withBasePath(basePath);
+  const { tmpPluginsDir, getPackagePath } = withBasePath(basePath)
 
-  logger.log("Adding plugin overrides");
+  logger.log('Adding plugin overrides')
 
   plugins
     .map((plugin) => ({
       pluginName: getPluginName(plugin),
       pluginOverridesPath: getPackagePath(
         getPluginName(plugin),
-        "src",
-        "components",
-        "overrides"
+        'src',
+        'components',
+        'overrides'
       ),
     }))
     .filter(({ pluginOverridesPath }) => existsSync(pluginOverridesPath))
     .reverse()
     .forEach(({ pluginName, pluginOverridesPath }) => {
-      const overrideFilesAlreadyCopied: string[] = [];
+      const overrideFilesAlreadyCopied: string[] = []
 
-      const sanitizedPluginName = sanitizePluginName(pluginName);
+      const sanitizedPluginName = sanitizePluginName(pluginName)
 
-      const overrideFiles = readdirSync(pluginOverridesPath);
+      const overrideFiles = readdirSync(pluginOverridesPath)
 
       overrideFiles
         .filter((file) => !overrideFilesAlreadyCopied.includes(file))
         .forEach((overrideFileName) => {
-          const overrideFileContent = `export { override } from 'src/plugins/${sanitizedPluginName}/components/overrides/${overrideFileName.split(".")[0]}'`;
+          const overrideFileContent = `export { override } from 'src/plugins/${sanitizedPluginName}/components/overrides/${overrideFileName.split('.')[0]}'`
 
           writeFileSync(
-            path.join(tmpPluginsDir, "overrides", overrideFileName),
+            path.join(tmpPluginsDir, 'overrides', overrideFileName),
             overrideFileContent
-          );
-          overrideFilesAlreadyCopied.push(overrideFileName);
-        });
-    });
+          )
+          overrideFilesAlreadyCopied.push(overrideFileName)
+        })
+    })
 }
 
 const addPluginsTheme = async (basePath: string, plugins: Plugin[]) => {
-  const { getPackagePath, tmpThemesPluginsFile } = withBasePath(basePath);
+  const { getPackagePath, tmpThemesPluginsFile } = withBasePath(basePath)
 
   const pluginImportsContent = plugins
     .filter((plugin) =>
       existsSync(
-        getPackagePath(getPluginName(plugin), "src", "themes", "index.scss")
+        getPackagePath(getPluginName(plugin), 'src', 'themes', 'index.scss')
       )
     )
     .map((plugin) => `@import "${getPluginName(plugin)}/src/themes/index.scss"`)
-    .join("\n");
+    .join('\n')
 
-  writeFileSync(tmpThemesPluginsFile, pluginImportsContent);
-};
+  writeFileSync(tmpThemesPluginsFile, pluginImportsContent)
+}
 
 const getPluginAPIFileContent = (pluginName: string, apiName: string) => `
 // GENERATED FILE
@@ -296,55 +296,55 @@ import { NextApiRequest, NextApiResponse } from "next/types"
 export default function handle(req: NextApiRequest, res: NextApiResponse) {
   return apiHandle(req, res)
 }
-`;
+`
 
 const generatePluginApis = async (basePath: string, plugins: Plugin[]) => {
-  const { tmpApiDir, getPackagePath } = withBasePath(basePath);
+  const { tmpApiDir, getPackagePath } = withBasePath(basePath)
 
-  logger.log("Generating plugin APIs");
+  logger.log('Generating plugin APIs')
 
   plugins.forEach(async (plugin) => {
-    const pluginName = getPluginName(plugin);
-    const pluginConfigPath = getPackagePath(pluginName, PLUGIN_CONFIG_FILE);
+    const pluginName = getPluginName(plugin)
+    const pluginConfigPath = getPackagePath(pluginName, PLUGIN_CONFIG_FILE)
 
-    const pluginConfig = await import(pluginConfigPath);
+    const pluginConfig = await import(pluginConfigPath)
 
-    const { apis: apisCustom } = getPluginCustomConfig(plugin);
+    const { apis: apisCustom } = getPluginCustomConfig(plugin)
 
     const apisConfig: Record<string, APIConfig> = {
       ...(pluginConfig.apis ?? {}),
       ...apisCustom,
-    };
+    }
 
-    const apis = Object.keys(apisConfig);
+    const apis = Object.keys(apisConfig)
 
     apis.forEach(async (apiName) => {
-      const paths = apisConfig[apiName].path.split("/");
+      const paths = apisConfig[apiName].path.split('/')
 
-      const apiFile = paths.pop();
-      const apiPaths = paths;
+      const apiFile = paths.pop()
+      const apiPaths = paths
 
-      const apiPath = path.join(tmpApiDir, ...apiPaths, apiFile + ".ts");
+      const apiPath = path.join(tmpApiDir, ...apiPaths, apiFile + '.ts')
 
       const fileContent = getPluginAPIFileContent(
         sanitizePluginName(pluginName),
         apiName
-      );
+      )
 
-      mkdirSync(path.dirname(apiPath), { recursive: true });
-      writeFileSync(apiPath, fileContent);
-    });
-  });
-};
+      mkdirSync(path.dirname(apiPath), { recursive: true })
+      writeFileSync(apiPath, fileContent)
+    })
+  })
+}
 
 export const installPlugins = async (basePath: string) => {
-  const plugins = await getPluginsList(basePath);
+  const plugins = await getPluginsList(basePath)
 
-  copyPluginsSrc(basePath, plugins);
-  copyPluginPublicFiles(basePath, plugins);
-  generatePluginPages(basePath, plugins);
-  generatePluginApis(basePath, plugins);
-  addPluginsSections(basePath, plugins);
-  addPluginsOverrides(basePath, plugins);
-  addPluginsTheme(basePath, plugins);
-};
+  copyPluginsSrc(basePath, plugins)
+  copyPluginPublicFiles(basePath, plugins)
+  generatePluginPages(basePath, plugins)
+  generatePluginApis(basePath, plugins)
+  addPluginsSections(basePath, plugins)
+  addPluginsOverrides(basePath, plugins)
+  addPluginsTheme(basePath, plugins)
+}

--- a/packages/cli/src/utils/plugins.ts
+++ b/packages/cli/src/utils/plugins.ts
@@ -324,7 +324,12 @@ const generatePluginApis = async (basePath: string, plugins: Plugin[]) => {
       const apiFile = paths.pop()
       const apiPaths = paths
 
-      const apiPath = path.join(tmpApiDir, ...apiPaths, apiFile + '.ts')
+      const apiPath = path.join(
+        tmpApiDir,
+        ...apiPaths,
+        'plugin',
+        apiFile + '.ts'
+      )
 
       const fileContent = getPluginAPIFileContent(
         sanitizePluginName(pluginName),

--- a/packages/cli/src/utils/plugins.ts
+++ b/packages/cli/src/utils/plugins.ts
@@ -327,7 +327,7 @@ const generatePluginApis = async (basePath: string, plugins: Plugin[]) => {
       const apiPath = path.join(
         tmpApiDir,
         ...apiPaths,
-        'plugin',
+        'plugins',
         apiFile + '.ts'
       )
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds support for creating new APIs in Faststore from plugins.

During the development of the Buyer Portal plugin, we identified the need to define API routes within the plugin structure. Since plugins already support creating new pages in Faststore, we extended this capability to allow the creation of API routes as well.

Some use cases for creating new API routes include:

- Adding new integrations with backend services within Faststore
- Defining API routes that can access HTTP-only hooks in the Faststore domain
- Enabling plugins to expose custom business logic via API endpoints
> [!NOTE]
> This pull request does not aim to add the API Override functionality to plugins. Developing this feature would require addressing specific challenges, such as orchestrating GraphQL requests to avoid conflicts while ensuring API stability.
This PR solely allows new REST routes to be added to a store without interfering with or integrating into Faststore's core API functionalities.

## How it works?

To add new APIs to a plugin, simply update the plugin.config.js file by adding the apis option with a list of the APIs that should be created, like this:

```js
// plugin.config.js
module.exports = {
  name: "plugin-name",
  pages: {
    ...
  },
  apis: {
    "new-route": {
      path: "/new-route",
    },
  },
};
```

Next, create a folder named "apis" inside the src directory of your plugin project. Then, add your API files using the same names as the keys defined in plugin.config.js. For example, if you specified "new-route", your file structure should look like this:

plugin-project/
│── src/
│   ├── apis/
│   │   ├── new-route.ts

This ensures that the API routes are correctly registered and accessible within your plugin.

The structure of an API file follows a format similar to Next.js 13 and can leverage Next.js types. For example:

```ts
import { NextApiRequest, NextApiResponse } from "next/types";

export default function handle(req: NextApiRequest, res: NextApiResponse) {
  return res.json({ ok: "from plugin" });
}
```

> [!NOTE]
> Based on[ this thread in the Faststore channel](https://vtex.slack.com/archives/C06EC3LCZA8/p1738703412005489), it was discussed that plugin routes should have a prefix for identification. As a result, all routes created in plugins will automatically have the /plugin prefix, making the final structure: `/api/plugin/{route-name}`.


## How to test it?

To test this functionality locally, you can either link the CLI package to a store or install the preview version. Follow the instructions to create an API and then access the route to verify it.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

A preview link was create based on b2bfaststoredev store, and the "new-route" api can be accessed in ["api/plugin/new-route"](https://sfj-157537c--b2bfaststoredev.preview.vtex.app/api/plugin/new-route)

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [x] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [x] Committed the `yarn.lock` file when there were changes to the packages

**Documentation**

- [x] PR description
- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)
