### PR TITLE
chore: on ci added script to set resolution on starter project before…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
         run: |
           cd starter
           for package in ../packed-packages/*.tgz; do
-            yarn add "$package"
+            ARR=(${package//-/ })
+            NAME=@faststore\/${ARR[2]}
+            ../scripts/set-resolution.js . $NAME $package
           done
 
       - name: Install dependencies in starter

--- a/scripts/set-resolution.js
+++ b/scripts/set-resolution.js
@@ -20,14 +20,15 @@ if (!fs.existsSync(packageJsonPath)) {
 
 const packageJson = require(packageJsonPath)
 
-packageJson.resolutions = packageJson.resolutions ?? {}
+packageJson.resolutions = {
+  ...packageJson.resolutions,
+  [packageToResolve]: versionResolution,
+}
 
 if (packageJson.devDependencies[packageToResolve]) {
   packageJson.devDependencies[packageToResolve] = versionResolution
-  packageJson.resolutions[packageToResolve] = versionResolution
 } else if (packageJson.dependencies[packageToResolve]) {
   packageJson.dependencies[packageToResolve] = versionResolution
-  packageJson.resolutions[packageToResolve] = versionResolution
 } else {
   console.info(
     `${packageToResolve} is not a dependence of the specified project`

--- a/scripts/set-resolution.js
+++ b/scripts/set-resolution.js
@@ -1,0 +1,38 @@
+#! /usr/bin/env node
+
+const path = require('path')
+const fs = require('fs')
+const [, , basePath, packageToResolve, versionResolution] = process.argv
+
+if (!basePath || !packageToResolve || !versionResolution) {
+  console.error(
+    'Usage: set-resolution <basePath> <packageToResolve> <versionResolution>'
+  )
+  process.exit(1)
+}
+
+const packageJsonPath = path.resolve(process.cwd(), basePath, 'package.json')
+
+if (!fs.existsSync(packageJsonPath)) {
+  console.error(`Error: package.json not found at ${packageJsonPath}`)
+  process.exit(1)
+}
+
+const packageJson = require(packageJsonPath)
+
+packageJson.resolutions = packageJson.resolutions ?? {}
+
+if (packageJson.devDependencies[packageToResolve]) {
+  packageJson.devDependencies[packageToResolve] = versionResolution
+  packageJson.resolutions[packageToResolve] = versionResolution
+} else if (packageJson.dependencies[packageToResolve]) {
+  packageJson.dependencies[packageToResolve] = versionResolution
+  packageJson.resolutions[packageToResolve] = versionResolution
+} else {
+  console.info(
+    `${packageToResolve} is not a dependence of the specified project`
+  )
+  // process.exit(0)
+}
+
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))

--- a/scripts/set-resolution.js
+++ b/scripts/set-resolution.js
@@ -33,7 +33,6 @@ if (packageJson.devDependencies[packageToResolve]) {
   console.info(
     `${packageToResolve} is not a dependence of the specified project`
   )
-  // process.exit(0)
 }
 
 fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))

--- a/scripts/set-resolution.js
+++ b/scripts/set-resolution.js
@@ -31,7 +31,7 @@ if (packageJson.devDependencies[packageToResolve]) {
   packageJson.dependencies[packageToResolve] = versionResolution
 } else {
   console.info(
-    `${packageToResolve} is not a dependence of the specified project`
+    `${packageToResolve} is not a dependency of the specified project`
   )
 }
 


### PR DESCRIPTION
… install

## What's the purpose of this pull request?

Prevent yarn of install a version of @faststore deps from registry on the CI. 

<!--- Considering the context, what is the problem we'll solve? Where in VTEX's big picture our issue fits in? Write a tweet about the context and the problem itself. --->

## How it works?

Created a script to add a resolution property on the package.json to make the yarn resolve all @faststore deps to resolve to the root version (the one generated on the build instead of the registry)

<!--- Tell us the role of the new feature, or component, in its context. Provide details about what you have implemented and screenshots if applicable.  --->

## How to test it?

Creating a PR that add something to the @faststore/component or UI and use it on the @faststore/core. This would make the CI fail saying the property does not exists in the @faststore/component or UI cause it would install in the @faststore/core deps from @faststore/ui or @faststore/component from the registry instead the new one generated on the PR. 

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

[SFS-2505](https://vtex-dev.atlassian.net/browse/SFS-2505)

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [ ] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [ ] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [ ] PR description
- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)


[SFS-2505]: https://vtex-dev.atlassian.net/browse/SFS-2505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