### PR TITLE
fix: properly end response for unsupported HTTP methods in GraphQL API

### DIFF
--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -61,7 +61,7 @@ const parseRequest = (request: NextApiRequest) => {
 
 const handler: NextApiHandler = async (request, response) => {
   if (request.method !== 'POST' && request.method !== 'GET') {
-    response.status(405)
+    response.status(405).end()
 
     return
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

properly end response for unsupported HTTP methods in GraphQL API
