### PR TITLE
chore: renames button sign in experimental prefix

### DIFF
--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -93,7 +93,7 @@ function Navbar({
     NavbarRow,
     NavbarButtons,
     IconButton,
-    _experimentalButtonSignIn: ButtonSignIn,
+    __experimentalButtonSignIn: ButtonSignIn,
   } = useOverrideComponents<'Navbar'>()
   const scrollDirection = useScrollDirection()
   const { openNavbar, navbar: displayNavbar } = useUI()

--- a/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
+++ b/packages/core/src/components/navigation/NavbarSlider/NavbarSlider.tsx
@@ -1,15 +1,15 @@
 import { useFadeEffect, useUI } from '@faststore/ui'
 import { Suspense } from 'react'
 
+import NavbarLinks from 'src/components/navigation/NavbarLinks'
 import { ButtonSignInFallback } from 'src/components/ui/Button'
 import Link from 'src/components/ui/Link'
-import NavbarLinks from 'src/components/navigation/NavbarLinks'
 import Logo from 'src/components/ui/Logo'
 
 import type { NavbarProps } from '../Navbar'
 
-import styles from './section.module.scss'
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
+import styles from './section.module.scss'
 
 interface NavbarSliderProps {
   logo: NavbarProps['logo']
@@ -31,7 +31,7 @@ function NavbarSlider({
     NavbarSliderHeader,
     NavbarSliderContent,
     NavbarSliderFooter,
-    _experimentalButtonSignIn: ButtonSignIn,
+    __experimentalButtonSignIn: ButtonSignIn,
   } = useOverrideComponents<'Navbar'>()
 
   const { closeNavbar } = useUI()

--- a/packages/core/src/components/sections/Navbar/DefaultComponents.ts
+++ b/packages/core/src/components/sections/Navbar/DefaultComponents.ts
@@ -49,5 +49,5 @@ export const NavbarDefaultComponents = {
   NavbarRow: UINavbarRow,
   NavbarButtons: UINavbarButtons,
   IconButton: UIIconButton,
-  _experimentalButtonSignIn: ButtonSignIn,
+  __experimentalButtonSignIn: ButtonSignIn,
 } as const

--- a/packages/core/src/typings/overrides.ts
+++ b/packages/core/src/typings/overrides.ts
@@ -1,4 +1,3 @@
-import type { PropsWithChildren } from 'react'
 import type {
   AlertProps,
   BannerTextContentProps,
@@ -26,11 +25,11 @@ import type {
   NavbarSliderFooterProps,
   NavbarSliderHeaderProps,
   NavbarSliderProps,
-  NewsletterProps,
   NewsletterAddendumProps,
   NewsletterContentProps,
   NewsletterFormProps,
   NewsletterHeaderProps,
+  NewsletterProps,
   ProductPriceProps,
   ProductShelfProps,
   ProductTitleProps,
@@ -38,28 +37,29 @@ import type {
   RegionBarProps,
   ShippingSimulationProps,
   SkeletonProps,
-  SkuSelectorProps,
   SKUMatrixProps,
-  SKUMatrixTriggerProps,
   SKUMatrixSidebarProps,
+  SKUMatrixTriggerProps,
+  SkuSelectorProps,
 } from '@faststore/ui'
+import type { PropsWithChildren } from 'react'
 
+import type Alert from '../components/sections/Alert'
+import type BannerText from '../components/sections/BannerText'
+import type Breadcrumb from '../components/sections/Breadcrumb'
+import type CrossSellingShelf from '../components/sections/CrossSellingShelf'
+import type EmptyState from '../components/sections/EmptyState'
+import type Hero from '../components/sections/Hero'
+import type Navbar from '../components/sections/Navbar'
+import type Newsletter from '../components/sections/Newsletter'
+import type ProductDetails from '../components/sections/ProductDetails'
+import type ProductGallery from '../components/sections/ProductGallery'
+import type ProductShelf from '../components/sections/ProductShelf'
+import type RegionBar from '../components/sections/RegionBar'
 import type {
   ComponentOverrideDefinition,
   SectionOverrideDefinitionV1,
 } from './overridesDefinition'
-import type Alert from '../components/sections/Alert'
-import type Breadcrumb from '../components/sections/Breadcrumb'
-import type BannerText from '../components/sections/BannerText'
-import type CrossSellingShelf from '../components/sections/CrossSellingShelf'
-import type EmptyState from '../components/sections/EmptyState'
-import type Hero from '../components/sections/Hero'
-import type ProductShelf from '../components/sections/ProductShelf'
-import type ProductDetails from '../components/sections/ProductDetails'
-import type Navbar from '../components/sections/Navbar'
-import type Newsletter from '../components/sections/Newsletter'
-import type ProductGallery from '../components/sections/ProductGallery'
-import type RegionBar from '../components/sections/RegionBar'
 
 export type SectionOverride = {
   [K in keyof SectionsOverrides]: SectionOverrideDefinitionV1<K>
@@ -198,7 +198,7 @@ export type SectionsOverrides = {
         IconButtonProps,
         Omit<IconButtonProps, 'onClick'>
       >
-      _experimentalButtonSignIn: ComponentOverrideDefinition<any, any>
+      __experimentalButtonSignIn: ComponentOverrideDefinition<any, any>
     }
   }
   Newsletter: {


### PR DESCRIPTION
## What's the purpose of this pull request?

- Fixing a small typo issue, it should be `__experimentalButtonSignIn` instead of `_experimentalButtonSignIn` (an `_` missing)
- I believe this override is not being used by clients so far, so we can update it now to prevent breaking changes in the future 🙇  (at least didn't find any mention in vtex-sites | can't guarantee in the other repos)
cc: @ataideverton 