### PR TITLE
feat: flag to enable faststore my account

### DIFF
--- a/packages/cli/src/utils/createNextjsPages.ts
+++ b/packages/cli/src/utils/createNextjsPages.ts
@@ -63,6 +63,12 @@ export function createNextJsPages(basePath: string) {
     'src/customizations/src/pages'
   )
 
+  if (!fs.existsSync(customizationPagesDir)) {
+    // If the customization pages directory doesn't exist, we don't need to create any pages
+    // and we can return early.
+    return
+  }
+
   const allPagesAreAllowed = fs
     .readdirSync(customizationPagesDir)
     .every((filePath) => isAllowedPrefixPage(path.join('/', filePath)))

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -116,5 +116,6 @@ module.exports = {
     preact: false,
     enableRedirects: false,
     enableSearchSSR: false,
+    enableFaststoreMyAccount: false,
   },
 }

--- a/packages/core/src/pages/account/index.tsx
+++ b/packages/core/src/pages/account/index.tsx
@@ -9,6 +9,7 @@ import {
   getServerSideProps,
   type MyAccountProps,
 } from 'src/experimental/myAccountSeverSideProps'
+import { useRouter } from 'next/router'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -17,8 +18,13 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
 }
 
 function Page({ globalSections }: MyAccountProps) {
+  const router = useRouter()
   useEffect(() => {
-    window.location.href = `${storeConfig.accountUrl}${window.location.search}`
+    if (storeConfig.experimental.enableFaststoreMyAccount) {
+      router.push('/account/profile') // current default path in my account
+    } else {
+      window.location.href = `${storeConfig.accountUrl}${window.location.search}`
+    }
   }, [])
 
   return (

--- a/packages/core/src/pages/account/profile.tsx
+++ b/packages/core/src/pages/account/profile.tsx
@@ -1,0 +1,48 @@
+/* ######################################### */
+/* Mocked Page until development is finished, it will be removed after */
+
+import { NextSeo } from 'next-seo'
+import type { ComponentType } from 'react'
+import { MyAccountLayout } from 'src/components/account'
+import RenderSections from 'src/components/cms/RenderSections'
+import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
+import CUSTOM_COMPONENTS from 'src/customizations/src/components'
+import {
+  getServerSideProps,
+  type MyAccountProps,
+} from 'src/experimental/myAccountSeverSideProps'
+
+/* A list of components that can be used in the CMS. */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  ...GLOBAL_COMPONENTS,
+  ...CUSTOM_COMPONENTS,
+}
+
+const style = {
+  alignContent: 'center',
+  justifyContent: 'center',
+  alignItems: 'center',
+  display: 'flex',
+  h1: {
+    fontSize: '100px',
+  },
+}
+
+export default function Profile({ globalSections }: MyAccountProps) {
+  return (
+    <RenderSections
+      globalSections={globalSections.sections}
+      components={COMPONENTS}
+    >
+      <NextSeo noindex nofollow />
+
+      <MyAccountLayout>
+        <div style={style}>
+          <h1 style={style.h1}>Profile</h1>
+        </div>
+      </MyAccountLayout>
+    </RenderSections>
+  )
+}
+
+export { getServerSideProps }


### PR DESCRIPTION
## What's the purpose of this pull request?

Create a experimental flag to enable faststore my-account
## How it works?

When the user tries to access the /account, he will be redirect to /account/profile if the flag is enabled. 

## How to test it?

Go to starter, add a flag `enableFaststoreMyAccount: true` in storeConfig. Try to access `/account` path. You should be redirected to `/account/profile`. 
### Starters Deploy Preview


