### PR TITLE
fix: Tooltip positions

### DIFF
--- a/packages/storybook/stories/tooltip.stories.tsx
+++ b/packages/storybook/stories/tooltip.stories.tsx
@@ -1,0 +1,141 @@
+import { Tooltip } from '@faststore/ui'
+import React from 'react'
+
+export default {
+  title: 'Tooltip',
+}
+
+export function BottomStart() {
+  return (
+    <div
+      style={{ margin: '16px', position: 'relative', display: 'inline-block' }}
+    >
+      <Tooltip
+        content={<div>Tooltip content goes here</div>}
+        placement="bottom-start"
+      >
+        <button>Hover over me</button>
+      </Tooltip>
+    </div>
+  )
+}
+
+export function BottomCenter() {
+  return (
+    <div
+      style={{ margin: '16px', position: 'relative', display: 'inline-block' }}
+    >
+      <Tooltip
+        content={<div>Tooltip content goes here</div>}
+        placement="bottom-center"
+      >
+        <button>Hover over me</button>
+      </Tooltip>
+    </div>
+  )
+}
+
+export function BottomEnd() {
+  return (
+    <div
+      style={{ margin: '16px', position: 'relative', display: 'inline-block' }}
+    >
+      <Tooltip
+        content={<div>Tooltip content goes here</div>}
+        placement="bottom-end"
+      >
+        <button>Hover over me</button>
+      </Tooltip>
+    </div>
+  )
+}
+
+export function TopStart() {
+  return (
+    <div
+      style={{ margin: '16px', position: 'relative', display: 'inline-block' }}
+    >
+      <Tooltip
+        content={<div>Tooltip content goes here</div>}
+        placement="top-start"
+      >
+        <button>Hover over me</button>
+      </Tooltip>
+    </div>
+  )
+}
+
+export function TopCenter() {
+  return (
+    <div
+      style={{ margin: '16px', position: 'relative', display: 'inline-block' }}
+    >
+      <Tooltip
+        content={<div>Tooltip content goes here</div>}
+        placement="top-center"
+      >
+        <button>Hover over me</button>
+      </Tooltip>
+    </div>
+  )
+}
+
+export function TopEnd() {
+  return (
+    <div
+      style={{ margin: '16px', position: 'relative', display: 'inline-block' }}
+    >
+      <Tooltip
+        content={<div>Tooltip content goes here</div>}
+        placement="top-end"
+      >
+        <button>Hover over me</button>
+      </Tooltip>
+    </div>
+  )
+}
+
+export function RightStart() {
+  return (
+    <div
+      style={{ margin: '16px', position: 'relative', display: 'inline-block' }}
+    >
+      <Tooltip
+        content={<div>Tooltip content goes here</div>}
+        placement="right-start"
+      >
+        <button>Hover over me</button>
+      </Tooltip>
+    </div>
+  )
+}
+
+export function RightCenter() {
+  return (
+    <div
+      style={{ margin: '16px', position: 'relative', display: 'inline-block' }}
+    >
+      <Tooltip
+        content={<div>Tooltip content goes here</div>}
+        placement="right-center"
+      >
+        <button>Hover over me</button>
+      </Tooltip>
+    </div>
+  )
+}
+
+export function RightEnd() {
+  return (
+    <div
+      style={{ margin: '16px', position: 'relative', display: 'inline-block' }}
+    >
+      <Tooltip
+        content={<div>Tooltip content goes here</div>}
+        placement="right-end"
+      >
+        <button>Hover over me</button>
+      </Tooltip>
+    </div>
+  )
+}

--- a/packages/ui/src/components/molecules/Tooltip/styles.scss
+++ b/packages/ui/src/components/molecules/Tooltip/styles.scss
@@ -73,12 +73,12 @@
   // --------------------------------------------------------
 
   /* TOP */
-  [data-fs-tooltip-placement^="top-center"] {
+  [data-fs-tooltip-placement^="top"] {
     bottom: 100%;
     transform: translateY(calc(-1 * var(--fs-tooltip-indicator-translate)));
   }
 
-  [data-fs-tooltip-placement^="top-center"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement^="top"] [data-fs-tooltip-indicator] {
     top: 100%;
     border-top-color: var(--fs-tooltip-background);
   }
@@ -115,12 +115,12 @@
   }
 
   /* RIGHT */
-  [data-fs-tooltip-placement^="right-center"] {
+  [data-fs-tooltip-placement^="right"] {
     left: 100%;
     transform: translateX(var(--fs-tooltip-indicator-translate));
   }
 
-  [data-fs-tooltip-placement^="right-center"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement^="right"] [data-fs-tooltip-indicator] {
     right: 100%;
     border-right-color: var(--fs-tooltip-background);
   }
@@ -157,12 +157,12 @@
   }
 
   /* BOTTOM */
-  [data-fs-tooltip-placement^="bottom-center"] {
+  [data-fs-tooltip-placement^="bottom"] {
     top: 100%;
     transform: translateY(var(--fs-tooltip-indicator-translate));
   }
 
-  [data-fs-tooltip-placement^="bottom-center"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement^="bottom"] [data-fs-tooltip-indicator] {
     bottom: 100%;
     border-bottom-color: var(--fs-tooltip-background);
   }
@@ -199,12 +199,12 @@
   }
 
   /* LEFT */
-  [data-fs-tooltip-placement^="left-center"] {
+  [data-fs-tooltip-placement^="left"] {
     right: 100%;
     transform: translateX(calc(-1 * var(--fs-tooltip-indicator-translate)));
   }
 
-  [data-fs-tooltip-placement^="left-center"] [data-fs-tooltip-indicator] {
+  [data-fs-tooltip-placement^="left"] [data-fs-tooltip-indicator] {
     left: 100%;
     border-left-color: var(--fs-tooltip-background);
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

Fixes tooltip indicator position (indicator style)

|before|after|
|-|-|
<img width="268" alt="image" src="https://github.com/user-attachments/assets/27ee5f30-28fb-4fc3-ae9a-b6b8b1ff4d55" />|<img width="225" alt="image" src="https://github.com/user-attachments/assets/19daf2db-7948-4658-97ba-9de4b5e28dee" />

