### PR TITLE
feat: my account menu

### DIFF
--- a/packages/cli/src/utils/templates/myAccountPage.ts
+++ b/packages/cli/src/utils/templates/myAccountPage.ts
@@ -9,6 +9,7 @@ export const myAccountPageTemplate = (pagePath: string) => `
   import RenderSections from 'src/components/cms/RenderSections'
   import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
   import CUSTOM_COMPONENTS from 'src/customizations/src/components'
+  import { MyAccountLayout } from 'src/components/account'
   import {
     getServerSideProps,
     type MyAccountProps,
@@ -27,7 +28,9 @@ export const myAccountPageTemplate = (pagePath: string) => `
         globalSections={globalSections.sections}
         components={COMPONENTS}
       >
-        <DynamicPage />
+        <MyAccountLayout>
+          <DynamicPage />
+        </MyAccountLayout>
       </RenderSections>
     )
   }

--- a/packages/core/src/components/account/MyAccountLayout/MyAccountLayout.tsx
+++ b/packages/core/src/components/account/MyAccountLayout/MyAccountLayout.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren } from 'react'
+import MyAccountMenu from '../MyAccountMenu'
+import menuRoutes from 'src/customizations/src/myAccount/navigation'
+import styles from '../section.module.scss'
+
+export type MyAccountLayoutProps = {}
+
+/* ######################################### */
+/* Mocked Data until development is finished */
+const mockedUserName = 'Mocked Username'
+
+/* ######################################### */
+
+const MyAccountLayout = ({
+  children,
+}: PropsWithChildren<MyAccountLayoutProps>) => {
+  return (
+    <div className={styles.layout}>
+      <MyAccountMenu accountName={mockedUserName} items={menuRoutes} />
+      {children}
+    </div>
+  )
+}
+
+export default MyAccountLayout

--- a/packages/core/src/components/account/MyAccountLayout/index.ts
+++ b/packages/core/src/components/account/MyAccountLayout/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MyAccountLayout'

--- a/packages/core/src/components/account/MyAccountLayout/styles.scss
+++ b/packages/core/src/components/account/MyAccountLayout/styles.scss
@@ -1,0 +1,17 @@
+.layout {
+  @import "@faststore/ui/src/components/atoms/Button/styles.scss";
+  @import "../MyAccountMenu/styles.scss";
+
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: calc(100vh - 18rem);
+
+  @include media(">=notebook") {
+    grid-template-rows: none;
+    grid-template-columns: max(300px) auto;
+    gap: var(--fs-spacing-8);
+    max-width: var(--fs-grid-max-width);
+    padding: 0;
+    margin: 0 auto;
+  }
+}

