### PR TITLE
chore: pass headers to playground graphql

### DIFF
--- a/packages/api/local/server.ts
+++ b/packages/api/local/server.ts
@@ -1,8 +1,8 @@
 import express from 'express'
 import { graphqlHTTP } from 'express-graphql'
 
-import { getContextFactory, getSchema } from '../src'
 import type { Options } from '../src'
+import { getContextFactory, getSchema } from '../src'
 
 const serverPort = '4000'
 
@@ -23,12 +23,14 @@ app.use(express.json())
 
 app.use(
   '/graphql',
-  graphqlHTTP(async () => {
+  graphqlHTTP(async (req) => {
     const schema = await getSchema(apiOptions)
 
     return {
       schema,
-      context: graphQLContext({}),
+      context: graphQLContext({
+        headers: req.headers,
+      }),
       graphiql: true,
       pretty: true,
     }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to pass the headers (+cookies) to the FastStore API graphql dev server.

## How it works?

Now, all the headers, including cookies, are passed through the dev server.

## How to test it?

`pnpm dev:server` in the FastStore API package.

