### PR TITLE
feat: Manually disable `hideUnavailableItems` flag for PDP queries

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -223,11 +223,6 @@ export const IntelligentSearch = (
       .map(({ key, value }) => `${key}/${value}`)
       .join('/')
 
-    console.log(
-      '~~~~~~~~~~> SEARCH REQUEST PATH: ',
-      `/_v/api/intelligent-search/${type}/${pathname}?${params.toString()}`
-    )
-
     return fetchAPI(
       `${base}/_v/api/intelligent-search/${type}/${pathname}?${params.toString()}`,
       { headers },

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -183,6 +183,7 @@ export const IntelligentSearch = (
     type,
     showInvisibleItems,
     sponsoredCount,
+    hideUnavailableItems: searchHideUnavailableItems,
   }: SearchArgs): Promise<T> => {
     const params = new URLSearchParams({
       page: (page + 1).toString(),
@@ -199,7 +200,11 @@ export const IntelligentSearch = (
     }
 
     if (hideUnavailableItems !== undefined) {
-      params.append('hideUnavailableItems', hideUnavailableItems.toString())
+      params.append(
+        'hideUnavailableItems',
+        searchHideUnavailableItems?.toString() ??
+          hideUnavailableItems.toString()
+      )
     }
 
     if (simulationBehavior !== undefined) {

--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -218,6 +218,11 @@ export const IntelligentSearch = (
       .map(({ key, value }) => `${key}/${value}`)
       .join('/')
 
+    console.log(
+      '~~~~~~~~~~> SEARCH REQUEST PATH: ',
+      `/_v/api/intelligent-search/${type}/${pathname}?${params.toString()}`
+    )
+
     return fetchAPI(
       `${base}/_v/api/intelligent-search/${type}/${pathname}?${params.toString()}`,
       { headers },

--- a/packages/api/src/platforms/vtex/loaders/sku.ts
+++ b/packages/api/src/platforms/vtex/loaders/sku.ts
@@ -6,17 +6,11 @@ import type { EnhancedSku } from '../utils/enhanceSku'
 import type { Options } from '..'
 import type { Clients } from '../clients'
 
-export const getSkuLoader = (
-  { hideUnavailableItems }: Options,
-  clients: Clients
-) => {
+export const getSkuLoader = (_: Options, clients: Clients) => {
   const loader = async (keys: readonly string[]) => {
     const skuIds = keys.map((key) => key.split('-')[0])
     const showInvisibleItems = keys.some(
       (key) => key.split('-')[1] === 'invisibleItems'
-    )
-    const disableHideUnavailableItems = keys.some(
-      (key) => key.split('-')[1] === 'disableHideUnavailableItems'
     )
 
     const { products } = await clients.search.products({
@@ -24,9 +18,6 @@ export const getSkuLoader = (
       page: 0,
       count: skuIds.length,
       showInvisibleItems,
-      hideUnavailableItems: disableHideUnavailableItems
-        ? false
-        : hideUnavailableItems,
     })
 
     const skuBySkuId = products.reduce(

--- a/packages/api/src/platforms/vtex/loaders/sku.ts
+++ b/packages/api/src/platforms/vtex/loaders/sku.ts
@@ -6,11 +6,17 @@ import type { EnhancedSku } from '../utils/enhanceSku'
 import type { Options } from '..'
 import type { Clients } from '../clients'
 
-export const getSkuLoader = (_: Options, clients: Clients) => {
+export const getSkuLoader = (
+  { hideUnavailableItems }: Options,
+  clients: Clients
+) => {
   const loader = async (keys: readonly string[]) => {
     const skuIds = keys.map((key) => key.split('-')[0])
     const showInvisibleItems = keys.some(
       (key) => key.split('-')[1] === 'invisibleItems'
+    )
+    const disableHideUnavailableItems = keys.some(
+      (key) => key.split('-')[1] === 'disableHideUnavailableItems'
     )
 
     const { products } = await clients.search.products({
@@ -18,6 +24,9 @@ export const getSkuLoader = (_: Options, clients: Clients) => {
       page: 0,
       count: skuIds.length,
       showInvisibleItems,
+      hideUnavailableItems: disableHideUnavailableItems
+        ? false
+        : hideUnavailableItems,
     })
 
     const skuBySkuId = products.reduce(

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -57,8 +57,7 @@ export const Query = {
         throw new Error('Invalid SkuId')
       }
 
-      // Manually disabling this flag to prevent regionalization issues
-      const sku = await skuLoader.load(`${skuId}-disableHideUnavailableItems`)
+      const sku = await skuLoader.load(skuId)
 
       /**
        * Here be dragons 🦄🦄🦄
@@ -72,9 +71,6 @@ export const Query = {
         sku.isVariantOf.linkText &&
         !slug.startsWith(sku.isVariantOf.linkText)
       ) {
-        console.log(
-          `~~~> THROWING ERROR:\n~> SLUG: ${slug}; LINKTEXT: ${sku.isVariantOf.linkText}; CONDITION RESULT: ${!slug.startsWith(sku.isVariantOf.linkText)}`
-        )
         throw new Error(
           `Slug was set but the fetched sku does not satisfy the slug condition. slug: ${slug}, linkText: ${sku.isVariantOf.linkText}`
         )
@@ -83,14 +79,12 @@ export const Query = {
       return sku
     } catch (err) {
       if (slug == null) {
-        console.log('~~~> BAD REQUEST ERROR', slug)
         throw new BadRequestError('Missing slug or id')
       }
 
       const route = await commerce.catalog.portal.pagetype(`${slug}/p`)
 
       if (route.pageType !== 'Product' || !route.id) {
-        console.log('~~~> NOT FOUND ERROR', route?.id)
         throw new NotFoundError(`No product found for slug ${slug}`)
       }
 
@@ -100,6 +94,8 @@ export const Query = {
         page: 0,
         count: 1,
         query: `product:${route.id}`,
+        // Manually disabling this flag to prevent regionalization issues
+        hideUnavailableItems: false,
       })
 
       if (!product) {

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -57,7 +57,8 @@ export const Query = {
         throw new Error('Invalid SkuId')
       }
 
-      const sku = await skuLoader.load(skuId)
+      // Manually disabling this flag to prevent regionalization issues
+      const sku = await skuLoader.load(`${skuId}-disableHideUnavailableItems`)
 
       /**
        * Here be dragons 🦄🦄🦄
@@ -71,6 +72,9 @@ export const Query = {
         sku.isVariantOf.linkText &&
         !slug.startsWith(sku.isVariantOf.linkText)
       ) {
+        console.log(
+          `~~~> THROWING ERROR:\n~> SLUG: ${slug}; LINKTEXT: ${sku.isVariantOf.linkText}; CONDITION RESULT: ${!slug.startsWith(sku.isVariantOf.linkText)}`
+        )
         throw new Error(
           `Slug was set but the fetched sku does not satisfy the slug condition. slug: ${slug}, linkText: ${sku.isVariantOf.linkText}`
         )
@@ -79,12 +83,14 @@ export const Query = {
       return sku
     } catch (err) {
       if (slug == null) {
+        console.log('~~~> BAD REQUEST ERROR', slug)
         throw new BadRequestError('Missing slug or id')
       }
 
       const route = await commerce.catalog.portal.pagetype(`${slug}/p`)
 
       if (route.pageType !== 'Product' || !route.id) {
+        console.log('~~~> NOT FOUND ERROR', route?.id)
         throw new NotFoundError(`No product found for slug ${slug}`)
       }
 
@@ -94,8 +100,6 @@ export const Query = {
         page: 0,
         count: 1,
         query: `product:${route.id}`,
-        // Manually disabling this flag to prevent regionalization issues
-        hideUnavailableItems: false,
       })
 
       if (!product) {

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -94,6 +94,8 @@ export const Query = {
         page: 0,
         count: 1,
         query: `product:${route.id}`,
+        // Manually disabling this flag to prevent regionalization issues
+        hideUnavailableItems: false,
       })
 
       if (!product) {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to manually disable the `hideUnavailableItems` flag for cases that the product is unavailable for certain regions.

## How it works?

it will manually pass `hideUnavailableItems: false` to the `product_search` request to the IS. By doing that and only if the merchant checks the option to show unavailable items on Catalog config (Admin), the PDP will always be accessible, even though the product is not available. So the store will need to handle the unavailable information (unavailable labels, no prices and disable buy button).

## How to test it?

Currently we do not have a testing store with regionalization features, but you can validate on Starter store if the pages are working as they should with and without postal code being set.

## Starter Deploy Preview

vtex-sites/starter.store#738

## References

Check the **RFC FastStore PDP regionalization** for context.
