### PR TITLE
fix: call redirect-evaluate only for pages

### DIFF
--- a/packages/core/src/sdk/redirects/index.ts
+++ b/packages/core/src/sdk/redirects/index.ts
@@ -17,9 +17,17 @@ type RewriterResponse = {
 
 const PERMANENT_STATUS = 308
 
+const ASSET_FILE_REGEX = /\.(js|css|png|jpg|jpeg|svg|gif|webp|ico|json|map)$/i
+
 export async function getRedirect({
   pathname,
 }: GetRedirectArgs): Promise<GetRedirectReturn> {
+  const isValidPath = !ASSET_FILE_REGEX.test(pathname)
+
+  if (!isValidPath) {
+    return null
+  }
+
   try {
     const redirectMatch = matcher({ pathname })
     if (redirectMatch) {


### PR DESCRIPTION
## What's the purpose of this pull request?

Avoid calling the redirect service when the pathname is from an asset.

## How it works?
I create this REGEX to validate the files extentions: 
`const ASSET_FILE_REGEX = /\.(js|css|png|jpg|jpeg|svg|gif|webp|ico|json|map)$/i`

