### PR TITLE
feat: only send is query event when url has fuzzy and operator

### DIFF
--- a/packages/core/src/sdk/product/useProductGalleryQuery.ts
+++ b/packages/core/src/sdk/product/useProductGalleryQuery.ts
@@ -153,7 +153,19 @@ export const useProductGalleryQuery = ({
       const updatedFuzzyFacetValue = data.search.metadata?.fuzzy
       const updatedOperatorFacetValue = data.search.metadata?.logicalOperator
 
-      if (data && term && updatedFuzzyFacetValue && updatedOperatorFacetValue) {
+      const params = new URLSearchParams(window.location.search)
+      const urlHasFuzzy = params.has('fuzzy')
+      const urlHasOperator = params.has('operator')
+
+      const shouldSendAnalyticsEvent =
+        data &&
+        term &&
+        updatedFuzzyFacetValue &&
+        updatedOperatorFacetValue &&
+        urlHasFuzzy &&
+        urlHasOperator
+
+      if (shouldSendAnalyticsEvent) {
         import('@faststore/sdk').then(({ sendAnalyticsEvent }) => {
           sendAnalyticsEvent<IntelligentSearchQueryEvent>({
             name: 'intelligent_search_query',


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to send the `intelligent_search_query` only when fuzzy and operator param exist in the URL, preventing the sending 2 events.

## How it works?

it checks the existence of fuzzy and operator in the URL before sending the event.

## How to test it?

You can run it locally by adding gtm_debug=true as a query string and seeing the `dataLayer` object in the console while searching products using search page.

Example:
http://localhost:3000/s?q=shirt&facets=fuzzy%2Coperator&sort=score_desc&page=0&gtm_debug=true

Before: 2 events
After: 1 event

| Before | After |
|--------|--------|
|<img width="1566" alt="Screenshot 2025-04-09 at 12 54 52" src="https://github.com/user-attachments/assets/2a4a6fda-86cd-4ee4-9ab2-6e56dc89451b" />|<img width="1893" alt="Screenshot 2025-04-09 at 12 54 37" src="https://github.com/user-attachments/assets/89b5eb89-1630-463e-9093-e821e4e34a62" />| 



### Starters Deploy Preview

PR
- https://github.com/vtex-sites/starter.store/pull/762

Preview
- https://starter-dxmsvht0l-vtex.vercel.app/s?q=shirt&fuzzy=0&operator=and&facets=fuzzy%2Coperator&sort=score_desc&page=0&gtm_debug=true

