### PR TITLE
chore: Add `useProductsQuery` function overloads to support full query response

### DIFF
--- a/packages/core/src/sdk/graphql/useQuery.ts
+++ b/packages/core/src/sdk/graphql/useQuery.ts
@@ -4,8 +4,12 @@ import type { SWRConfiguration } from 'swr'
 import { request } from './request'
 import type { Operation, RequestOptions } from './request'
 
-export type QueryOptions = SWRConfiguration &
-  RequestOptions & { doNotRun?: boolean }
+type CustomOptions = {
+  doNotRun?: boolean
+  fullQueryResponse?: boolean
+}
+
+export type QueryOptions = SWRConfiguration & RequestOptions & CustomOptions
 
 export const getKey = <Variables>(
   operationName: string,

--- a/packages/core/src/sdk/product/useProductsQuery.ts
+++ b/packages/core/src/sdk/product/useProductsQuery.ts
@@ -1,3 +1,4 @@
+import type { KeyedMutator } from 'swr'
 import { gql } from '@generated'
 import type {
   ClientManyProductsQueryQuery,
@@ -40,16 +41,33 @@ export const query = gql(`
   }
 `)
 
+// Overloads
+export function useProductsQuery(
+  variables: Partial<ClientManyProductsQueryQueryVariables>,
+  options?: QueryOptions & { fullQueryResponse?: false }
+): ClientManyProductsQueryQuery
+
+export function useProductsQuery(
+  variables: Partial<ClientManyProductsQueryQueryVariables>,
+  options?: QueryOptions & { fullQueryResponse: true }
+): {
+  error: any
+  mutate: KeyedMutator<ClientManyProductsQueryQuery>
+  isValidating: boolean
+  isLoading: boolean
+  data: ClientManyProductsQueryQuery
+}
+
 /**
  * Use this hook for fetching a list of products, like shelves and tiles
  */
-export const useProductsQuery = (
+export function useProductsQuery(
   variables: Partial<ClientManyProductsQueryQueryVariables>,
   options?: QueryOptions
-) => {
+) {
   const localizedVariables = useLocalizedVariables(variables)
 
-  const { data } = useQuery<
+  const { data, ...queryResponse } = useQuery<
     ClientManyProductsQueryQuery,
     ClientManyProductsQueryQueryVariables
   >(query, localizedVariables, {
@@ -57,6 +75,10 @@ export const useProductsQuery = (
     suspense: true,
     ...options,
   })
+
+  if (options?.fullQueryResponse) {
+    return { data, ...queryResponse }
+  }
 
   return data
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds `useProductsQuery` function overloads to support merchants to ask for full query response attributes (e.g. `isLoading`, `error`...).

## How it works?

Support the following usage of `useProductsQuery`:

`const data = useProductsQuery(variables)`

or

`const { data, isLoading, ... } = useProductsQuery(variables, { fullQueryResponse: true })`


### Starters Deploy Preview