--- a/packages/core/src/components/account/MyAccountMenu/MyAccountMenu.tsx
+++ b/packages/core/src/components/account/MyAccountMenu/MyAccountMenu.tsx
@@ -1,0 +1,74 @@
+import { Button, Link } from '@faststore/ui'
+import { useRouter } from 'next/router'
+
+import styles from '../section.module.scss'
+
+import useScreenResize from 'src/sdk/ui/useScreenResize'
+
+interface NavItem {
+  title: string
+  route: string
+}
+
+export interface MyAccountMenuProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  avatarImageUrl?: string
+  accountName: string
+  items: NavItem[]
+}
+
+const Nav = ({ items }: Pick<MyAccountMenuProps, 'items'>) => {
+  const router = useRouter()
+  const currentRoute = router.pathname
+
+  return (
+    <ul className={styles.nav}>
+      {items.map(({ route, title }) => (
+        <li
+          className={styles.navItem}
+          data-is-selected={currentRoute === route}
+          key={route}
+        >
+          <Link href={route} tabIndex={0}>
+            {title}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+const MyAccountMenu = ({
+  avatarImageUrl,
+  accountName,
+  items,
+}: MyAccountMenuProps) => {
+  const { isDesktop } = useScreenResize()
+
+  return (
+    <div className={styles.menu}>
+      {isDesktop ? (
+        <div className={styles.account}>
+          <div className={styles.avatarContainer}>
+            {avatarImageUrl ? (
+              <img className={styles.avatar} src={avatarImageUrl} />
+            ) : (
+              <span className={styles.avatar}>{accountName[0]}</span>
+            )}
+            <h2>{accountName}</h2>
+          </div>
+          <Button
+            className={styles.switchButton}
+            variant="secondary"
+            size="small"
+          >
+            Switch
+          </Button>
+        </div>
+      ) : null}
+      <Nav items={items} />
+    </div>
+  )
+}
+
+export default MyAccountMenu

--- a/packages/core/src/components/account/MyAccountMenu/index.ts
+++ b/packages/core/src/components/account/MyAccountMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MyAccountMenu'

--- a/packages/core/src/components/account/MyAccountMenu/styles.scss
+++ b/packages/core/src/components/account/MyAccountMenu/styles.scss
@@ -1,0 +1,124 @@
+.menu {
+  display: flex;
+  flex-direction: column;
+  max-height: inherit;
+  padding: var(--fs-spacing-3);
+  overflow: scroll;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.account {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  width: 100%;
+  padding-bottom: var(--fs-spacing-5);
+}
+
+.avatarContainer {
+  display: grid;
+  grid-template-rows: auto;
+  gap: var(--fs-spacing-2);
+  align-items: center;
+  padding-bottom: var(--fs-spacing-1);
+
+  h2 {
+    font-size: var(--fs-text-size-3);
+    font-weight: var(--fs-text-weight-semibold);
+    line-height: var(--fs-text-size-5);
+  }
+}
+
+.switchButton {
+  display: none; /* While it's use case is not implemented */
+  max-width: fit-content;
+  height: 1.5rem;
+}
+
+.nav {
+  display: flex;
+  gap: var(--fs-spacing-1);
+}
+
+.navItem {
+  align-content: center;
+  height: var(--fs-spacing-6);
+  font-size: var(--fs-text-size-1);
+  font-weight: var(--fs-text-weight-medium);
+  background-color: var(--fs-color-tertiary-bkg);
+  border-radius: var(--fs-border-radius-pill);
+
+  &:hover,
+  &[data-is-selected="true"] {
+    background-color: var(--fs-color-tertiary-bkg-hover);
+  }
+
+  &:active {
+    background-color: var(--fs-color-tertiary-bkg-active);
+    outline: none;
+  }
+
+  &:disabled {
+    color: var(--fs-color-disabled-text);
+    cursor: not-allowed;
+    background-color: var(--fs-color-tertiary-bkg-disabled);
+  }
+
+  >a,
+  a:link,
+  a:visited {
+    display: inline-block;
+    align-content: center;
+    width: max-content;
+    width: 100%;
+    height: 100%;
+    padding: 0 var(--fs-spacing-3);
+    color: var(--fs-color-text);
+    text-decoration: none;
+    background-color: transparent;
+    border-radius: var(--fs-border-radius-pill);
+
+    &:focus-visible {
+      outline: 3px solid var(--fs-color-focus-ring);
+      box-shadow: none;
+    }
+  }
+}
+
+@include media(">=notebook") {
+  grid-template-rows: none;
+  grid-template-columns: max(300px) 80%;
+  gap: var(--fs-spacing-8);
+  padding: 0 var(--fs-spacing-8);
+
+  .menu {
+    padding: 0;
+    padding-top: var(--fs-spacing-6);
+    overflow: visible;
+  }
+
+  .nav {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .navItem {
+    margin-left: -16px;
+  }
+
+  .avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--fs-spacing-8);
+    height: var(--fs-spacing-8);
+    font-size: var(--fs-text-size-4);
+    font-weight: var(--fs-text-weight-semibold);
+    color: var(--fs-color-main-2);
+    text-align: center;
+    background-color: var(--fs-color-accent-0);
+    border: var(--spacing-1) solid var(--fs-color-neutral-0);
+    border-radius: var(--fs-border-radius-circle);
+  }
+}

--- a/packages/core/src/components/account/index.ts
+++ b/packages/core/src/components/account/index.ts
@@ -1,0 +1,2 @@
+export { default as MyAccountLayout } from './MyAccountLayout'
+export { default as MyAccountMenu } from './MyAccountMenu'

--- a/packages/core/src/components/account/section.module.scss
+++ b/packages/core/src/components/account/section.module.scss
@@ -1,0 +1,3 @@
+@layer components {
+  @import "./MyAccountLayout/styles.scss";
+}

--- a/packages/core/src/pages/account/profile.tsx
+++ b/packages/core/src/pages/account/profile.tsx
@@ -1,0 +1,50 @@
+/* ######################################### */
+/* Mocked Page until development is finished, it will be removed after */
+
+import { NextSeo } from 'next-seo'
+import type { ComponentType } from 'react'
+import { MyAccountLayout } from 'src/components/account'
+import RenderSections from 'src/components/cms/RenderSections'
+import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
+import CUSTOM_COMPONENTS from 'src/customizations/src/components'
+import {
+  getServerSideProps,
+  type MyAccountProps,
+} from 'src/experimental/myAccountSeverSideProps'
+
+/* A list of components that can be used in the CMS. */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  ...GLOBAL_COMPONENTS,
+  ...CUSTOM_COMPONENTS,
+}
+
+const style = {
+  alignContent: 'center',
+  justifyContent: 'center',
+  alignItems: 'center',
+  display: 'flex',
+  backgroundColor: 'blue',
+  h1: {
+    color: 'white',
+    fontSize: '100px',
+  },
+}
+
+export default function Profile({ globalSections }: MyAccountProps) {
+  return (
+    <RenderSections
+      globalSections={globalSections.sections}
+      components={COMPONENTS}
+    >
+      <NextSeo noindex nofollow />
+
+      <MyAccountLayout>
+        <div style={style}>
+          <h1 style={style.h1}>Profile</h1>
+        </div>
+      </MyAccountLayout>
+    </RenderSections>
+  )
+}
+
+export { getServerSideProps }

--- a/packages/core/src/pages/account/security.tsx
+++ b/packages/core/src/pages/account/security.tsx
@@ -1,0 +1,50 @@
+/* ######################################### */
+/* Mocked Page until development is finished, it will be removed after */
+
+import { NextSeo } from 'next-seo'
+import type { ComponentType } from 'react'
+import { MyAccountLayout } from 'src/components/account'
+import RenderSections from 'src/components/cms/RenderSections'
+import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
+import CUSTOM_COMPONENTS from 'src/customizations/src/components'
+import {
+  getServerSideProps,
+  type MyAccountProps,
+} from 'src/experimental/myAccountSeverSideProps'
+
+/* A list of components that can be used in the CMS. */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  ...GLOBAL_COMPONENTS,
+  ...CUSTOM_COMPONENTS,
+}
+
+const style = {
+  alignContent: 'center',
+  justifyContent: 'center',
+  alignItems: 'center',
+  display: 'flex',
+  backgroundColor: 'black',
+  h1: {
+    color: 'red',
+    fontSize: '100px',
+  },
+}
+
+export default function Page({ globalSections }: MyAccountProps) {
+  return (
+    <RenderSections
+      globalSections={globalSections.sections}
+      components={COMPONENTS}
+    >
+      <NextSeo noindex nofollow />
+
+      <MyAccountLayout>
+        <div style={style}>
+          <h1 style={style.h1}>Security</h1>
+        </div>
+      </MyAccountLayout>
+    </RenderSections>
+  )
+}
+
+export { getServerSideProps }

--- a/packages/core/src/pages/account/user-details.tsx
+++ b/packages/core/src/pages/account/user-details.tsx
@@ -1,0 +1,50 @@
+/* ######################################### */
+/* Mocked Page until development is finished, it will be removed after */
+
+import { NextSeo } from 'next-seo'
+import type { ComponentType } from 'react'
+import { MyAccountLayout } from 'src/components/account'
+import RenderSections from 'src/components/cms/RenderSections'
+import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
+import CUSTOM_COMPONENTS from 'src/customizations/src/components'
+import {
+  getServerSideProps,
+  type MyAccountProps,
+} from 'src/experimental/myAccountSeverSideProps'
+
+/* A list of components that can be used in the CMS. */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  ...GLOBAL_COMPONENTS,
+  ...CUSTOM_COMPONENTS,
+}
+
+const style = {
+  alignContent: 'center',
+  justifyContent: 'center',
+  alignItems: 'center',
+  display: 'flex',
+  backgroundColor: 'green',
+  h1: {
+    color: 'black',
+    fontSize: '100px',
+  },
+}
+
+export default function Page({ globalSections }: MyAccountProps) {
+  return (
+    <RenderSections
+      globalSections={globalSections.sections}
+      components={COMPONENTS}
+    >
+      <NextSeo noindex nofollow />
+
+      <MyAccountLayout>
+        <div style={style}>
+          <h1 style={style.h1}>User Details</h1>
+        </div>
+      </MyAccountLayout>
+    </RenderSections>
+  )
+}
+
+export { getServerSideProps }


### PR DESCRIPTION
## What's the purpose of this pull request?

To implements My Account menu

## How it works?

Creates an Avatar component to be used on this menu and futurely on other components

Creates a MenuLayout component and a Menu component. 
The MenuLayout uses the Menu component inside and receives the page to be rendered as children

The menu itens and it's related routes comes from `src/customizations/src/myAccount/navigation` 

>[!IMPORTANT]
> The pages are mocks only. The subject of this PR is only the Menu structure



### Starters Deploy Preview
[PREVIEW](https://starter-git-feat-my-account-menu-vtex.vercel.app/account)

## References

[JIRA-SFS-2310](https://vtex-dev.atlassian.net/browse/SFS-2310)
[MyAccount RFC](https://docs.google.com/document/d/17qlQerzx3cva2dupafbEaJhsu_aLLuxFf6IniVIwRBM/edit?tab=t.0#heading=h.tglo77yl0lf5)
