### PR TITLE
chore: Ensure session with location data

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -22,7 +22,7 @@ async function getGeoCoordinates(
     return { latitude, longitude }
   } catch (err) {
     console.error(
-      'Error while getting geo coordinates for the current postal code and country.\n'
+      `Error while getting geo coordinates for the current postal code (${postalCode}) and country (${country}).\n`
     )
 
     throw err

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -66,7 +66,8 @@ function RegionModal({
       const newSession = {
         ...session,
         postalCode,
-      }
+        geoCoordinates: null, // If users set postal code, we should revalidate geo coordinates in API
+      } as typeof session
 
       const validatedSession = await validateSession(newSession)
 

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -66,7 +66,7 @@ function RegionModal({
       const newSession = {
         ...session,
         postalCode,
-        geoCoordinates: null, // If users set postal code, we should revalidate geo coordinates in API
+        geoCoordinates: null, // Revalidate geo coordinates in API when users set a new postal code
       } as typeof session
 
       const validatedSession = await validateSession(newSession)

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -70,7 +70,6 @@ function RegionModal({
       } as typeof session
 
       const validatedSession = await validateSession(newSession)
-
       sessionStore.set(validatedSession ?? newSession)
     } catch (error) {
       setErrorMessage(inputFieldErrorMessage)

--- a/packages/core/src/sdk/geolocation/useGeolocation.ts
+++ b/packages/core/src/sdk/geolocation/useGeolocation.ts
@@ -12,7 +12,7 @@ export default function useGeolocation() {
       return
     }
 
-    if (navigator?.geolocation && (!stalePostalCode || staleGeoCoordinates)) {
+    if (navigator?.geolocation && (!stalePostalCode || !staleGeoCoordinates)) {
       navigator.geolocation.getCurrentPosition(
         async ({ coords: { latitude, longitude } }) => {
           // We need to revalidate the session because users can set a zip code while granting consent.

--- a/packages/core/src/sdk/geolocation/useGeolocation.ts
+++ b/packages/core/src/sdk/geolocation/useGeolocation.ts
@@ -1,36 +1,43 @@
 import { useEffect } from 'react'
 
 import { deliveryPromise } from 'discovery.config'
-import { useSession, validateSession, sessionStore } from 'src/sdk/session'
+import { validateSession, sessionStore } from 'src/sdk/session'
+
+const TIME_TO_VALIDATE_SESSION = 3000
+
+async function askGeolocationConsent() {
+  const { postalCode: stalePostalCode, geoCoordinates: staleGeoCoordinates } =
+    sessionStore.read()
+
+  if (navigator?.geolocation && (!stalePostalCode || !staleGeoCoordinates)) {
+    navigator.geolocation.getCurrentPosition(
+      async ({ coords: { latitude, longitude } }) => {
+        // We need to revalidate the session because users can set a zip code while granting consent.
+        const revalidatedSession = sessionStore.read()
+        if (
+          revalidatedSession.postalCode ||
+          revalidatedSession.geoCoordinates
+        ) {
+          return
+        }
+
+        const newSession = {
+          ...revalidatedSession,
+          geoCoordinates: { latitude, longitude },
+        }
+        const validatedSession = await validateSession(newSession)
+        sessionStore.set(validatedSession ?? newSession)
+      }
+    )
+  }
+}
 
 export default function useGeolocation() {
-  const { geoCoordinates: staleGeoCoordinates } = useSession()
-
   useEffect(() => {
     if (!deliveryPromise.enabled) {
       return
     }
 
-    if (navigator?.geolocation && !staleGeoCoordinates) {
-      navigator.geolocation.getCurrentPosition(
-        async ({ coords: { latitude, longitude } }) => {
-          // We need to revalidate the session because users can set a zip code while granting consent.
-          const revalidatedSession = sessionStore.read()
-          if (
-            revalidatedSession.postalCode ||
-            revalidatedSession.geoCoordinates
-          ) {
-            return
-          }
-
-          const newSession = {
-            ...revalidatedSession,
-            geoCoordinates: { latitude, longitude },
-          }
-          const validatedSession = await validateSession(newSession)
-          sessionStore.set(validatedSession ?? newSession)
-        }
-      )
-    }
+    setTimeout(() => askGeolocationConsent(), TIME_TO_VALIDATE_SESSION)
   }, [])
 }

--- a/packages/core/src/sdk/geolocation/useGeolocation.ts
+++ b/packages/core/src/sdk/geolocation/useGeolocation.ts
@@ -4,18 +4,28 @@ import { deliveryPromise } from 'discovery.config'
 import { useSession, validateSession, sessionStore } from 'src/sdk/session'
 
 export default function useGeolocation() {
-  const { isValidating: _, ...session } = useSession()
+  const { postalCode: stalePostalCode, geoCoordinates: staleGeoCoordinates } =
+    useSession()
 
   useEffect(() => {
     if (!deliveryPromise.enabled) {
       return
     }
 
-    if (navigator?.geolocation && !session.geoCoordinates) {
+    if (navigator?.geolocation && (!stalePostalCode || staleGeoCoordinates)) {
       navigator.geolocation.getCurrentPosition(
         async ({ coords: { latitude, longitude } }) => {
+          // We need to revalidate the session because users can set a zip code while granting consent.
+          const revalidatedSession = sessionStore.read()
+          if (
+            revalidatedSession.postalCode ||
+            revalidatedSession.geoCoordinates
+          ) {
+            return
+          }
+
           const newSession = {
-            ...session,
+            ...revalidatedSession,
             geoCoordinates: { latitude, longitude },
           }
           const validatedSession = await validateSession(newSession)

--- a/packages/core/src/sdk/geolocation/useGeolocation.ts
+++ b/packages/core/src/sdk/geolocation/useGeolocation.ts
@@ -12,7 +12,7 @@ async function askGeolocationConsent() {
   if (navigator?.geolocation && (!stalePostalCode || !staleGeoCoordinates)) {
     navigator.geolocation.getCurrentPosition(
       async ({ coords: { latitude, longitude } }) => {
-        // We need to revalidate the session because users can set a zip code while granting consent.
+        // Revalidate the session because users can set a zip code while granting consent.
         const revalidatedSession = sessionStore.read()
         if (
           revalidatedSession.postalCode ||

--- a/packages/core/src/sdk/geolocation/useGeolocation.ts
+++ b/packages/core/src/sdk/geolocation/useGeolocation.ts
@@ -4,15 +4,14 @@ import { deliveryPromise } from 'discovery.config'
 import { useSession, validateSession, sessionStore } from 'src/sdk/session'
 
 export default function useGeolocation() {
-  const { postalCode: stalePostalCode, geoCoordinates: staleGeoCoordinates } =
-    useSession()
+  const { geoCoordinates: staleGeoCoordinates } = useSession()
 
   useEffect(() => {
     if (!deliveryPromise.enabled) {
       return
     }
 
-    if (navigator?.geolocation && (!stalePostalCode || !staleGeoCoordinates)) {
+    if (navigator?.geolocation && !staleGeoCoordinates) {
       navigator.geolocation.getCurrentPosition(
         async ({ coords: { latitude, longitude } }) => {
           // We need to revalidate the session because users can set a zip code while granting consent.


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to ensure all location data (`postalCode`, `geoCoordinates` and `country`) is being synchronized when needed.

## How it works?

It updates geo coordinates when users set a postal code and ensure location data won't be overwritten if users grant geo location consent late.

## How to test it?

- Enable Delivery Promise on discovery.config;
- Open the localhost store on anon tab (to ensure no stale data);
- First, consent geo location data from popup and look to the IDB `fs::session` value, it should fill `geoCoordinates` data after `useGeolocation` hook execution;
- Then try to set a postal code, the `postalCode` should be set and `geoCoordinates` should be different now (based on the postal code);
- Another test: open another anon tab and, while the popup asking for geo location consent set a postal code. Then, after the session is updated with the new location (based on the postal code), grant the geo location consent and nothing should happen since user have already set the postal code.

### Starters Deploy Preview

vtex-sites/starter.store#734