### PR TITLE
feat: Add SEO specifics for PDP

### DIFF
--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -10,6 +10,10 @@ module.exports = {
       titleTemplate: '%s | FastStore PLP',
       descriptionTemplate: '%s products on FastStore Product Listing Page',
     },
+    pdp: {
+      titleTemplate: '%s | FastStore PDP',
+      descriptionTemplate: '%s products on FastStore Product Detail Page',
+    },
     search: {
       titleTemplate: '%s: Search results title',
       descriptionTemplate: '%s: Search results description',

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -91,7 +91,17 @@ function Page({
 }: Props) {
   const { product } = server
   const { currency } = useSession()
-  const titleTemplate = storeConfig?.seo?.titleTemplate ?? ''
+  const {
+    seo: { pdp: pdpSeo, ...storeSeo },
+  } = storeConfig
+
+  // SEO data
+  const title = meta.title ?? storeSeo.title
+  const titleTemplate = pdpSeo.titleTemplate ?? storeSeo?.titleTemplate
+  const description =
+    meta.title ||
+    pdpSeo.descriptionTemplate.replace(/%s/g, () => title) ||
+    storeSeo.description
 
   let itemListElements = product.breadcrumbList.itemListElement ?? []
   if (itemListElements.length !== 0) {
@@ -144,8 +154,8 @@ function Page({
       )}
       {/* SEO */}
       <NextSeo
-        title={meta.title}
-        description={meta.description}
+        title={title}
+        description={description}
         canonical={meta.canonical}
         openGraph={{
           type: 'og:product',
@@ -314,8 +324,8 @@ export const getStaticProps: GetStaticProps<
   const cmsPage: PDPContentType = await getPDP(data.product, previewData)
 
   const { seo } = data.product
-  const title = seo.title || storeConfig.seo.title
-  const description = seo.description || storeConfig.seo.description
+  const title = seo.title
+  const description = seo.description
   const canonical = `${storeConfig.storeUrl}${seo.canonical}`
 
   const meta = { title, description, canonical }

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -99,7 +99,7 @@ function Page({
   const title = meta?.title ?? storeSeo.title
   const titleTemplate = pdpSeo.titleTemplate ?? storeSeo?.titleTemplate
   const description =
-    meta?.title ||
+    meta?.description ||
     pdpSeo.descriptionTemplate.replace(/%s/g, () => title) ||
     storeSeo.description
 

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -96,10 +96,10 @@ function Page({
   } = storeConfig
 
   // SEO data
-  const title = meta.title ?? storeSeo.title
+  const title = meta?.title ?? storeSeo.title
   const titleTemplate = pdpSeo.titleTemplate ?? storeSeo?.titleTemplate
   const description =
-    meta.title ||
+    meta?.title ||
     pdpSeo.descriptionTemplate.replace(/%s/g, () => title) ||
     storeSeo.description
 
@@ -160,8 +160,8 @@ function Page({
         openGraph={{
           type: 'og:product',
           url: meta.canonical,
-          title: meta.title,
-          description: meta.description,
+          title,
+          description,
           images: product.image.map((img) => ({
             url: img.url,
             alt: img.alternateName,


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds SEO specifics (`title` and `description` templates) for PDPs.

## How it works?

The store will be able to define both `title` and `description` templates through the `discovery.config.js` file.

## How to test it?

Check if the metatags for` title` and `description` are being built correctly on a PDP, that is with the shape defined at `discovery.config.default.js` file.

### Starters Deploy Preview

vtex-sites/starter.store#724

