### PR TITLE
feat: delete review

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -394,6 +394,8 @@ export type Mutation = {
   __typename?: 'Mutation';
   /** Create a new product review. */
   createProductReview: Scalars['String'];
+  /** Delete a product review. */
+  deleteProductReview: Scalars['Boolean'];
   /** Subscribes a new person to the newsletter list. */
   subscribeToNewsletter?: Maybe<PersonNewsletter>;
   /** Checks for changes between the cart presented in the UI and the cart stored in the ecommerce platform. If changes are detected, it returns the cart stored on the platform. Otherwise, it returns `null`. */
@@ -405,6 +407,11 @@ export type Mutation = {
 
 export type MutationCreateProductReviewArgs = {
   data: ICreateProductReview;
+};
+
+
+export type MutationDeleteProductReviewArgs = {
+  reviewId: Scalars['String'];
 };
 
 

--- a/packages/api/src/platforms/errors.ts
+++ b/packages/api/src/platforms/errors.ts
@@ -2,7 +2,7 @@ type ErrorType =
   | 'BadRequestError'
   | 'NotFoundError'
   | 'RedirectError'
-  | 'NotAuthorizedError'
+  | 'UnauthorizedError'
 
 interface Extension {
   type: ErrorType
@@ -31,9 +31,9 @@ export class NotFoundError extends FastStoreError {
   }
 }
 
-export class NotAuthorizedError extends FastStoreError {
+export class UnauthorizedError extends FastStoreError {
   constructor(message?: string) {
-    super({ status: 401, type: 'NotAuthorizedError' }, message)
+    super({ status: 401, type: 'UnauthorizedError' }, message)
   }
 }
 

--- a/packages/api/src/platforms/vtex/clients/commerce/types/ProductReview.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/ProductReview.ts
@@ -16,7 +16,7 @@ export interface ProductReview {
   pastReviews: string | null
 }
 
-export enum ProductReviewsInputOrderBy {
+export enum ListProductReviewsInputOrderBy {
   productId = 'ProductId',
   shopperId = 'ShopperId',
   approved = 'Approved',
@@ -26,20 +26,20 @@ export enum ProductReviewsInputOrderBy {
   locale = 'Locale',
 }
 
-export type ProductReviewsInputOrderWay = 'asc' | 'desc'
+export type ListProductReviewsInputOrderWay = 'asc' | 'desc'
 
-export interface ProductReviewsInput {
+export interface ListProductReviewsInput {
   searchTerm?: string
   from?: number
   to?: number
-  orderBy?: ProductReviewsInputOrderBy
-  orderWay?: ProductReviewsInputOrderWay
+  orderBy?: ListProductReviewsInputOrderBy
+  orderWay?: ListProductReviewsInputOrderWay
   status?: boolean
   productId?: string
   rating?: number
 }
 
-export interface ProductReviewsResult {
+export interface ListProductReviewsResult {
   data: ProductReview[]
   range: {
     from: number

--- a/packages/api/src/platforms/vtex/resolvers/deleteProductReview.ts
+++ b/packages/api/src/platforms/vtex/resolvers/deleteProductReview.ts
@@ -1,0 +1,10 @@
+import type { Context } from '..'
+import type { MutationDeleteProductReviewArgs } from '../../../__generated__/schema'
+
+export const deleteProductReview = async (
+  _: unknown,
+  { reviewId }: MutationDeleteProductReviewArgs,
+  { clients: { commerce } }: Context
+): Promise<boolean> => {
+  return await commerce.reviews.delete(reviewId)
+}

--- a/packages/api/src/platforms/vtex/resolvers/mutation.ts
+++ b/packages/api/src/platforms/vtex/resolvers/mutation.ts
@@ -2,10 +2,12 @@ import { subscribeToNewsletter } from './subscribeToNewsletter'
 import { validateCart } from './validateCart'
 import { validateSession } from './validateSession'
 import { createProductReview } from './createProductReview'
+import { deleteProductReview } from './deleteProductReview'
 
 export const Mutation = {
   validateCart,
   validateSession,
   subscribeToNewsletter,
   createProductReview,
+  deleteProductReview,
 }

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -28,8 +28,8 @@ import type { Context } from '../index'
 import { isValidSkuId, pickBestSku } from '../utils/sku'
 import type { SearchArgs } from '../clients/search'
 import {
-  ProductReviewsInputOrderBy,
-  type ProductReviewsInputOrderWay,
+  ListProductReviewsInputOrderBy,
+  type ListProductReviewsInputOrderWay,
 } from '../clients/commerce/types/ProductReview'
 import { buildRatingDistribution } from '../utils/rating'
 
@@ -364,15 +364,15 @@ export const Query = {
     const to = from + (first ?? 6)
 
     const [orderByKey, orderWay] = sort?.split('_') as [
-      keyof typeof ProductReviewsInputOrderBy,
-      ProductReviewsInputOrderWay,
+      keyof typeof ListProductReviewsInputOrderBy,
+      ListProductReviewsInputOrderWay,
     ]
 
     return await commerce.reviews.list({
       productId,
       from,
       to,
-      orderBy: ProductReviewsInputOrderBy[orderByKey],
+      orderBy: ListProductReviewsInputOrderBy[orderByKey],
       orderWay,
       status: true,
       rating: rating ?? undefined,

--- a/packages/api/src/typeDefs/mutation.graphql
+++ b/packages/api/src/typeDefs/mutation.graphql
@@ -15,4 +15,8 @@ type Mutation {
   Create a new product review.
   """
   createProductReview(data: ICreateProductReview!): String!
+  """
+  Delete a product review.
+  """
+  deleteProductReview(reviewId: String!): Boolean!
 }

--- a/packages/api/test/schema.test.ts
+++ b/packages/api/test/schema.test.ts
@@ -76,6 +76,7 @@ const MUTATIONS = [
   'validateSession',
   'subscribeToNewsletter',
   'createProductReview',
+  'deleteProductReview',
 ]
 
 let schema: GraphQLSchema

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -403,6 +403,8 @@ export type MessageInfo = {
 export type Mutation = {
   /** Create a new product review. */
   createProductReview: Scalars['String']['output']
+  /** Delete a product review. */
+  deleteProductReview: Scalars['Boolean']['output']
   /** Subscribes a new person to the newsletter list. */
   subscribeToNewsletter: Maybe<PersonNewsletter>
   /** Checks for changes between the cart presented in the UI and the cart stored in the ecommerce platform. If changes are detected, it returns the cart stored on the platform. Otherwise, it returns `null`. */
@@ -413,6 +415,10 @@ export type Mutation = {
 
 export type MutationCreateProductReviewArgs = {
   data: ICreateProductReview
+}
+
+export type MutationDeleteProductReviewArgs = {
+  reviewId: Scalars['String']['input']
 }
 
 export type MutationSubscribeToNewsletterArgs = {

--- a/packages/core/test/server/index.test.ts
+++ b/packages/core/test/server/index.test.ts
@@ -80,6 +80,7 @@ const MUTATIONS = [
   'validateSession',
   'subscribeToNewsletter',
   'createProductReview',
+  'deleteProductReview',
 ]
 
 describe('FastStore GraphQL Layer', () => {


### PR DESCRIPTION
## What's the purpose of this pull request?

To add the `deleteProductReview` mutation on the API 

## How it works?

Passing the `reviewId` it's possible to delete a review.

>[!IMPORTANT]
> Authentication is required

>[!IMPORTANT]
> It's only possible to delete a review that you have ownership

## How to test it?

run `api` and `core` packages locally with the following command:
```bash
npm run dev -- --filter="./packages/api/**" --filter="./packages/core/**"
```

open your browser and adds the `VtexIdclientAutCookie_storeframework` cookie

run the following mutation and fill it with the correct `reviewId`
```graphQL
mutation {
  deleteProductReview(reviewId: "")  
}
```

## References

[FEATURE BRANCH](https://github.com/vtex/faststore/pull/2676)

[API DOC](https://developers.vtex.com/docs/api-reference/reviews-and-ratings-api#delete-/reviews-and-ratings/api/review/-reviewId-)

[JIRA-SFS-2132](https://vtex-dev.atlassian.net/browse/SFS-2132)