### PR TITLE
fix: Prevent whitespaces in Search page's `canonical`

### DIFF
--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -77,7 +77,7 @@ function generateSEOData(storeConfig: StoreConfig, searchTerm?: string) {
     : seo.description
 
   const canonical = searchTerm
-    ? `${storeConfig.storeUrl}/s?q=${searchTerm}`
+    ? `${storeConfig.storeUrl}/s?q=${searchTerm.replace(' ', '+')}`
     : undefined
 
   return {

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -77,7 +77,7 @@ function generateSEOData(storeConfig: StoreConfig, searchTerm?: string) {
     : seo.description
 
   const canonical = searchTerm
-    ? `${storeConfig.storeUrl}/s?q=${searchTerm.replace(' ', '+')}`
+    ? `${storeConfig.storeUrl}/s?q=${searchTerm.replaceAll(' ', '+')}`
     : undefined
 
   return {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the behavior when users search for term with whitespaces and those whitespaces are considered as canonical.

## How it works?

It replaces the whitespaces with `+`, the same way the page does for the url.

![Screenshot 2025-03-18 at 17 08 51](https://github.com/user-attachments/assets/31bd05b3-edcc-48af-8280-8bd68b9d09a4)

## How to test it?

It will work for stores that enabled the experimental flag:
`experimental: {
    ...,
    enableSearchSSR: true,
  },
`.

Search for terms with whitespaces and check the search page's `canonical` if it uses `+` instead.

### Starters Deploy Preview

vtex-sites/starter.store#726