### PR TITLE
feat:  MyAccount redirects using SSR - SFS-2440

### DIFF
--- a/packages/core/src/pages/account/index.tsx
+++ b/packages/core/src/pages/account/index.tsx
@@ -1,44 +1,35 @@
-import { NextSeo } from 'next-seo'
-import type { ComponentType } from 'react'
-import { useEffect } from 'react'
-import RenderSections from 'src/components/cms/RenderSections'
-import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
-import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import storeConfig from 'discovery.config'
-import {
-  getServerSideProps,
-  type MyAccountProps,
-} from 'src/experimental/myAccountSeverSideProps'
-import { useRouter } from 'next/router'
 
-/* A list of components that can be used in the CMS. */
-const COMPONENTS: Record<string, ComponentType<any>> = {
-  ...GLOBAL_COMPONENTS,
-  ...CUSTOM_COMPONENTS,
+import type { GetServerSideProps, NextPage } from 'next'
+
+const MyAccountRedirectPage: NextPage = () => {
+  return null
 }
 
-function Page({ globalSections }: MyAccountProps) {
-  const router = useRouter()
-  useEffect(() => {
-    if (storeConfig.experimental.enableFaststoreMyAccount) {
-      router.push('/account/profile') // current default path in my account
-    } else {
-      window.location.href = `${storeConfig.accountUrl}${window.location.search}`
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+  if (storeConfig.experimental.enableFaststoreMyAccount) {
+    return {
+      redirect: {
+        destination: '/account/profile',
+        permanent: false,
+      },
     }
-  }, [])
+  }
 
-  return (
-    <RenderSections
-      globalSections={globalSections.sections}
-      components={COMPONENTS}
-    >
-      <NextSeo noindex nofollow />
+  const searchParams = new URLSearchParams()
 
-      <div>loading...</div>
-    </RenderSections>
-  )
+  for (const key in query) {
+    const value = query[key]
+    const values = Array.isArray(value) ? value : [value]
+    values.forEach((v) => v && searchParams.append(key, v))
+  }
+
+  return {
+    redirect: {
+      destination: `${storeConfig.accountUrl}?${searchParams.toString()}`,
+      permanent: false,
+    },
+  }
 }
 
-export { getServerSideProps }
-
-export default Page
+export default MyAccountRedirectPage


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to move the redirect logic from my account to the Server Side.

## How it works?

If the flag enableFaststoreMyAccount: true, you should see the new myAccount page.
If the flag enableFaststoreMyAccount: false, you should be redirected to the new myAccount page (/account/profile).

| Flag enabled | Flag disabled |
|--------|--------|
|<img width="1266" alt="Screenshot 2025-04-10 at 19 56 18" src="https://github.com/user-attachments/assets/4703f5da-22ff-49f9-b720-f0997f745808" />|<img width="1282" alt="Screenshot 2025-04-10 at 19 49 21" src="https://github.com/user-attachments/assets/daa6c0ca-741c-4fec-96e9-55c161e1d7a4" />| 

## How to test it?

Change the value of the flag and access: http://localhost:3000/account

### Starters Deploy Preview

PR
- https://github.com/vtex-sites/faststoreqa.store/pull/765

Preview
flag is disabled
https://starter-d3npsn75d-vtex.vercel.app/account


### references

https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props
