### PR TITLE
fix: Region Modal / Region Popover element focus & z-index

### DIFF
--- a/packages/components/src/molecules/Modal/Modal.tsx
+++ b/packages/components/src/molecules/Modal/Modal.tsx
@@ -39,6 +39,10 @@ export interface ModalProps extends Omit<ModalContentProps, 'children'> {
    */
   onDismiss?: () => void
   /**
+   * Callback function when the modal is opened.
+   */
+  onEntered?: () => void
+  /**
    * Props forwarded to the `Overlay` component.
    */
   overlayProps?: OverlayProps
@@ -65,6 +69,7 @@ const Modal = ({
   onDismiss,
   overlayProps,
   disableEscapeKeyDown = false,
+  onEntered,
   ...otherProps
 }: ModalProps) => {
   const { closeModal } = useUI()
@@ -102,7 +107,13 @@ const Modal = ({
           {...overlayProps}
         >
           <ModalContent
-            onTransitionEnd={() => fade === 'out' && closeModal()}
+            onTransitionEnd={() => {
+              if (fade === 'out') {
+                closeModal()
+              } else if (fade === 'in' && onEntered) {
+                onEntered()
+              }
+            }}
             data-fs-modal
             data-fs-modal-state={fade}
             testId={testId}

--- a/packages/components/src/molecules/Modal/Modal.tsx
+++ b/packages/components/src/molecules/Modal/Modal.tsx
@@ -20,7 +20,8 @@ export type ModalChildrenProps = {
 
 type ModalChildrenFunction = (props: ModalChildrenProps) => ReactNode
 
-export interface ModalProps extends Omit<ModalContentProps, 'children'> {
+export interface ModalProps
+  extends Omit<ModalContentProps, 'children' | 'onEntered'> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
    */

--- a/packages/components/src/molecules/Popover/Popover.tsx
+++ b/packages/components/src/molecules/Popover/Popover.tsx
@@ -52,6 +52,10 @@ export interface PopoverProps
    */
   onDismiss?: () => void
   /**
+   * Callback when the Popover is fully rendered and positioned.
+   */
+  onEntered?: () => void
+  /**
    * Close button aria-label.
    */
   closeButtonAriaLabel?: string
@@ -117,6 +121,7 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(function Popover(
     closeButtonAriaLabel = 'Close Popover',
     testId = 'fs-popover',
     style,
+    onEntered,
     ...otherProps
   },
   ref
@@ -141,6 +146,11 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(function Popover(
     setPopoverPosition(
       calculatePosition(rect, placement, offsetTop, offsetLeft)
     )
+
+    // Trigger the onEntered callback after positioning
+    if (onEntered) {
+      onEntered()
+    }
   }, [isOpen, triggerRef, offsetTop, offsetLeft, placement])
 
   const handleDismiss = useCallback(() => {

--- a/packages/components/src/organisms/RegionModal/RegionModal.tsx
+++ b/packages/components/src/organisms/RegionModal/RegionModal.tsx
@@ -114,6 +114,11 @@ function RegionModal({
       title="Region modal"
       aria-label="Region modal"
       disableEscapeKeyDown={!dismissible}
+      onEntered={() => {
+        if (inputRef?.current) {
+          inputRef.current.focus()
+        }
+      }}
       {...otherProps}
     >
       {({ fadeOut }) => (

--- a/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
+++ b/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
@@ -157,6 +157,11 @@ function RegionPopover({
             offsetTop={offsetTop}
             offsetLeft={offsetLeft}
             closeButtonAriaLabel={closeButtonAriaLabel}
+            onEntered={() => {
+              if (inputRef.current) {
+                inputRef.current.focus()
+              }
+            }}
           />
         </div>
       )}

--- a/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
+++ b/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
@@ -158,7 +158,7 @@ function RegionPopover({
             offsetLeft={offsetLeft}
             closeButtonAriaLabel={closeButtonAriaLabel}
             onEntered={() => {
-              if (inputRef.current) {
+              if (!postalCode && inputRef.current) {
                 inputRef.current.focus()
               }
             }}

--- a/packages/ui/src/components/molecules/Popover/styles.scss
+++ b/packages/ui/src/components/molecules/Popover/styles.scss
@@ -9,7 +9,7 @@
   --fs-popover-border-radius                         : var(--fs-border-radius);
   --fs-popover-bkg-color                             : var(--fs-color-body-bkg);
   --fs-popover-box-shadow                            : var(--fs-shadow-darker);
-  --fs-popover-z-index                               : var(--fs-z-index-high);
+  --fs-popover-z-index                               : var(--fs-z-index-top);
 
   // Indicator
   --fs-popover-indicator-size                        : var(--fs-spacing-1);


### PR DESCRIPTION
## What's the purpose of this pull request?

1. Sets input focus on `RegionModal`
2. Sets input focus on `RegionPopover`
3. Fix Popover` z-index` priority

## How it works?

1.  When opening the `RegionPopover`, if no zip code set the focus should be on the input field instead of the closing button.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/0c025d56-bdb3-43f9-95c3-6e677e8379b5" />


2. When opening the `RegionModal`, the focus should be on the input field instead of the closing button.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b458b995-f30c-4c4f-a6c3-e9fc3553953d" />

3. Popover should be under the `Navbar` head when scrolling.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/d202b739-d1b8-4db8-b2d2-ce4d1a0d2d3a" />

## How to test it?

Run the project locally or use the [preview link ](https://storeframework-cm652ufll028lmgv665a6xv0g-fw7dvhgml.b.vtex.app)
1. If the Popover appears, the initial focus should be on the input field
1.a scroll the page, the popover should appear under the Navbar header.
3. Click to edit zip code, when the `RegionModal` appears, the focus should be on the input field 

### Starters Deploy Preview

https://github.com/vtex-sites/faststoreqa.store/pull/784