### PR TITLE
feat: getMyAccountRotes sdk

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -10,6 +10,7 @@ export { useProductsQuery } from './src/sdk/product/useProductsQuery'
 
 export * from './src/typings/overrides'
 export { getOverriddenSection } from './src/sdk/overrides/getOverriddenSection'
+export { getMyAccountRoutes } from './src/sdk/account/getMyAccountRoutes'
 
 // Overridable Sections
 export { default as AlertSection } from './src/components/sections/Alert'

--- a/packages/core/src/customizations/src/myAccount/navigation.ts
+++ b/packages/core/src/customizations/src/myAccount/navigation.ts
@@ -1,0 +1,3 @@
+import { getMyAccountRoutes } from 'src/sdk/account/getMyAccountRoutes'
+
+export default getMyAccountRoutes({ routes: [] })

--- a/packages/core/src/sdk/account/getMyAccountRoutes.ts
+++ b/packages/core/src/sdk/account/getMyAccountRoutes.ts
@@ -1,0 +1,34 @@
+interface Route {
+  /* Page name, displayed in the sidebar */
+  title: string
+  /* Accessible path within My Account */
+  route: string
+}
+
+interface GetMyAccountRouteParams {
+  /* Route list */
+  routes: Route[]
+}
+
+const DEFAULT_ROUTES: Route[] = [
+  {
+    title: 'Profile',
+    route: '/account/profile',
+  },
+  {
+    title: 'Orders',
+    route: '/account/orders',
+  },
+  {
+    title: 'User Details',
+    route: '/account/user-details',
+  },
+  {
+    title: 'Security',
+    route: '/account/security',
+  },
+]
+
+export function getMyAccountRoutes({ routes }: GetMyAccountRouteParams) {
+  return [...DEFAULT_ROUTES, ...routes]
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

Create a helper to return the my account routes. The default and the customizations routes.  

## How it works?

The My Account Menu Will use this helper to render the menu itens. 

## How to test it?

Create a folder called myAccount/navigation.ts. 

Só we can create a new menu item like this: 

```
export default getMyAccountRoutes({
  routes: [
    {
      title: "Shopping List",
      route: "account/shopping-list",
    },
  ],
});
```
