### PR TITLE
feat: implement order status badge color logic

### DIFF
--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountOrderDetails.tsx
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountOrderDetails.tsx
@@ -4,13 +4,18 @@ import {
   Icon as UIIcon,
   IconButton as UIIconButton,
 } from '@faststore/ui'
+
+import {
+  getStatusBadgeColor,
+  type OrderStatus,
+} from 'src/utils/getStatusBadgeColor'
 import MyAccountStatusCard from 'src/components/account/orders/MyAccountOrderDetails/MyAccountStatusCard'
+import type { ServerOrderDetailsQueryQuery } from '@generated/graphql'
+
 import MyAccountDeliveryCard from './MyAccountDeliveryCard'
 import MyAccountOrderedByCard from './MyAccountOrderedByCard'
 import MyAccountPaymentCard from './MyAccountPaymentCard'
 import MyAccountSummaryCard from './MyAccountSummaryCard'
-
-import type { ServerOrderDetailsQueryQuery } from '@generated/graphql'
 import styles from './section.module.scss'
 
 export interface MyAccountOrderDetailsProps {
@@ -20,6 +25,10 @@ export interface MyAccountOrderDetailsProps {
 export default function MyAccountOrderDetails({
   order,
 }: MyAccountOrderDetailsProps) {
+  const { color: badgeVariant } = getStatusBadgeColor(
+    order.status as OrderStatus
+  )
+
   return (
     <div className={styles.page} data-fs-order-details>
       <header data-fs-order-details-header>
@@ -32,7 +41,7 @@ export default function MyAccountOrderDetails({
           <h1 data-fs-order-details-header-title-text>
             Order #{order.orderId}
           </h1>
-          <UIBadge variant="warning">Pending approval</UIBadge>
+          <UIBadge variant={badgeVariant}>{order.statusDescription}</UIBadge>
         </div>
         <div data-fs-order-details-header-actions>
           <UIButton variant="secondary" size="small">

--- a/packages/core/src/utils/getStatusBadgeColor.ts
+++ b/packages/core/src/utils/getStatusBadgeColor.ts
@@ -1,0 +1,55 @@
+import type { BadgeVariants } from '@faststore/components/dist/esm/atoms/Badge/Badge'
+
+export type OrderStatus =
+  | 'order-created'
+  | 'ready-for-handling'
+  | 'start-handling'
+  | 'waiting-for-manual-authorization'
+  | 'authorize-fulfillment'
+  | 'payment-approved'
+  | 'payment-denied'
+  | 'payment-pending'
+  | 'canceled'
+  | 'cancel'
+  | 'request-cancel'
+  | 'invoiced'
+  | 'invoice'
+
+/**
+ * @description Returns the color of the badge based on the order status.
+ * @link See the full list of order statuses in the OrderStatus type on: https://help.vtex.com/en/tutorial/fluxo-e-status-de-pedidos--tutorials_196#order-status-details
+ */
+export const getStatusBadgeColor = (
+  status: OrderStatus
+): { color: BadgeVariants } => {
+  switch (status) {
+    case 'order-created':
+      return { color: 'success' }
+    case 'ready-for-handling':
+      return { color: 'success' }
+    case 'start-handling':
+      return { color: 'success' }
+    case 'waiting-for-manual-authorization':
+      return { color: 'success' }
+    case 'authorize-fulfillment':
+      return { color: 'success' }
+    case 'payment-approved':
+      return { color: 'success' }
+    case 'payment-denied':
+      return { color: 'neutral' }
+    case 'payment-pending':
+      return { color: 'warning' }
+    case 'canceled':
+      return { color: 'neutral' }
+    case 'cancel':
+      return { color: 'neutral' }
+    case 'request-cancel':
+      return { color: 'neutral' }
+    case 'invoiced':
+      return { color: 'success' }
+    case 'invoice':
+      return { color: 'success' }
+    default:
+      return { color: 'neutral' }
+  }
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

The order status badge should vary depending on the current status of the order.
Must follow [current design](https://www.figma.com/design/JppevzwPSV58ud0JDCFE7o/My-Account?node-id=2124-44748&t=pBH9HXNsVSyxI7t5-4).

## How it works?

![image](https://github.com/user-attachments/assets/8fba3958-9611-4dc8-a5c5-82f8f302eef6)


## How to test it?

After creating an order, go to: `/account/orders/{{orderId}}`.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [x] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [ ] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [x] PR description
- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)
