### PR TITLE
fix: pass cookies to intelligent search requests

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -106,8 +106,6 @@ export const IntelligentSearch = (
     'X-FORWARDED-HOST': forwardedHost,
   })
 
-  const requestInit = headers ? { headers } : undefined
-
   const getPolicyFacet = (): IStoreSelectedFacet | null => {
     const { salesChannel } = ctx.storage.channel
 
@@ -222,7 +220,7 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/${type}/${pathname}?${params.toString()}`,
-      requestInit,
+      { headers },
       { storeCookies }
     )
   }
@@ -240,7 +238,7 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/search_suggestions?${params.toString()}`,
-      requestInit,
+      { headers },
       { storeCookies }
     )
   }
@@ -252,7 +250,7 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/top_searches?${params.toString()}`,
-      requestInit,
+      { headers },
       { storeCookies }
     )
   }

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -156,6 +156,17 @@ export const IntelligentSearch = (
     }
   }
 
+  function getHeaders(ctx: Context) {
+    const cookie = ctx?.headers?.cookie
+    const headers = cookie
+      ? {
+          cookie,
+        }
+      : undefined
+
+    return headers
+  }
+
   const search = <T>({
     query = '',
     page,
@@ -202,7 +213,9 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/${type}/${pathname}?${params.toString()}`,
-      undefined,
+      {
+        headers: getHeaders(ctx),
+      },
       { storeCookies }
     )
   }
@@ -220,7 +233,9 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/search_suggestions?${params.toString()}`,
-      undefined,
+      {
+        headers: getHeaders(ctx),
+      },
       { storeCookies }
     )
   }
@@ -232,7 +247,9 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/top_searches?${params.toString()}`,
-      undefined,
+      {
+        headers: getHeaders(ctx),
+      },
       { storeCookies }
     )
   }

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -156,15 +156,17 @@ export const IntelligentSearch = (
     }
   }
 
-  function getHeaders(ctx: Context) {
+  function getRequestInit(ctx: Context) {
     const cookie = ctx?.headers?.cookie
-    const headers = cookie
+    const requestInit = cookie
       ? {
-          cookie,
+          headers: {
+            cookie,
+          },
         }
       : undefined
 
-    return headers
+    return requestInit
   }
 
   const search = <T>({
@@ -213,9 +215,7 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/${type}/${pathname}?${params.toString()}`,
-      {
-        headers: getHeaders(ctx),
-      },
+      getRequestInit(ctx),
       { storeCookies }
     )
   }
@@ -233,9 +233,7 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/search_suggestions?${params.toString()}`,
-      {
-        headers: getHeaders(ctx),
-      },
+      getRequestInit(ctx),
       { storeCookies }
     )
   }
@@ -247,9 +245,7 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/top_searches?${params.toString()}`,
-      {
-        headers: getHeaders(ctx),
-      },
+      getRequestInit(ctx),
       { storeCookies }
     )
   }

--- a/packages/api/test/mocks/AllProductsQuery.ts
+++ b/packages/api/test/mocks/AllProductsQuery.ts
@@ -79,7 +79,9 @@ export const AllProductsQueryFirst5 = `query AllProducts {
 
 export const productSearchPage1Count5Fetch = {
   info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false',
-  init: undefined,
+  init: {
+    headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
+  },
   options: { storeCookies: expect.any(Function) },
   result: {
     products: [

--- a/packages/api/test/mocks/ProductQuery.ts
+++ b/packages/api/test/mocks/ProductQuery.ts
@@ -64,7 +64,9 @@ export const ProductByIdQuery = `query ProductQuery {
 
 export const productSearchFetch = {
   info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A64953394&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false',
-  init: undefined,
+  init: {
+    headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
+  },
   options: { storeCookies: expect.any(Function) },
   result: {
     products: [

--- a/packages/api/test/mocks/RedirectQuery.ts
+++ b/packages/api/test/mocks/RedirectQuery.ts
@@ -7,7 +7,9 @@ export const RedirectQueryTermTech = `query RedirectSearch {
 
 export const redirectTermTechFetch = {
   info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=2&count=1&query=tech&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false',
-  init: undefined,
+  init: {
+    headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
+  },
   options: { storeCookies: expect.any(Function) },
   result: {
     products: [],

--- a/packages/api/test/mocks/SearchQuery.ts
+++ b/packages/api/test/mocks/SearchQuery.ts
@@ -102,7 +102,9 @@ export const SearchQueryFirst5Products = `query SearchQuery {
 
 export const productSearchCategory1Fetch = {
   info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false',
-  init: undefined,
+  init: {
+    headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
+  },
   options: { storeCookies: expect.any(Function) },
   result: {
     products: [
@@ -1396,7 +1398,9 @@ export const productSearchCategory1Fetch = {
 
 export const attributeSearchCategory1Fetch = {
   info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/facets/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false',
-  init: undefined,
+  init: {
+    headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
+  },
   options: { storeCookies: expect.any(Function) },
   result: {
     facets: [

--- a/packages/api/test/mocks/ValidateCartMutation.ts
+++ b/packages/api/test/mocks/ValidateCartMutation.ts
@@ -348,7 +348,9 @@ export const checkoutOrderFormCustomDataInvalidFetch = {
 
 export const productSearchPage1Count1Fetch = {
   info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A2737806&sort=&locale=en-US&show-invisible-items=true&hideUnavailableItems=false',
-  init: undefined,
+  init: {
+    headers: { 'content-type': 'application/json', 'X-FORWARDED-HOST': '' },
+  },
   options: { storeCookies: expect.any(Function) },
   result: {
     products: [


### PR DESCRIPTION
## What's the purpose of this pull request?

The cookie information (especially vtex_segment) is relevant for intelligent search, this PR forwards them on the request headers. 

## How to test it?

1. Make a search
2. Check the request Headers.Cookie on the Search request
3. You should see several cookies sent

Preview: https://starter-git-test-segment-vtex.vercel.app/
