### PR TITLE
fix: loading rc with accountName 

### DIFF
--- a/packages/core/src/components/ThirdPartyScripts/vtex.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/vtex.tsx
@@ -11,12 +11,14 @@ function VTEX() {
     window.sendrc=function(en,ed){window.NavigationCapture&&window.NavigationCapture.sendEvent(en,ed)};
     `,
         }}
+        data-an={storeConfig.api.storeId}
       />
       <script
         key="vtexrc.js-script"
         type="text/partytown"
         async
-        src="https://io.vtex.com.br/rc/rc.js"
+        src="https://activity-flow.vtex.com/af/rc.js"
+        data-an={storeConfig.api.storeId}
       />
       <script
         type="text/javascript"

--- a/packages/core/src/components/ThirdPartyScripts/vtex.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/vtex.tsx
@@ -8,17 +8,16 @@ function VTEX() {
         type="text/partytown"
         dangerouslySetInnerHTML={{
           __html: `
+    window.VTEX_METADATA = {account:'${storeConfig.api.storeId}', renderer: 'faststore'};
     window.sendrc=function(en,ed){window.NavigationCapture&&window.NavigationCapture.sendEvent(en,ed)};
     `,
         }}
-        data-an={storeConfig.api.storeId}
       />
       <script
         key="vtexrc.js-script"
         type="text/partytown"
         async
         src="https://activity-flow.vtex.com/af/rc.js"
-        data-an={storeConfig.api.storeId}
       />
       <script
         type="text/javascript"

--- a/packages/core/src/components/ThirdPartyScripts/vtex.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/vtex.tsx
@@ -8,16 +8,16 @@ function VTEX() {
         type="text/partytown"
         dangerouslySetInnerHTML={{
           __html: `
-    window.VTEX_METADATA = {account:'${storeConfig.api.storeId}', renderer: 'faststore'};
-    window.sendrc=function(en,ed){window.NavigationCapture&&window.NavigationCapture.sendEvent(en,ed)};
-    `,
+            window.VTEX_METADATA = {account:'${storeConfig.api.storeId}', renderer: 'faststore'};
+            window.sendrc=function(en,ed){window.NavigationCapture&&window.NavigationCapture.sendEvent(en,ed)};
+          `,
         }}
       />
       <script
         key="vtexrc.js-script"
         type="text/partytown"
         async
-        src="https://activity-flow.vtex.com/af/rc.js"
+        src="https://io.vtex.com.br/rc/rc.js"
       />
       <script
         type="text/javascript"


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix how we inform the account name to rc, so the rc can correctly read the accountName of FastStore stores.

PS: rc will fix the way it reads account info on FastStore stores

## How it works?
|before|now|
|-|-|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/c7a0deb8-04bf-41a8-b5e5-00986fede176" />|<img width="500" alt="image" src="https://github.com/user-attachments/assets/49e3d413-9773-4ed1-bc52-bf9ab7be47b8" />|

## How to test it?

1. Run the store
2. check for v8 events, the accountName should be in the payload.

## References
inc-2496
