### PR TITLE
fix: Product Details' Buy Button excessive state reset

### DIFF
--- a/packages/core/src/components/ui/ProductDetails/ProductDetailsSettings.tsx
+++ b/packages/core/src/components/ui/ProductDetails/ProductDetailsSettings.tsx
@@ -101,29 +101,6 @@ function ProductDetailsSettings({
     [availability]
   )
 
-  const AddToCartButton = () => {
-    return outOfStock ? (
-      // TODO: Adds <OutOfStock /> when component is ready to use
-      <NotAvailableButton.Component>
-        {notAvailableButtonTitle}
-      </NotAvailableButton.Component>
-    ) : (
-      <BuyButton.Component
-        {...BuyButton.props}
-        icon={
-          <Icon.Component
-            {...Icon.props}
-            name={buyButtonIconName ?? Icon.props.name}
-            aria-label={buyButtonIconAlt ?? Icon.props['aria-label']}
-          />
-        }
-        {...buyProps}
-      >
-        {buyButtonTitle || 'Add to Cart'}
-      </BuyButton.Component>
-    )
-  }
-
   return (
     <>
       {!outOfStock && (
@@ -192,8 +169,25 @@ function ProductDetailsSettings({
           background color when changing from its initial disabled to active state.
           See full explanation on commit https://git.io/JyXV5. */
         <AddToCartLoadingSkeleton />
+      ) : outOfStock ? (
+        // TODO: Adds <OutOfStock /> when component is ready to use
+        <NotAvailableButton.Component>
+          {notAvailableButtonTitle}
+        </NotAvailableButton.Component>
       ) : (
-        <AddToCartButton />
+        <BuyButton.Component
+          {...BuyButton.props}
+          icon={
+            <Icon.Component
+              {...Icon.props}
+              name={buyButtonIconName ?? Icon.props.name}
+              aria-label={buyButtonIconAlt ?? Icon.props['aria-label']}
+            />
+          }
+          {...buyProps}
+        >
+          {buyButtonTitle || 'Add to Cart'}
+        </BuyButton.Component>
       )}
     </>
   )


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix an issue happening when overriding the `BuyButton` component of the `ProductDetails` section: when the user change tabs it resets the state.

## How it works?

It's related to how React handles with state. In this [doc](https://react.dev/learn/preserving-and-resetting-state) there is more info about it, but the main point here is that React doesn't recommend nesting component functions, so I've removed the nested `AddToCartButton` definition.

## How to test it?

I've used the `playground` store because it already has a custom BuyButton, so I added a Counter in this override to test the change.
To test it, click on the "Click here to increment!" and change browser tabs, after coming back to the tab it should've maintained the state (the counter).
In this preview you can see the issue happening: https://sfj-5061a5d--playground.preview.vtex.app/adidas-mens-performance-polo-green-night-99984111/p ([PR](https://github.com/vtex-sites/playground.store/pull/150)) 
This other preview has this PR version installed and the issue doesn't happen anymore: https://sfj-a8c406f--playground.preview.vtex.app/adidas-mens-performance-polo-green-night-99984111/p ([PR](https://github.com/vtex-sites/playground.store/pull/149))

https://github.com/user-attachments/assets/7dfe573b-4007-4a84-b323-7a427c23b23a

https://github.com/user-attachments/assets/bbe6cc42-fdd0-453c-8868-4cb8b1fd201d

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SO-418)
- [React doc: Preserving and resetting state](https://react.dev/learn/preserving-and-resetting-state#different-components-at-the-same-position-reset-state)