### PR TITLE
feat: empty search with global sections

### DIFF
--- a/packages/core/src/components/templates/SearchPage/EmptySearch.tsx
+++ b/packages/core/src/components/templates/SearchPage/EmptySearch.tsx
@@ -1,0 +1,29 @@
+import EmptyState from 'src/components/sections/EmptyState'
+import ProductGalleryStyles from 'src/components/sections/ProductGallery/section.module.scss'
+import Section from 'src/components/sections/Section'
+
+export type EmptySearchProps = {
+  title?: string
+  term?: string
+}
+
+export default function EmptySearch({ title, term }: EmptySearchProps) {
+  return (
+    <Section
+      className={`${ProductGalleryStyles.section} section-product-gallery`}
+    >
+      <section
+        data-testid="product-gallery"
+        data-fs-product-listing
+        data-fs-search-loading
+      >
+        {title && (
+          <h1 data-fs-empty-search-title>
+            {title} <strong>{term}</strong>
+          </h1>
+        )}
+        <EmptyState title="" showLoader />
+      </section>
+    </Section>
+  )
+}

--- a/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
@@ -47,7 +47,11 @@ export default function SearchWrapper({
     : {}
 
   if (isValidating || !pageProductGalleryData) {
-    return <EmptySearch {...emptySearchProps} />
+    return (
+      <RenderSections globalSections={globalSections}>
+        <EmptySearch {...emptySearchProps} />
+      </RenderSections>
+    )
   }
 
   // Redirect when there are registered Intelligent Search redirects on VTEX Admin
@@ -56,7 +60,11 @@ export default function SearchWrapper({
       shallow: true,
     })
 
-    return <EmptySearch {...emptySearchProps} />
+    return (
+      <RenderSections globalSections={globalSections}>
+        <EmptySearch {...emptySearchProps} />
+      </RenderSections>
+    )
   }
 
   const productGalleryProducts = pageProductGalleryData?.search?.products

--- a/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
@@ -1,41 +1,14 @@
 import { useSearch } from '@faststore/sdk'
 import { useRouter } from 'next/router'
 
-import EmptyState from 'src/components/sections/EmptyState'
-import ProductGalleryStyles from 'src/components/sections/ProductGallery/section.module.scss'
-import Section from 'src/components/sections/Section'
 import type { SearchPageContextType } from 'src/pages/s'
 import { useProductGalleryQuery } from 'src/sdk/product/useProductGalleryQuery'
 import type { SearchContentType } from 'src/server/cms'
 import storeConfig from 'discovery.config'
 
+import RenderSections from 'src/components/cms/RenderSections'
+import EmptySearch from './EmptySearch'
 import SearchPage from './SearchPage'
-
-type EmptySearchProps = {
-  title?: string
-  term?: string
-}
-
-function EmptySearch({ title, term }: EmptySearchProps) {
-  return (
-    <Section
-      className={`${ProductGalleryStyles.section} section-product-gallery`}
-    >
-      <section
-        data-testid="product-gallery"
-        data-fs-product-listing
-        data-fs-search-loading
-      >
-        {title && (
-          <h1 data-fs-empty-search-title>
-            {title} <strong>{term}</strong>
-          </h1>
-        )}
-        <EmptyState title="" showLoader />
-      </section>
-    </Section>
-  )
-}
 
 export type SearchWrapperProps = {
   itemsPerPage: number

--- a/packages/core/src/components/templates/SearchPage/index.ts
+++ b/packages/core/src/components/templates/SearchPage/index.ts
@@ -3,3 +3,6 @@ export type { SearchPageProps } from './SearchPage'
 
 export { default as SearchWrapper } from './SearchWrapper'
 export type { SearchWrapperProps } from './SearchWrapper'
+
+export { default as EmptySearch } from './EmptySearch'
+export type { EmptySearchProps } from './EmptySearch'


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to wrap the EmptySearch with the Render sections so that this page state can have GlobalSections.

| Before | After |
|--------|--------|
| <img width="407" alt="Screenshot 2025-02-17 at 16 25 41" src="https://github.com/user-attachments/assets/1486c831-f140-4ac8-a3d6-77a236611d0e" /> | <img width="812" alt="Screenshot 2025-02-17 at 16 28 17" src="https://github.com/user-attachments/assets/5a053e15-809c-4073-a4c9-84085c5364f2" /> |


## How to test it?

You can test this PR locally and see a search page without results or use the preview link.

### Starters Deploy Preview

TBD

## References

https://vtex.slack.com/archives/C051B6LL91U/p1739734780585179
