### PR TITLE
chore: `No products available` label from Headless CMS and code refactor

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -520,7 +520,7 @@ export type Query = {
   collection: StoreCollection;
   /** Returns the details of a product based on the specified locator. */
   product: StoreProduct;
-  /** Returns information about total product count based on VTEX segment cookie. */
+  /** Returns the total product count information based on a specific location accessible through the VTEX segment cookie. */
   productCount?: Maybe<ProductCountResult>;
   /** Returns information about the profile. */
   profile?: Maybe<Profile>;

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -519,7 +519,7 @@ export type Query = {
   collection: StoreCollection
   /** Returns the details of a product based on the specified locator. */
   product: StoreProduct
-  /** Returns information about total product count based on VTEX segment cookie. */
+  /** Returns the total product count information based on a specific location accessible through the VTEX segment cookie. */
   productCount: Maybe<ProductCountResult>
   /** Returns information about the profile. */
   profile: Maybe<Profile>

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -2230,8 +2230,8 @@
             "noProductsAvailableErrorMessage": {
               "title": "Input field error message for the scenario of no products available",
               "type": "string",
-              "default": "There are no products available for",
-              "description": "If postal code is available, this error message will be shown before the postal code in the following format: 'There are no products available for {postalCode}'."
+              "default": "There are no products available for %s",
+              "description": "If postal code is available, the '%s' will be replaced by the postal code value."
             },
             "buttonActionText": {
               "title": "Input field action button label",
@@ -2311,8 +2311,8 @@
             "noProductsAvailableErrorMessage": {
               "title": "Input field error message for the scenario of no products available",
               "type": "string",
-              "default": "There are no products available for",
-              "description": "If postal code is available, this error message will be shown before the postal code in the following format: 'There are no products available for {postalCode}'."
+              "default": "There are no products available for %s",
+              "description": "If postal code is available, the '%s' will be replaced by the postal code value."
             },
             "buttonActionText": {
               "title": "Input field action button label",

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -2228,10 +2228,10 @@
               "default": "You entered an invalid Postal Code"
             },
             "noProductsAvailableErrorMessage": {
-              "title": "Input field error message for the scenario of no products available",
+              "title": "Input field error message for the scenario of no products available for a given location",
               "type": "string",
               "default": "There are no products available for %s",
-              "description": "If postal code is available, the '%s' will be replaced by the postal code value."
+              "description": "The '%s' will be replaced by the postal code value."
             },
             "buttonActionText": {
               "title": "Input field action button label",
@@ -2309,10 +2309,10 @@
               "default": "You entered an invalid Postal Code"
             },
             "noProductsAvailableErrorMessage": {
-              "title": "Input field error message for the scenario of no products available",
+              "title": "Input field error message for the scenario of no products available for a given location",
               "type": "string",
               "default": "There are no products available for %s",
-              "description": "If postal code is available, the '%s' will be replaced by the postal code value."
+              "description": "The '%s' will be replaced by the postal code value."
             },
             "buttonActionText": {
               "title": "Input field action button label",

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -2230,7 +2230,7 @@
             "noProductsAvailableErrorMessage": {
               "title": "Input field error message for the scenario of no products available for a given location",
               "type": "string",
-              "default": "There are no products available for %s",
+              "default": "There are no products available for %s.",
               "description": "The '%s' will be replaced by the postal code value."
             },
             "buttonActionText": {
@@ -2311,7 +2311,7 @@
             "noProductsAvailableErrorMessage": {
               "title": "Input field error message for the scenario of no products available for a given location",
               "type": "string",
-              "default": "There are no products available for %s",
+              "default": "There are no products available for %s.",
               "description": "The '%s' will be replaced by the postal code value."
             },
             "buttonActionText": {

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -2227,6 +2227,12 @@
               "type": "string",
               "default": "You entered an invalid Postal Code"
             },
+            "noProductsAvailableErrorMessage": {
+              "title": "Input field error message for the scenario of no products available",
+              "type": "string",
+              "default": "There are no products available for",
+              "description": "If postal code is available, this error message will be shown before the postal code in the following format: 'There are no products available for {postalCode}'."
+            },
             "buttonActionText": {
               "title": "Input field action button label",
               "type": "string",
@@ -2301,6 +2307,12 @@
               "title": "Input field error message",
               "type": "string",
               "default": "You entered an invalid Postal Code"
+            },
+            "noProductsAvailableErrorMessage": {
+              "title": "Input field error message for the scenario of no products available",
+              "type": "string",
+              "default": "There are no products available for",
+              "description": "If postal code is available, this error message will be shown before the postal code in the following format: 'There are no products available for {postalCode}'."
             },
             "buttonActionText": {
               "title": "Input field action button label",

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -73,7 +73,7 @@ function RegionModal({
         setInput('')
         closeModal()
       },
-      postalCode: inputRef.current?.value,
+      postalCode: input,
       errorMessage: inputFieldErrorMessage,
       noProductsAvailableErrorMessage:
         inputFieldNoProductsAvailableErrorMessage,

--- a/packages/core/src/components/region/RegionModal/useRegion.ts
+++ b/packages/core/src/components/region/RegionModal/useRegion.ts
@@ -50,7 +50,10 @@ export default function useRegion(): UseRegionValues {
         // Check product availability for specific postal code
         const productCount = await getProductCount()
         if (productCount === 0) {
-          setRegionError(`${noProductsAvailableErrorMessage} ${postalCode}.`)
+          const noProductsAvailableError =
+            noProductsAvailableErrorMessage.replace(/%s/g, () => postalCode)
+
+          setRegionError(noProductsAvailableError)
           setLoading(false)
           return
         }

--- a/packages/core/src/components/region/RegionModal/useRegion.ts
+++ b/packages/core/src/components/region/RegionModal/useRegion.ts
@@ -50,10 +50,11 @@ export default function useRegion(): UseRegionValues {
         // Check product availability for specific postal code
         const productCount = await getProductCount()
         if (productCount === 0) {
+          const errorFallback = `There are no products available for ${postalCode}.`
           const noProductsAvailableError =
             noProductsAvailableErrorMessage?.replace(/%s/g, () => postalCode)
 
-          setRegionError(noProductsAvailableError)
+          setRegionError(noProductsAvailableError ?? errorFallback)
           setLoading(false)
           return
         }

--- a/packages/core/src/components/region/RegionModal/useRegion.ts
+++ b/packages/core/src/components/region/RegionModal/useRegion.ts
@@ -51,7 +51,7 @@ export default function useRegion(): UseRegionValues {
         const productCount = await getProductCount()
         if (productCount === 0) {
           const noProductsAvailableError =
-            noProductsAvailableErrorMessage.replace(/%s/g, () => postalCode)
+            noProductsAvailableErrorMessage?.replace(/%s/g, () => postalCode)
 
           setRegionError(noProductsAvailableError)
           setLoading(false)

--- a/packages/core/src/components/region/RegionModal/useRegion.ts
+++ b/packages/core/src/components/region/RegionModal/useRegion.ts
@@ -1,41 +1,36 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import type { Session } from '@faststore/sdk'
 import { sessionStore, validateSession } from 'src/sdk/session'
 import { getProductCount } from 'src/sdk/product'
 import { deliveryPromise } from 'discovery.config'
 
-interface UseSetLocationParams {
-  input: string
-  setInput: (value: string) => void
-  resetInputField: () => void
-  setLocation: (
-    postalCode: string | undefined,
-    inputFieldErrorMessage: string,
-    session: Session,
-    onSuccess?: () => void
-  ) => Promise<void>
+type SetRegionProps = {
+  session: Session
+  postalCode: string | undefined
+  onSuccess?: () => void
   errorMessage: string
-  setErrorMessage: (value: string) => void
-  loading: boolean
+  noProductsAvailableErrorMessage?: string
 }
 
-export function useSetLocation(): UseSetLocationParams {
-  const [input, setInput] = useState<string>('')
-  const [errorMessage, setErrorMessage] = useState<string>('')
+type UseRegionValues = {
+  loading: boolean
+  regionError: string
+  setRegion: (props: SetRegionProps) => Promise<void>
+  setRegionError: (value: string) => void
+}
+
+export default function useRegion(): UseRegionValues {
   const [loading, setLoading] = useState<boolean>(false)
+  const [regionError, setRegionError] = useState<string>('')
 
-  const resetInputField = () => {
-    setInput('')
-    setErrorMessage('')
-  }
-
-  const setLocation = async (
-    postalCode: string | undefined,
-    inputFieldErrorMessage: string,
-    session: Session,
-    onSuccess?: () => void
-  ) => {
+  const setRegion = async ({
+    postalCode,
+    errorMessage,
+    session,
+    onSuccess,
+    noProductsAvailableErrorMessage,
+  }: SetRegionProps) => {
     if (typeof postalCode !== 'string') {
       return
     }
@@ -52,32 +47,29 @@ export function useSetLocation(): UseSetLocationParams {
       const validatedSession = await validateSession(newSession)
 
       if (deliveryPromise.enabled) {
-        // Check product availability for specific location
+        // Check product availability for specific postal code
         const productCount = await getProductCount()
         if (productCount === 0) {
-          setErrorMessage(`There are no products available for ${postalCode}.`)
+          setRegionError(`${noProductsAvailableErrorMessage} ${postalCode}.`)
           setLoading(false)
           return
         }
       }
 
       sessionStore.set(validatedSession ?? newSession)
-      resetInputField()
+      setRegionError('')
       onSuccess?.() // Execute the post-validation action (close modal, etc.)
     } catch (error) {
-      setErrorMessage(inputFieldErrorMessage)
+      setRegionError(errorMessage)
     } finally {
       setLoading(false) // Reset loading to false when validation is complete
     }
   }
 
   return {
-    input,
-    setInput,
-    resetInputField,
-    setLocation,
-    errorMessage,
-    setErrorMessage,
     loading,
+    setRegion,
+    regionError,
+    setRegionError,
   }
 }

--- a/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
+++ b/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
@@ -84,7 +84,7 @@ function RegionPopover({
         setInput('')
         closePopover()
       },
-      postalCode: inputRef.current?.value,
+      postalCode: input,
       errorMessage: inputFieldErrorMessage,
       noProductsAvailableErrorMessage:
         inputFieldNoProductsAvailableErrorMessage,

--- a/packages/ui/src/components/molecules/Popover/styles.scss
+++ b/packages/ui/src/components/molecules/Popover/styles.scss
@@ -9,7 +9,7 @@
   --fs-popover-border-radius                         : var(--fs-border-radius);
   --fs-popover-bkg-color                             : var(--fs-color-body-bkg);
   --fs-popover-box-shadow                            : var(--fs-shadow-darker);
-  --fs-popover-z-index                               : var(--fs-z-index-high);
+  --fs-popover-z-index                               : var(--fs-z-index-top);
 
   // Indicator
   --fs-popover-indicator-size                        : var(--fs-spacing-1);

--- a/packages/ui/src/components/molecules/Popover/styles.scss
+++ b/packages/ui/src/components/molecules/Popover/styles.scss
@@ -9,7 +9,7 @@
   --fs-popover-border-radius                         : var(--fs-border-radius);
   --fs-popover-bkg-color                             : var(--fs-color-body-bkg);
   --fs-popover-box-shadow                            : var(--fs-shadow-darker);
-  --fs-popover-z-index                               : var(--fs-z-index-top);
+  --fs-popover-z-index                               : var(--fs-z-index-high);
 
   // Indicator
   --fs-popover-indicator-size                        : var(--fs-spacing-1);


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to apply some code refactor and receive the `no products available` error scenario.

## How to test it?

Remember to apply `cms-sync` to a dev workspace to validate the new error message from hCMS.

### Starters Deploy Preview

vtex-sites/faststoreqa.store#791