### PR TITLE
fix: Get offer url only if `enableClientOffer` is enabled

### DIFF
--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -112,15 +112,17 @@ function Page({ data: server, sections, globalSections, offers, meta }: Props) {
 
   return (
     <>
-      <Head>
-        <link
-          rel="preload"
-          href={getOfferUrl(product.sku)}
-          as="fetch"
-          crossOrigin="anonymous"
-          fetchPriority="high"
-        />
-      </Head>
+      {isClientOfferEnabled && (
+        <Head>
+          <link
+            rel="preload"
+            href={getOfferUrl(product.sku)}
+            as="fetch"
+            crossOrigin="anonymous"
+            fetchPriority="high"
+          />
+        </Head>
+      )}
       {/* SEO */}
       <NextSeo
         title={meta.title}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the `product_search` request being made on PDP when `enableClientOffer` is disabled.

## How to test it?

Navigate to PDP and check if no `product_search` request is being made.

### Starters Deploy Preview