### PR TITLE
chore: export usePageProductsQuery hooks

### DIFF
--- a/packages/core/src/experimental/index.ts
+++ b/packages/core/src/experimental/index.ts
@@ -1,42 +1,47 @@
 // SDK
-export {
-  useSession as useSession_unstable,
-  sessionStore as sessionStore_unstable,
-  validateSession as validateSession_unstable,
-} from '../../src/sdk/session'
 export { useAuth as useAuth_unstable } from '../../src/sdk/auth'
 export {
-  useCart as useCart_unstable,
   cartStore as cartStore_unstable,
+  useCart as useCart_unstable,
 } from '../../src/sdk/cart'
-export type { CartItem, Cart } from '../../src/sdk/cart'
+export type { Cart, CartItem } from '../../src/sdk/cart'
 export { useBuyButton as useBuyButton_unstable } from '../../src/sdk/cart/useBuyButton'
 export { useCartToggleButton as useCartToggleButton_unstable } from '../../src/sdk/cart/useCartToggleButton'
 export { useCheckoutButton as useCheckoutButton_unstable } from '../../src/sdk/cart/useCheckoutButton'
 export { useRemoveButton as useRemoveButton_unstable } from '../../src/sdk/cart/useRemoveButton'
-export { useQuery as useQuery_unstable } from '../../src/sdk/graphql/useQuery'
 export { useLazyQuery as useLazyQuery_unstable } from '../../src/sdk/graphql/useLazyQuery'
+export { useQuery as useQuery_unstable } from '../../src/sdk/graphql/useQuery'
 export { useNewsletter as useNewsletter_unstable } from '../../src/sdk/newsletter/useNewsletter'
 export { useDiscountPercent as useDiscountPercent_unstable } from '../../src/sdk/product/useDiscountPercent'
 export { useFormattedPrice as useFormattedPrice_unstable } from '../../src/sdk/product/useFormattedPrice'
 export { useLocalizedVariables as useLocalizedVariables_unstable } from '../../src/sdk/product/useLocalizedVariables'
+export {
+  useCreateUseGalleryPage as useCreateUseGalleryPage_unstable,
+  useGalleryPage as useGalleryPage_unstable,
+  UseGalleryPageContext as UseGalleryPageContext_unstable,
+} from '../../src/sdk/product/usePageProductsQuery'
 export { useProductGalleryQuery as useProductGalleryQuery_unstable } from '../../src/sdk/product/useProductGalleryQuery'
 export { useProductLink as useProductLink_unstable } from '../../src/sdk/product/useProductLink'
 export { useProductQuery as useProductQuery_unstable } from '../../src/sdk/product/useProductQuery'
 export { useProductsPrefetch as useProductsPrefetch_unstable } from '../../src/sdk/product/useProductsPrefetch'
+export { useDelayedFacets as useDelayedFacets_unstable } from '../../src/sdk/search/useDelayedFacets'
+export { useDelayedPagination as useDelayedPagination_unstable } from '../../src/sdk/search/useDelayedPagination'
+export { useFilter as useFilter_unstable } from '../../src/sdk/search/useFilter'
 export { default as useSearchHistory_unstable } from '../../src/sdk/search/useSearchHistory'
 export { default as useSuggestions_unstable } from '../../src/sdk/search/useSuggestions'
 export { default as useTopSearch_unstable } from '../../src/sdk/search/useTopSearch'
-export { useFilter as useFilter_unstable } from '../../src/sdk/search/useFilter'
-export { useDelayedFacets as useDelayedFacets_unstable } from '../../src/sdk/search/useDelayedFacets'
-export { useDelayedPagination as useDelayedPagination_unstable } from '../../src/sdk/search/useDelayedPagination'
+export {
+  sessionStore as sessionStore_unstable,
+  useSession as useSession_unstable,
+  validateSession as validateSession_unstable,
+} from '../../src/sdk/session'
 
 export { getShippingSimulation as getShippingSimulation_unstable } from '../../src/sdk/shipping'
 export { useShippingSimulation as useShippingSimulation_unstable } from '../../src/sdk/shipping/useShippingSimulation'
 export { default as useScreenResize_unstable } from '../../src/sdk/ui/useScreenResize'
 
 // Components
-export { Image as Image_unstable } from '../../src/components/ui/Image'
 export { ProfileChallenge as ProfileChallenge_unstable } from '../../src/components/auth/ProfileChallenge'
-export { default as Selectors_unstable } from '../../src/components/ui/SkuSelector'
 export { ButtonSignIn as ButtonSignIn_unstable } from '../../src/components/ui/Button'
+export { Image as Image_unstable } from '../../src/components/ui/Image'
+export { default as Selectors_unstable } from '../../src/components/ui/SkuSelector'


### PR DESCRIPTION
## What's the purpose of this pull request?

Export hooks and context from `usePageProductsQuery` so stores can import them from `@faststore/core/experimental`

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SO-454)

## Checklist

**Documentation**

- [x] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request) -> [doc request](https://vtex.slack.com/archives/C01664JGV43/p1744901927991569)
