### PR TITLE
fix: update telemetry configuration to use integer

### DIFF
--- a/packages/core/vtex.env
+++ b/packages/core/vtex.env
@@ -1,5 +1,5 @@
 # configures NextJS
-NEXT_TELEMETRY_DISABLED=true
+NEXT_TELEMETRY_DISABLED=1
 
 # configures WebOps
 ## Enable re-using node_modules from previous runs for faster builds


### PR DESCRIPTION
## What's the purpose of this pull request?

The right value for this flag should be 1 according to NEXT doc.

## References

https://nextjs.org/telemetry#:~:text=NEXT_TELEMETRY_DISABLED