### PR TITLE
feat: add API GraphQL cache control using flags

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -1,6 +1,6 @@
 import type { Context, Options } from '../../'
 import type { IStoreSelectedFacet } from '../../../../__generated__/schema'
-import { getStoreCookie, getWithCookie } from '../../utils/cookies'
+import { getWithCookie } from '../../utils/cookies'
 import type {
   FuzzyFacet,
   OperatorFacet,
@@ -87,7 +87,6 @@ export const IntelligentSearch = (
   ctx: Context
 ) => {
   const base = `https://${account}.${environment}.com.br/api/io`
-  const storeCookies = getStoreCookie(ctx)
   const withCookie = getWithCookie(ctx)
 
   const host =
@@ -225,8 +224,7 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/${type}/${pathname}?${params.toString()}`,
-      { headers },
-      { storeCookies }
+      { headers }
     )
   }
 
@@ -243,8 +241,7 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/search_suggestions?${params.toString()}`,
-      { headers },
-      { storeCookies }
+      { headers }
     )
   }
 
@@ -255,8 +252,7 @@ export const IntelligentSearch = (
 
     return fetchAPI(
       `${base}/_v/api/intelligent-search/top_searches?${params.toString()}`,
-      { headers },
-      { storeCookies }
+      { headers }
     )
   }
 

--- a/packages/api/test/integration/queries.test.ts
+++ b/packages/api/test/integration/queries.test.ts
@@ -274,7 +274,7 @@ test('`redirect` query', async () => {
     expect(mockedFetch).toHaveBeenCalledWith(
       fetchAPICall.info,
       fetchAPICall.init,
-      { storeCookies: expect.any(Function) }
+      fetchAPICall.options
     )
   })
   expect(response).toMatchSnapshot()

