### PR TITLE
feat: GA `view_item_list` event only when item is in viewport of `ProductGallery`

### DIFF
--- a/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
@@ -10,6 +10,7 @@ import { memo } from 'react'
 import ViewportObserver from 'src/components/cms/ViewportObserver'
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 import useScreenResize from 'src/sdk/ui/useScreenResize'
+import ProductSentinel from 'src/sdk/product/ProductSentinel'
 
 interface Props {
   /**
@@ -35,6 +36,10 @@ interface Props {
    * Determine if the current page is the first page.
    */
   firstPage?: number
+  /**
+   * Title for the `ProductGrid` component that will be send to GA events.
+   */
+  title?: string
 }
 
 function ProductGrid({
@@ -48,6 +53,7 @@ function ProductGrid({
     sponsoredLabel,
   } = {},
   firstPage,
+  title,
 }: Props) {
   const { isMobile } = useScreenResize()
   const { __experimentalProductCard: ProductCard } =
@@ -67,36 +73,19 @@ function ProductGrid({
           <>
             {products.slice(0, 2).map(({ node: product }, idx) => (
               <UIProductGridItem key={`${product.id}`}>
-                <ProductCard.Component
-                  aspectRatio={aspectRatio}
-                  imgProps={{
-                    width: 150,
-                    height: 150,
-                    sizes: '30vw',
-                    loading: 'eager',
-                  }}
-                  {...ProductCard.props}
-                  bordered={bordered ?? ProductCard.props.bordered}
-                  showDiscountBadge={
-                    showDiscountBadge ?? ProductCard.props.showDiscountBadge
-                  }
+                <ProductSentinel
                   product={product}
-                  index={pageSize * page + idx + 1}
-                  taxesConfiguration={taxesConfiguration}
-                  sponsoredLabel={sponsoredLabel}
-                />
-              </UIProductGridItem>
-            ))}
-            <ViewportObserver sectionName="UIProductGrid-out-viewport">
-              {products.slice(2).map(({ node: product }, idx) => (
-                <UIProductGridItem key={`${product.id}`}>
+                  title={title}
+                  page={page}
+                  pageSize={pageSize}
+                >
                   <ProductCard.Component
                     aspectRatio={aspectRatio}
                     imgProps={{
                       width: 150,
                       height: 150,
                       sizes: '30vw',
-                      loading: 'lazy',
+                      loading: 'eager',
                     }}
                     {...ProductCard.props}
                     bordered={bordered ?? ProductCard.props.bordered}
@@ -108,6 +97,37 @@ function ProductGrid({
                     taxesConfiguration={taxesConfiguration}
                     sponsoredLabel={sponsoredLabel}
                   />
+                </ProductSentinel>
+              </UIProductGridItem>
+            ))}
+            <ViewportObserver sectionName="UIProductGrid-out-viewport">
+              {products.slice(2).map(({ node: product }, idx) => (
+                <UIProductGridItem key={`${product.id}`}>
+                  <ProductSentinel
+                    product={product}
+                    title={title}
+                    page={page}
+                    pageSize={pageSize}
+                  >
+                    <ProductCard.Component
+                      aspectRatio={aspectRatio}
+                      imgProps={{
+                        width: 150,
+                        height: 150,
+                        sizes: '30vw',
+                        loading: 'lazy',
+                      }}
+                      {...ProductCard.props}
+                      bordered={bordered ?? ProductCard.props.bordered}
+                      showDiscountBadge={
+                        showDiscountBadge ?? ProductCard.props.showDiscountBadge
+                      }
+                      product={product}
+                      index={pageSize * page + idx + 1}
+                      taxesConfiguration={taxesConfiguration}
+                      sponsoredLabel={sponsoredLabel}
+                    />
+                  </ProductSentinel>
                 </UIProductGridItem>
               ))}
             </ViewportObserver>
@@ -116,24 +136,31 @@ function ProductGrid({
           <>
             {products.map(({ node: product }, idx) => (
               <UIProductGridItem key={`${product.id}`}>
-                <ProductCard.Component
-                  aspectRatio={aspectRatio}
-                  imgProps={{
-                    width: 150,
-                    height: 150,
-                    sizes: '30vw',
-                    loading: idx === 0 ? 'eager' : 'lazy',
-                  }}
-                  {...ProductCard.props}
-                  bordered={bordered ?? ProductCard.props.bordered}
-                  showDiscountBadge={
-                    showDiscountBadge ?? ProductCard.props.showDiscountBadge
-                  }
+                <ProductSentinel
                   product={product}
-                  index={pageSize * page + idx + 1}
-                  taxesConfiguration={taxesConfiguration}
-                  sponsoredLabel={sponsoredLabel}
-                />
+                  title={title}
+                  page={page}
+                  pageSize={pageSize}
+                >
+                  <ProductCard.Component
+                    aspectRatio={aspectRatio}
+                    imgProps={{
+                      width: 150,
+                      height: 150,
+                      sizes: '30vw',
+                      loading: idx === 0 ? 'eager' : 'lazy',
+                    }}
+                    {...ProductCard.props}
+                    bordered={bordered ?? ProductCard.props.bordered}
+                    showDiscountBadge={
+                      showDiscountBadge ?? ProductCard.props.showDiscountBadge
+                    }
+                    product={product}
+                    index={pageSize * page + idx + 1}
+                    taxesConfiguration={taxesConfiguration}
+                    sponsoredLabel={sponsoredLabel}
+                  />
+                </ProductSentinel>
               </UIProductGridItem>
             ))}
           </>

--- a/packages/core/src/components/ui/ProductGallery/ProductGalleryPage.tsx
+++ b/packages/core/src/components/ui/ProductGallery/ProductGalleryPage.tsx
@@ -40,6 +40,7 @@ function ProductGalleryPage({
         pageSize={itemsPerPage}
         productCard={productCard}
         firstPage={firstPage}
+        title={title}
       />
     </Sentinel>
   )

--- a/packages/core/src/sdk/analytics/hooks/useViewItemListEvent.ts
+++ b/packages/core/src/sdk/analytics/hooks/useViewItemListEvent.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import type { CurrencyCode, ViewItemListEvent } from '@faststore/sdk'
 
 import { useSession } from 'src/sdk/session'
@@ -7,10 +7,14 @@ import type { ProductSummary_ProductFragment } from '@generated/graphql'
 import type { AnalyticsItem } from '../types'
 
 type Props = {
-  products: Array<{ node: ProductSummary_ProductFragment }>
+  products?: Array<{ node: ProductSummary_ProductFragment }>
   title: string
   page: number
   pageSize: number
+}
+
+type ProductsFallbackProps = {
+  products?: Array<{ node: ProductSummary_ProductFragment }>
 }
 
 export const useViewItemListEvent = ({
@@ -23,31 +27,40 @@ export const useViewItemListEvent = ({
     currency: { code },
   } = useSession()
 
-  const sendViewItemListEvent = useCallback(() => {
-    import('@faststore/sdk').then(({ sendAnalyticsEvent }) => {
-      sendAnalyticsEvent<ViewItemListEvent<AnalyticsItem>>({
-        name: 'view_item_list',
-        params: {
-          item_list_name: title,
-          item_list_id: title,
-          items: products.map(({ node: product }, index) => ({
-            item_id: product.isVariantOf.productGroupID,
-            item_name: product.isVariantOf.name,
-            item_brand: product.brand.name,
-            item_variant: product.sku,
-            price: product.offers.offers[0].price,
-            index: page * pageSize + index + 1,
-            discount:
-              product.offers.offers[0].listPrice -
-              product.offers.offers[0].price,
-            currency: code as CurrencyCode,
-            item_variant_name: product.name,
-            product_reference_id: product.gtin,
-          })),
-        },
+  const sendViewItemListEvent = useCallback(
+    (productsFallback?: ProductsFallbackProps) => {
+      const items = products?.length ? products : productsFallback?.products
+
+      if (!items || items.length === 0) {
+        return
+      }
+
+      import('@faststore/sdk').then(({ sendAnalyticsEvent }) => {
+        sendAnalyticsEvent<ViewItemListEvent<AnalyticsItem>>({
+          name: 'view_item_list',
+          params: {
+            item_list_name: title,
+            item_list_id: title,
+            items: items.map(({ node: product }, index) => ({
+              item_id: product.isVariantOf.productGroupID,
+              item_name: product.isVariantOf.name,
+              item_brand: product.brand.name,
+              item_variant: product.sku,
+              price: product.offers.offers[0].price,
+              index: page * pageSize + index + 1,
+              discount:
+                product.offers.offers[0].listPrice -
+                product.offers.offers[0].price,
+              currency: code as CurrencyCode,
+              item_variant_name: product.name,
+              product_reference_id: product.gtin,
+            })),
+          },
+        })
       })
-    })
-  }, [code, products, title, page, pageSize])
+    },
+    [code, products, title, page, pageSize]
+  )
 
   return { sendViewItemListEvent }
 }

--- a/packages/core/src/sdk/product/ProductSentinel.tsx
+++ b/packages/core/src/sdk/product/ProductSentinel.tsx
@@ -1,0 +1,60 @@
+import { useEffect, type PropsWithChildren } from 'react'
+import { useInView } from 'react-intersection-observer'
+
+import type { ProductSummary_ProductFragment } from '@generated/graphql'
+
+import { useViewItemListEvent } from '../analytics/hooks/useViewItemListEvent'
+import { queueViewItemList } from './viewItemListQueue'
+
+interface ProductSentinelProps {
+  /**
+   * Title for the `ProductSentinel` component.
+   */
+  title: string
+  /**
+   * Products listed on the grid.
+   */
+  product: ProductSummary_ProductFragment
+  /**
+   * The page's number that the Product is being rendered.
+   */
+  page: number
+  /**
+   * Quantity of products listed by page.
+   */
+  pageSize: number
+}
+
+/**
+ * Use this component to add a boundary between Products to send the right view_item_list event to GA in ProductGallery
+ */
+export function ProductSentinel({
+  product,
+  title,
+  page,
+  pageSize,
+  children,
+}: PropsWithChildren<ProductSentinelProps>) {
+  const { ref, inView } = useInView()
+
+  const { sendViewItemListEvent } = useViewItemListEvent({
+    title,
+    page,
+    pageSize,
+  })
+
+  useEffect(() => {
+    if (inView) {
+      queueViewItemList({ product, sendViewItemListEvent })
+    }
+  }, [inView, product])
+
+  return (
+    // minHeight to avoid the layout shift when the sentinel is not in view, '15.225rem' is the min value from the Product Card
+    <div ref={ref} style={{ minHeight: '15.225rem' }}>
+      {children}
+    </div>
+  )
+}
+
+export default ProductSentinel

--- a/packages/core/src/sdk/product/ProductSentinel.tsx
+++ b/packages/core/src/sdk/product/ProductSentinel.tsx
@@ -12,7 +12,7 @@ interface ProductSentinelProps {
    */
   title: string
   /**
-   * Products listed on the grid.
+   * Product listed on the grid.
    */
   product: ProductSummary_ProductFragment
   /**

--- a/packages/core/src/sdk/product/viewItemListQueue.ts
+++ b/packages/core/src/sdk/product/viewItemListQueue.ts
@@ -1,0 +1,31 @@
+import type { ProductSummary_ProductFragment } from '@generated/graphql'
+
+const sentItems = new Set<string>()
+let pendingItems: { node: ProductSummary_ProductFragment }[] = []
+let debounceTimeout: NodeJS.Timeout | null = null
+
+type QueueViewItemListProps = {
+  product: ProductSummary_ProductFragment
+  sendViewItemListEvent: (props: {
+    products: Array<{ node: ProductSummary_ProductFragment }>
+  }) => void
+}
+
+export function queueViewItemList({
+  product,
+  sendViewItemListEvent,
+}: QueueViewItemListProps) {
+  if (sentItems.has(product.id)) return
+
+  sentItems.add(product.id)
+  pendingItems.push({ node: product })
+
+  if (debounceTimeout) clearTimeout(debounceTimeout)
+
+  debounceTimeout = setTimeout(() => {
+    if (pendingItems.length > 0) {
+      sendViewItemListEvent({ products: pendingItems })
+      pendingItems = []
+    }
+  }, 300)
+}

--- a/packages/core/src/sdk/search/Sentinel.tsx
+++ b/packages/core/src/sdk/search/Sentinel.tsx
@@ -1,5 +1,5 @@
 import { useSearch } from '@faststore/sdk'
-import { useEffect, useRef, type PropsWithChildren } from 'react'
+import { useEffect, type PropsWithChildren } from 'react'
 import { useInView } from 'react-intersection-observer'
 import type { NextRouter } from 'next/router'
 import { useRouter } from 'next/router'
@@ -7,7 +7,6 @@ import { useRouter } from 'next/router'
 import type { ProductSummary_ProductFragment } from '@generated/graphql'
 
 import useScreenResize from 'src/sdk/ui/useScreenResize'
-import { useViewItemListEvent } from '../analytics/hooks/useViewItemListEvent'
 
 interface SentinelProps {
   page: number
@@ -39,24 +38,11 @@ const replacePagination = (page: string, router: NextRouter) => {
  * Also, this component's name is kind of curious. Wikipedia calls is Page Break(https://en.wikipedia.org/wiki/Page_break)
  * however all codes I've seen online use Sentinel
  */
-function Sentinel({
-  page,
-  pageSize,
-  products,
-  title,
-  children,
-}: PropsWithChildren<SentinelProps>) {
+function Sentinel({ page, children }: PropsWithChildren<SentinelProps>) {
   const router = useRouter()
   const { pages } = useSearch()
   const { isMobile } = useScreenResize()
   const { ref, inView } = useInView({ threshold: isMobile ? 0.3 : 0.7 })
-  const { sendViewItemListEvent } = useViewItemListEvent({
-    products,
-    title,
-    page,
-    pageSize,
-  })
-  const viewedRef = useRef(false)
 
   useEffect(() => {
     // Only replace pagination state when infinite scroll
@@ -64,19 +50,7 @@ function Sentinel({
     if (inView && pages.length > 1) {
       replacePagination(page.toString(), router)
     }
-
-    if (inView && !viewedRef.current && products.length) {
-      sendViewItemListEvent()
-      viewedRef.current = true
-    }
-  }, [
-    pages.length,
-    inView,
-    page,
-    router,
-    sendViewItemListEvent,
-    products.length,
-  ])
+  }, [pages.length, inView, page])
 
   return <div ref={ref}>{children}</div>
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

**Suggestion: review this PR using the `Hide white space` option.**

This PR aims to send the `view_item_list` event only when the item is in the viewport of `ProductGallery` instead of sending all items even when not in the viewport.

## How it works?

It creates a new `ProductSentinel` component that uses the viewport observer from the 'react-intersection-observer' lib and a debounce to group all new products in the viewport.

We don't need to remove objects from the event or add the product that was already in the viewport, only the new ones.

## How to test it?

You can run it locally by adding gtm_debug=true as a query string and seeing the `dataLayer` object in the console while scrolling in the PLP.

Example:
http://localhost:3000/office?gtm_debug=true

Before: All PLP products were sent.
After: as the scroll was being performed and the items appeared in the viewport, they were sent.

| Before | After |
|--------|--------|
|<img width="1189" alt="Screenshot 2025-04-08 at 20 53 44" src="https://github.com/user-attachments/assets/b0c0b6b3-b17c-4815-8efb-0a0ebe476f64" />|<img width="1418" alt="Screenshot 2025-04-08 at 20 56 11" src="https://github.com/user-attachments/assets/4fe1d976-45ca-4a7f-b24f-b0763f0eed4a" />| 



### Starters Deploy Preview

PR
- https://github.com/vtex-sites/starter.store/pull/759

Preview
- https://starter-9o3z6fhnr-vtex.vercel.app/office?gtm_debug=true

