### PR TITLE
fix: PLP layout shift

### DIFF
--- a/packages/ui/src/components/organisms/ProductGallery/styles.scss
+++ b/packages/ui/src/components/organisms/ProductGallery/styles.scss
@@ -27,8 +27,8 @@
   [data-fs-product-listing-content-grid] {
     display: flex;
     flex-direction: column;
-    height: 100%;
     width: 100%;
+    height: 100%;
 
     @include media("<notebook") {
       padding-right: 0;
@@ -127,6 +127,8 @@
       padding: 0;
       background-color: unset;
     }
+
+    [data-fs-product-grid] { min-height: rem(290px); }
 
     [data-fs-product-card] { min-width: 100%; }
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

In some LH runs, we catch Layout Shift in the PLP (related to the ProductGrid + Load More Button) that can affect +- 20 score points. This PR aims to fix it.

![Mar-19-2025 17-51-35](https://github.com/user-attachments/assets/6d0eb62a-b7ba-4e96-8d22-96548004e384)

![Screenshot 2025-03-12 at 17 57 53](https://github.com/user-attachments/assets/55a836bc-5a92-4e52-878a-f17c086e5033)

| Before | After |
|--------|--------|
| ![Screenshot 2025-03-12 at 17 55 32](https://github.com/user-attachments/assets/e8b30e08-b2ad-4665-80b0-b56d05833e75)| ![Screenshot 2025-03-12 at 17 55 41](https://github.com/user-attachments/assets/e4c5a8f6-cd4f-459b-8700-01fc70b74598) | 

