### PR TITLE
fix: term required in `ClientSearchSuggestionsQuery` (useSuggestions)

### DIFF
--- a/packages/core/src/sdk/search/useSuggestions.ts
+++ b/packages/core/src/sdk/search/useSuggestions.ts
@@ -52,6 +52,7 @@ function useSuggestions(term: string) {
     [term, locale, channel]
   )
   const { data, error } = useQuery<Query, Variables>(query, variables, {
+    doNotRun: term === null || term === undefined, // it is ok to be empty string ""
     onSuccess: (callbackData) => {
       if (callbackData && term) {
         import('@faststore/sdk').then(({ sendAnalyticsEvent }) => {


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix this kind of error in `ClientSearchSuggestionsQuery` .
`GraphQLError [Object]: Variable "$term" of required type "String!" was not provided.
    at getVariables (eval at compileVariableParsing (/var/task/node_modules/graphql-jit/dist/variables.js:103:19), <anonymous>:197:21)
    at ClientSearchSuggestionsQuery (/var/task/node_modules/graphql-jit/dist/execution.js:159:31)`

<img width="1019" alt="Screenshot 2025-04-14 at 10 53 11" src="https://github.com/user-attachments/assets/dbb68f9d-854d-47e0-8ad3-5496a07c93a0" />
