### PR TITLE
fix: Breadcrumb display and it style

### DIFF
--- a/packages/core/src/components/sections/Breadcrumb/section.module.scss
+++ b/packages/core/src/components/sections/Breadcrumb/section.module.scss
@@ -1,5 +1,6 @@
 @layer components {
   .section {
+    @import "@faststore/ui/src/components/atoms/Button/styles.scss";
     @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
     @import "@faststore/ui/src/components/atoms/Link/styles.scss";
     @import "@faststore/ui/src/components/atoms/List/styles.scss";

--- a/packages/core/src/components/sections/Navbar/section.module.scss
+++ b/packages/core/src/components/sections/Navbar/section.module.scss
@@ -29,6 +29,15 @@
 
     @include media(">=notebook") {
       height: var(--fs-navbar-height-desktop);
+
+      // Sets margin to avoid overlapping the section below
+      &:has([data-fs-navbar-scroll]) {
+        margin-bottom: var(--fs-control-min-height);
+      }
+
+      &:has([data-fs-navbar-scroll="down"]) {
+        margin-bottom: 0;
+      }
     }
   }
 }

--- a/packages/core/src/styles/global/index.scss
+++ b/packages/core/src/styles/global/index.scss
@@ -9,3 +9,6 @@
 @import "@faststore/ui/src/components/atoms/Overlay/styles.scss";
 @import "@faststore/ui/src/components/atoms/SROnly/styles.scss";
 @import "src/components/sections/Section/section.scss";
+
+// Importing this component because is being used outside the context of the Section
+@import "@faststore/ui/src/components/molecules/Dropdown/styles.scss";

--- a/packages/ui/src/components/molecules/Dropdown/styles.scss
+++ b/packages/ui/src/components/molecules/Dropdown/styles.scss
@@ -39,8 +39,8 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  overflow: hidden;
   margin-top: var(--fs-spacing-0);
+  overflow: hidden;
   background: var(--fs-dropdown-menu-bkg-color);
   border-radius: var(--fs-dropdown-menu-border-radius);
   box-shadow: var(--fs-dropdown-menu-box-shadow);
@@ -50,7 +50,6 @@
     align-items: center;
     width: 100%;
     min-height: var(--fs-dropdown-item-min-height);
-    padding: var(--fs-dropdown-item-padding);
     overflow: hidden;
     font-size: var(--fs-dropdown-item-text-size);
     font-weight: var(--fs-dropdown-item-text-weight);
@@ -67,9 +66,9 @@
     }
 
     &:focus, &:hover {
-    text-decoration: none;
-    background-color: var(--fs-dropdown-item-bkg-color-hover);
-    outline: none;
+      text-decoration: none;
+      background-color: var(--fs-dropdown-item-bkg-color-hover);
+      outline: none;
     }
 
     [data-fs-dropdown-item-icon] {

--- a/packages/ui/src/components/molecules/Dropdown/styles.scss
+++ b/packages/ui/src/components/molecules/Dropdown/styles.scss
@@ -76,6 +76,10 @@
       min-width: var(--fs-dropdown-item-icon-min-width);
       margin-right: var(--fs-dropdown-item-icon-margin-right);
     }
+
+    > a {
+      color: var(--fs-dropdown-item-color);
+    }
   }
 
   // --------------------------------------------------------

--- a/packages/ui/src/components/organisms/Navbar/styles.scss
+++ b/packages/ui/src/components/organisms/Navbar/styles.scss
@@ -50,7 +50,7 @@
   }
 
   &[data-fs-navbar-scroll="down"] {
-    > nav {
+    > [data-fs-navbar-links] {
       top: calc(-1 * var(--fs-spacing-3));
       height: 0;
       padding: 0;
@@ -59,7 +59,7 @@
   }
 
   &[data-fs-navbar-scroll="up"] {
-    > nav {
+    > [data-fs-navbar-links] {
       top: 0;
       opacity: 1;
     }
@@ -175,22 +175,22 @@
       }
 
       [data-fs-cart-toggle] {
-        display: none;
         right: 0;
+        display: none;
       }
     }
   }
 
   [data-fs-navbar-header] {
     z-index: var(--fs-z-index-top);
+    height: 100%;
     background-color: var(--fs-navbar-bkg-color);
     backdrop-filter: blur(10px);
-    height: 100%;
   }
 
   [data-fs-navbar-logo] {
-    height: 100%;
     align-self: stretch;
+    height: 100%;
 
     @include media("<notebook") {
       padding: var(--fs-spacing-1) 0 var(--fs-spacing-1) var(--fs-spacing-3);


### PR DESCRIPTION
## What's the purpose of this pull request?

- Fix Breadcrumb section display on pages
![video](https://github.com/user-attachments/assets/66f14935-5d5c-45bb-b795-c445f56f3071)
When scrolling the page, either the RegionBar or the Breadcrumb was displayed. In addiction, the Breadcrumb section was not appearing on PLP/search pages.

- Fix the Breadcrumb Dropdown Menu style 

## How it works?

|Before - PDP |After - PDP|
|-|-|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/849956cc-d601-4fa0-8d22-f4241aa18589" />|<img width="500" alt="image" src="https://github.com/user-attachments/assets/60953a1e-2100-4f17-a3a2-c013b9e13882" />|

|Before - Dropdown Menu | After - Dropdown Menu|
|-|-|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/a3b01428-5ac8-4491-b67a-8e1de23ffc98" />|<img width="500" alt="image" src="https://github.com/user-attachments/assets/5ec9d767-6e8d-4988-a2da-37bc5a7d2390" />|

|Before - PLP |After - PLP|
|-|-|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/fa99e4b2-ea84-46a2-acf1-fa4c3b146c82" />|<img width="500" alt="image" src="https://github.com/user-attachments/assets/31dca464-03ab-4df0-9787-e5076031b5e7" />|

|Before - Search Page |After - Search|
|-|-|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/47678beb-c468-46f0-8126-5f9ef16c2d76" />|<img width="500" alt="image" src="https://github.com/user-attachments/assets/548a80b5-0e66-4f72-a7e9-f5bb37f9a454" />|

@renatamottam In this page, I'm just putting it back, but we can discuss later if we should keep displaying it or fix its style.


## How to test it?

- Run core locally or use this preview [link](https://starter-i1wv0yz35-vtex.vercel.app).
- Navigate through PLP and Search page to test the listed scenario above
- Look for `Handmade Cotton Computer` product and check the dropdown menu style. 

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/712

## References

- It partially address the issues mentioned in this [task](https://vtex-dev.atlassian.net/browse/SFS-1999) : Breadcrumb section now always appears as expected.
- I'll create a new one to review the Dropdown Menu style and placement. (So we don't need to import it globally)
- https://caniuse.com/css-has

