### PR TITLE
fix: removes MissingContentError checks in getPage 

### DIFF
--- a/packages/core/src/server/cms/index.ts
+++ b/packages/core/src/server/cms/index.ts
@@ -118,10 +118,6 @@ export const getPage = async <T extends ContentData>(options: Options) => {
 
   const pages = result.data
 
-  if (!pages[0]) {
-    throw new MissingContentError(options)
-  }
-
   if (pages.length > 1) {
     throw new MultipleContentError(options)
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

- https://github.com/vtex/faststore/pull/2668
introduces a bug in its last commit. This PR removes the checking for the MissingContentError in getPage

## How it works?

<!--- Tell us the role of the new feature, or component, in its context. Provide details about what you have implemented and screenshots if applicable.  --->

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**

- [ ] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [ ] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [ ] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [ ] PR description
- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)
