### PR TITLE
feat: explicitly add allowRedirect to IS req

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -39,6 +39,7 @@ export interface SearchArgs {
   showInvisibleItems?: boolean
   showSponsored?: boolean
   sponsoredCount?: number
+  allowRedirect?: boolean
 }
 
 export interface ProductLocator {
@@ -183,6 +184,7 @@ export const IntelligentSearch = (
     showInvisibleItems,
     sponsoredCount,
     hideUnavailableItems: searchHideUnavailableItems,
+    allowRedirect = false,
   }: SearchArgs): Promise<T> => {
     const params = new URLSearchParams({
       page: (page + 1).toString(),
@@ -216,6 +218,10 @@ export const IntelligentSearch = (
 
     if (sponsoredCount !== undefined) {
       params.append('sponsoredCount', sponsoredCount.toString())
+    }
+
+    if (allowRedirect !== undefined) {
+      params.append('allowRedirect', allowRedirect.toString())
     }
 
     const pathname = addDefaultFacets(selectedFacets)

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -308,6 +308,7 @@ export const Query = {
       count: 1,
       query: term ?? undefined,
       selectedFacets: selectedFacets?.flatMap(transformSelectedFacet) ?? [],
+      allowRedirect: true,
     })
 
     return {

--- a/packages/api/test/mocks/AllProductsQuery.ts
+++ b/packages/api/test/mocks/AllProductsQuery.ts
@@ -78,7 +78,7 @@ export const AllProductsQueryFirst5 = `query AllProducts {
 `
 
 export const productSearchPage1Count5Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false&allowRedirect=false',
   init: {
     headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
   },

--- a/packages/api/test/mocks/ProductQuery.ts
+++ b/packages/api/test/mocks/ProductQuery.ts
@@ -63,7 +63,7 @@ export const ProductByIdQuery = `query ProductQuery {
 `
 
 export const productSearchFetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A64953394&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A64953394&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false&allowRedirect=false',
   init: {
     headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
   },

--- a/packages/api/test/mocks/RedirectQuery.ts
+++ b/packages/api/test/mocks/RedirectQuery.ts
@@ -6,7 +6,7 @@ export const RedirectQueryTermTech = `query RedirectSearch {
   `
 
 export const redirectTermTechFetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=2&count=1&query=tech&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=2&count=1&query=tech&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false&allowRedirect=true',
   init: {
     headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
   },

--- a/packages/api/test/mocks/SearchQuery.ts
+++ b/packages/api/test/mocks/SearchQuery.ts
@@ -101,7 +101,7 @@ export const SearchQueryFirst5Products = `query SearchQuery {
 }`
 
 export const productSearchCategory1Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false&allowRedirect=false',
   init: {
     headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
   },
@@ -1397,7 +1397,7 @@ export const productSearchCategory1Fetch = {
 }
 
 export const attributeSearchCategory1Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/facets/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/facets/category-1/office/trade-policy/1?page=1&count=5&query=&sort=&locale=en-US&hideUnavailableItems=false&simulationBehavior=skip&showSponsored=false&allowRedirect=false',
   init: {
     headers: { 'X-FORWARDED-HOST': '', 'content-type': 'application/json' },
   },

--- a/packages/api/test/mocks/ValidateCartMutation.ts
+++ b/packages/api/test/mocks/ValidateCartMutation.ts
@@ -347,7 +347,7 @@ export const checkoutOrderFormCustomDataInvalidFetch = {
 }
 
 export const productSearchPage1Count1Fetch = {
-  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A2737806&sort=&locale=en-US&show-invisible-items=true&hideUnavailableItems=false',
+  info: 'https://storeframework.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?page=1&count=1&query=sku%3A2737806&sort=&locale=en-US&show-invisible-items=true&hideUnavailableItems=false&allowRedirect=false',
   init: {
     headers: { 'content-type': 'application/json', 'X-FORWARDED-HOST': '' },
   },


### PR DESCRIPTION
## What's the purpose of this pull request?

Use the `allowRedirect` facet from IS. 

## How it works?

The default value would be `false` so it won't affect the IS products return. 
It'll be `true` for the request we make when checking if there is some redirect configured for that search term on IS (it's configured through Admin).
When there is a `redirect` value in the return of the IS req, the IS doesn't return the list of products, so the `allowRedirect = true` causes an issue for searches inside a carousel, for example. 

## How to test it?

I've configured the landing page `/test-lari-lp-redirect` which has a shelf. The shelf uses the `nike` search term. I've also configured the redirect for the term `nike` to go to the `/technology` page.

- Without this PR the `/test-lari-lp-redirect` doesn't display the shelf because the search is empty.
https://storeframework.vtex.app/test-lari-lp-redirect
<img width="1508" alt="Screenshot 2025-04-15 at 17 14 34" src="https://github.com/user-attachments/assets/085cb322-e538-440c-831a-14820ac9f35e" />

- With the changes of this PR
    - it uses `allowRedirect = false` so there are results for this search: https://storeframework-cm652ufll028lmgv665a6xv0g-gd881p5dm.b.vtex.app/test-lari-lp-redirect <img width="1503" alt="Screenshot 2025-04-15 at 17 08 55" src="https://github.com/user-attachments/assets/87a6297f-4220-4dc5-a90b-3f20b472e8bc" />
    - If you test searching for `nike` in the search bar it's redirected normally to `/technology`. https://storeframework-cm652ufll028lmgv665a6xv0g-gd881p5dm.b.vtex.app/s?q=nike 

https://github.com/user-attachments/assets/98b4564a-74de-4a2a-af81-c0666cd5b5bc



### Starters Deploy Preview
https://github.com/vtex-sites/faststoreqa.store/pull/776

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SO-464)