### PR TITLE
fix: channel regionId conditional

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -82,7 +82,7 @@ export const validateSession = async (
   }
 
   const [regionData, sessionData] = await Promise.all([
-    postalCode || geoCoordinates
+    !enableDeliveryPromise && (postalCode || geoCoordinates)
       ? clients.commerce.checkout.region({
           postalCode,
           geoCoordinates,
@@ -110,7 +110,7 @@ export const validateSession = async (
     country: store?.countryCode?.value ?? oldSession.country,
     channel: ChannelMarshal.stringify({
       salesChannel: store?.channel?.value ?? channel.salesChannel,
-      regionId: checkout?.regionId?.value ?? channel.regionId,
+      regionId: checkout?.regionId?.value ?? region?.id ?? channel.regionId,
       seller: seller?.id,
       hasOnlyDefaultSalesChannel: !store?.channel?.value,
     }),


### PR DESCRIPTION
## What's the purpose of this pull request?

The PR https://github.com/vtex/faststore/pull/2749 introduced a bug: when the store doesn't have the Delivery Promise feature enabled, the channel `regionId` wasn't being updated.

## How it works?

The Checkout updates the session's `regionId` when we update the session to add info about `geoCoordinates`, `country`, and `postalCode`. But we only do that when the Delivery Promise feature is enabled.

For the cases that don't have this `regionId` updated automatically by checkout, we'll need to request Checkout directly to get the `regionId`. So, updating the conditional to `regionId: checkout?.regionId?.value ?? region?.id ?? channel.regionId,` it'll use the `region.id` from the Checkout request when it can't get it from the session (`sessionData?.namespaces.checkout?.regionId?.value`). 
And the Checkout request will be made only when the store doesn't use Delivery Promise.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->