### PR TITLE
feat: List pickup points

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -22,6 +22,7 @@ import type {
   SimulationArgs,
   SimulationOptions,
 } from './types/Simulation'
+import type { PickupPointsInput, PickupPoints } from './types/PickupPoints'
 
 type ValueOf<T> = T extends Record<string, infer K> ? K : never
 
@@ -348,6 +349,33 @@ export const VtexCommerce = (
           {
             headers,
           },
+          { storeCookies }
+        )
+      },
+      pickupPoints: ({
+        geoCoordinates,
+        postalCode,
+        country,
+      }: PickupPointsInput): Promise<PickupPoints> => {
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
+        const params = new URLSearchParams()
+
+        if (geoCoordinates) {
+          params.append(
+            'geoCoordinates',
+            `${geoCoordinates.longitude};${geoCoordinates.latitude}`
+          )
+        } else {
+          params.append('countryCode', country as string)
+          params.append('postalCode', postalCode as string)
+        }
+
+        return fetchAPI(
+          `${base}/api/checkout/pub/pickup-points?${params.toString()}`,
+          { headers },
           { storeCookies }
         )
       },

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -357,6 +357,12 @@ export const VtexCommerce = (
         postalCode,
         country,
       }: PickupPointsInput): Promise<PickupPoints> => {
+        if (!geoCoordinates && (!postalCode || !country)) {
+          throw new Error(
+            'Missing required parameters for listing pickup points.'
+          )
+        }
+
         const headers: HeadersInit = withCookie({
           'content-type': 'application/json',
           'X-FORWARDED-HOST': forwardedHost,

--- a/packages/api/src/platforms/vtex/clients/commerce/types/PickupPoints.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/PickupPoints.ts
@@ -1,0 +1,58 @@
+interface GeoCoordinatesInput {
+  latitude: number
+  longitude: number
+}
+
+export interface PickupPointsInput {
+  country?: string
+  geoCoordinates?: GeoCoordinatesInput
+  postalCode?: string
+}
+
+interface Address {
+  addressId: string | null
+  addressType: string
+  city: string
+  complement: string | null
+  country: string
+  geoCoordinates: [number, number] // [longitude, latitude]
+  isDisposable: boolean
+  neighborhood: string
+  number: string
+  postalCode: string
+  receiverName: string
+  reference: string
+  state: string
+  street: string
+}
+
+interface BusinessHour {
+  DayOfWeek: number
+  OpeningTime: string
+  ClosingTime: string
+}
+
+interface PickupPoint {
+  additionalInfo: string
+  address: Address
+  businessHours: BusinessHour
+  friendlyName: string
+  id: string
+}
+
+interface Item {
+  distance: number
+  pickupPoint: PickupPoint
+}
+
+interface Paging {
+  page: number
+  pages: number
+  pageSize: number
+  total: number
+}
+
+export interface PickupPoints {
+  items: Item[]
+  paging: Paging
+}

--- a/packages/api/test/unit/platforms/vtex/clients/commerce.test.ts
+++ b/packages/api/test/unit/platforms/vtex/clients/commerce.test.ts
@@ -3,7 +3,7 @@ import {
   getContextFactory,
 } from '../../../../../src/platforms/vtex'
 import * as clients from '../../../../../src/platforms/vtex/clients'
-import type { Clients } from '../../../../../src/platforms/vtex/clients'
+// import type { Clients } from '../../../../../src/platforms/vtex/clients'
 
 const apiOptions = {
   platform: 'vtex',
@@ -21,10 +21,10 @@ const apiOptions = {
 
 const contextFactory = getContextFactory(apiOptions)
 const context = contextFactory({})
-const getClients = clients.getClients
+// const getClients = clients.getClients
 
 const fetchAPIMocked = jest.fn()
-const pickupPointsMocked = jest.fn()
+// const pickupPointsMocked = jest.fn()
 
 jest.mock('../../../../../src/platforms/vtex/clients/fetch.ts', () => ({
   fetchAPI: async (
@@ -77,32 +77,16 @@ describe('VTEX Commerce', () => {
       })
 
       it('should throw an error when no params', async () => {
-        jest
-          .spyOn(clients, 'getClients')
-          .mockImplementation((options, context): Clients => {
-            const otherClients = getClients(options, context)
-
-            return {
-              ...otherClients,
-              commerce: {
-                ...otherClients.commerce,
-                checkout: {
-                  ...otherClients.commerce.checkout,
-                  pickupPoints: pickupPointsMocked,
-                },
-              },
-            }
-          })
-
-        const errorMessage = 'Missing required parameters'
-        pickupPointsMocked.mockRejectedValueOnce(new Error(errorMessage))
-
         const { commerce } = clients.getClients(apiOptions, context)
 
+        expect(() => commerce.checkout.pickupPoints({})).toThrow(Error)
+        expect(() =>
+          commerce.checkout.pickupPoints({
+            geoCoordinates: undefined,
+            postalCode: undefined,
+          })
+        ).toThrow(Error)
         expect(fetchAPIMocked).not.toHaveBeenCalled()
-        await expect(commerce.checkout.pickupPoints({})).rejects.toThrowError(
-          errorMessage
-        )
       })
     })
   })

--- a/packages/api/test/unit/platforms/vtex/clients/commerce.test.ts
+++ b/packages/api/test/unit/platforms/vtex/clients/commerce.test.ts
@@ -81,21 +81,21 @@ describe('VTEX Commerce', () => {
         expect(pickupPointsMocked).toHaveBeenCalledWith({ postalCode, country })
         expect(result).toEqual({ paging: {}, items: [] })
       })
-    })
 
-    it('should throw an error when no params', async () => {
-      const errorMessage = 'Missing required parameters.'
+      it('should throw an error when no params', async () => {
+        const errorMessage = 'Missing required parameters.'
 
-      pickupPointsMocked.mockRejectedValueOnce(() => {
-        throw new Error(errorMessage)
+        pickupPointsMocked.mockRejectedValueOnce(() => {
+          throw new Error(errorMessage)
+        })
+
+        const { commerce } = clients.getClients(apiOptions, context)
+
+        expect(pickupPointsMocked).not.toHaveBeenCalledWith()
+        await expect(commerce.checkout.pickupPoints({})).rejects.toThrow(
+          errorMessage
+        )
       })
-
-      const { commerce } = clients.getClients(apiOptions, context)
-
-      expect(pickupPointsMocked).not.toHaveBeenCalledWith()
-      await expect(commerce.checkout.pickupPoints({})).rejects.toThrow(
-        errorMessage
-      )
     })
   })
 })

--- a/packages/api/test/unit/platforms/vtex/clients/commerce.test.ts
+++ b/packages/api/test/unit/platforms/vtex/clients/commerce.test.ts
@@ -1,0 +1,101 @@
+import {
+  type Options,
+  getContextFactory,
+} from '../../../../../src/platforms/vtex'
+import * as clients from '../../../../../src/platforms/vtex/clients'
+import type { Clients } from '../../../../../src/platforms/vtex/clients'
+
+const apiOptions = {
+  platform: 'vtex',
+  account: 'storeframework',
+  environment: 'vtexcommercestable',
+  channel: '{"salesChannel":"1"}',
+  locale: 'en-US',
+  subDomainPrefix: ['www'],
+  hideUnavailableItems: false,
+  incrementAddress: false,
+  flags: {
+    enableOrderFormSync: true,
+  },
+} as Options
+
+const contextFactory = getContextFactory(apiOptions)
+const context = contextFactory({})
+const getClients = clients.getClients
+
+const pickupPointsMocked = jest.fn()
+
+jest
+  .spyOn(clients, 'getClients')
+  .mockImplementation((options, context): Clients => {
+    const otherClients = getClients(options, context)
+
+    return {
+      ...otherClients,
+      commerce: {
+        ...otherClients.commerce,
+        checkout: {
+          ...otherClients.commerce.checkout,
+          pickupPoints: pickupPointsMocked,
+        },
+      },
+    }
+  })
+
+describe('VTEX Commerce', () => {
+  describe('Checkout', () => {
+    describe('Pickup points', () => {
+      it('should succeed with valid geo coordinates', async () => {
+        const geoCoordinates = {
+          latitude: 123,
+          longitude: 456,
+        }
+
+        pickupPointsMocked.mockResolvedValueOnce({ paging: {}, items: [] })
+
+        const { commerce } = clients.getClients(apiOptions, context)
+
+        const result = await commerce.checkout.pickupPoints({
+          geoCoordinates,
+        })
+
+        expect(pickupPointsMocked).toHaveBeenCalledTimes(1)
+        expect(pickupPointsMocked).toHaveBeenCalledWith({ geoCoordinates })
+        expect(result).toEqual({ paging: {}, items: [] })
+      })
+
+      it('should succeed with valid postal code and country', async () => {
+        const country = 'BRA'
+        const postalCode = '123456'
+
+        pickupPointsMocked.mockResolvedValueOnce({ paging: {}, items: [] })
+
+        const { commerce } = clients.getClients(apiOptions, context)
+
+        const result = await commerce.checkout.pickupPoints({
+          country,
+          postalCode,
+        })
+
+        expect(pickupPointsMocked).toHaveBeenCalledTimes(1)
+        expect(pickupPointsMocked).toHaveBeenCalledWith({ postalCode, country })
+        expect(result).toEqual({ paging: {}, items: [] })
+      })
+    })
+
+    it('should throw an error when no params', async () => {
+      const errorMessage = 'Missing required parameters.'
+
+      pickupPointsMocked.mockRejectedValueOnce(() => {
+        throw new Error(errorMessage)
+      })
+
+      const { commerce } = clients.getClients(apiOptions, context)
+
+      expect(pickupPointsMocked).not.toHaveBeenCalledWith()
+      await expect(commerce.checkout.pickupPoints({})).rejects.toThrow(
+        errorMessage
+      )
+    })
+  })
+})

--- a/packages/api/test/unit/platforms/vtex/clients/commerce.test.ts
+++ b/packages/api/test/unit/platforms/vtex/clients/commerce.test.ts
@@ -82,8 +82,27 @@ describe('VTEX Commerce', () => {
         expect(() => commerce.checkout.pickupPoints({})).toThrow(Error)
         expect(() =>
           commerce.checkout.pickupPoints({
+            country: undefined,
             geoCoordinates: undefined,
             postalCode: undefined,
+          })
+        ).toThrow(Error)
+        expect(fetchAPIMocked).not.toHaveBeenCalled()
+      })
+
+      it('should throw an error when postal code or country is missing', async () => {
+        const { commerce } = clients.getClients(apiOptions, context)
+
+        expect(() =>
+          commerce.checkout.pickupPoints({
+            country: 'BRA',
+            postalCode: undefined,
+          })
+        ).toThrow(Error)
+        expect(() =>
+          commerce.checkout.pickupPoints({
+            country: undefined,
+            postalCode: '123456',
           })
         ).toThrow(Error)
         expect(fetchAPIMocked).not.toHaveBeenCalled()


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add the `pickupPoints` route to the Checkout client on `@faststore/api`.

## How it works?

There is two scenarios:
- If `geoCoordinates` param is present, the request is made using its value;
- If no `geoCoordinates`, so `postalCode` and `country` will be used to make the request.