### PR TITLE
feat: create modal footer compound component

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -108,7 +108,12 @@ export { default as InputField } from './molecules/InputField'
 export type { InputFieldProps } from './molecules/InputField'
 export { default as LinkButton } from './molecules/LinkButton'
 export type { LinkButtonProps } from './molecules/LinkButton'
-export { default as Modal, ModalHeader, ModalBody } from './molecules/Modal'
+export {
+  default as Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from './molecules/Modal'
 export type { ModalProps, ModalHeaderProps } from './molecules/Modal'
 export {
   default as NavbarLinks,

--- a/packages/components/src/molecules/Modal/ModalFooter.tsx
+++ b/packages/components/src/molecules/Modal/ModalFooter.tsx
@@ -1,0 +1,35 @@
+import React, { type ReactNode, type HTMLAttributes } from 'react'
+
+export interface ModalFooterProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Children or function as a children
+   */
+  children: ReactNode
+  /**
+   * Layout direction. Default is `horizontal`.
+   */
+  direction?: 'horizontal' | 'vertical'
+  /**
+   * Allows wrapping. Default is `true`
+   */
+  wrap?: boolean
+}
+
+const ModalFooter = ({
+  children,
+  direction = 'horizontal',
+  wrap = true,
+  ...otherProps
+}: ModalFooterProps) => (
+  <div data-fs-modal-footer {...otherProps}>
+    <div
+      data-fs-modal-footer-actions
+      data-fs-modal-footer-actions-direction={direction}
+      data-fs-modal-footer-actions-wrap={wrap}
+    >
+      {children}
+    </div>
+  </div>
+)
+
+export default ModalFooter

--- a/packages/components/src/molecules/Modal/index.tsx
+++ b/packages/components/src/molecules/Modal/index.tsx
@@ -1,5 +1,7 @@
 export { default } from './Modal'
 export { default as ModalHeader } from './ModalHeader'
+export { default as ModalFooter } from './ModalFooter'
 export { default as ModalBody } from './ModalBody'
 export type { ModalProps } from './Modal'
 export type { ModalHeaderProps } from './ModalHeader'
+export type { ModalFooterProps } from './ModalFooter'

--- a/packages/ui/src/components/molecules/Modal/styles.scss
+++ b/packages/ui/src/components/molecules/Modal/styles.scss
@@ -42,6 +42,12 @@
   // Body
   --fs-modal-body-padding                          : var(--fs-spacing-1) var(--fs-spacing-4) var(--fs-spacing-5);
 
+  // Footer
+  --fs-modal-footer-padding                        : var(--fs-spacing-3) 0 var(--fs-spacing-3);
+  --fs-modal-footer-box-shadow                     : 0 -1px 15px 0 rgb(0 0 0 / 10.2%);
+  --fs-modal-footer-actions-padding                : var(--fs-spacing-1) var(--fs-spacing-4);
+  --fs-modal-footer-actions-gap                    : var(--fs-spacing-3);
+
   position: fixed;
   top: var(--fs-modal-position-top);
   right: var(--fs-modal-position-right);
@@ -93,5 +99,32 @@
 
   [data-fs-modal-body] {
     padding: var(--fs-modal-body-padding);
+  }
+
+  [data-fs-modal-footer] {
+    padding: var(--fs-modal-footer-padding);
+    box-shadow: var(--fs-modal-footer-box-shadow);
+
+    [data-fs-modal-footer-actions] {
+      display: flex;
+      gap: var(--fs-modal-footer-actions-gap);
+      align-items: center;
+      justify-content: flex-end;
+      padding: var(--fs-modal-footer-actions-padding);
+
+      > * {
+        flex-shrink: 0;
+      }
+
+      &[data-fs-modal-footer-actions-direction="vertical"] {
+        flex-direction: column;
+        align-items: flex-end;
+        justify-content: center;
+      }
+
+      &[data-fs-modal-footer-actions-wrap="true"] {
+        flex-wrap: wrap;
+      }
+    }
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This pull request adds the ModalFooter compound component. This component will be used inside the Modal in initially in the Modal to add a new review in the new Reviews and Ratings section.

## How does it work?

You need to use `<ModalFooter />` inside the Modal and pass to it action buttons. The ModalFooter is already spacing out the buttons and is wrapping by default. You can pass `direction` prop to it, and it can be `vertical` or `horizontal` and it is `horizontal` by default.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

[Preview](https://starter-git-feat-preview-modal-footer-vtex.vercel.app/modal-footer)

## References

[JIRA TASK: SFS-2080](https://vtex-dev.atlassian.net/browse/SFS-2080)

[Figma](https://www.figma.com/design/YXU6IX2htN2yg7udpCumZv/Reviews-%26-Ratings?node-id=131-66913&t=hvdVQfzTmgTLIa32-4)


