### PR TITLE
feat: create RatingSummarySkeleton

### DIFF
--- a/packages/components/src/atoms/Skeleton/Skeleton.tsx
+++ b/packages/components/src/atoms/Skeleton/Skeleton.tsx
@@ -50,11 +50,6 @@ const Skeleton = forwardRef<HTMLDivElement, PropsWithChildren<SkeletonProps>>(
     },
     ref
   ) {
-    const styles = {
-      width: size.width,
-      height: size.height,
-    }
-
     return loading ? (
       <div
         ref={ref}

--- a/packages/components/src/atoms/Skeleton/Skeleton.tsx
+++ b/packages/components/src/atoms/Skeleton/Skeleton.tsx
@@ -45,6 +45,7 @@ const Skeleton = forwardRef<HTMLDivElement, PropsWithChildren<SkeletonProps>>(
       size,
       border,
       borderRadius,
+      style,
       ...otherProps
     },
     ref
@@ -60,9 +61,12 @@ const Skeleton = forwardRef<HTMLDivElement, PropsWithChildren<SkeletonProps>>(
         data-fs-skeleton
         data-testid={testId}
         data-fs-skeleton-border={border ? border : null}
-        style={
-          borderRadius ? { ...styles, borderRadius: borderRadius } : styles
-        }
+        style={{
+          ...style,
+          borderRadius: borderRadius ? borderRadius : style?.borderRadius,
+          width: size.width,
+          height: size.height,
+        }}
         {...otherProps}
       >
         {shimmer && <div data-fs-skeleton-shimmer />}

--- a/packages/core/src/components/sections/ReviewsAndRatings/DefaultComponents.ts
+++ b/packages/core/src/components/sections/ReviewsAndRatings/DefaultComponents.ts
@@ -11,7 +11,14 @@ const ReviewModal = dynamic(
     import('src/components/reviews/ReviewModal')
 )
 
+const RatingSummarySkeleton = dynamic(
+  () =>
+    /* webpackChunkName: "RatingSummarySkeleton" */
+    import('src/components/skeletons/RatingSummarySkeleton')
+)
+
 export const ReviewsAndRatingsDefaultComponents = {
   RatingSummary: UIRatingSummary,
+  __experimentalRatingSummarySkeleton: RatingSummarySkeleton,
   __experimentalReviewModal: ReviewModal,
 } as const

--- a/packages/core/src/components/skeletons/RatingSummarySkeleton/RatingSummarySkeleton.tsx
+++ b/packages/core/src/components/skeletons/RatingSummarySkeleton/RatingSummarySkeleton.tsx
@@ -1,0 +1,70 @@
+import { Skeleton as UISkeleton } from '@faststore/ui'
+
+function RatingSummarySkeleton() {
+  return (
+    <div data-fs-rating-summary>
+      <div data-fs-rating-summary-header>
+        <UISkeleton
+          data-fs-rating-summary-header-average
+          size={{
+            height: '2rem',
+            width: '2.75rem',
+          }}
+        />
+        <UISkeleton
+          size={{
+            height: '1.2rem',
+            width: '6rem',
+          }}
+        />
+        <UISkeleton
+          data-fs-rating-summary-header-total-count
+          size={{
+            height: '0.75rem',
+            width: '3.75rem',
+          }}
+        />
+      </div>
+
+      <UISkeleton
+        size={{
+          height: '2.5rem',
+          width: '8rem',
+        }}
+      />
+
+      <div data-fs-rating-distribution>
+        {Array.from({ length: 5 }).map((_, index) => (
+          <div key={index} data-fs-distribution-item>
+            <UISkeleton
+              data-fs-rating-distribution-item-star
+              size={{
+                height: '1rem',
+                width: '1rem',
+              }}
+            />
+            <UISkeleton
+              data-fs-rating-distribution-item-bar
+              size={{
+                height: '0.5rem',
+                width: '100%',
+              }}
+            />
+            <UISkeleton
+              data-fs-rating-distribution-item-percentage
+              size={{
+                height: '1rem',
+                width: '1rem',
+              }}
+              style={{
+                justifySelf: 'end',
+              }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default RatingSummarySkeleton

--- a/packages/core/src/components/skeletons/RatingSummarySkeleton/index.ts
+++ b/packages/core/src/components/skeletons/RatingSummarySkeleton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RatingSummarySkeleton'

--- a/packages/core/src/components/ui/ReviewsAndRatings/ReviewsAndRatings.tsx
+++ b/packages/core/src/components/ui/ReviewsAndRatings/ReviewsAndRatings.tsx
@@ -18,45 +18,53 @@ function ReviewsAndRatings({
   ratingSummary,
   reviewModal,
 }: ReviewsAndRatingsProps) {
-  const { RatingSummary, __experimentalReviewModal: ReviewModal } =
-    useOverrideComponents<'ReviewsAndRatings'>()
+  const {
+    RatingSummary,
+    __experimentalRatingSummarySkeleton: RatingSummarySkeleton,
+    __experimentalReviewModal: ReviewModal,
+  } = useOverrideComponents<'ReviewsAndRatings'>()
   const context = usePDP()
   const { openReviewModal, reviewModal: displayReviewModal } = useUI()
   const { isDesktop } = useScreenResize()
   const { product, isValidating } = context.data
 
+  const rating = context?.data?.product?.rating
+
   return (
-    product?.rating && (
-      <>
-        <h2 className="text__title-section layout__content">{title}</h2>
-        <div data-fs-content>
-          {(isDesktop || product?.rating?.totalCount > 0) && (
+    <>
+      <h2 className="text__title-section layout__content">{title}</h2>
+      <div data-fs-content>
+        {isValidating ? (
+          <RatingSummarySkeleton.Component />
+        ) : (
+          rating &&
+          (isDesktop || rating?.totalCount > 0) && (
             <RatingSummary.Component
               {...RatingSummary.props}
               textLabels={{ ...ratingSummary }}
               // Dynamic props shouldn't be overridable
               // This decision can be reviewed later if needed
-              {...product?.rating}
+              {...rating}
               onCreateReviewClick={openReviewModal}
             />
-          )}
-        </div>
-
-        {displayReviewModal && !isValidating && (
-          <ReviewModal.Component
-            {...ReviewModal.props}
-            {...reviewModal}
-            // Dynamic props shouldn't be overridable
-            // This decision can be reviewed later if needed
-            product={{
-              id: product.id,
-              name: product.name,
-              image: product.image[0],
-            }}
-          />
+          )
         )}
-      </>
-    )
+      </div>
+
+      {displayReviewModal && !isValidating && (
+        <ReviewModal.Component
+          {...ReviewModal.props}
+          {...reviewModal}
+          // Dynamic props shouldn't be overridable
+          // This decision can be reviewed later if needed
+          product={{
+            id: product.id,
+            name: product.name,
+            image: product.image[0],
+          }}
+        />
+      )}
+    </>
   )
 }
 

--- a/packages/core/src/typings/overrides.ts
+++ b/packages/core/src/typings/overrides.ts
@@ -366,6 +366,7 @@ export type SectionsOverrides = {
         RatingSummaryProps,
         RatingSummaryProps
       >
+      __experimentalRatingSummarySkeleton: ComponentOverrideDefinition<any, any>
       __experimentalReviewModal: ComponentOverrideDefinition<any, any>
     }
   }


### PR DESCRIPTION
## What's the purpose of this pull request?  
This PR adds the `RatingSummarySkeleton` component.  

## How does it work?  
When `isValidating` from `usePDP` is `true`, the skeleton will be displayed until the data is ready.  

## How to test it?  
Load a product page and check if the skeleton is shown before being replaced by the `RatingSummary` with the updated product rating data.

### Starters Deploy Preview

[Preview](https://starter-git-feat-rating-summary-skeleton-vtex.vercel.app/)

## References

[JIRA SFS-2321](https://vtex-dev.atlassian.net/browse/SFS-2321)
[FEATURE BRANCH](https://github.com/vtex/faststore/pull/2676)

![image](https://github.com/user-attachments/assets/7e6e3ddb-6e25-4b79-b8f6-7da525c1bac3)
