### PR TITLE
feat: my account 404 error with page structure

### DIFF
--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -88,7 +88,7 @@ export const LazyLoadingSection = ({
   )
 }
 
-const RenderSectionsBase = ({
+export const RenderSectionsBase = ({
   sections = [],
   components,
   isInteractive,

--- a/packages/core/src/pages/account/404.tsx
+++ b/packages/core/src/pages/account/404.tsx
@@ -1,0 +1,95 @@
+import type { Locator } from '@vtex/client-cms'
+import type { GetStaticProps } from 'next'
+import { NextSeo } from 'next-seo'
+import type { ComponentType } from 'react'
+import {
+  type GlobalSectionsData,
+  getGlobalSectionsData,
+} from 'src/components/cms/GlobalSections'
+
+import { MyAccountLayout } from 'src/components/account'
+import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
+import RenderSections, {
+  RenderSectionsBase,
+} from 'src/components/cms/RenderSections'
+import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
+import CUSTOM_COMPONENTS from 'src/customizations/src/components'
+import PLUGINS_COMPONENTS from 'src/plugins'
+import { type PageContentType, getPage } from 'src/server/cms'
+import { injectGlobalSections } from 'src/server/cms/global'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
+
+/* A list of components that can be used in the CMS. */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  ...GLOBAL_COMPONENTS,
+  EmptyState,
+  ...PLUGINS_COMPONENTS,
+  ...CUSTOM_COMPONENTS,
+}
+
+type Props = {
+  page: PageContentType
+  globalSections: GlobalSectionsData
+}
+
+function Page({ page: { sections }, globalSections }: Props) {
+  return (
+    <RenderSections
+      globalSections={globalSections.sections}
+      components={COMPONENTS}
+    >
+      <NextSeo noindex nofollow />
+
+      <MyAccountLayout>
+        {sections && sections.length > 0 && (
+          <RenderSectionsBase sections={sections} components={COMPONENTS} />
+        )}
+      </MyAccountLayout>
+    </RenderSections>
+  )
+}
+
+export const getStaticProps: GetStaticProps<
+  Props,
+  Record<string, string>,
+  Locator
+> = async ({ previewData }) => {
+  // TODO validate permissions here
+
+  const { isFaststoreMyAccountEnabled, redirect } = getMyAccountRedirect({
+    query: {},
+  })
+
+  if (!isFaststoreMyAccountEnabled) {
+    return { redirect }
+  }
+
+  const [
+    globalSectionsPromise,
+    globalSectionsHeaderPromise,
+    globalSectionsFooterPromise,
+  ] = getGlobalSectionsData(previewData)
+
+  const [page, globalSections, globalSectionsHeader, globalSectionsFooter] =
+    await Promise.all([
+      getPage<PageContentType>({
+        ...(previewData?.contentType === '404' && previewData),
+        contentType: '404',
+      }),
+      globalSectionsPromise,
+      globalSectionsHeaderPromise,
+      globalSectionsFooterPromise,
+    ])
+
+  const globalSectionsResult = injectGlobalSections({
+    globalSections,
+    globalSectionsHeader,
+    globalSectionsFooter,
+  })
+
+  return {
+    props: { page, globalSections: globalSectionsResult },
+  }
+}
+
+export default Page

--- a/packages/core/src/pages/account/[...unknown].tsx
+++ b/packages/core/src/pages/account/[...unknown].tsx
@@ -1,0 +1,39 @@
+import type { Locator } from '@vtex/client-cms'
+import type { GetStaticPaths, GetStaticProps } from 'next'
+
+import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
+
+export default function Page() {
+  return <></>
+}
+
+export const getStaticProps: GetStaticProps<
+  MyAccountProps,
+  Record<string, string>,
+  Locator
+> = async () => {
+  // TODO validate permissions here
+
+  const { isFaststoreMyAccountEnabled, redirect } = getMyAccountRedirect({
+    query: {},
+  })
+
+  if (!isFaststoreMyAccountEnabled) {
+    return { redirect }
+  }
+
+  return {
+    redirect: {
+      destination: '/account/404',
+      permanent: false,
+    },
+  }
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}

--- a/packages/core/src/pages/account/orders/[id].tsx
+++ b/packages/core/src/pages/account/orders/[id].tsx
@@ -726,7 +726,10 @@ export const getServerSideProps: GetServerSideProps<
 
   if (orderDetails.errors) {
     return {
-      notFound: true,
+      redirect: {
+        destination: '/account/404',
+        permanent: false,
+      },
     }
   }
 

--- a/packages/core/src/pages/account/orders/index.tsx
+++ b/packages/core/src/pages/account/orders/index.tsx
@@ -71,6 +71,16 @@ export const getServerSideProps: GetServerSideProps<
       globalSectionsFooterPromise,
     ])
 
+  // TODO handle 404 when listOrders request is made
+  // if (listOrders.errors) {
+  //   return {
+  //     redirect: {
+  //       destination: '/account/404',
+  //       permanent: false,
+  //     },
+  //   }
+  // }
+
   const globalSectionsResult = injectGlobalSections({
     globalSections,
     globalSectionsHeader,

--- a/packages/core/src/pages/account/profile.tsx
+++ b/packages/core/src/pages/account/profile.tsx
@@ -71,6 +71,16 @@ export const getServerSideProps: GetServerSideProps<
       globalSectionsFooterPromise,
     ])
 
+  // TODO handle 404 when profile request is made
+  // if (profile.errors) {
+  //   return {
+  //     redirect: {
+  //       destination: '/account/404',
+  //       permanent: false,
+  //     },
+  //   }
+  // }
+
   const globalSectionsResult = injectGlobalSections({
     globalSections,
     globalSectionsHeader,

--- a/packages/core/src/pages/account/security.tsx
+++ b/packages/core/src/pages/account/security.tsx
@@ -72,6 +72,16 @@ export const getServerSideProps: GetServerSideProps<
       globalSectionsFooterPromise,
     ])
 
+  // TODO handle 404 when security request is made
+  // if (security.errors) {
+  //   return {
+  //     redirect: {
+  //       destination: '/account/404',
+  //       permanent: false,
+  //     },
+  //   }
+  // }
+
   const globalSectionsResult = injectGlobalSections({
     globalSections,
     globalSectionsHeader,

--- a/packages/core/src/pages/account/user-details.tsx
+++ b/packages/core/src/pages/account/user-details.tsx
@@ -72,6 +72,16 @@ export const getServerSideProps: GetServerSideProps<
       globalSectionsFooterPromise,
     ])
 
+  // TODO handle 404 when userDetails request is made
+  // if (userDetails.errors) {
+  //   return {
+  //     redirect: {
+  //       destination: '/account/404',
+  //       permanent: false,
+  //     },
+  //   }
+  // }
+
   const globalSectionsResult = injectGlobalSections({
     globalSections,
     globalSectionsHeader,


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to implement the 404 page error with the page structure (global sections) + my account menu.

![Apr-30-2025 19-27-51](https://github.com/user-attachments/assets/ab37a778-3fda-46ab-ac8e-d04c1fd6241a)


## How it works?

It creates a custom 404 page for unknown account routes and for 404 error cases.

## How to test it?

Attempts to access some unknown route like `/account/profile/123` or `/account/123`

### Starters Deploy Preview

TBD