### PR TITLE
fix: add yarn to volta config

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,8 @@
   },
   "volta": {
     "node": "18.19.0",
-    "pnpm": "9.15.1"
+    "pnpm": "9.15.1",
+    "yarn": "1.22.22"
   },
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
## What's the purpose of this pull request?

- Adds yarn version to volta config.

After the changes in core we added the ppm version but we haven't set any version to yarn.

<img width="1293" alt="image" src="https://github.com/user-attachments/assets/4607c150-d7bb-457c-89a6-f7cea4cfc8c6" />

TODO: check faststore cli

## How to test it?

- Update the package.json of the starter.store with this codesanbox version
- Attempts to run `yarn build`
- You should be able to build the project without the previous error

