### PR TITLE
fix: Do not include similar categories in the breadcrumb list

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -40,6 +40,8 @@ function removeTrailingSlashes(path: string) {
 /**
  * Finds the index of the main category tree that matches the given category ID.
  * This avoids including similar categories in the breadcrumb list.
+ * If Intelligent Search starts providing the list without similar categories, we'll have direct access to the main tree
+ * and we won't need this logic. Hopefully in the future we can remove this.
  *
  * @param categoriesIds - An array of category IDs representing different category trees.
  * @param categoryId - The category ID to find within the category trees.


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the breadcrumb list construction. It was including the similar categories, which is not correct.

## How it works?

The main point of this PR is the `findMainTreeIndex` function that finds the index of the main category tree that matches the product's category ID. Having this index is possible to build the correct breadcrumb list, using only the "main" categories, not the similar ones.

Example:
For the `storeframework` account's product `Gorgeous Cotton Car`, I've added the similar category `/Computer & Software/Smartphones/`. In that case, the categories, categoryId and categoriesIds would be:
categories -> `[ '/Office/Furniture | Chairs/', '/Office/', '/Computer & Software/Smartphones/', '/Computer & Software/']`
categoryId -> `'9296'` 
categoriesIds -> `['/9282/9296/', '/9282/', '/9286/9291/', '/9286/']`
The `findMainTreeIndex` would find that `'9296'` is in the index `0` and the breadcrumb list would be built using the `'/Office/Furniture | Chairs/'` path.

## How to test it?

Access the `Gorgeous Cotton Car` PDP (`/gorgeous-cotton-car-38366208/p`) and see the breadcrumb list. It should be only `Office -> Furniture | Chairs`.

| Before | After |
| ---- | ---- |
| <img width="785" alt="Screenshot 2025-03-04 at 11 13 24" src="https://github.com/user-attachments/assets/6e181f5d-25e4-41d9-b3c6-79dd52ec2572" /> | <img width="856" alt="Screenshot 2025-03-04 at 11 20 00" src="https://github.com/user-attachments/assets/47501ba0-18b8-425d-b833-4951fcc93a3a" /> |

### Starters Deploy Preview

https://storeframework-cm652ufll028lmgv665a6xv0g-qy5et2s0u.b.vtex.app/gorgeous-cotton-car-38366208/p ([PR](https://github.com/vtex-sites/starter.store/pull/709))

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SO-404)