### PR TITLE
fix: log error and properly end response in GraphQL handler

### DIFF
--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -88,8 +88,10 @@ const handler: NextApiHandler = async (request, response) => {
 
     if (hasErrors) {
       const error = errors.find(isFastStoreError)
+      console.error(error)
 
-      response.status(error?.extensions.status ?? 500)
+      response.status(error?.extensions.status ?? 500).end()
+      return
     }
 
     const cacheControl =


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to add error log, and also `.end()` responses with error status, preventing timeouts.
