### PR TITLE
chore: `BreadcrumbList` using full page URL for PDP and PLP

### DIFF
--- a/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
+++ b/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
@@ -82,6 +82,17 @@ export default function ProductListingPage({
   const canonical = `${storeConfig.storeUrl}${pathname}`
   const itemsPerPage = settings?.productGallery?.itemsPerPage ?? ITEMS_PER_PAGE
 
+  let itemListElements = collection?.breadcrumbList.itemListElement ?? []
+  if (itemListElements.length !== 0) {
+    itemListElements = itemListElements.map(
+      ({ item: pathname, name, position }) => {
+        const pageUrl = storeConfig.storeUrl + pathname
+
+        return { name, position, item: pageUrl }
+      }
+    )
+  }
+
   return (
     <SearchProvider
       onChange={applySearchState}
@@ -100,9 +111,7 @@ export default function ProductListingPage({
           description,
         }}
       />
-      <BreadcrumbJsonLd
-        itemListElements={collection?.breadcrumbList.itemListElement ?? []}
-      />
+      <BreadcrumbJsonLd itemListElements={itemListElements} />
 
       <ProductListing
         globalSections={globalSections}

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -85,6 +85,17 @@ function Page({ data: server, sections, globalSections, offers, meta }: Props) {
   const { currency } = useSession()
   const titleTemplate = storeConfig?.seo?.titleTemplate ?? ''
 
+  let itemListElements = product.breadcrumbList.itemListElement ?? []
+  if (itemListElements.length !== 0) {
+    itemListElements = itemListElements.map(
+      ({ item: pathname, name, position }) => {
+        const pageUrl = storeConfig.storeUrl + pathname
+
+        return { name, position, item: pageUrl }
+      }
+    )
+  }
+
   const { client, isValidating } = isClientOfferEnabled
     ? (() => {
         const offer = useOffer({ skuId: product.sku })
@@ -148,9 +159,7 @@ function Page({ data: server, sections, globalSections, offers, meta }: Props) {
         ]}
         titleTemplate={titleTemplate}
       />
-      <BreadcrumbJsonLd
-        itemListElements={product.breadcrumbList.itemListElement}
-      />
+      <BreadcrumbJsonLd itemListElements={itemListElements} />
       <ProductJsonLd
         productName={product.name}
         description={product.description}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to set `item` as full store's page URL (PLP and PDP) for `BreadcrumbList`'s item list elements.

## How it works?

The `collection` and `product` data is built in `@faststore/api`. The `breadcrumList` attribute consists of `item`, `name` and `position`. The `item` is the pathname of that specific page, so it is in the relative path form.

We should use URL's absolute path, so we have to prepend the `storeUrl` (production domain) to a correct structured data.

## How to test it?

- Get the [preview URL](https://storeframework-cm652ufll028lmgv665a6xv0g-355x7sm3b.b.vtex.app/), navigate to a PLP or PDP, inspect the page and look for `BreadcrumList`;
- Copy the generated script and perform the Google Rich Test to validate the schema: https://search.google.com/test/rich-results.

PDP
<img width="500" alt="image" src="https://github.com/user-attachments/assets/ad044a28-6ab7-473a-8982-063c9e4b9e83" />

PLP
<img width="500" alt="image" src="https://github.com/user-attachments/assets/96df312b-bffc-435c-80bd-240c9cc5619c" />


### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/690