### PR TITLE
feat: use ssr in my account routes

### DIFF
--- a/packages/core/src/experimental/myAccountSeverSideProps.ts
+++ b/packages/core/src/experimental/myAccountSeverSideProps.ts
@@ -17,6 +17,8 @@ export const getServerSideProps: GetServerSideProps<
   Record<string, string>,
   Locator
 > = async ({ previewData }) => {
+  // TODO validate permissions here
+
   const [
     globalSectionsPromise,
     globalSectionsHeaderPromise,

--- a/packages/core/src/pages/account/index.tsx
+++ b/packages/core/src/pages/account/index.tsx
@@ -7,6 +7,8 @@ const MyAccountRedirectPage: NextPage = () => {
 }
 
 export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+  // TODO validate permissions here
+
   if (storeConfig.experimental.enableFaststoreMyAccount) {
     return {
       redirect: {

--- a/packages/core/src/pages/account/orders/[id].tsx
+++ b/packages/core/src/pages/account/orders/[id].tsx
@@ -1,29 +1,30 @@
+import type { Locator } from '@vtex/client-cms'
+import type { GetServerSideProps } from 'next'
 import { NextSeo } from 'next-seo'
-import { useRouter } from 'next/router'
 import type { ComponentType } from 'react'
 import { MyAccountLayout } from 'src/components/account'
 import MyAccountOrderDetails from 'src/components/account/orders/MyAccountOrderDetails'
 import RenderSections from 'src/components/cms/RenderSections'
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
-import {
-  getServerSideProps,
-  type MyAccountProps,
-} from 'src/experimental/myAccountSeverSideProps'
+import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
+
+import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'
+import { injectGlobalSections } from 'src/server/cms/global'
 
 const COMPONENTS: Record<string, ComponentType<any>> = {
   ...GLOBAL_COMPONENTS,
   ...CUSTOM_COMPONENTS,
 }
 
-export default function OrderDetailsPage({ globalSections }: MyAccountProps) {
-  // TODO: This is a temporary solution to get the order id from the url.
-  // We should use the getServerSideProps to get the order id from the api
-  const router = useRouter()
-  const id = Array.isArray(router.query.id)
-    ? router.query.id[0]
-    : router.query.id
+type OrderDetailsPageProps = {
+  orderId: string
+} & MyAccountProps
 
+export default function OrderDetailsPage({
+  globalSections,
+  orderId,
+}: OrderDetailsPageProps) {
   return (
     <RenderSections
       globalSections={globalSections.sections}
@@ -32,10 +33,41 @@ export default function OrderDetailsPage({ globalSections }: MyAccountProps) {
       <NextSeo noindex nofollow />
 
       <MyAccountLayout>
-        <MyAccountOrderDetails orderId={id} />
+        <MyAccountOrderDetails orderId={orderId} />
       </MyAccountLayout>
     </RenderSections>
   )
 }
 
-export { getServerSideProps }
+export const getServerSideProps: GetServerSideProps<
+  OrderDetailsPageProps,
+  Record<string, string>,
+  Locator
+> = async (context) => {
+  const {
+    previewData,
+    params: { orderId },
+  } = context
+  const [
+    globalSectionsPromise,
+    globalSectionsHeaderPromise,
+    globalSectionsFooterPromise,
+  ] = getGlobalSectionsData(previewData)
+
+  const [globalSections, globalSectionsHeader, globalSectionsFooter] =
+    await Promise.all([
+      globalSectionsPromise,
+      globalSectionsHeaderPromise,
+      globalSectionsFooterPromise,
+    ])
+
+  const globalSectionsResult = injectGlobalSections({
+    globalSections,
+    globalSectionsHeader,
+    globalSectionsFooter,
+  })
+
+  return {
+    props: { globalSections: globalSectionsResult, orderId },
+  }
+}

--- a/packages/core/src/pages/account/orders/[id].tsx
+++ b/packages/core/src/pages/account/orders/[id].tsx
@@ -18,12 +18,12 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
 }
 
 type OrderDetailsPageProps = {
-  orderId: string
+  id: string
 } & MyAccountProps
 
 export default function OrderDetailsPage({
   globalSections,
-  orderId,
+  id,
 }: OrderDetailsPageProps) {
   return (
     <RenderSections
@@ -33,7 +33,7 @@ export default function OrderDetailsPage({
       <NextSeo noindex nofollow />
 
       <MyAccountLayout>
-        <MyAccountOrderDetails orderId={orderId} />
+        <MyAccountOrderDetails orderId={id} />
       </MyAccountLayout>
     </RenderSections>
   )
@@ -46,7 +46,7 @@ export const getServerSideProps: GetServerSideProps<
 > = async (context) => {
   const {
     previewData,
-    params: { orderId },
+    params: { id },
   } = context
   const [
     globalSectionsPromise,
@@ -68,6 +68,6 @@ export const getServerSideProps: GetServerSideProps<
   })
 
   return {
-    props: { globalSections: globalSectionsResult, orderId },
+    props: { globalSections: globalSectionsResult, id },
   }
 }

--- a/packages/core/src/pages/account/orders/[id].tsx
+++ b/packages/core/src/pages/account/orders/[id].tsx
@@ -44,6 +44,8 @@ export const getServerSideProps: GetServerSideProps<
   Record<string, string>,
   Locator
 > = async (context) => {
+  // TODO validate permissions here
+
   const {
     previewData,
     params: { id },

--- a/packages/core/src/pages/account/profile.tsx
+++ b/packages/core/src/pages/account/profile.tsx
@@ -1,16 +1,19 @@
 /* ######################################### */
 /* Mocked Page until development is finished, it will be removed after */
 
+import type { Locator } from '@vtex/client-cms'
+import type { GetServerSideProps } from 'next'
 import { NextSeo } from 'next-seo'
 import type { ComponentType } from 'react'
 import { MyAccountLayout } from 'src/components/account'
 import RenderSections from 'src/components/cms/RenderSections'
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
-import {
-  getServerSideProps,
-  type MyAccountProps,
-} from 'src/experimental/myAccountSeverSideProps'
+
+import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'
+
+import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
+import { injectGlobalSections } from 'src/server/cms/global'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -45,4 +48,31 @@ export default function Profile({ globalSections }: MyAccountProps) {
   )
 }
 
-export { getServerSideProps }
+export const getServerSideProps: GetServerSideProps<
+  MyAccountProps,
+  Record<string, string>,
+  Locator
+> = async ({ previewData }) => {
+  const [
+    globalSectionsPromise,
+    globalSectionsHeaderPromise,
+    globalSectionsFooterPromise,
+  ] = getGlobalSectionsData(previewData)
+
+  const [globalSections, globalSectionsHeader, globalSectionsFooter] =
+    await Promise.all([
+      globalSectionsPromise,
+      globalSectionsHeaderPromise,
+      globalSectionsFooterPromise,
+    ])
+
+  const globalSectionsResult = injectGlobalSections({
+    globalSections,
+    globalSectionsHeader,
+    globalSectionsFooter,
+  })
+
+  return {
+    props: { globalSections: globalSectionsResult },
+  }
+}

--- a/packages/core/src/pages/account/profile.tsx
+++ b/packages/core/src/pages/account/profile.tsx
@@ -53,6 +53,8 @@ export const getServerSideProps: GetServerSideProps<
   Record<string, string>,
   Locator
 > = async ({ previewData }) => {
+  // TODO validate permissions here
+
   const [
     globalSectionsPromise,
     globalSectionsHeaderPromise,

--- a/packages/core/src/pages/account/security.tsx
+++ b/packages/core/src/pages/account/security.tsx
@@ -1,0 +1,83 @@
+/* ######################################### */
+/* Mocked Page until development is finished, it will be removed after */
+
+import { NextSeo } from 'next-seo'
+import type { ComponentType } from 'react'
+import { MyAccountLayout } from 'src/components/account'
+import RenderSections from 'src/components/cms/RenderSections'
+import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
+import CUSTOM_COMPONENTS from 'src/customizations/src/components'
+
+import type { Locator } from '@vtex/client-cms'
+import type { GetServerSideProps } from 'next'
+
+import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'
+
+import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
+import { injectGlobalSections } from 'src/server/cms/global'
+
+/* A list of components that can be used in the CMS. */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  ...GLOBAL_COMPONENTS,
+  ...CUSTOM_COMPONENTS,
+}
+
+const style = {
+  alignContent: 'center',
+  justifyContent: 'center',
+  alignItems: 'center',
+  display: 'flex',
+  backgroundColor: 'black',
+  h1: {
+    color: 'red',
+    fontSize: '100px',
+  },
+}
+
+export default function Page({ globalSections }: MyAccountProps) {
+  return (
+    <RenderSections
+      globalSections={globalSections.sections}
+      components={COMPONENTS}
+    >
+      <NextSeo noindex nofollow />
+
+      <MyAccountLayout>
+        <div style={style}>
+          <h1 style={style.h1}>Security</h1>
+        </div>
+      </MyAccountLayout>
+    </RenderSections>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps<
+  MyAccountProps,
+  Record<string, string>,
+  Locator
+> = async ({ previewData }) => {
+  // TODO validate permissions here
+
+  const [
+    globalSectionsPromise,
+    globalSectionsHeaderPromise,
+    globalSectionsFooterPromise,
+  ] = getGlobalSectionsData(previewData)
+
+  const [globalSections, globalSectionsHeader, globalSectionsFooter] =
+    await Promise.all([
+      globalSectionsPromise,
+      globalSectionsHeaderPromise,
+      globalSectionsFooterPromise,
+    ])
+
+  const globalSectionsResult = injectGlobalSections({
+    globalSections,
+    globalSectionsHeader,
+    globalSectionsFooter,
+  })
+
+  return {
+    props: { globalSections: globalSectionsResult },
+  }
+}

--- a/packages/core/src/pages/account/user-details.tsx
+++ b/packages/core/src/pages/account/user-details.tsx
@@ -1,0 +1,83 @@
+/* ######################################### */
+/* Mocked Page until development is finished, it will be removed after */
+
+import { NextSeo } from 'next-seo'
+import type { ComponentType } from 'react'
+import { MyAccountLayout } from 'src/components/account'
+import RenderSections from 'src/components/cms/RenderSections'
+import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
+import CUSTOM_COMPONENTS from 'src/customizations/src/components'
+
+import type { Locator } from '@vtex/client-cms'
+import type { GetServerSideProps } from 'next'
+
+import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'
+
+import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
+import { injectGlobalSections } from 'src/server/cms/global'
+
+/* A list of components that can be used in the CMS. */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  ...GLOBAL_COMPONENTS,
+  ...CUSTOM_COMPONENTS,
+}
+
+const style = {
+  alignContent: 'center',
+  justifyContent: 'center',
+  alignItems: 'center',
+  display: 'flex',
+  backgroundColor: 'green',
+  h1: {
+    color: 'black',
+    fontSize: '100px',
+  },
+}
+
+export default function Page({ globalSections }: MyAccountProps) {
+  return (
+    <RenderSections
+      globalSections={globalSections.sections}
+      components={COMPONENTS}
+    >
+      <NextSeo noindex nofollow />
+
+      <MyAccountLayout>
+        <div style={style}>
+          <h1 style={style.h1}>User Details</h1>
+        </div>
+      </MyAccountLayout>
+    </RenderSections>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps<
+  MyAccountProps,
+  Record<string, string>,
+  Locator
+> = async ({ previewData }) => {
+  // TODO validate permissions here
+
+  const [
+    globalSectionsPromise,
+    globalSectionsHeaderPromise,
+    globalSectionsFooterPromise,
+  ] = getGlobalSectionsData(previewData)
+
+  const [globalSections, globalSectionsHeader, globalSectionsFooter] =
+    await Promise.all([
+      globalSectionsPromise,
+      globalSectionsHeaderPromise,
+      globalSectionsFooterPromise,
+    ])
+
+  const globalSectionsResult = injectGlobalSections({
+    globalSections,
+    globalSectionsHeader,
+    globalSectionsFooter,
+  })
+
+  return {
+    props: { globalSections: globalSectionsResult },
+  }
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to move the getServerSideProps from each my account page to its own implementation instead of a general one.

This PR also adds `user-details` and `security` pages with own SSR functions.

## How it works?

This should work as before.

The order ID should now come from SSR instead of the client (`useRouter`).


### Starters Deploy Preview

- https://github.com/vtex-sites/faststoreqa.store/pull/772

preview:
https://starter-ceshp4j3i-vtex.vercel.app/account/profile