### PR TITLE
chore: Handle B2B users

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -94,9 +94,11 @@ export const validateSession = async (
       seller: seller?.id,
       hasOnlyDefaultSalesChannel: !store?.channel?.value,
     }),
-    b2b: {
-      customerId: authentication?.customerId?.value ?? '',
-    },
+    b2b: authentication?.customerId?.value
+      ? {
+          customerId: authentication?.customerId?.value ?? '',
+        }
+      : null,
     marketingData,
     person: profile?.id
       ? {

--- a/packages/core/src/sdk/session/index.ts
+++ b/packages/core/src/sdk/session/index.ts
@@ -61,11 +61,10 @@ export const mutation = gql(`
 export const validateSession = async (session: Session) => {
   // If deliveryPromise is enabled and there is no postalCode in the session
   if (storeConfig.deliveryPromise?.enabled && !session.postalCode) {
-    const isLoggedIn = !!session.person?.id
+    const userId = session.b2b?.customerId ?? session.person?.id
 
-    // If user is logged try to get the location (postalCode / geoCoordinates / country) from the user's address
-    if (isLoggedIn) {
-      const userId = session.person?.id
+    // If user is logged in try to get the location (postalCode, geoCoordinates and country) from the user's address
+    if (userId) {
       const address = await getSavedAddress(userId)
 
       // Save the location in the session


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to check for `customerId` when a user is related to a B2B org.

## How to test it?

- Change account to `b2bfaststoredev` and run the server;
- When login and create the cookie, use it on http://localhost:3000 and check IndexedDB for the `customerId` value.

### Starters Deploy Preview

