### PR TITLE
fix: multiple view_cart events

### DIFF
--- a/packages/core/src/components/cart/CartSidebar/CartSidebar.tsx
+++ b/packages/core/src/components/cart/CartSidebar/CartSidebar.tsx
@@ -65,7 +65,12 @@ function useViewCartEvent() {
   const {
     currency: { code },
   } = useSession()
-  const { items, gifts, total } = useCart()
+  const { items: itemsFromCart, gifts: giftsFromCart, total } = useCart()
+
+  // We need to stringify the items and gifts to avoid circular references
+  // when sending the event to the analytics
+  const gifts = JSON.stringify(giftsFromCart)
+  const items = JSON.stringify(itemsFromCart)
 
   const sendViewCartEvent = useCallback(() => {
     import('@faststore/sdk').then(({ sendAnalyticsEvent }) => {
@@ -74,7 +79,7 @@ function useViewCartEvent() {
         params: {
           currency: code as CurrencyCode,
           value: total,
-          items: items.concat(gifts).map((item) => ({
+          items: itemsFromCart.concat(giftsFromCart).map((item) => ({
             item_id: item.itemOffered.isVariantOf.productGroupID,
             item_name: item.itemOffered.isVariantOf.name,
             item_brand: item.itemOffered.brand.name,


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to prevent multiple `view_cart` events from being sent to GA.

## How it works?

It turns the items and gifts array's stringified before passing to the `useCallback` dependency of `sendAnalyticsEvent.` to prevent circular dependencies and send wrong values to GA.

I also tested these arrays with `useMemo` but it didn't work as expected.

## How to test it?

You can run it locally by adding gtm_debug=true as a query string and seeing the `dataLayer` object in the console.

Example:
http://localhost:3000/?gtm_debug=true

Before: multiple view_cart being triggered.
After: 1 view_cart event being triggered after each interaction (add to cart, remove to cart).

| Before | After |
|--------|--------|
|<img width="1113" alt="Screenshot 2025-04-08 at 16 04 04" src="https://github.com/user-attachments/assets/171624a3-63ef-4d40-a8c7-88383466376b" />|<img width="1195" alt="Screenshot 2025-04-08 at 16 05 16" src="https://github.com/user-attachments/assets/a546455a-a204-4871-8522-4ad0f6d1b576" />| 



### Starters Deploy Preview

PR
- https://github.com/vtex-sites/starter.store/pull/758

preview
https://starter-n12j04z8c-vtex.vercel.app/4k-philips-monitor-99988213/p?gtm_debug=true

