### PR TITLE
chore: removes weird label from friendly name

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/userOrder.ts
+++ b/packages/api/src/platforms/vtex/resolvers/userOrder.ts
@@ -56,9 +56,8 @@ export const UserOrder: Record<string, Resolver<Root>> = {
           (address) => address?.addressId === addressId
         )
 
-        // Express delivery up to 1 business day / Standard shipping to SpringField / Pickup today
         const friendlyDeliveryOptionName =
-          `${selectedSla} ${deliveryChannelsMapping[deliveryChannel as keyof typeof deliveryChannelsMapping] || ''} ${friendlyShippingEstimate} ${address?.neighborhood ? `to ${address?.neighborhood}` : ''}`.trim()
+          `${deliveryChannelsMapping[deliveryChannel as keyof typeof deliveryChannelsMapping] || ''} ${friendlyShippingEstimate} ${address?.neighborhood ? `to ${address?.neighborhood}` : ''}`.trim()
 
         // TODO check other totals like bundleItems etc
         const itemTotal =


### PR DESCRIPTION
## What's the purpose of this pull request?

removes the beginning of the friendly name

before
<img width="777" alt="Screenshot 2025-04-30 at 11 39 01" src="https://github.com/user-attachments/assets/e32445a3-91ac-497b-9536-38ddd3ac58ea" />