--- a/packages/api/test/mocks/AllProductsQuery.ts
+++ b/packages/api/test/mocks/AllProductsQuery.ts
@@ -82,7 +82,7 @@ export const productSearchPage1Count5Fetch = {
   init: {
     headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
   },
-  options: { storeCookies: expect.any(Function) },
+  options: undefined,
   result: {
     products: [
       {

--- a/packages/api/test/mocks/ProductQuery.ts
+++ b/packages/api/test/mocks/ProductQuery.ts
@@ -67,7 +67,7 @@ export const productSearchFetch = {
   init: {
     headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
   },
-  options: { storeCookies: expect.any(Function) },
+  options: undefined,
   result: {
     products: [
       {

--- a/packages/api/test/mocks/RedirectQuery.ts
+++ b/packages/api/test/mocks/RedirectQuery.ts
@@ -10,7 +10,7 @@ export const redirectTermTechFetch = {
   init: {
     headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
   },
-  options: { storeCookies: expect.any(Function) },
+  options: undefined,
   result: {
     products: [],
     recordsFiltered: 0,

--- a/packages/api/test/mocks/SearchQuery.ts
+++ b/packages/api/test/mocks/SearchQuery.ts
@@ -105,7 +105,7 @@ export const productSearchCategory1Fetch = {
   init: {
     headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
   },
-  options: { storeCookies: expect.any(Function) },
+  options: undefined,
   result: {
     products: [
       {
@@ -1401,7 +1401,7 @@ export const attributeSearchCategory1Fetch = {
   init: {
     headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
   },
-  options: { storeCookies: expect.any(Function) },
+  options: undefined,
   result: {
     facets: [
       {

--- a/packages/api/test/mocks/ValidateCartMutation.ts
+++ b/packages/api/test/mocks/ValidateCartMutation.ts
@@ -351,7 +351,7 @@ export const productSearchPage1Count1Fetch = {
   init: {
     headers: { 'content-type': 'application/json', 'X-FORWARDED-HOST': '' },
   },
-  options: { storeCookies: expect.any(Function) },
+  options: undefined,
   result: {
     products: [
       {

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -131,5 +131,9 @@ module.exports = {
     enableRedirects: false,
     enableSearchSSR: false,
     enableVtexAssetsLoader: false,
+    graphqlCacheControl: {
+      maxAge: 0, // 0 disables cache, 5 * 60 enable cache control maxAge 5 minutes
+      staleWhileRevalidate: 60,
+    },
   },
 }

--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -107,17 +107,17 @@ const handler: NextApiHandler = async (request, response) => {
       response.setHeader('cache-control', cacheControl)
     }
 
-    const setCookieValues = Array.from(extensions.cookies.values())
-    if (setCookieValues.length > 0 && !hasErrors) {
-      response.setHeader(
-        'set-cookie',
-        setCookieValues.map(({ setCookie }) =>
-          process.env.NODE_ENV !== 'production'
-            ? replaceSetCookieDomain(request, setCookie)
-            : setCookie
-        )
-      )
-    }
+    // const setCookieValues = Array.from(extensions.cookies.values())
+    // if (setCookieValues.length > 0 && !hasErrors) {
+    //   response.setHeader(
+    //     'set-cookie',
+    //     setCookieValues.map(({ setCookie }) =>
+    //       process.env.NODE_ENV !== 'production'
+    //         ? replaceSetCookieDomain(request, setCookie)
+    //         : setCookie
+    //     )
+    //   )
+    // }
 
     response.setHeader('content-type', 'application/json')
     response.send(JSON.stringify({ data, errors }))

--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -101,7 +101,7 @@ const handler: NextApiHandler = async (request, response) => {
 
       response.setHeader(
         'cache-control',
-        `public, max-age=${maxAge}, stale-while-revalidate=${staleWhileRevalidate}`
+        `public, s-maxage=${maxAge}, stale-while-revalidate=${staleWhileRevalidate}`
       )
     } else {
       response.setHeader('cache-control', cacheControl)

--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -2,7 +2,7 @@ import { isFastStoreError, stringifyCacheControl } from '@faststore/api'
 import type { NextApiHandler, NextApiRequest } from 'next'
 
 import { execute } from '../../server'
-import discoveryConfigDefault from 'discovery.config.default'
+import discoveryConfig from 'discovery.config'
 
 const ONE_MINUTE = 60
 
@@ -89,13 +89,12 @@ const handler: NextApiHandler = async (request, response) => {
 
     if (
       request.method === 'GET' &&
-      discoveryConfigDefault?.experimental?.graphqlCacheControl?.maxAge
+      discoveryConfig?.experimental?.graphqlCacheControl?.maxAge
     ) {
-      const maxAge =
-        discoveryConfigDefault.experimental.graphqlCacheControl.maxAge
+      const maxAge = discoveryConfig.experimental.graphqlCacheControl.maxAge
       const staleWhileRevalidate =
-        discoveryConfigDefault.experimental.graphqlCacheControl
-          .staleWhileRevalidate ?? ONE_MINUTE
+        discoveryConfig?.experimental?.graphqlCacheControl
+          ?.staleWhileRevalidate ?? ONE_MINUTE
 
       response.setHeader(
         'cache-control',

--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -107,17 +107,17 @@ const handler: NextApiHandler = async (request, response) => {
       response.setHeader('cache-control', cacheControl)
     }
 
-    // const setCookieValues = Array.from(extensions.cookies.values())
-    // if (setCookieValues.length > 0 && !hasErrors) {
-    //   response.setHeader(
-    //     'set-cookie',
-    //     setCookieValues.map(({ setCookie }) =>
-    //       process.env.NODE_ENV !== 'production'
-    //         ? replaceSetCookieDomain(request, setCookie)
-    //         : setCookie
-    //     )
-    //   )
-    // }
+    const setCookieValues = Array.from(extensions.cookies.values())
+    if (setCookieValues.length > 0 && !hasErrors) {
+      response.setHeader(
+        'set-cookie',
+        setCookieValues.map(({ setCookie }) =>
+          process.env.NODE_ENV !== 'production'
+            ? replaceSetCookieDomain(request, setCookie)
+            : setCookie
+        )
+      )
+    }
 
     response.setHeader('content-type', 'application/json')
     response.send(JSON.stringify({ data, errors }))

--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -96,6 +96,9 @@ const handler: NextApiHandler = async (request, response) => {
         discoveryConfig?.experimental?.graphqlCacheControl
           ?.staleWhileRevalidate ?? ONE_MINUTE
 
+      console.log('🚀 ~ maxAge:', maxAge)
+      console.log('🚀 ~ staleWhileRevalidate:', staleWhileRevalidate)
+
       response.setHeader(
         'cache-control',
         `public, max-age=${maxAge}, stale-while-revalidate=${staleWhileRevalidate}`

--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -98,7 +98,7 @@ const handler: NextApiHandler = async (request, response) => {
 
       response.setHeader(
         'cache-control',
-        `max-age=${maxAge}, stale-while-revalidate=${staleWhileRevalidate}`
+        `public, max-age=${maxAge}, stale-while-revalidate=${staleWhileRevalidate}`
       )
     } else {
       response.setHeader('cache-control', cacheControl)

--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -96,9 +96,6 @@ const handler: NextApiHandler = async (request, response) => {
         discoveryConfig?.experimental?.graphqlCacheControl
           ?.staleWhileRevalidate ?? ONE_MINUTE
 
-      console.log('🚀 ~ maxAge:', maxAge)
-      console.log('🚀 ~ staleWhileRevalidate:', staleWhileRevalidate)
-
       response.setHeader(
         'cache-control',
         `public, s-maxage=${maxAge}, stale-while-revalidate=${staleWhileRevalidate}`


### PR DESCRIPTION
## What's the purpose of this pull request?

Add GraphQL cache control configuration and handling using experimental flags.

You should change the experimental flag in `discovery.config` inside the `experimental`.

`maxAge` value different from 0 enables the cache in GET requests.
```js
graphqlCacheControl: {
  maxAge: 5 * 60, 
  staleWhileRevalidate: 60,
},
```

`maxAge` value 0 disables cache

```js
graphqlCacheControl: {
  maxAge: 0, // 0 disables cache
  staleWhileRevalidate: 60,
},
```

POST request didn't use cache.

// TODO create docs related with this feature flag. @mariana-caetano 

