### PR TITLE
feat: order details status card

### DIFF
--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountOrderDetails.tsx
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountOrderDetails.tsx
@@ -1,5 +1,11 @@
-import { Icon as UIIcon, IconButton as UIIconButton } from '@faststore/ui'
-import MyAccountStatusCard from 'src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard'
+import {
+  Badge as UIBadge,
+  Icon as UIIcon,
+  IconButton as UIIconButton,
+} from '@faststore/ui'
+import MyAccountStatusCard, {
+  type ApiOrderStatus,
+} from 'src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard'
 import MyAccountDeliveryCard from './MyAccountDeliveryCard'
 import { MyAccountDeliveryOptionAccordion } from './MyAccountDeliveryOptionAccordion'
 import MyAccountOrderActions from './MyAccountOrderActions'
@@ -64,7 +70,7 @@ export default function MyAccountOrderDetails({
         <MyAccountDeliveryCard
           deliveryOptionsData={order.deliveryOptionsData}
         />
-        <MyAccountStatusCard />
+        <MyAccountStatusCard status={order.status as ApiOrderStatus} />
         <MyAccountPaymentCard
           currencyCode={order.storePreferencesData.currencyCode}
           paymentData={order.paymentData}

--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountOrderDetails.tsx
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountOrderDetails.tsx
@@ -3,9 +3,7 @@ import {
   Icon as UIIcon,
   IconButton as UIIconButton,
 } from '@faststore/ui'
-import MyAccountStatusCard, {
-  type ApiOrderStatus,
-} from 'src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard'
+import MyAccountStatusCard, {} from 'src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard'
 import MyAccountDeliveryCard from './MyAccountDeliveryCard'
 import { MyAccountDeliveryOptionAccordion } from './MyAccountDeliveryOptionAccordion'
 import MyAccountOrderActions from './MyAccountOrderActions'
@@ -17,6 +15,7 @@ import type { ServerOrderDetailsQueryQuery } from '@generated/graphql'
 import { useRouter } from 'next/router'
 import MyAccountStatusBadge from '../../components/MyAccountStatusBadge'
 import styles from './section.module.scss'
+import type { OrderStatusKey } from 'src/utils/userOrderStatus'
 
 export interface MyAccountOrderDetailsProps {
   order: ServerOrderDetailsQueryQuery['userOrder']
@@ -70,7 +69,7 @@ export default function MyAccountOrderDetails({
         <MyAccountDeliveryCard
           deliveryOptionsData={order.deliveryOptionsData}
         />
-        <MyAccountStatusCard status={order.status as ApiOrderStatus} />
+        <MyAccountStatusCard status={order.status as OrderStatusKey} />
         <MyAccountPaymentCard
           currencyCode={order.storePreferencesData.currencyCode}
           paymentData={order.paymentData}

--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/MyAccountStatusCard.tsx
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/MyAccountStatusCard.tsx
@@ -234,3 +234,5 @@ function MyAccountStatusCard({ status }: MyAccountStatusCardProps) {
     </MyAccountCard>
   )
 }
+
+export default MyAccountStatusCard

--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/MyAccountStatusCard.tsx
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/MyAccountStatusCard.tsx
@@ -1,9 +1,241 @@
-import MyAccountCard from '../../../components/MyAccountCard'
+import { Icon as UIIcon } from '@faststore/ui'
+import React from 'react'
+import MyAccountCard from 'src/components/account/components/MyAccountCard'
 
-function MyAccountCardStatus() {
+export type StepStatus = 'completed' | 'loading' | 'not-started' | 'failed'
+export type StepKey =
+  | 'order'
+  | 'approval'
+  | 'payment'
+  | 'processing'
+  | 'delivery'
+  | 'shipping'
+
+export type ApiOrderStatus = keyof typeof STATUS_MAPPING
+
+interface Step {
+  label: string
+  status: StepStatus
+  completedAt?: string
+}
+
+interface MyAccountStatusCardProps {
+  status: ApiOrderStatus
+}
+
+const APPROVAL_LABELS: Record<StepStatus, string> = {
+  completed: 'Order approved',
+  loading: 'Approval pending',
+  'not-started': 'Approval pending',
+  failed: 'Order denied',
+}
+
+const PAYMENT_LABELS: Record<StepStatus, string> = {
+  completed: 'Payment approved',
+  loading: 'Payment pending',
+  'not-started': 'Payment authorization',
+  failed: 'Payment denied',
+}
+
+const PROCESSING_LABELS: Record<StepStatus, string> = {
+  completed: 'Ready for shipping',
+  loading: 'Handling order',
+  'not-started': 'Handling order',
+  failed: 'Order canceled',
+}
+
+const SHIPPING_LABELS: Record<StepStatus, string> = {
+  completed: 'Invoiced',
+  loading: 'Shipping order',
+  'not-started': 'Ship order',
+  failed: 'Order canceled',
+}
+
+const VISUAL_STEPS = [
+  {
+    label: (stepStatus: StepStatus) => APPROVAL_LABELS[stepStatus],
+    key: 'approval',
+  },
+  { label: (_: StepStatus) => 'Order Placed', key: 'order' },
+  {
+    label: (stepStatus: StepStatus) => PAYMENT_LABELS[stepStatus],
+    key: 'payment',
+  },
+  {
+    label: (stepStatus: StepStatus) => PROCESSING_LABELS[stepStatus],
+    key: 'processing',
+  },
+  {
+    label: (stepStatus: StepStatus) => SHIPPING_LABELS[stepStatus],
+    key: 'shipping',
+  },
+] as const
+
+const STATUS_MAPPING = {
+  // Approval steps
+  null: 'approval',
+  'pending-approval': 'approval',
+  denied: 'approval',
+  cancel: 'approval',
+
+  // Order steps
+  'order-created': 'order',
+  'order-accepted': 'order',
+
+  // Payment steps
+  'payment-pending': 'payment',
+  'payment-denied': 'payment',
+  'window-to-change-payment': 'payment',
+
+  // Processing steps
+  'payment-approved': 'processing',
+  'ready-for-handling': 'processing',
+  'ready-for-packing': 'processing',
+  'start-handling': 'processing',
+  'authorize-fulfillment': 'processing',
+  handling: 'processing',
+  canceled: 'processing',
+  'verifying-invoice': 'processing',
+  canceling: 'processing',
+  'request-cancel': 'processing',
+  'on-order-completed': 'processing',
+  'on-order-completed-ffm': 'processing',
+  'cancellation-requested': 'processing',
+
+  // Shipping steps
+  'shipping-in-progress': 'shipping',
+  'ready-for-invoicing': 'shipping',
+  'ready-for-picking': 'shipping',
+  shipped: 'shipping',
+  invoice: 'processing',
+  invoiced: 'processing',
+} as const
+
+const FAILED_STATUSES = [
+  'denied',
+  'request-cancel',
+  'canceling',
+  'canceled',
+  'cancellation-requested',
+  'payment-denied',
+] as const
+
+const formatDate = (date: string) => {
+  return new Intl.DateTimeFormat('en-US', {
+    month: '2-digit',
+    day: '2-digit',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).format(new Date(date))
+}
+
+const StepIcon = ({ status }: { status: StepStatus }) => {
+  if (status === 'completed') {
+    return (
+      <div data-fs-shipping-step-icon data-fs-shipping-step-completed>
+        <UIIcon name="Checked" height={20} width={20} />
+      </div>
+    )
+  }
+
+  if (status === 'loading') {
+    return (
+      <div data-fs-shipping-step-icon data-fs-shipping-step-loading>
+        <UIIcon name="DotsThree" height={20} width={20} />
+      </div>
+    )
+  }
+
+  if (status === 'failed') {
+    return (
+      <div data-fs-shipping-step-icon data-fs-shipping-step-failed>
+        <UIIcon name="X" height={20} width={20} />
+      </div>
+    )
+  }
+
+  return <div data-fs-shipping-step-icon />
+}
+
+const getStepStatus = (
+  stepKey: StepKey,
+  currentStatus: ApiOrderStatus,
+  isCanceled: boolean
+): StepStatus => {
+  if (isCanceled && stepKey === STATUS_MAPPING[currentStatus]) {
+    return 'failed'
+  }
+
+  const currentStepIndex = VISUAL_STEPS.findIndex(
+    (step) => step.key === STATUS_MAPPING[currentStatus]
+  )
+
+  const thisStepIndex = VISUAL_STEPS.findIndex((step) => step.key === stepKey)
+
+  if (currentStepIndex === -1) {
+    if (thisStepIndex === 0) {
+      return 'loading'
+    }
+
+    return 'not-started'
+  }
+
+  if (thisStepIndex === currentStepIndex) {
+    return 'loading'
+  }
+
+  return thisStepIndex < currentStepIndex ? 'completed' : 'not-started'
+}
+
+function MyAccountStatusCard({ status }: MyAccountStatusCardProps) {
+  const isCanceled = FAILED_STATUSES.includes(
+    status as (typeof FAILED_STATUSES)[number]
+  )
+
+  const steps: Step[] = VISUAL_STEPS.map((step) => {
+    const stepStatus = getStepStatus(step.key, status, isCanceled)
+
+    return {
+      label: step.label(stepStatus),
+      status: stepStatus,
+    }
+  })
+
   return (
-    <MyAccountCard title="Status" data-fs-order-status-card></MyAccountCard>
+    <MyAccountCard title="Status" data-fs-order-status-card>
+      <div data-fs-order-status-content>
+        {steps.map((step, index) => (
+          <div
+            key={`${step.label}-${index}`}
+            data-fs-shipping-step
+            data-fs-shipping-status={step.status}
+          >
+            <StepIcon status={step.status} />
+            <div data-fs-shipping-step-content>
+              <p data-fs-shipping-step-label>{step.label}</p>
+              {step.completedAt && (
+                <div data-fs-shipping-step-details>
+                  <span data-fs-shipping-step-date>
+                    {formatDate(step.completedAt)}
+                  </span>
+                </div>
+              )}
+            </div>
+            {index < steps.length - 1 && (
+              <div
+                data-fs-shipping-connector
+                data-fs-shipping-connector-status={
+                  step.status === 'completed' ? 'completed' : 'not-started'
+                }
+              />
+            )}
+          </div>
+        ))}
+      </div>
+    </MyAccountCard>
   )
 }
 
-export default MyAccountCardStatus
+export default MyAccountStatusCard

--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/MyAccountStatusCard.tsx
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/MyAccountStatusCard.tsx
@@ -1,6 +1,8 @@
 import { Icon as UIIcon } from '@faststore/ui'
+import { useEffect, useRef } from 'react'
 import MyAccountCard from 'src/components/account/components/MyAccountCard'
 import { orderStatusMap, type OrderStatusKey } from 'src/utils/userOrderStatus'
+import { useConnectorPositioning } from './useConnectorPositioning'
 
 export type StepStatus = 'completed' | 'loading' | 'not-started' | 'failed'
 export type StepKey =
@@ -111,7 +113,7 @@ const StepIcon = ({ status }: { status: StepStatus }) => {
   if (status === 'completed') {
     return (
       <div data-fs-shipping-step-icon data-fs-shipping-step-completed>
-        <UIIcon name="Checked" height={20} width={20} />
+        <UIIcon name="Checked" height={16} width={16} />
       </div>
     )
   }
@@ -119,7 +121,7 @@ const StepIcon = ({ status }: { status: StepStatus }) => {
   if (status === 'loading') {
     return (
       <div data-fs-shipping-step-icon data-fs-shipping-step-loading>
-        <UIIcon name="DotsThree" height={20} width={20} />
+        <UIIcon name="DotsThree" height={16} width={16} />
       </div>
     )
   }
@@ -127,7 +129,7 @@ const StepIcon = ({ status }: { status: StepStatus }) => {
   if (status === 'failed') {
     return (
       <div data-fs-shipping-step-icon data-fs-shipping-step-failed>
-        <UIIcon name="X" height={20} width={20} />
+        <UIIcon name="X" height={16} width={16} />
       </div>
     )
   }
@@ -179,6 +181,10 @@ const getStepStatus = (
 }
 
 function MyAccountStatusCard({ status }: MyAccountStatusCardProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useConnectorPositioning(containerRef)
+
   // Get the label for the current status and check if it's a failed status
   const currentStatusLabel = orderStatusMap[status]?.label
   const isCanceled = currentStatusLabel
@@ -196,7 +202,7 @@ function MyAccountStatusCard({ status }: MyAccountStatusCardProps) {
 
   return (
     <MyAccountCard title="Status" data-fs-order-status-card>
-      <div data-fs-order-status-content>
+      <div data-fs-order-status-content ref={containerRef}>
         {steps.map((step, index) => (
           <div
             key={`${step.label}-${index}`}
@@ -228,5 +234,3 @@ function MyAccountStatusCard({ status }: MyAccountStatusCardProps) {
     </MyAccountCard>
   )
 }
-
-export default MyAccountStatusCard

--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/index.ts
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/index.ts
@@ -1,2 +1,1 @@
 export { default } from './MyAccountStatusCard'
-export type { ApiOrderStatus } from './MyAccountStatusCard'

--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/index.ts
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/index.ts
@@ -1,1 +1,2 @@
 export { default } from './MyAccountStatusCard'
+export type { ApiOrderStatus } from './MyAccountStatusCard'

--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/styles.scss
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/styles.scss
@@ -177,20 +177,6 @@
       &[data-fs-shipping-connector-status="completed"] {
         background-color: var(--fs-order-status-connector-completed-color);
       }
-
-      @include media("<notebook") {
-        top: calc(50% + var(--fs-order-status-step-icon-half-size) + var(--fs-order-status-connector-spacing));
-        left: calc(var(--fs-spacing-2) + var(--fs-order-status-step-icon-half-size) + var(--fs-order-status-step-icon-margin));
-        width: var(--fs-border-width);
-        height: calc((50% - var(--fs-order-status-step-icon-half-size)) + var(--fs-order-status-card-gap) + (50% - var(--fs-order-status-step-icon-half-size)) - (var(--fs-order-status-connector-spacing) * 2));
-      }
-
-      @include media(">=notebook") {
-        top: calc(1rem + var(--fs-order-status-step-icon-half-size));
-        left: calc(50% + var(--fs-order-status-step-icon-half-size) + var(--fs-order-status-connector-desktop-spacing) + var(--fs-order-status-step-icon-margin));
-        width: calc((50% - var(--fs-order-status-step-icon-half-size)) + var(--fs-order-status-card-gap) + (50% - var(--fs-order-status-step-icon-half-size)) - (var(--fs-order-status-connector-desktop-spacing) * 2));
-        height: var(--fs-border-width);
-      }
     }
   }
 

--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/styles.scss
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/styles.scss
@@ -1,0 +1,220 @@
+[data-fs-order-status-card] {
+  // --------------------------------------------------------
+  // Design Tokens for Order Status Card
+  // --------------------------------------------------------
+
+  // Default properties
+  --fs-order-status-card-gap                     : var(--fs-spacing-1);
+  --fs-order-status-card-padding                 : var(--fs-spacing-3) var(--fs-spacing-2);
+  --fs-order-status-card-bkg-color               : var(--fs-color-neutral-1);
+  --fs-order-status-card-border-radius           : var(--fs-border-radius-medium);
+
+  // Step Icon
+  --fs-order-status-step-icon-size              : var(--fs-spacing-4);
+  --fs-order-status-step-icon-half-size         : calc(var(--fs-order-status-step-icon-size) / 2);
+  --fs-order-status-step-icon-border            : var(--fs-border-width) solid var(--fs-border-color-light);
+  --fs-order-status-step-icon-border-radius     : var(--fs-border-radius-circle);
+  --fs-order-status-step-icon-margin            : var(--fs-spacing-0);
+
+  // Step Icon States
+  --fs-order-status-step-icon-completed-color   : #08a822;
+  --fs-order-status-step-icon-failed-color      : #5c5c5c;
+  --fs-order-status-step-icon-loading-color     : var(--fs-color-neutral-4);
+  --fs-order-status-step-icon-text-color        : var(--fs-color-neutral-0);
+
+  // Step Content
+  --fs-order-status-step-content-gap            : var(--fs-spacing-0);
+  --fs-order-status-step-label-size             : var(--fs-text-size-2);
+  --fs-order-status-step-label-weight           : var(--fs-text-weight-medium);
+  --fs-order-status-step-label-line-height      : 1.25;
+  --fs-order-status-step-details-size           : var(--fs-text-size-1);
+
+  // Step States Colors
+  --fs-order-status-step-loading-color          : var(--fs-color-neutral-5);
+  --fs-order-status-step-completed-color        : var(--fs-color-text);
+  --fs-order-status-step-failed-color           : var(--fs-color-text);
+  --fs-order-status-step-not-started-color      : var(--fs-color-disabled-text);
+
+  // Connector
+  --fs-order-status-connector-color             : var(--fs-border-color-light);
+  --fs-order-status-connector-completed-color   : var(--fs-order-status-step-icon-completed-color);
+  --fs-order-status-connector-spacing           : var(--fs-spacing-0);
+
+  // Desktop Specific
+  --fs-order-status-step-desktop-height         : 7.75rem;
+  --fs-order-status-step-desktop-min-width      : 6.25rem;
+  --fs-order-status-step-desktop-max-width      : 9rem;
+  --fs-order-status-connector-desktop-spacing   : 0.625rem;
+
+  [data-fs-card-body] {
+    @include media(">=notebook") {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  }
+
+  [data-fs-order-status-content] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--fs-order-status-card-gap);
+    width: 100%;
+    overflow-x: auto;
+
+    @include media(">=notebook") {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+    }
+  }
+
+  [data-fs-shipping-step] {
+    position: relative;
+    display: flex;
+    gap: var(--fs-spacing-1);
+    align-items: center;
+    width: 100%;
+    padding: var(--fs-order-status-card-padding);
+
+    &[data-fs-shipping-status="loading"] {
+      background-color: var(--fs-order-status-card-bkg-color);
+      border-radius: var(--fs-order-status-card-border-radius);
+    }
+
+    @include media(">=notebook") {
+      flex: 1;
+      flex-direction: column;
+      gap: var(--fs-spacing-2);
+      align-items: center;
+      width: clamp(var(--fs-order-status-step-desktop-min-width), calc((100% - (5 * var(--fs-spacing-2))) / 6), var(--fs-order-status-step-desktop-max-width));
+      min-width: var(--fs-order-status-step-desktop-min-width);
+      max-width: var(--fs-order-status-step-desktop-max-width);
+      height: var(--fs-order-status-step-desktop-height);
+      text-align: center;
+    }
+
+    [data-fs-shipping-step-icon] {
+      position: relative;
+      z-index: 1;
+      display: flex;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
+      width: var(--fs-order-status-step-icon-size);
+      height: var(--fs-order-status-step-icon-size);
+      margin: var(--fs-order-status-step-icon-margin);
+
+      [data-fs-icon] {
+        color: var(--fs-color-neutral-0);
+      }
+
+      &[data-fs-shipping-step-completed] {
+        background-color: var(--fs-order-status-step-icon-completed-color);
+        border-radius: var(--fs-order-status-step-icon-border-radius);
+
+        [class*="icon"] {
+          color: var(--fs-order-status-step-icon-text-color);
+        }
+      }
+
+      &[data-fs-shipping-step-failed] {
+        background-color: var(--fs-order-status-step-icon-failed-color);
+        border-radius: var(--fs-order-status-step-icon-border-radius);
+
+        [class*="icon"] {
+          color: var(--fs-order-status-step-icon-text-color);
+        }
+      }
+
+      &[data-fs-shipping-step-loading] {
+        background-color: var(--fs-order-status-step-icon-loading-color);
+        border-radius: var(--fs-order-status-step-icon-border-radius);
+
+        [class*="icon"] {
+          color: var(--fs-order-status-step-icon-text-color);
+        }
+      }
+
+      &:not([data-fs-shipping-step-completed]):not([data-fs-shipping-step-loading]) {
+        border: var(--fs-order-status-step-icon-border);
+        border-radius: var(--fs-order-status-step-icon-border-radius);
+      }
+    }
+
+    [data-fs-shipping-step-content] {
+      display: flex;
+      flex: 1;
+      flex-direction: column;
+      gap: var(--fs-order-status-step-content-gap);
+
+      @include media(">=notebook") {
+        text-align: center;
+      }
+    }
+
+    [data-fs-shipping-step-label] {
+      font-size: var(--fs-order-status-step-label-size);
+      font-weight: var(--fs-order-status-step-label-weight);
+      line-height: var(--fs-order-status-step-label-line-height);
+      color: var(--fs-color-text);
+    }
+
+    [data-fs-shipping-step-details] {
+      display: flex;
+      font-size: var(--fs-order-status-step-details-size);
+      color: var(--fs-color-text-light);
+
+      @include media(">=notebook") {
+        flex-direction: column;
+      }
+    }
+
+    [data-fs-shipping-connector] {
+      position: absolute;
+      z-index: 1;
+      background-color: var(--fs-order-status-connector-color);
+
+      &[data-fs-shipping-connector-status="completed"] {
+        background-color: var(--fs-order-status-connector-completed-color);
+      }
+
+      @include media("<notebook") {
+        top: calc(50% + var(--fs-order-status-step-icon-half-size) + var(--fs-order-status-connector-spacing));
+        left: calc(var(--fs-spacing-2) + var(--fs-order-status-step-icon-half-size) + var(--fs-order-status-step-icon-margin));
+        width: var(--fs-border-width);
+        height: calc((50% - var(--fs-order-status-step-icon-half-size)) + var(--fs-order-status-card-gap) + (50% - var(--fs-order-status-step-icon-half-size)) - (var(--fs-order-status-connector-spacing) * 2));
+      }
+
+      @include media(">=notebook") {
+        top: calc(1rem + var(--fs-order-status-step-icon-half-size));
+        left: calc(50% + var(--fs-order-status-step-icon-half-size) + var(--fs-order-status-connector-desktop-spacing) + var(--fs-order-status-step-icon-margin));
+        width: calc((50% - var(--fs-order-status-step-icon-half-size)) + var(--fs-order-status-card-gap) + (50% - var(--fs-order-status-step-icon-half-size)) - (var(--fs-order-status-connector-desktop-spacing) * 2));
+        height: var(--fs-border-width);
+      }
+    }
+  }
+
+  [data-fs-shipping-status="loading"] {
+    [data-fs-shipping-step-label] {
+      color: var(--fs-order-status-step-loading-color);
+    }
+  }
+
+  [data-fs-shipping-status="completed"] {
+    [data-fs-shipping-step-label] {
+      color: var(--fs-order-status-step-completed-color);
+    }
+  }
+
+  [data-fs-shipping-status="not-started"] {
+    [data-fs-shipping-step-label] {
+      color: var(--fs-order-status-step-not-started-color);
+    }
+  }
+
+  [data-fs-shipping-status="failed"] {
+    [data-fs-shipping-step-label] {
+      color: var(--fs-order-status-step-failed-color);
+    }
+  }
+}

--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/styles.scss
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/styles.scss
@@ -77,6 +77,7 @@
     padding: var(--fs-order-status-card-padding);
 
     &[data-fs-shipping-status="loading"] {
+      z-index: -1;
       background-color: var(--fs-order-status-card-bkg-color);
       border-radius: var(--fs-order-status-card-border-radius);
     }
@@ -95,7 +96,6 @@
 
     [data-fs-shipping-step-icon] {
       position: relative;
-      z-index: 1;
       display: flex;
       flex-shrink: 0;
       align-items: center;
@@ -171,7 +171,6 @@
 
     [data-fs-shipping-connector] {
       position: absolute;
-      z-index: 1;
       background-color: var(--fs-order-status-connector-color);
 
       &[data-fs-shipping-connector-status="completed"] {

--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/useConnectorPositioning.ts
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard/useConnectorPositioning.ts
@@ -1,0 +1,74 @@
+import { useEffect } from 'react'
+import useScreenResize from 'src/sdk/ui/useScreenResize'
+
+export function useConnectorPositioning(
+  containerRef: React.RefObject<HTMLDivElement>
+) {
+  const { isDesktop, isMobile, isTablet } = useScreenResize()
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const calculateContainerGap = () => {
+      // Get all steps
+      const steps = container.querySelectorAll(
+        '[data-fs-shipping-step]'
+      ) as NodeListOf<HTMLElement>
+
+      if (steps.length === 0) return
+
+      // Get container width
+      const containerWidth = container.offsetWidth
+
+      // Calculate total step width
+      let totalStepWidth = 0
+      steps.forEach((step) => {
+        totalStepWidth += step.offsetWidth
+      })
+
+      // Calculate gap width
+      const numberOfGaps = steps.length - 1
+      const totalGapSpace = containerWidth - totalStepWidth
+      const gapWidth = totalGapSpace / numberOfGaps
+
+      return gapWidth
+    }
+
+    const setUpConnectorPositioning = () => {
+      const connectors = container.querySelectorAll(
+        '[data-fs-shipping-connector]'
+      ) as NodeListOf<HTMLElement>
+
+      if (connectors.length === 0) return
+
+      if (isDesktop) {
+        const containerGap = calculateContainerGap()
+        connectors.forEach((connector) => {
+          connector.style.top =
+            'calc(1rem + var(--fs-order-status-step-icon-margin) + var(--fs-order-status-step-icon-half-size))'
+          connector.style.left =
+            'calc(50% + var(--fs-order-status-step-icon-half-size) + var(--fs-order-status-card-gap))'
+          connector.style.width = `calc(((50% - var(--fs-order-status-step-icon-half-size) - var(--fs-order-status-card-gap)) * 2) + ${containerGap}px)`
+          connector.style.height = 'var(--fs-border-width)'
+        })
+      } else {
+        connectors.forEach((connector) => {
+          connector.style.top =
+            'calc(50% + var(--fs-order-status-step-icon-half-size) + var(--fs-order-status-connector-spacing))'
+          connector.style.left =
+            'calc(var(--fs-spacing-2) + var(--fs-order-status-step-icon-half-size) + var(--fs-order-status-step-icon-margin))'
+          connector.style.width = 'var(--fs-border-width)'
+          connector.style.height =
+            'calc((50% - var(--fs-order-status-step-icon-half-size)) + var(--fs-order-status-card-gap) + (50% - var(--fs-order-status-step-icon-half-size)) - (var(--fs-order-status-connector-spacing) * 2))'
+        })
+      }
+    }
+
+    // Calculate on mount and window resize
+    setUpConnectorPositioning()
+    window.addEventListener('resize', setUpConnectorPositioning)
+
+    return () => window.removeEventListener('resize', setUpConnectorPositioning)
+  }, [containerRef, isDesktop])
+}

--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/section.module.scss
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/section.module.scss
@@ -12,6 +12,8 @@
   @import "./MyAccountPaymentCard/styles.scss";
   @import "./MyAccountDeliveryOptionAccordion/styles.scss";
   @import "./MyAccountOrderActions/styles.scss";
+  @import "./MyAccountStatusCard/styles.scss";
+
 
   // --------------------------------------------------------
   // Design Tokens


### PR DESCRIPTION
## What's the purpose of this pull request?

To implements the Status card on Order Details page

## How it works?

creates a new component called `MyAccountStatusCard` that receives the order status as props
The current status the component populates the state machine

### Starters Deploy Preview
[PREVIEW](https://sfj-750696f--faststoreqa.preview.vtex.app/)

## References

[FEATURE BRANCH](https://github.com/vtex/faststore/tree/feat/my-account-release-2)
[FIGMA](https://www.figma.com/design/JppevzwPSV58ud0JDCFE7o/My-Account?node-id=832-50457&t=8JNRc3sBFjsCOPao-0)
[JIRA SFS-2423](https://vtex-dev.atlassian.net/browse/SFS-2423)

