### PR TITLE
fix: adds .end to the catch of api/graphql

### DIFF
--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -102,7 +102,7 @@ const handler: NextApiHandler = async (request, response) => {
   } catch (err) {
     console.error(err)
 
-    response.status(500)
+    response.status(500).end()
   }
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to prevent the 500 timeout error when the operation hash of any graphql operation changes.

