### PR TITLE
fix: Sets domain search cookies

### DIFF
--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -4,8 +4,9 @@
 import type { AnalyticsEvent } from '@faststore/sdk'
 import type { SearchEvents } from '../../types'
 
+import { getBaseDomain } from 'src/utils/getBaseDomain'
+import { getCookie } from 'src/utils/getCookie'
 import config from '../../../../../discovery.config'
-import { getCookie } from '../../../../utils/getCookie'
 
 const THIRTY_MINUTES_S = 30 * 60
 const ONE_YEAR_S = 365 * 24 * 3600
@@ -14,46 +15,6 @@ const randomUUID = () =>
   typeof crypto.randomUUID === 'function'
     ? crypto.randomUUID().replaceAll('-', '')
     : (Math.random() * 1e6).toFixed(0)
-
-const getBaseDomain = (urls: string[]) => {
-  const extractHostname = (url: string) => {
-    try {
-      const hostname = new URL(url).hostname
-      const subDomainPrefixes = config.api.subDomainPrefix || []
-
-      const prefixRegex = new RegExp(`^(${subDomainPrefixes.join('|')})\\.`)
-
-      return hostname.replace(prefixRegex, '')
-    } catch {
-      return ''
-    }
-  }
-  const hostnames = urls.map(extractHostname)
-
-  // Find common parts
-  const splitHostnames = hostnames.map((hostname) =>
-    hostname.split('.').reverse()
-  )
-
-  const minLength = Math.min(...splitHostnames.map((parts) => parts.length))
-
-  const commonParts = []
-  for (let i = 0; i < minLength; i++) {
-    const partSet = new Set(splitHostnames.map((parts) => parts[i]))
-    if (partSet.size === 1) {
-      commonParts.push(splitHostnames[0][i])
-    } else {
-      break
-    }
-  }
-
-  if (commonParts.length < 2) {
-    // If we cannot find at least domain + tld, fallback to ''
-    return ''
-  }
-
-  return '.' + commonParts.reverse().join('.')
-}
 
 const createOrRefreshCookie = (key: string, expiresSecond: number) => {
   // Setting the domain attribute specifies which host can receive it; we need it to make the cookies available on the `secure` subdomain.

--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -18,24 +18,19 @@ const randomUUID = () =>
 const getBaseDomain = (urls: string[]) => {
   const domains = urls.map((url) => new URL(url).hostname.split('.'))
 
+  const minLength = Math.min(...domains.map((d) => d.length))
+  const commonParts: string[] = []
   // Find the common parts of the domains store / secure subdomain
-  const commonParts = domains.reduce((common, parts) => {
-    const result: string[] = []
-    const minLength = Math.min(common.length, parts.length)
 
-    for (let i = 1; i <= minLength; i++) {
-      const commonPart = common[common.length - i]
-      const part = parts[parts.length - i]
+  for (let i = 1; i <= minLength; i++) {
+    const parts = domains.map((d) => d[d.length - i])
 
-      if (commonPart === part) {
-        result.push(commonPart)
-      } else {
-        return []
-      }
+    if (parts.every((p) => p === parts[0])) {
+      commonParts.unshift(parts[0])
+    } else {
+      break
     }
-
-    return result
-  })
+  }
 
   if (commonParts.length === 0) {
     const err = `No common domain found for URLs: ${urls.join(', ')}`
@@ -45,7 +40,7 @@ const getBaseDomain = (urls: string[]) => {
     return ''
   }
 
-  return `.${commonParts.reverse().join('.')}`
+  return `.${commonParts.join('.')}`
 }
 
 const createOrRefreshCookie = (key: string, expiresSecond: number) => {

--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -18,12 +18,16 @@ const randomUUID = () =>
 const getBaseDomain = (urls: string[]) => {
   const extractHostname = (url: string) => {
     try {
-      return new URL(url).hostname.replace(/^www\./, '')
+      const hostname = new URL(url).hostname
+      const subDomainPrefixes = config.api.subDomainPrefix || []
+
+      const prefixRegex = new RegExp(`^(${subDomainPrefixes.join('|')})\\.`)
+
+      return hostname.replace(prefixRegex, '')
     } catch {
       return ''
     }
   }
-
   const hostnames = urls.map(extractHostname)
 
   // Find common parts

--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -18,24 +18,34 @@ const randomUUID = () =>
 const getBaseDomain = (urls: string[]) => {
   const domains = urls.map((url) => new URL(url).hostname.split('.'))
 
-  // Attempts to get the common domain from the store and secure urls
+  // Find the common parts of the domains store / secure subdomain
   const commonParts = domains.reduce((common, parts) => {
-    const result = []
-
+    const result: string[] = []
     const minLength = Math.min(common.length, parts.length)
 
     for (let i = 1; i <= minLength; i++) {
-      if (common[common.length - i] === parts[parts.length - i]) {
-        result.push(common[common.length - i])
+      const commonPart = common[common.length - i]
+      const part = parts[parts.length - i]
+
+      if (commonPart === part) {
+        result.push(commonPart)
       } else {
-        break
+        return []
       }
     }
 
     return result
   })
 
-  return commonParts.length ? `.${commonParts.reverse().join('.')}` : ''
+  if (commonParts.length === 0) {
+    const err = `No common domain found for URLs: ${urls.join(', ')}`
+    console.warn(
+      `${err}. Please check the Production URLs in the discovery.config file.`
+    )
+    return ''
+  }
+
+  return `.${commonParts.reverse().join('.')}`
 }
 
 const createOrRefreshCookie = (key: string, expiresSecond: number) => {

--- a/packages/core/src/utils/getBaseDomain.ts
+++ b/packages/core/src/utils/getBaseDomain.ts
@@ -1,0 +1,50 @@
+import config from '../../discovery.config'
+
+export const getBaseDomain = (urls: string[]) => {
+  const extractHostname = (url: string) => {
+    try {
+      const hostname = new URL(url).hostname
+      const subDomainPrefixes = config.api.subDomainPrefix || []
+
+      // Remove subdomain prefixes
+      // e.g. 'www.', 'shop.', 'loja.' from the hostname
+      const prefixRegex = new RegExp(
+        `^(${['www', ...subDomainPrefixes].join('|')})\\.`
+      )
+
+      return hostname.replace(prefixRegex, '')
+    } catch {
+      return ''
+    }
+  }
+
+  const hostnames = urls.map(extractHostname)
+
+  // Find common parts
+  const splitHostnames = hostnames.map((hostname) =>
+    hostname.split('.').reverse()
+  )
+
+  const minLength = Math.min(...splitHostnames.map((parts) => parts.length))
+
+  const commonParts = []
+  for (let i = 0; i < minLength; i++) {
+    const partSet = new Set(splitHostnames.map((parts) => parts[i]))
+    if (partSet.size === 1) {
+      commonParts.push(splitHostnames[0][i])
+    } else {
+      break
+    }
+  }
+
+  if (commonParts.length < 2) {
+    // If we cannot find at least domain + tld, fallback to ''
+    const err = `No common domain found for URLs: ${urls.join(', ')}`
+    console.warn(
+      `${err}. Please check the Production URLs in the discovery.config file.`
+    )
+    return ''
+  }
+
+  return '.' + commonParts.reverse().join('.')
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

After an investigation, we noticed that for some scenarios the search cookies are not being sets in the correct domain so it's not accessible in the subdomain as expected.

PS: this won't be an issue when using unification domain.

## How it works?

Some stores uses different url settings and we should cover it to set the cookie in the right domain.
Examples:

const example1 = {
  storeUrl: 'https://vtexfaststore.com/',
  secureSubdomain: 'https://secure.vtexfaststore.com/',
}

const example2 = {
  storeUrl: 'https://www.vtexfaststore.com/',
  secureSubdomain: 'https://secure.vtexfaststore.com/',
}

const example3 = {
  storeUrl: 'https://www.arte.com.br/',
  secureSubdomain: 'https://securee.arte.com.br/',
}

const example4 = {
  storeUrl: 'https://www.pepper.com',
  secureSubdomain: 'https://secure.www.pepper.com/',
}

const example5 = {
  storeUrl: 'https://site.faststore.com.br/',
  secureSubdomain: 'https://secure4.faststore.com.br/',
}

const example6 = {
  storeUrl: 'https://loja.super.com.br',
  secureSubdomain: 'https://secure.super.com.br/',
}

// case when we have subDomainPrefix set
const example7 = {
  storeUrl: 'https://shop.cosmo.com',
  secureSubdomain: 'https://secure.shop.cosmo.com/',
}

const example8 = {
  storeUrl: 'https://www.exit.com/',
  secureSubdomain: 'https://loja.exit.com/checkout-io/',
}

// no different secure subdomain
const example9 = {
  storeUrl: 'https://www.vtexfaststore.com/',
  secureSubdomain: 'https://www.vtexfaststore.com/',
}

const error = {
  storeUrl: 'https://www.vtexfaststore.com.br/',
  secureSubdomain: 'https://secure.vtexfasstore.com/',
}

## How to test it?

Expected outputs:

example1: `.vtexfaststore.com`
example2: `.vtexfaststore.com`
example3: `.arte.com.br`
example4: `.pepper.com`
example5:`.faststore.com.br`
example6: `.super.com.br`
example7: `.cosmo.com`
example8: `.exit.com`
example9: `.vtexfaststore.com`

error:
`No common domain found for URLs: https://www.vtexfaststore.com.br/, https://secure.vtexfasstore.com/. Please check the Production URLs in the discovery.config file.`



### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References
