### PR TITLE
fix: Adds back SKUMatrix to PDP

### DIFF
--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -259,6 +259,27 @@ function ProductDetails({
                   isValidating={isValidating}
                   taxesConfiguration={taxesConfiguration}
                 />
+
+                {skuMatrix?.shouldDisplaySKUMatrix &&
+                  Object.keys(slugsMap).length > 1 && (
+                    <>
+                      <div data-fs-product-details-settings-separator>
+                        {skuMatrix.separatorButtonsText}
+                      </div>
+
+                      <SKUMatrix.Component>
+                        <SKUMatrixTrigger.Component disabled={isValidating}>
+                          {skuMatrix.triggerButtonLabel}
+                        </SKUMatrixTrigger.Component>
+
+                        <SKUMatrixSidebar.Component
+                          formatter={useFormattedPrice}
+                          columns={skuMatrix.columns}
+                          overlayProps={{ className: styles.section }}
+                        />
+                      </SKUMatrix.Component>
+                    </>
+                  )}
               </section>
 
               {!outOfStock && (


### PR DESCRIPTION
## What's the purpose of this pull request?

We accidentally removed this component in the previous version v3.15, so I'm putting it back.

## How to test it?

Navigate to Headphone Default product and you should be able to see the `Select multiple` button and open the modal.

PDP

<img width="1394" alt="image" src="https://github.com/user-attachments/assets/693d99b5-10fd-48a0-8b08-043342e87e6d" />

<img width="1888" alt="image" src="https://github.com/user-attachments/assets/7c50b95d-703b-4364-92a4-61c6bc82cbfb" />

### Starters Deploy Preview
[WIP]

