### PR TITLE
feat: [Delivery Promise] Default postal code

### DIFF
--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -111,7 +111,6 @@ module.exports = {
 
   deliveryPromise: {
     enabled: false,
-    locationMandatory: false,
   },
 
   experimental: {

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -109,6 +109,11 @@ module.exports = {
     data: process.env.CMS_DATA,
   },
 
+  deliveryPromise: {
+    active: false,
+    locationMandatory: false,
+  },
+
   experimental: {
     cypressVersion: 12,
     enableCypressExtension: false,

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -110,7 +110,7 @@ module.exports = {
   },
 
   deliveryPromise: {
-    active: false,
+    enabled: false,
     locationMandatory: false,
   },
 

--- a/packages/core/src/sdk/session/index.ts
+++ b/packages/core/src/sdk/session/index.ts
@@ -55,8 +55,7 @@ export const validateSession = async (session: Session) => {
     const initialPostalCode = defaultStore.readInitial().postalCode
 
     if (!!initialPostalCode) {
-      session = { ...session, postalCode: initialPostalCode }
-      sessionStore.set(session)
+      sessionStore.set({ ...session, postalCode: initialPostalCode })
     }
   }
 

--- a/packages/core/src/sdk/session/index.ts
+++ b/packages/core/src/sdk/session/index.ts
@@ -50,6 +50,16 @@ export const mutation = gql(`
 `)
 
 export const validateSession = async (session: Session) => {
+  if (storeConfig.deliveryPromise?.enabled && !session.postalCode) {
+    // Use the initial postalCode defined in discovery.config.js when there is no postalCode in the session
+    const initialPostalCode = defaultStore.readInitial().postalCode
+
+    if (!!initialPostalCode) {
+      session = { ...session, postalCode: initialPostalCode }
+      sessionStore.set(session)
+    }
+  }
+
   const data = await request<
     ValidateSessionMutation,
     ValidateSessionMutationVariables

--- a/packages/sdk/src/store/persisted.ts
+++ b/packages/sdk/src/store/persisted.ts
@@ -45,23 +45,7 @@ export const persisted =
       const payload = await getIDB<T>(key)
 
       if (typeof document !== 'undefined') {
-        const hasNoPostalCodeInPayload =
-          payload &&
-          typeof payload === 'object' &&
-          'postalCode' in payload &&
-          (payload.postalCode === null || payload.postalCode === '')
-
-        const initial = store.readInitial()
-        const isInitialObject = initial && typeof initial === 'object'
-        const hasPostalCodeInInitial =
-          isInitialObject && 'postalCode' in initial
-
-        if (hasNoPostalCodeInPayload && hasPostalCodeInInitial) {
-          // Use the default postalCode defined in discovery.config.js when there is no postalCode in the IDB
-          payload.postalCode = initial.postalCode
-        }
-
-        store.set(payload ?? initial)
+        store.set(payload ?? store.readInitial())
       }
     }
 

--- a/packages/sdk/src/store/persisted.ts
+++ b/packages/sdk/src/store/persisted.ts
@@ -45,7 +45,23 @@ export const persisted =
       const payload = await getIDB<T>(key)
 
       if (typeof document !== 'undefined') {
-        store.set(payload ?? store.readInitial())
+        const hasNoPostalCodeInPayload =
+          payload &&
+          typeof payload === 'object' &&
+          'postalCode' in payload &&
+          (payload.postalCode === null || payload.postalCode === '')
+
+        const initial = store.readInitial()
+        const isInitialObject = initial && typeof initial === 'object'
+        const hasPostalCodeInInitial =
+          isInitialObject && 'postalCode' in initial
+
+        if (hasNoPostalCodeInPayload && hasPostalCodeInInitial) {
+          // Use the default postalCode defined in discovery.config.js when there is no postalCode in the IDB
+          payload.postalCode = initial.postalCode
+        }
+
+        store.set(payload ?? initial)
       }
     }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Add in `discovery.config.js` the config that will be used for the new feature Delivery Promise and update code related to validate session to change the `postalCode` to the default one if it's null or empty.

## How it works?

If the session's `postalCode` is null or empty, it changes to the initial/default one configured in `discovery.config.js` in the `session` object.

## How to test it?

In the starter preview's `discovery.config.js` file, I've added `90210` as the default postal code and enabled the deliveryPromise feature. Then if you test the preview you should see this postal code in the IndexedDB of the browser's devtools.
![Screenshot 2025-02-28 at 14 00 42](https://github.com/user-attachments/assets/26db75a2-339d-4eef-bf83-0c3cb6fab915)

You can also test that it'll be updated to the default postal code if the postal code in the IDB is null or empty previously for some reason (like if you had already accessed the store before this change). It can be done by [editing the IDB through a script in the browser's devtools](https://developer.chrome.com/docs/devtools/storage/indexeddb). Here is the snippet I've used:
![Screenshot 2025-02-28 at 14 17 40](https://github.com/user-attachments/assets/b15de9e7-0b77-44c9-b999-cdaad5062663)
```
var connection = indexedDB.open('keyval-store', 1);

connection.onsuccess = (e) => {
    var database = e.target.result;
    var objectStore = database.transaction(['keyval'],'readwrite').objectStore('keyval');
    var getRequest = objectStore.get('fs::session');
    getRequest.onsuccess = (e) => {
        var data = e.target.result;
        data.postalCode = null;
        var updateRequest = objectStore.put(data, 'fs::session');
        updateRequest.onsuccess = (event) => {
            console.log(event.target.result);
        }
    }
}
```
https://github.com/user-attachments/assets/104164bf-80e8-4bec-bcd5-982f4fe60e04


### Starters Deploy Preview

https://storeframework-cm652ufll028lmgv665a6xv0g-8kzj40dcm.b.vtex.app/ ([PR](https://github.com/vtex-sites/starter.store/pull/705))

## References

- [Jira task 1](https://vtex-dev.atlassian.net/browse/SFS-2199)
- [Jira task 2](https://vtex-dev.atlassian.net/browse/SFS-2200)
- [Delivery Promise RFC - related section 1](https://docs.google.com/document/d/15IUc7_sQ_MxM67TJJI4fqbnTyc9PVdy_jJb5M0iMhyE/edit?tab=t.0#heading=h.igtfl04jtxbb)
- [Delivery Promise RFC - related section 2](https://docs.google.com/document/d/15IUc7_sQ_MxM67TJJI4fqbnTyc9PVdy_jJb5M0iMhyE/edit?tab=t.0#heading=h.h45g42imthwf)

## Checklist

- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)
