### PR TITLE
feat: Displays region modal if no addresses and location is mandatory

### DIFF
--- a/packages/components/src/molecules/Modal/Modal.tsx
+++ b/packages/components/src/molecules/Modal/Modal.tsx
@@ -31,21 +31,25 @@ export interface ModalProps extends Omit<ModalContentProps, 'children'> {
    */
   'aria-labelledby'?: AriaAttributes['aria-label']
   /**
-   * A boolean value that represents the state of the Modal
+   * A boolean value that represents the state of the Modal.
    */
   isOpen?: boolean
   /**
-   * Event emitted when the modal is closed
+   * Event emitted when the modal is closed.
    */
   onDismiss?: () => void
   /**
-   * Props forwarded to the `Overlay` component
+   * Props forwarded to the `Overlay` component.
    */
   overlayProps?: OverlayProps
   /**
-   * Children or function as a children
+   * Children or function as a children.
    */
   children: ModalChildrenFunction | ReactNode
+  /**
+   * Disable being closed using the Escape key.
+   */
+  disableEscapeKeyDown?: boolean
 }
 
 /*
@@ -60,13 +64,14 @@ const Modal = ({
   isOpen = true,
   onDismiss,
   overlayProps,
+  disableEscapeKeyDown = false,
   ...otherProps
 }: ModalProps) => {
   const { closeModal } = useUI()
   const { fade, fadeOut, fadeIn } = useFadeEffect()
 
   const handleBackdropClick = (event: MouseEvent) => {
-    if (event.defaultPrevented) {
+    if (disableEscapeKeyDown || event.defaultPrevented) {
       return
     }
 
@@ -76,7 +81,11 @@ const Modal = ({
   }
 
   const handleBackdropKeyDown = (event: KeyboardEvent) => {
-    if (event.key !== 'Escape' || event.defaultPrevented) {
+    if (
+      disableEscapeKeyDown ||
+      event.key !== 'Escape' ||
+      event.defaultPrevented
+    ) {
       return
     }
 

--- a/packages/components/src/organisms/RegionModal/RegionModal.tsx
+++ b/packages/components/src/organisms/RegionModal/RegionModal.tsx
@@ -80,9 +80,10 @@ export interface RegionModalProps extends Omit<ModalProps, 'children'> {
    */
   onClear?: () => void
   /**
-   * Prevent modal from being closed using the close button or the Escape key.
+   * Determines if the modal can be dismissed using the close button or the Escape key.
+   * @default true
    */
