### PR TITLE
fix: Search page blink

### DIFF
--- a/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
@@ -30,14 +30,12 @@ export default function SearchWrapper({
     resetInfiniteScroll,
   } = useSearch()
 
-  const { data: pageProductGalleryData, isValidating } = useProductGalleryQuery(
-    {
-      term,
-      sort,
-      itemsPerPage,
-      selectedFacets,
-    }
-  )
+  const { data: pageProductGalleryData } = useProductGalleryQuery({
+    term,
+    sort,
+    itemsPerPage,
+    selectedFacets,
+  })
 
   const emptySearchProps = storeConfig.experimental.enableSearchSSR
     ? {
@@ -46,7 +44,7 @@ export default function SearchWrapper({
       }
     : {}
 
-  if (isValidating || !pageProductGalleryData) {
+  if (!pageProductGalleryData) {
     return (
       <RenderSections globalSections={globalSections}>
         <EmptySearch {...emptySearchProps} />

--- a/packages/core/src/sdk/product/useProductGalleryQuery.ts
+++ b/packages/core/src/sdk/product/useProductGalleryQuery.ts
@@ -192,5 +192,13 @@ export const useProductGalleryQuery = ({
     },
   })
 
+  const fuzzyFacetValue = findFacetValue(selectedFacets, 'fuzzy')
+  const operatorFacetValue = findFacetValue(selectedFacets, 'operator')
+  const shouldRefetchQuery =
+    !queryResult.error && (!fuzzyFacetValue || !operatorFacetValue)
+  if (shouldRefetchQuery) {
+    // The first result is not relevant, return null data to avoid rendering the page while the query is being re-fetched
+    return { ...queryResult, isValidating: true, data: null }
+  }
   return queryResult
 }

--- a/packages/core/src/sdk/product/useProductGalleryQuery.ts
+++ b/packages/core/src/sdk/product/useProductGalleryQuery.ts
@@ -200,5 +200,6 @@ export const useProductGalleryQuery = ({
     // The first result is not relevant, return null data to avoid rendering the page while the query is being re-fetched
     return { ...queryResult, isValidating: true, data: null }
   }
+
   return queryResult
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the blinking content on Search page when searching for terms.

## How it works?

We check if the query should be refetched and now we render the `EmptySearch` component only for cases we don't have any product data to show.

## How to test it?

- Do a search for terms like `ergonomic`, `apple` and `unbranded` and check if the page content does not blink anymore.

### Starters Deploy Preview

vtex-sites/faststoreqa.store#775