### PR TITLE
feat: Update Session with location info

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -357,7 +357,7 @@ export const VtexCommerce = (
 
       params.set(
         'items',
-        'profile.id,profile.email,profile.firstName,profile.lastName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol,authentication.customerId,'
+        'profile.id,profile.email,profile.firstName,profile.lastName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol,authentication.customerId,checkout.regionId,'
       )
 
       const headers: HeadersInit = withCookie({

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -364,32 +364,14 @@ export const VtexCommerce = (
         'content-type': 'application/json',
       })
 
+      const sessionCookie = parse(ctx?.headers?.cookie ?? '').vtex_session
+
       return fetchAPI(
         `${base}/api/sessions?${params.toString()}`,
         {
-          method: 'POST',
+          method: sessionCookie ? 'PATCH' : 'POST',
           headers,
           body: '{}',
-        },
-        { storeCookies }
-      )
-    },
-    updateSession: (
-      body: Session['namespaces']
-    ): Promise<{
-      sessionToken: string
-      segmentToken: string
-    }> => {
-      const headers: HeadersInit = withCookie({
-        'content-type': 'application/json',
-      })
-
-      return fetchAPI(
-        `${base}/api/sessions`,
-        {
-          method: 'PATCH',
-          headers,
-          body: JSON.stringify(body),
         },
         { storeCookies }
       )

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -364,7 +364,7 @@ export const VtexCommerce = (
         'content-type': 'application/json',
       })
 
-      const sessionCookie = parse(ctx?.headers?.cookie ?? '').vtex_session
+      const sessionCookie = parse(ctx?.headers?.cookie ?? '')?.vtex_session
 
       return fetchAPI(
         `${base}/api/sessions?${params.toString()}`,

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -374,6 +374,26 @@ export const VtexCommerce = (
         { storeCookies }
       )
     },
+    updateSession: (
+      body: Session['namespaces']
+    ): Promise<{
+      sessionToken: string
+      segmentToken: string
+    }> => {
+      const headers: HeadersInit = withCookie({
+        'content-type': 'application/json',
+      })
+
+      return fetchAPI(
+        `${base}/api/sessions`,
+        {
+          method: 'PATCH',
+          headers,
+          body: JSON.stringify(body),
+        },
+        { storeCookies }
+      )
+    },
     subscribeToNewsletter: (data: {
       name: string
       email: string

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
@@ -41,7 +41,4 @@ export interface Checkout {
 export interface Public {
   orderFormId?: Value
   items?: Value
-  postalCode?: Value
-  geoCoordinates?: Value
-  country?: Value
 }

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
@@ -41,4 +41,5 @@ export interface Checkout {
 export interface Public {
   orderFormId?: Value
   items?: Value
+  facets?: Value
 }

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
@@ -41,5 +41,7 @@ export interface Checkout {
 export interface Public {
   orderFormId?: Value
   items?: Value
-  facets?: Value
+  postalCode?: Value
+  geoCoordinates?: Value
+  country?: Value
 }

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
@@ -36,6 +36,7 @@ export interface Profile {
 
 export interface Checkout {
   orderFormId?: Value
+  regionId?: Value
 }
 
 export interface Public {

--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -44,6 +44,7 @@ export interface Options {
 
 interface FeatureFlags {
   enableOrderFormSync?: boolean
+  enableDeliveryPromise?: boolean
 }
 
 export interface Context {

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -44,15 +44,18 @@ async function updateSessionFacets(
   { postalCode, country, geoCoordinates }: StoreSession
 ) {
   try {
+    const shouldUpdate = !!postalCode && !!country && !!geoCoordinates
+    if (!shouldUpdate) {
+      // Early return when postal code, country, or geo-coordinates are not provided
+      return
+    }
+
     const facetsObject = {
       'zip-code': postalCode,
       country,
-      coordinates: geoCoordinates
-        ? `${geoCoordinates.latitude},${geoCoordinates.longitude}`
-        : undefined,
+      coordinates: `${geoCoordinates.latitude},${geoCoordinates.longitude}`,
     }
     const facets = Object.entries(facetsObject)
-      .filter(([, value]) => !!value)
       .map(([key, value]) => `${key}=${value}`)
       .join(';')
 

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -45,15 +45,14 @@ async function updateSessionWithLocation(
   { postalCode, country, geoCoordinates }: StoreSession,
   enableDeliveryPromise?: boolean
 ) {
-  try {
-    const hasRequiredLocationData =
-      !!postalCode && !!country && !!geoCoordinates
-    if (!(enableDeliveryPromise && hasRequiredLocationData)) {
-      // Update the session with the location data only if the Delivery Promise feature flag is enabled and if all required data is available
-      // otherwise there will be make unnecessary requests and operations from FastStore and Intelligent Search
-      return
-    }
+  const hasRequiredLocationData = !!postalCode && !!country && !!geoCoordinates
+  if (!(enableDeliveryPromise && hasRequiredLocationData)) {
+    // Update the session with the location data only if the Delivery Promise feature flag is enabled and if all required data is available
+    // otherwise there will be make unnecessary requests and operations from FastStore and Intelligent Search
+    return
+  }
 
+  try {
     return clients.commerce.updateSession({
       public: {
         postalCode: { value: postalCode },

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -96,8 +96,9 @@ export const validateSession = async (
   const profile = sessionData?.namespaces.profile ?? null
   const store = sessionData?.namespaces.store ?? null
   const authentication = sessionData?.namespaces.authentication ?? null
-  const region = regionData?.[0]
+  const checkout = sessionData?.namespaces.checkout ?? null
   // Set seller only if it's inside a region
+  const region = regionData?.[0]
   const seller = region?.sellers.find((seller) => channel.seller === seller.id)
 
   const newSession = {
@@ -109,7 +110,7 @@ export const validateSession = async (
     country: store?.countryCode?.value ?? oldSession.country,
     channel: ChannelMarshal.stringify({
       salesChannel: store?.channel?.value ?? channel.salesChannel,
-      regionId: region?.id ?? channel.regionId,
+      regionId: checkout?.regionId?.value ?? channel.regionId,
       seller: seller?.id,
       hasOnlyDefaultSalesChannel: !store?.channel?.value,
     }),

--- a/packages/core/src/server/options.ts
+++ b/packages/core/src/server/options.ts
@@ -16,5 +16,6 @@ export const apiOptions: APIOptions = {
   locale: storeConfig.session.locale,
   flags: {
     enableOrderFormSync: true,
+    enableDeliveryPromise: storeConfig.deliveryPromise.enabled,
   },
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Update the Session with postal code, country, and geo-coordinates. 
The Intelligent Search will use this for the Delivery Promise feature. FastStore updates the session with the location information and IS access it.

## How it works?

The update is a PATCH request to the Session Manager API. The fields that IS will use from the session are `postalCode`, `geoCoordinates` and `country`, inside the `public` namespace.

## How to test it?

Run this code (or use the preview link below) and test changing the postal code and/or using a default one.
The fields inside public namespace of the session should be updated accordingly.
To check it you can run this request:
```curl
curl --location 'https://storeframework.vtexcommercestable.com.br/api/sessions?items=public.postalCode,public.geoCoordinates,public.country' \
--header 'Cookie: vtex_session=ADD_HERE'
```
⚠️ Substitute the "ADD_HERE" with the vtex_session cookie that you can get in the browser

#### Preview with Delivery Promise NOT enabled
https://storeframework-cm652ufll028lmgv665a6xv0g-lqicw1ez2.b.vtex.app/
The session shouldn't update the public field.

![Screenshot 2025-03-28 at 11 47 29](https://github.com/user-attachments/assets/5796d143-becf-4141-8751-e7bbab93821e)
![Screenshot 2025-04-07 at 08 43 45](https://github.com/user-attachments/assets/6ab9e4ed-268a-437c-9cdb-2bc29628defc)

#### Preview with Delivery Promise enabled
https://storeframework-cm652ufll028lmgv665a6xv0g-58v0e6a7h.b.vtex.app/
##### Without postal code set
The session shouldn't update the public field.

![Screenshot 2025-03-28 at 12 08 36](https://github.com/user-attachments/assets/11ed56f9-1836-4da1-95f4-1b1b5bfdafc2)
![Screenshot 2025-04-07 at 08 45 10](https://github.com/user-attachments/assets/3c44b25c-73ac-4554-a7c1-a7455fe61492)

##### With postal code (and country and geo coordinates)
The session should update the public field!

![Screenshot 2025-03-28 at 12 09 28](https://github.com/user-attachments/assets/7e85d0cc-c676-403b-89db-6e5bffcdbada)
![Screenshot 2025-04-07 at 08 45 57](https://github.com/user-attachments/assets/29ec6991-3733-439e-a783-8c8be9c1ee0e)

### Starters Deploy Preview
https://github.com/vtex-sites/starter.store/pull/737

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SFS-2362)
- [Slack thread](https://vtex.slack.com/archives/C069YM7R73P/p1741962308203469?thread_ts=1741782251.679469&cid=C069YM7R73P)
- [Session Manager API - Edit session](https://developers.vtex.com/docs/api-reference/session-manager-api#patch-/api/sessions)
