### PR TITLE
feat: Add PDP redirects support

### DIFF
--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -314,9 +314,8 @@ export const getStaticProps: GetStaticProps<
 
   if (notFound) {
     if (storeConfig.experimental.enableRedirects) {
-      console.log('~> slug: ', slug)
-      const redirect = await getRedirect({ pathname: `/${slug}` })
-      console.log('~> redirect: ', redirect)
+      const redirect = await getRedirect({ pathname: `/${slug}/p` })
+
       if (redirect) {
         return {
           redirect,

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -25,6 +25,7 @@ import ProductTiles from 'src/components/sections/ProductTiles'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
 import { useSession } from 'src/sdk/session'
+import { getRedirect } from 'src/sdk/redirects'
 import { execute } from 'src/server'
 
 import storeConfig from 'discovery.config'
@@ -312,6 +313,16 @@ export const getStaticProps: GetStaticProps<
   const notFound = errors.find(isNotFoundError)
 
   if (notFound) {
+    if (storeConfig.experimental.enableRedirects) {
+      const redirect = await getRedirect({ pathname: `/${slug}/p` })
+      if (redirect) {
+        return {
+          redirect,
+          revalidate: 60 * 5, // 5 minutes
+        }
+      }
+    }
+
     return {
       notFound: true,
     }

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -314,7 +314,9 @@ export const getStaticProps: GetStaticProps<
 
   if (notFound) {
     if (storeConfig.experimental.enableRedirects) {
+      console.log('~> slug: ', slug)
       const redirect = await getRedirect({ pathname: `/${slug}` })
+      console.log('~> redirect: ', redirect)
       if (redirect) {
         return {
           redirect,

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -314,7 +314,7 @@ export const getStaticProps: GetStaticProps<
 
   if (notFound) {
     if (storeConfig.experimental.enableRedirects) {
-      const redirect = await getRedirect({ pathname: `/${slug}/p` })
+      const redirect = await getRedirect({ pathname: `/${slug}` })
       if (redirect) {
         return {
           redirect,


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add redirects support for PDPs in the same way we do for PLPs.

See #2583 for further details.

## How it works?

It performs the redirect in the `getStaticProps` function when a certain page is not found and there is a registered redirect for that. Before rendering a `404 Not Found` result to the user, we will check if there is a redirect associated to the pathname requested by the user.

## How to test it?

- Use the starter deploy preview;
- Navigate to `.../ergonomic/p` then you should be redirected to `.../ergonomic-granite-mouse-57815628/p`;

### Starters Deploy Preview

vtex-sites/faststoreqa.store#764