### PR TITLE
fix: validate response status before parsing to json

### DIFF
--- a/packages/core/src/sdk/redirects/index.ts
+++ b/packages/core/src/sdk/redirects/index.ts
@@ -40,6 +40,11 @@ export async function getRedirect({
     const response = await fetch(
       `https://${storeConfig.api.storeId}.myvtex.com/_v/public/redirect-evaluate${pathname}`
     )
+
+    if (!response.ok) {
+      return null
+    }
+
     const rewriterData = (await response.json()) as RewriterResponse
 
     if (rewriterData.location) {


### PR DESCRIPTION
## What's the purpose of this pull request?

Validate response status before parsing to json. 

## How it works?

"The ok read-only property of the Response interface contains a Boolean stating whether the response was successful (status in the range 200-299) or not." Reference: https://developer.mozilla.org/en-US/docs/Web/API/Response/ok

Check if the **response.ok** is true before trying to parse.

