### PR TITLE
feat: add support for VTEX assets loader in image component

### DIFF
--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -122,5 +122,6 @@ module.exports = {
     preact: false,
     enableRedirects: false,
     enableSearchSSR: false,
+    enableVtexAssetsLoader: false,
   },
 }

--- a/packages/core/src/components/ui/Image/loader.ts
+++ b/packages/core/src/components/ui/Image/loader.ts
@@ -7,6 +7,12 @@ export default function customImageLoader({
   width,
   quality,
 }: ImageLoaderProps) {
+  return storeConfig.experimental.enableVtexAssetsLoader
+    ? fileServerLoader({ src, width })
+    : thumborLoader({ src, width, quality })
+}
+
+function thumborLoader({ src, width, quality }: ImageLoaderProps) {
   const preSizeComponents = [THUMBOR_SERVER, 'unsafe']
 
   // proportional to the width, enter a height of 0,
@@ -18,4 +24,16 @@ export default function customImageLoader({
   postSizeComponents.push(encodeURIComponent(src))
 
   return [...preSizeComponents, finalSize, ...postSizeComponents].join('/')
+}
+
+function fileServerLoader({ src, width }: ImageLoaderProps) {
+  // Regular expression to match the pattern: /ids/{number}/{filename}.{extension}?{queryParams}
+  const regex = /(\/ids\/\d+)\/([^/?]+)(\.[^/?]+)(\?.+)?$/
+
+  return src.replace(
+    regex,
+    (_match, idPart, filename, _extension, queryString = '') => {
+      return `${idPart}-${width}-auto/${filename}.webp${queryString}`
+    }
+  )
 }


### PR DESCRIPTION
This pull request introduces a new feature to enable a custom image loader based on a configuration setting. The main changes include adding a new configuration option and implementing two loader functions to handle different image loading strategies.

New feature implementation:

* [`packages/core/discovery.config.default.js`](diffhunk://#diff-4da6f8e98efa58c9a40ce9b654b9bfeecb6813091999cdea3d2408679d1bf3d3R119): Added a new configuration option `enableVtexAssetsLoader` to control the use of the VTEX assets loader.

Image loader enhancements:

* [`packages/core/src/components/ui/Image/loader.ts`](diffhunk://#diff-73ffbd4b30ea7347ce7cc718527810b0f8b51f897bcf48efdd48fbe36652afdaR10-R15): Modified the `customImageLoader` function to use either `fileServerLoader` or `thumborLoader` based on the `enableVtexAssetsLoader` configuration setting.
* [`packages/core/src/components/ui/Image/loader.ts`](diffhunk://#diff-73ffbd4b30ea7347ce7cc718527810b0f8b51f897bcf48efdd48fbe36652afdaR28-R39): Implemented the `fileServerLoader` function to format image URLs for the file server.