### PR TITLE
feat: feature flag all my account pages

### DIFF
--- a/packages/core/src/experimental/myAccountSeverSideProps.ts
+++ b/packages/core/src/experimental/myAccountSeverSideProps.ts
@@ -7,6 +7,7 @@ import {
 } from 'src/components/cms/GlobalSections'
 
 import { injectGlobalSections } from 'src/server/cms/global'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 
 export type MyAccountProps = {
   globalSections: GlobalSectionsData
@@ -16,8 +17,16 @@ export const getServerSideProps: GetServerSideProps<
   MyAccountProps,
   Record<string, string>,
   Locator
-> = async ({ previewData }) => {
+> = async ({ previewData, query }) => {
   // TODO validate permissions here
+
+  const { isFaststoreMyAccountEnabled, redirect } = getMyAccountRedirect({
+    query,
+  })
+
+  if (!isFaststoreMyAccountEnabled) {
+    return { redirect }
+  }
 
   const [
     globalSectionsPromise,

--- a/packages/core/src/pages/account/index.tsx
+++ b/packages/core/src/pages/account/index.tsx
@@ -1,6 +1,5 @@
-import storeConfig from 'discovery.config'
-
 import type { GetServerSideProps, NextPage } from 'next'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 
 const MyAccountRedirectPage: NextPage = () => {
   return null
@@ -9,26 +8,17 @@ const MyAccountRedirectPage: NextPage = () => {
 export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   // TODO validate permissions here
 
-  if (storeConfig.experimental.enableFaststoreMyAccount) {
-    return {
-      redirect: {
-        destination: '/account/profile',
-        permanent: false,
-      },
-    }
-  }
+  const { isFaststoreMyAccountEnabled, redirect } = getMyAccountRedirect({
+    query,
+  })
 
-  const searchParams = new URLSearchParams()
-
-  for (const key in query) {
-    const value = query[key]
-    const values = Array.isArray(value) ? value : [value]
-    values.forEach((v) => v && searchParams.append(key, v))
+  if (!isFaststoreMyAccountEnabled) {
+    return { redirect }
   }
 
   return {
     redirect: {
-      destination: `${storeConfig.accountUrl}?${searchParams.toString()}`,
+      destination: '/account/profile',
       permanent: false,
     },
   }

--- a/packages/core/src/pages/account/orders/[id].tsx
+++ b/packages/core/src/pages/account/orders/[id].tsx
@@ -19,6 +19,7 @@ import { default as AfterSection } from 'src/customizations/src/myAccount/extens
 import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/orders/[id]/before'
 import { execute } from 'src/server'
 import { injectGlobalSections } from 'src/server/cms/global'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 
 const COMPONENTS: Record<string, ComponentType<any>> = {
   ...GLOBAL_COMPONENTS,
@@ -518,6 +519,14 @@ export const getServerSideProps: GetServerSideProps<
   Locator
 > = async (context) => {
   // TODO validate permissions here
+
+  const { isFaststoreMyAccountEnabled, redirect } = getMyAccountRedirect({
+    query: context.query,
+  })
+
+  if (!isFaststoreMyAccountEnabled) {
+    return { redirect }
+  }
 
   const {
     previewData,

--- a/packages/core/src/pages/account/orders/index.tsx
+++ b/packages/core/src/pages/account/orders/index.tsx
@@ -16,6 +16,7 @@ import { default as AfterSection } from 'src/customizations/src/myAccount/extens
 import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/orders/before'
 import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
 import { injectGlobalSections } from 'src/server/cms/global'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -46,8 +47,16 @@ export const getServerSideProps: GetServerSideProps<
   MyAccountProps,
   Record<string, string>,
   Locator
-> = async ({ previewData }) => {
+> = async ({ previewData, query }) => {
   // TODO validate permissions here
+
+  const { isFaststoreMyAccountEnabled, redirect } = getMyAccountRedirect({
+    query,
+  })
+
+  if (!isFaststoreMyAccountEnabled) {
+    return { redirect }
+  }
 
   const [
     globalSectionsPromise,

--- a/packages/core/src/pages/account/profile.tsx
+++ b/packages/core/src/pages/account/profile.tsx
@@ -16,6 +16,7 @@ import { default as AfterSection } from 'src/customizations/src/myAccount/extens
 import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/profile/before'
 import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
 import { injectGlobalSections } from 'src/server/cms/global'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -46,8 +47,16 @@ export const getServerSideProps: GetServerSideProps<
   MyAccountProps,
   Record<string, string>,
   Locator
-> = async ({ previewData }) => {
+> = async ({ previewData, query }) => {
   // TODO validate permissions here
+
+  const { isFaststoreMyAccountEnabled, redirect } = getMyAccountRedirect({
+    query,
+  })
+
+  if (!isFaststoreMyAccountEnabled) {
+    return { redirect }
+  }
 
   const [
     globalSectionsPromise,

--- a/packages/core/src/pages/account/security.tsx
+++ b/packages/core/src/pages/account/security.tsx
@@ -17,6 +17,7 @@ import { default as AfterSection } from 'src/customizations/src/myAccount/extens
 import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/security/before'
 import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
 import { injectGlobalSections } from 'src/server/cms/global'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -47,8 +48,16 @@ export const getServerSideProps: GetServerSideProps<
   MyAccountProps,
   Record<string, string>,
   Locator
-> = async ({ previewData }) => {
+> = async ({ previewData, query }) => {
   // TODO validate permissions here
+
+  const { isFaststoreMyAccountEnabled, redirect } = getMyAccountRedirect({
+    query,
+  })
+
+  if (!isFaststoreMyAccountEnabled) {
+    return { redirect }
+  }
 
   const [
     globalSectionsPromise,

--- a/packages/core/src/pages/account/user-details.tsx
+++ b/packages/core/src/pages/account/user-details.tsx
@@ -17,6 +17,7 @@ import { default as AfterSection } from 'src/customizations/src/myAccount/extens
 import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/user-details/before'
 import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
 import { injectGlobalSections } from 'src/server/cms/global'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -47,8 +48,16 @@ export const getServerSideProps: GetServerSideProps<
   MyAccountProps,
   Record<string, string>,
   Locator
-> = async ({ previewData }) => {
+> = async ({ previewData, query }) => {
   // TODO validate permissions here
+
+  const { isFaststoreMyAccountEnabled, redirect } = getMyAccountRedirect({
+    query,
+  })
+
+  if (!isFaststoreMyAccountEnabled) {
+    return { redirect }
+  }
 
   const [
     globalSectionsPromise,

--- a/packages/core/src/utils/myAccountRedirect.tsx
+++ b/packages/core/src/utils/myAccountRedirect.tsx
@@ -1,0 +1,36 @@
+import storeConfig from 'discovery.config'
+import type { ParsedUrlQuery } from 'querystring'
+
+/**
+ * Check if the Faststore My Account feature flag is enabled.
+ * If not, redirect to the legacy My Account URL with the query parameters.
+ *
+ * @param {ParsedUrlQuery} query - The query parameters from the request.
+ * @returns {Object} - An object containing the feature flag status and redirect information.
+ */
+export function getMyAccountRedirect({ query }: { query: ParsedUrlQuery }): {
+  isFaststoreMyAccountEnabled: boolean
+  redirect: { destination: string; permanent: boolean } | null
+} {
+  const isFaststoreMyAccountEnabled =
+    storeConfig.experimental?.enableFaststoreMyAccount
+
+  if (!isFaststoreMyAccountEnabled) {
+    const searchParams = new URLSearchParams()
+
+    for (const key in query) {
+      const value = query[key]
+      const values = Array.isArray(value) ? value : [value]
+      values.forEach((v) => v && searchParams.append(key, v))
+    }
+
+    const redirect = {
+      destination: `${storeConfig.accountUrl}${searchParams.size > 0 ? '?' + searchParams.toString() : ''}`,
+      permanent: false,
+    }
+
+    return { isFaststoreMyAccountEnabled, redirect }
+  }
+
+  return { isFaststoreMyAccountEnabled, redirect: null }
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

This pull is to centralize and streamline the feature flag check and redirection logic for my account feature.

## How it works?

* Added `getMyAccountRedirect` in `src/utils/myAccountRedirect.tsx`. This function checks if the Faststore My Account feature is enabled and determines the appropriate redirection destination based on the feature flag and query parameters.

* Updated the `getServerSideProps` function in multiple pages (`account/index.tsx`, `account/orders/[id].tsx`, `account/orders/index.tsx`, `account/profile.tsx`, `account/security.tsx`, `account/user-details.tsx`) to use `getMyAccountRedirect` for handling redirection logic. This ensures consistent behavior across all pages.

## How to test it

you can enable or disable the `enableFaststoreMyAccount` flag in discovery.config.js and try to access any my account page.
`enableFaststoreMyAccount` true should use faststore
`enableFaststoreMyAccount` false should redirect to IO

### Starters Deploy Preview

TBD
