### PR TITLE
fix: override to use core breadcrumb component

### DIFF
--- a/packages/core/src/components/sections/Breadcrumb/Breadcrumb.tsx
+++ b/packages/core/src/components/sections/Breadcrumb/Breadcrumb.tsx
@@ -2,7 +2,8 @@ import { memo } from 'react'
 
 import Section from '../Section'
 
-import styles from './section.module.scss'
+import { getOverridableSection } from '../../../sdk/overrides/getOverriddenSection'
+import { useOverrideComponents } from '../../../sdk/overrides/OverrideContext'
 import {
   type PDPContext,
   type PLPContext,
@@ -10,9 +11,8 @@ import {
   isPLP,
   usePage,
 } from '../../../sdk/overrides/PageProvider'
-import { useOverrideComponents } from '../../../sdk/overrides/OverrideContext'
 import { BreadcrumbDefaultComponents } from './DefaultComponents'
-import { getOverridableSection } from '../../../sdk/overrides/getOverriddenSection'
+import styles from './section.module.scss'
 
 interface BreadcrumbSectionProps {
   icon: string
@@ -20,7 +20,8 @@ interface BreadcrumbSectionProps {
 }
 
 function BreadcrumbSection({ ...otherProps }: BreadcrumbSectionProps) {
-  const { Breadcrumb } = useOverrideComponents<'Breadcrumb'>()
+  const { __experimentalBreadcrumb: Breadcrumb } =
+    useOverrideComponents<'Breadcrumb'>()
 
   const context = usePage<PDPContext | PLPContext>()
   const title = isPLP(context)

--- a/packages/core/src/components/sections/Breadcrumb/Breadcrumb.tsx
+++ b/packages/core/src/components/sections/Breadcrumb/Breadcrumb.tsx
@@ -20,8 +20,7 @@ interface BreadcrumbSectionProps {
 }
 
 function BreadcrumbSection({ ...otherProps }: BreadcrumbSectionProps) {
-  const { __experimentalBreadcrumb: Breadcrumb } =
-    useOverrideComponents<'Breadcrumb'>()
+  const { Breadcrumb } = useOverrideComponents<'Breadcrumb'>()
 
   const context = usePage<PDPContext | PLPContext>()
   const title = isPLP(context)

--- a/packages/core/src/components/sections/Breadcrumb/DefaultComponents.ts
+++ b/packages/core/src/components/sections/Breadcrumb/DefaultComponents.ts
@@ -1,6 +1,7 @@
-import { Breadcrumb as UIBreadcrumb, Icon as UIIcon } from '@faststore/ui'
+import { Icon as UIIcon } from '@faststore/ui'
+import Breadcrumb from 'src/components/ui/Breadcrumb'
 
 export const BreadcrumbDefaultComponents = {
-  Breadcrumb: UIBreadcrumb,
+  __experimentalBreadcrumb: Breadcrumb,
   Icon: UIIcon,
 } as const

--- a/packages/core/src/components/sections/Breadcrumb/DefaultComponents.ts
+++ b/packages/core/src/components/sections/Breadcrumb/DefaultComponents.ts
@@ -2,6 +2,6 @@ import { Icon as UIIcon } from '@faststore/ui'
 import Breadcrumb from 'src/components/ui/Breadcrumb'
 
 export const BreadcrumbDefaultComponents = {
-  Breadcrumb: Breadcrumb,
+  Breadcrumb,
   Icon: UIIcon,
 } as const

--- a/packages/core/src/components/sections/Breadcrumb/DefaultComponents.ts
+++ b/packages/core/src/components/sections/Breadcrumb/DefaultComponents.ts
@@ -2,6 +2,6 @@ import { Icon as UIIcon } from '@faststore/ui'
 import Breadcrumb from 'src/components/ui/Breadcrumb'
 
 export const BreadcrumbDefaultComponents = {
-  __experimentalBreadcrumb: Breadcrumb,
+  Breadcrumb: Breadcrumb,
   Icon: UIIcon,
 } as const

--- a/packages/core/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/packages/core/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -14,7 +14,7 @@ const Breadcrumb = ({
   alt = 'Go to homepage',
   ...otherProps
 }: BreadcrumbProps) => {
-  const { Icon } = useOverrideComponents<'Breadcrumb'>()
+  const { Breadcrumb, Icon } = useOverrideComponents<'Breadcrumb'>()
 
   return (
     <UIBreadcrumb
@@ -40,6 +40,7 @@ const Breadcrumb = ({
           {name}
         </Link>
       )}
+      {...Breadcrumb.props}
       {...otherProps}
     />
   )

--- a/packages/core/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/packages/core/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -1,10 +1,9 @@
 import type { BreadcrumbProps as UIBreadcrumbProps } from '@faststore/ui'
+import { Breadcrumb as UIBreadcrumb } from '@faststore/ui'
 import { memo } from 'react'
 
 import Link from 'src/components/ui/Link'
-
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
-
 export interface BreadcrumbProps extends UIBreadcrumbProps {
   icon: string
   alt: string
@@ -15,11 +14,10 @@ const Breadcrumb = ({
   alt = 'Go to homepage',
   ...otherProps
 }: BreadcrumbProps) => {
-  const { Breadcrumb: BreadcrumbWrapper, Icon } =
-    useOverrideComponents<'Breadcrumb'>()
+  const { Icon } = useOverrideComponents<'Breadcrumb'>()
 
   return (
-    <BreadcrumbWrapper.Component
+    <UIBreadcrumb
       homeLink={
         <Link
           data-fs-breadcrumb-link
@@ -42,7 +40,6 @@ const Breadcrumb = ({
           {name}
         </Link>
       )}
-      {...BreadcrumbWrapper.props}
       {...otherProps}
     />
   )

--- a/packages/core/src/typings/overrides.ts
+++ b/packages/core/src/typings/overrides.ts
@@ -1,9 +1,7 @@
-import type { PropsWithChildren } from 'react'
 import type {
   AlertProps,
   BannerTextContentProps,
   BannerTextProps,
-  BreadcrumbProps,
   ButtonProps,
   DiscountBadgeProps,
   EmptyStateProps,
@@ -26,11 +24,11 @@ import type {
   NavbarSliderFooterProps,
   NavbarSliderHeaderProps,
   NavbarSliderProps,
-  NewsletterProps,
   NewsletterAddendumProps,
   NewsletterContentProps,
   NewsletterFormProps,
   NewsletterHeaderProps,
+  NewsletterProps,
   ProductPriceProps,
   ProductShelfProps,
   ProductTitleProps,
@@ -38,28 +36,29 @@ import type {
   RegionBarProps,
   ShippingSimulationProps,
   SkeletonProps,
-  SkuSelectorProps,
   SKUMatrixProps,
-  SKUMatrixTriggerProps,
   SKUMatrixSidebarProps,
+  SKUMatrixTriggerProps,
+  SkuSelectorProps,
 } from '@faststore/ui'
+import type { PropsWithChildren } from 'react'
 
+import type Alert from '../components/sections/Alert'
+import type BannerText from '../components/sections/BannerText'
+import type Breadcrumb from '../components/sections/Breadcrumb'
+import type CrossSellingShelf from '../components/sections/CrossSellingShelf'
+import type EmptyState from '../components/sections/EmptyState'
+import type Hero from '../components/sections/Hero'
+import type Navbar from '../components/sections/Navbar'
+import type Newsletter from '../components/sections/Newsletter'
+import type ProductDetails from '../components/sections/ProductDetails'
+import type ProductGallery from '../components/sections/ProductGallery'
+import type ProductShelf from '../components/sections/ProductShelf'
+import type RegionBar from '../components/sections/RegionBar'
 import type {
   ComponentOverrideDefinition,
   SectionOverrideDefinitionV1,
 } from './overridesDefinition'
-import type Alert from '../components/sections/Alert'
-import type Breadcrumb from '../components/sections/Breadcrumb'
-import type BannerText from '../components/sections/BannerText'
-import type CrossSellingShelf from '../components/sections/CrossSellingShelf'
-import type EmptyState from '../components/sections/EmptyState'
-import type Hero from '../components/sections/Hero'
-import type ProductShelf from '../components/sections/ProductShelf'
-import type ProductDetails from '../components/sections/ProductDetails'
-import type Navbar from '../components/sections/Navbar'
-import type Newsletter from '../components/sections/Newsletter'
-import type ProductGallery from '../components/sections/ProductGallery'
-import type RegionBar from '../components/sections/RegionBar'
 
 export type SectionOverride = {
   [K in keyof SectionsOverrides]: SectionOverrideDefinitionV1<K>
@@ -136,7 +135,7 @@ export type SectionsOverrides = {
   Breadcrumb: {
     Section: typeof Breadcrumb
     components: {
-      Breadcrumb: ComponentOverrideDefinition<BreadcrumbProps, BreadcrumbProps>
+      __experimentalBreadcrumb: ComponentOverrideDefinition<any, any>
       Icon: ComponentOverrideDefinition<IconProps, IconProps>
     }
   }

--- a/packages/core/src/typings/overrides.ts
+++ b/packages/core/src/typings/overrides.ts
@@ -135,7 +135,7 @@ export type SectionsOverrides = {
   Breadcrumb: {
     Section: typeof Breadcrumb
     components: {
-      __experimentalBreadcrumb: ComponentOverrideDefinition<any, any>
+      Breadcrumb: ComponentOverrideDefinition<any, any>
       Icon: ComponentOverrideDefinition<IconProps, IconProps>
     }
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

- We were not using the `Breadcrumb` component from the [core](https://github.com/vtex/faststore/blob/main/packages/core/src/components/ui/Breadcrumb/Breadcrumb.tsx). 

I'm not sure if it was a mistake when handling this component override in the Breadcrumb section or was intentional. But the Home icon/link that we previously is implemented in the breadcrumb core component. So in order to display it, we have to use the component from core.

|before|after|
|-|-|
|<img width="500" alt="before breadcrumb" src="https://github.com/user-attachments/assets/3405b84f-3bed-4ec3-868e-39a8ed7e38db" />|<img width="500" alt="after breadcrumb" src="https://github.com/user-attachments/assets/e66aab8a-4d85-44a6-b658-e3c63632d4ad" />|

## How to test it?

- Run core locally or use this preview [link](https://sfj-42a0752--starter.preview.vtex.app).
- Check if the Breadcrumb component that is being used is from core.

### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/713

## References

- It address the home icon missing mentioned in this [task SFS-1999](https://vtex-dev.atlassian.net/browse/SFS-1999)