### PR TITLE
fix: Encode redirect destination

### DIFF
--- a/packages/core/src/sdk/redirects/index.ts
+++ b/packages/core/src/sdk/redirects/index.ts
@@ -31,8 +31,10 @@ export async function getRedirect({
   try {
     const redirectMatch = matcher({ pathname })
     if (redirectMatch) {
+      const encodedDestination = encodeURI(redirectMatch.destination)
+      console.log({ encodedDestination })
       return {
-        destination: redirectMatch.destination,
+        destination: encodedDestination,
         permanent: redirectMatch.permanent ?? true,
       }
     }

--- a/packages/core/src/sdk/redirects/index.ts
+++ b/packages/core/src/sdk/redirects/index.ts
@@ -31,10 +31,8 @@ export async function getRedirect({
   try {
     const redirectMatch = matcher({ pathname })
     if (redirectMatch) {
-      const encodedDestination = encodeURI(redirectMatch.destination)
-      console.log({ encodedDestination })
       return {
-        destination: encodedDestination,
+        destination: encodeURI(redirectMatch.destination),
         permanent: redirectMatch.permanent ?? true,
       }
     }


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the redirect destination. Vercel was throwing an error when the search term had non ascii characters.

## How it works?

Encodes the redirect destination.

## How to test it?

You can test using this repo to test locally, but the error isn't being thrown locally.

You can test using the previews, I've created one [**with** the fix](https://github.com/vtex-sites/starter.store/pull/745) and one [**without** the fix](https://github.com/vtex-sites/starter.store/pull/747). Both of them have the `enableRedirects` active and have the same matcher configured.

**Without** the fix: https://starter-h6x15or7b-vtex.vercel.app/busca/tasty-wôoden-bacón
![Screenshot 2025-04-01 at 09 53 42](https://github.com/user-attachments/assets/85a617c5-e6ed-471d-b528-3608e3e89b02)

**With** the fix: https://starter-m0b8fpkw8-vtex.vercel.app/busca/tasty-wôoden-bacón
![Screenshot 2025-04-01 at 09 54 16](https://github.com/user-attachments/assets/b8478cb8-b3de-423e-9816-eb0160d8001b)

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->