### PR TITLE
fix: add pnpm-lock.yaml to ignored files in biome.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,8 @@
       ".cache/",
       "__generated__",
       "@generated",
-      "storybook-static"
+      "storybook-static",
+      "pnpm-lock.yaml"
     ]
   },
   "formatter": {


### PR DESCRIPTION
This pull request includes a small change to the `biome.json` file. The change adds the `pnpm-lock.yaml` file to the list of ignored files.