-  preventClose?: boolean
+  dismissible?: boolean
 }
 
 function RegionModal({
@@ -102,7 +103,7 @@ function RegionModal({
   onInput,
   onSubmit,
   onClear,
-  preventClose = false,
+  dismissible = true,
   ...otherProps
 }: RegionModalProps) {
   return (
@@ -112,13 +113,13 @@ function RegionModal({
       overlayProps={overlayProps}
       title="Region modal"
       aria-label="Region modal"
-      disableEscapeKeyDown={preventClose}
+      disableEscapeKeyDown={!dismissible}
       {...otherProps}
     >
       {({ fadeOut }) => (
         <>
           <ModalHeader
-            {...(!preventClose && {
+            {...(dismissible && {
               onClose: () => {
                 fadeOut()
                 onClear?.()

--- a/packages/components/src/organisms/RegionModal/RegionModal.tsx
+++ b/packages/components/src/organisms/RegionModal/RegionModal.tsx
@@ -96,7 +96,7 @@ function RegionModal({
   inputRef,
   inputValue,
   inputLabel = 'Postal Code',
-  inputButtonActionText,
+  inputButtonActionText = 'Apply',
   fadeOutOnSubmit,
   overlayProps,
   onClose,

--- a/packages/components/src/organisms/RegionModal/RegionModal.tsx
+++ b/packages/components/src/organisms/RegionModal/RegionModal.tsx
@@ -80,7 +80,7 @@ export interface RegionModalProps extends Omit<ModalProps, 'children'> {
 function RegionModal({
   testId = 'fs-region-modal',
   title = 'Set your location',
-  description = 'Prices, offers and availability may vary according to your location.',
+  description = 'Offers and availability vary by location.',
   closeButtonAriaLabel = 'Close Region Modal',
   idkPostalCodeLinkProps,
   errorMessage,

--- a/packages/components/src/organisms/RegionModal/RegionModal.tsx
+++ b/packages/components/src/organisms/RegionModal/RegionModal.tsx
@@ -52,6 +52,10 @@ export interface RegionModalProps extends Omit<ModalProps, 'children'> {
    */
   inputLabel?: string
   /**
+   * The text displayed on the InputField Button. Suggestion: maximum 9 characters.
+   */
+  inputButtonActionText?: string
+  /**
    * Enables fadeOut effect on modal after onSubmit function
    */
   fadeOutOnSubmit?: boolean
@@ -75,6 +79,10 @@ export interface RegionModalProps extends Omit<ModalProps, 'children'> {
    * Callback function when the input clear button is clicked.
    */
   onClear?: () => void
+  /**
+   * Prevent modal from being closed using the close button or the Escape key.
+   */
+  preventClose?: boolean
 }
 
 function RegionModal({
@@ -87,12 +95,14 @@ function RegionModal({
   inputRef,
   inputValue,
   inputLabel = 'Postal Code',
+  inputButtonActionText,
   fadeOutOnSubmit,
   overlayProps,
   onClose,
   onInput,
   onSubmit,
   onClear,
+  preventClose = false,
   ...otherProps
 }: RegionModalProps) {
   return (
@@ -102,21 +112,26 @@ function RegionModal({
       overlayProps={overlayProps}
       title="Region modal"
       aria-label="Region modal"
+      disableEscapeKeyDown={preventClose}
       {...otherProps}
     >
       {({ fadeOut }) => (
         <>
           <ModalHeader
-            onClose={() => {
-              fadeOut()
-              onClose?.()
-            }}
+            {...(!preventClose && {
+              onClose: () => {
+                fadeOut()
+                onClear?.()
+                onClose?.()
+              },
+            })}
             title={title}
             description={description}
             closeBtnProps={{
               'aria-label': closeButtonAriaLabel,
             }}
           />
+
           <ModalBody>
             <InputField
               data-fs-region-modal-input
@@ -125,6 +140,7 @@ function RegionModal({
               label={inputLabel}
               actionable
               value={inputValue}
+              buttonActionText={inputButtonActionText}
               onInput={(event) => onInput?.(event)}
               onSubmit={() => {
                 onSubmit?.()
@@ -133,7 +149,6 @@ function RegionModal({
               onClear={() => onClear?.()}
               error={errorMessage}
             />
-
             <Link data-fs-region-modal-link {...idkPostalCodeLinkProps} />
           </ModalBody>
         </>

--- a/packages/components/src/organisms/RegionModal/RegionModal.tsx
+++ b/packages/components/src/organisms/RegionModal/RegionModal.tsx
@@ -131,7 +131,6 @@ function RegionModal({
               'aria-label': closeButtonAriaLabel,
             }}
           />
-
           <ModalBody>
             <InputField
               data-fs-region-modal-input

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -2141,6 +2141,11 @@
               "title": "Input field error message",
               "type": "string",
               "default": "You entered an invalid Postal Code"
+            },
+            "buttonActionText": {
+              "title": "Input field action button label",
+              "type": "string",
+              "default": "Apply"
             }
           }
         },

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -2121,7 +2121,7 @@
         "description": {
           "title": "Description",
           "type": "string",
-          "default": "Prices, offers and availability may vary according to your location."
+          "default": "Offers and availability vary by location"
         },
         "closeButtonAriaLabel": {
           "title": "Close modal aria-label",

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -122,8 +122,8 @@ module.exports = {
   },
 
   deliveryPromise: {
-    enabled: true,
-    mandatory: true,
+    enabled: false,
+    mandatory: false,
   },
 
   experimental: {

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -122,7 +122,8 @@ module.exports = {
   },
 
   deliveryPromise: {
-    enabled: false,
+    enabled: true,
+    mandatory: true,
   },
 
   experimental: {

--- a/packages/core/src/Layout.tsx
+++ b/packages/core/src/Layout.tsx
@@ -1,9 +1,32 @@
+import { useUI } from '@faststore/ui'
 import type { PropsWithChildren, ReactElement } from 'react'
+import { useEffect } from 'react'
+import { sessionStore } from 'src/sdk/session'
 
 import { usePageViewEvent } from './sdk/analytics/hooks/usePageViewEvent'
 
+import { deliveryPromise } from 'discovery.config'
+
 function Layout({ children }: PropsWithChildren) {
   usePageViewEvent((children as ReactElement)?.props)
+  const { openModal } = useUI()
+
+  const TIME_TO_VALIDATE_SESSION = 3000
+
+  const openRegionModal = () => {
+    const { postalCode } = sessionStore.read()
+    if (!postalCode) {
+      openModal()
+    }
+  }
+
+  useEffect(() => {
+    if (deliveryPromise.enabled && deliveryPromise.mandatory) {
+      setTimeout(() => openRegionModal(), TIME_TO_VALIDATE_SESSION)
+    }
+
+    return
+  }, [openModal])
 
   return <>{children}</>
 }

--- a/packages/core/src/Layout.tsx
+++ b/packages/core/src/Layout.tsx
@@ -1,38 +1,10 @@
-import { useUI } from '@faststore/ui'
 import type { PropsWithChildren, ReactElement } from 'react'
-import { useEffect } from 'react'
-import { sessionStore } from 'src/sdk/session'
+import { usePageViewEvent } from 'src/sdk/analytics/hooks/usePageViewEvent'
+import { useRegionModal } from './components/region/RegionModal/useRegionModal'
 
-import { usePageViewEvent } from './sdk/analytics/hooks/usePageViewEvent'
-
-import { deliveryPromise } from 'discovery.config'
-import { TIME_TO_VALIDATE_SESSION } from 'src/constants'
-
-function useRegionModal() {
-  const { openModal } = useUI()
-
-  const openRegionModal = () => {
-    const { postalCode } = sessionStore.read()
-    if (!postalCode) {
-      openModal()
-    }
-  }
-  return openRegionModal
-}
-
-function Layout({ children }: PropsWithChildren) {
+const Layout = function Layout({ children }: PropsWithChildren) {
   usePageViewEvent((children as ReactElement)?.props)
-  const { openModal } = useUI()
-  const openRegionModal = useRegionModal()
-
-  // Opens the region modal if the delivery promise is enabled, mandatory, and the user has not set a postal code.
-  // A delay is added to ensure the session is validated before triggering the modal.
-  useEffect(() => {
-    if (deliveryPromise.enabled && deliveryPromise.mandatory) {
-      setTimeout(() => openRegionModal(), TIME_TO_VALIDATE_SESSION)
-    }
-    return
-  }, [openModal])
+  useRegionModal()
 
   return <>{children}</>
 }

--- a/packages/core/src/Layout.tsx
+++ b/packages/core/src/Layout.tsx
@@ -6,12 +6,11 @@ import { sessionStore } from 'src/sdk/session'
 import { usePageViewEvent } from './sdk/analytics/hooks/usePageViewEvent'
 
 import { deliveryPromise } from 'discovery.config'
+import { TIME_TO_VALIDATE_SESSION } from 'src/constants'
 
 function Layout({ children }: PropsWithChildren) {
   usePageViewEvent((children as ReactElement)?.props)
   const { openModal } = useUI()
-
-  const TIME_TO_VALIDATE_SESSION = 3000
 
   const openRegionModal = () => {
     const { postalCode } = sessionStore.read()

--- a/packages/core/src/Layout.tsx
+++ b/packages/core/src/Layout.tsx
@@ -8,8 +8,7 @@ import { usePageViewEvent } from './sdk/analytics/hooks/usePageViewEvent'
 import { deliveryPromise } from 'discovery.config'
 import { TIME_TO_VALIDATE_SESSION } from 'src/constants'
 
-function Layout({ children }: PropsWithChildren) {
-  usePageViewEvent((children as ReactElement)?.props)
+function useRegionModal() {
   const { openModal } = useUI()
 
   const openRegionModal = () => {
@@ -18,12 +17,20 @@ function Layout({ children }: PropsWithChildren) {
       openModal()
     }
   }
+  return openRegionModal
+}
 
+function Layout({ children }: PropsWithChildren) {
+  usePageViewEvent((children as ReactElement)?.props)
+  const { openModal } = useUI()
+  const openRegionModal = useRegionModal()
+
+  // Opens the region modal if the delivery promise is enabled, mandatory, and the user has not set a postal code.
+  // A delay is added to ensure the session is validated before triggering the modal.
   useEffect(() => {
     if (deliveryPromise.enabled && deliveryPromise.mandatory) {
       setTimeout(() => openRegionModal(), TIME_TO_VALIDATE_SESSION)
     }
-
     return
   }, [openModal])
 

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -43,7 +43,7 @@ function RegionModal({
     label: inputFieldLabel,
     errorMessage: inputFieldErrorMessage,
     buttonActionText: inputButtonActionText,
-  } = {},
+  },
   idkPostalCodeLink: {
     text: idkPostalCodeLinkText,
     to: idkPostalCodeLinkTo,

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -128,7 +128,7 @@ function RegionModal({
           fadeOutOnSubmit={false}
           onClear={resetInputField}
           inputButtonActionText={loading ? '...' : 'Apply'}
-          preventClose={isMandatory}
+          dismissible={!isMandatory}
         />
       )}
     </>

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -1,15 +1,12 @@
-import {
-  Icon,
-  type RegionModalProps as UIRegionModalProps,
-  useUI,
-} from '@faststore/ui'
+import dynamic from 'next/dynamic'
 import { useRef, useState } from 'react'
 
-import { sessionStore, useSession, validateSession } from 'src/sdk/session'
+import type { RegionModalProps as UIRegionModalProps } from '@faststore/ui'
+import { Icon, useUI } from '@faststore/ui'
 
 import { deliveryPromise } from 'discovery.config'
+import { sessionStore, useSession, validateSession } from 'src/sdk/session'
 
-import dynamic from 'next/dynamic'
 import styles from './section.module.scss'
 
 const UIRegionModal = dynamic<UIRegionModalProps>(
@@ -19,7 +16,6 @@ const UIRegionModal = dynamic<UIRegionModalProps>(
     ),
   { ssr: false }
 )
-
 interface RegionModalProps {
   title?: UIRegionModalProps['title']
   description?: UIRegionModalProps['description']
@@ -56,7 +52,12 @@ function RegionModal({
   const [loading, setLoading] = useState<boolean>(false)
   const { modal: displayModal, closeModal } = useUI()
 
-  const mandatory = deliveryPromise.mandatory && !session.postalCode
+  const isMandatory = deliveryPromise.mandatory && !session.postalCode
+
+  const resetInputField = () => {
+    setInput('')
+    setErrorMessage('')
+  }
 
   const handleSubmit = async () => {
     const postalCode = inputRef.current?.value
@@ -78,8 +79,7 @@ function RegionModal({
       const validatedSession = await validateSession(newSession)
 
       sessionStore.set(validatedSession ?? newSession)
-      setInput('')
-      setErrorMessage('')
+      resetInputField()
       closeModal() // Close modal after successfully applied postal code
     } catch (error) {
       setErrorMessage(inputFieldErrorMessage)
@@ -126,12 +126,9 @@ function RegionModal({
           }}
           onSubmit={handleSubmit}
           fadeOutOnSubmit={false}
-          onClear={() => {
-            setInput('')
-            setErrorMessage('')
-          }}
+          onClear={resetInputField}
           inputButtonActionText={loading ? '...' : 'Apply'}
-          preventClose={mandatory}
+          preventClose={isMandatory}
         />
       )}
     </>

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -52,7 +52,7 @@ function RegionModal({
   const [loading, setLoading] = useState<boolean>(false)
   const { modal: displayModal, closeModal } = useUI()
 
-  const isMandatory = deliveryPromise.mandatory && !session.postalCode
+  const isDismissible = !!(!deliveryPromise?.mandatory || session.postalCode)
 
   const resetInputField = () => {
     setInput('')
@@ -128,7 +128,7 @@ function RegionModal({
           fadeOutOnSubmit={false}
           onClear={resetInputField}
           inputButtonActionText={loading ? '...' : 'Apply'}
-          dismissible={!isMandatory}
+          dismissible={isDismissible}
         />
       )}
     </>

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -23,6 +23,7 @@ interface RegionModalProps {
   inputField?: {
     label?: UIRegionModalProps['inputLabel']
     errorMessage?: UIRegionModalProps['errorMessage']
+    buttonActionText?: UIRegionModalProps['inputButtonActionText']
   }
   idkPostalCodeLink?: {
     text?: string
@@ -38,7 +39,11 @@ function RegionModal({
   title,
   description,
   closeButtonAriaLabel,
-  inputField: { label: inputFieldLabel, errorMessage: inputFieldErrorMessage },
+  inputField: {
+    label: inputFieldLabel,
+    errorMessage: inputFieldErrorMessage,
+    buttonActionText: inputButtonActionText,
+  } = {},
   idkPostalCodeLink: {
     text: idkPostalCodeLinkText,
     to: idkPostalCodeLinkTo,
@@ -127,7 +132,7 @@ function RegionModal({
           onSubmit={handleSubmit}
           fadeOutOnSubmit={false}
           onClear={resetInputField}
-          inputButtonActionText={loading ? '...' : 'Apply'}
+          inputButtonActionText={loading ? '...' : inputButtonActionText}
           dismissible={isDismissible}
         />
       )}

--- a/packages/core/src/components/region/RegionModal/useRegionModal.ts
+++ b/packages/core/src/components/region/RegionModal/useRegionModal.ts
@@ -19,10 +19,12 @@ export function useRegionModal() {
 
   // Effect to handle when isValidating changes from true to false
   useEffect(() => {
+    if (!deliveryPromise.enabled || !deliveryPromise.mandatory) {
+      return
+    }
+
     if (prevIsValidating.current && !isValidating) {
-      if (deliveryPromise.enabled && deliveryPromise.mandatory) {
-        openRegionModal()
-      }
+      openRegionModal()
     }
 
     // Update the previous value of isValidating

--- a/packages/core/src/components/region/RegionModal/useRegionModal.ts
+++ b/packages/core/src/components/region/RegionModal/useRegionModal.ts
@@ -1,0 +1,33 @@
+import { useUI } from '@faststore/ui'
+import { deliveryPromise } from 'discovery.config'
+import { useEffect, useRef } from 'react'
+import { sessionStore, useSession } from 'src/sdk/session'
+
+export function useRegionModal() {
+  const { openModal } = useUI()
+  const { isValidating } = useSession()
+
+  // Ref to track the previous value of isValidating
+  const prevIsValidating = useRef(isValidating)
+
+  const openRegionModal = () => {
+    const { postalCode } = sessionStore.read()
+    if (!postalCode) {
+      openModal()
+    }
+  }
+
+  // Effect to handle when isValidating changes from true to false
+  useEffect(() => {
+    if (prevIsValidating.current && !isValidating) {
+      if (deliveryPromise.enabled && deliveryPromise.mandatory) {
+        openRegionModal()
+      }
+    }
+
+    // Update the previous value of isValidating
+    prevIsValidating.current = isValidating
+  }, [openRegionModal])
+
+  return openRegionModal
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,2 +1,3 @@
 export const ITEMS_PER_PAGE = 12
 export const ITEMS_PER_SECTION = 5
+export const TIME_TO_VALIDATE_SESSION = 3000

--- a/packages/core/src/sdk/geolocation/useGeolocation.ts
+++ b/packages/core/src/sdk/geolocation/useGeolocation.ts
@@ -1,9 +1,8 @@
 import { useEffect } from 'react'
 
 import { deliveryPromise } from 'discovery.config'
-import { validateSession, sessionStore } from 'src/sdk/session'
-
-const TIME_TO_VALIDATE_SESSION = 3000
+import { TIME_TO_VALIDATE_SESSION } from 'src/constants'
+import { sessionStore, validateSession } from 'src/sdk/session'
 
 async function askGeolocationConsent() {
   const { postalCode: stalePostalCode, geoCoordinates: staleGeoCoordinates } =

--- a/packages/ui/src/components/organisms/RegionModal/styles.scss
+++ b/packages/ui/src/components/organisms/RegionModal/styles.scss
@@ -15,17 +15,23 @@
   // Structural Styles
   // --------------------------------------------------------
   [data-fs-input-field] {
+    flex: 1;
     margin-bottom: var(--fs-region-modal-margin-bottom);
   }
 
   [data-fs-region-modal-link] {
     display: flex;
     flex-direction: row;
+    column-gap: var(--fs-region-modal-link-column-gap);
     align-content: flex-start;
     align-items: center;
     justify-content: flex-start;
-    column-gap: var(--fs-region-modal-link-column-gap);
     padding: var(--fs-region-modal-link-padding);
     color: var(--fs-region-modal-link-color);
+  }
+
+  [data-fs-modal-body] {
+    display: flex;
+    flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR implements the scenario where no address is available and the location is set as mandatory on `discovery.config`

<img width="400" alt="image" src="https://github.com/user-attachments/assets/c37757e3-7d4f-4cbe-9ea6-9fabf781547e" />

**note**: The region modal and the flow implemented in this PR differ from the previous prototype. But I've already aligned with @renatamottam (design team) and she will update the figma file. (The main difference is that we won't be using the `Set Location` button, we agreed to use the `Apply` from the input field)

<img width="263" alt="image" src="https://github.com/user-attachments/assets/827d0a3e-10c9-4628-99b3-3a86f0b6013e" />

We also made a fix in the current flow of the default `RegionModal`. 
- It won't automatically close if the added postalCode is invalid and not applied.

Adds `buttonActionText` field in hCMS (the default is `Apply`)
| hCMS | RegionModal|
|-|-|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/64b8aa01-a5e7-48a0-95fe-4d742d8b2f8d" />|<img width="589" alt="image" src="https://github.com/user-attachments/assets/cbe4c7e3-e6e9-4fad-bfbe-c4a8d10ed683" />|

TODO: when merging the feature branch, remind to run cms-sync in the default account.

## How it works?

1.  when accessing the website, If there is no address and location is set as mandatory,  regardless of the page they are accessing, the region modal should appear "forcing" the user to add a valid postal code.
2. while the region modal is displayed the user won't see the modal's close button and won't be able to use the escape key to close it.
3. when a valid postal code is entered, the region modal will close automatically.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/662caa3b-3fad-4c45-9f2e-c492dc4776d3" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/eb6fcef6-f95c-4b92-aa72-0a5d56c42415" />

## How to test it?

1. Run locally or test via this [preview](https://starter-6czvt97g2-vtex.vercel.app)

in the `discovery.config` file, sets `mandatory` as true:

 ```
 deliveryPromise: {
    enabled: true,
    mandatory: true,
  },
```

2. **Logged in / postalCode available scenario**
If there is a postalCode already set, you shouldn't see a region modal appearing when accessing the website.
When clicking to edit the postalCode button (in this example `07008`), you should able to see the `RegionModal` with the close button and be able to close it using the esc key.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/65be27fe-a76a-40cd-81cf-6d13f014fca9" />

3. **postalCode not defined**
When accessing the website, `RegionModal`  should appear "forcing" the user to add a valid postal code. There won't be a close button and you won't be able to close it using the esc key.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/99f4021a-9166-4c25-87bc-a27c27da5af3" />


### Starters Deploy Preview

https://github.com/vtex-sites/starter.store/pull/741

