### PR TITLE
chore: adding flag to the build command that would prevent verification of deps

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -22,10 +22,10 @@ export default class Build extends Command {
   ]
 
   static flags = {
-    checkDeps: Flags.boolean({
-      description: 'Skips check of faststore dependencies check.',
-      char: 'c',
-      default: true,
+    checkDeps: Flags.string({
+      description:
+        'Check of faststore dependencies version string to prevent usage of packages outside npm registry.',
+      default: 'true',
     }),
   }
 
@@ -34,7 +34,8 @@ export default class Build extends Command {
 
     const basePath = args.path ?? process.cwd()
 
-    if (flags.checkDeps === true) {
+    //negating false to make any typo on the value to be true.
+    if (!(flags.checkDeps === 'false')) {
       try {
         await checkDeps(basePath)
       } catch (error: unknown) {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -146,18 +146,23 @@ async function checkDeps(basePath: string) {
     dependencies
   )
 
-  const deps = [
+  let hasInvalidVersion = false,
+    invalidPackages = ''
+  ;[
     '@faststore/core',
     '@faststore/components',
     '@faststore/api',
     '@faststore/cli',
-  ]
-  Object.entries(allDeps).forEach(([key, version]) => {
-    if (deps.includes(key) === false) return
-
-    if (/^(http|https|git):.+/.test(version) === true)
-      throw new Error(
-        `Incorrect ${key} version. Please provides a valid version.`
-      )
+  ].forEach((pkg) => {
+    const version = allDeps[pkg]
+    if (version && /^(http|https|git):.+/.test(version) === true) {
+      hasInvalidVersion = true
+      invalidPackages = `${invalidPackages}${pkg},`
+    }
   })
+
+  if (hasInvalidVersion)
+    throw new Error(
+      `Incorrect version specified for packages. Please provides a valid version.\n ---> ${invalidPackages}`
+    )
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -36,7 +36,7 @@ export default class Build extends Command {
 
     if (flags.checkDeps === true) {
       try {
-        checkDeps(basePath)
+        await checkDeps(basePath)
       } catch (error: unknown) {
         if (error instanceof Error) this.error(error)
         else this.error('Something bad happened while checking dependencies.')

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -34,7 +34,6 @@ export default class Build extends Command {
 
     const basePath = args.path ?? process.cwd()
 
-    //negating false to make any typo on the value to be true.
     if (!flags['no-verify']) {
       const invalidPackages = await checkDeps(basePath)
       invalidPackages.forEach((pkg) =>

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -41,7 +41,7 @@ export default class Build extends Command {
         logger.warn(
           `${chalk.yellow(
             'warning'
-          )} - Package ${pkg} dependency has invalid version signature. Please use a semver like ^1.0.0`
+          )} - Dependency ${pkg} has invalid version signature. Please use a semver like ^1.0.0 (check the official releases on https://github.com/vtex/faststore)`
         )
       )
     }


### PR DESCRIPTION
This PR provides a new flag to the faststore/cli build command where enforces that versions of our packages   `'@faststore/core', '@faststore/components', '@faststore/api', '@faststore/cli'` wouldn't be used with packages over http like the codesandbox pr versions used to test. This flag can be set to false to skip the check.