### PR TITLE
feat: order not found

### DIFF
--- a/packages/api/src/platforms/errors.ts
+++ b/packages/api/src/platforms/errors.ts
@@ -1,4 +1,8 @@
-type ErrorType = 'BadRequestError' | 'NotFoundError' | 'RedirectError'
+type ErrorType =
+  | 'BadRequestError'
+  | 'NotFoundError'
+  | 'RedirectError'
+  | 'ForbiddenError'
 
 interface Extension {
   type: ErrorType
@@ -27,6 +31,12 @@ export class NotFoundError extends FastStoreError {
   }
 }
 
+export class ForbiddenError extends FastStoreError {
+  constructor(message?: string) {
+    super({ status: 403, type: 'ForbiddenError' }, message)
+  }
+}
+
 export const isFastStoreError = (error: any): error is FastStoreError =>
   error?.name === 'FastStoreError'
 
@@ -35,3 +45,6 @@ export const isNotFoundError = (error: any): error is NotFoundError =>
 
 export const isBadRequestError = (error: any): error is BadRequestError =>
   error?.extensions?.type === 'BadRequestError'
+
+export const isForbiddenError = (error: any): error is ForbiddenError =>
+  error?.extensions?.type === 'ForbiddenError'

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -389,11 +389,11 @@ export const Query = {
         exception: any
       }
 
-      if (message.toLowerCase() === 'order not found') {
+      if (message.toLowerCase().includes('order not found')) {
         throw new NotFoundError(`No order found for id ${orderId}`)
       }
 
-      if (message.toLowerCase() === 'acesso negado') {
+      if (message.toLowerCase().includes('acesso negado')) {
         throw new ForbiddenError(
           `You are forbidden to interact with order with id ${orderId}`
         )

--- a/packages/core/src/components/account/MyAccountLayout/styles.scss
+++ b/packages/core/src/components/account/MyAccountLayout/styles.scss
@@ -3,6 +3,7 @@
   @import "@faststore/ui/src/components/atoms/Button/styles.scss";
   @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
   @import "@faststore/ui/src/components/atoms/Input/styles.scss";
+  @import "@faststore/ui/src/components/molecules/LinkButton/styles.scss";
   @import "@faststore/ui/src/components/molecules/SearchInputField/styles.scss";
   @import "../MyAccountMenu/styles.scss";
 

--- a/packages/core/src/pages/account/403.tsx
+++ b/packages/core/src/pages/account/403.tsx
@@ -16,7 +16,7 @@ import PLUGINS_COMPONENTS from 'src/plugins'
 import { type PageContentType, getPage } from 'src/server/cms'
 import { injectGlobalSections } from 'src/server/cms/global'
 import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
-import { Button } from '@faststore/components'
+import { LinkButton } from '@faststore/components'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -44,16 +44,9 @@ function Page({ globalSections }: Props) {
           subtitle="You don't have permission to access this page."
           showLoader={false}
         >
-          <Button
-            variant="secondary"
-            inverse={false}
-            size="regular"
-            onClick={() => {
-              window.location.href = '/account/orders'
-            }}
-          >
-            Back to Orders
-          </Button>
+          <LinkButton variant="secondary" href="/account">
+            Back to Account
+          </LinkButton>
         </EmptyState>
       </MyAccountLayout>
     </RenderSections>

--- a/packages/core/src/pages/account/403.tsx
+++ b/packages/core/src/pages/account/403.tsx
@@ -9,9 +9,7 @@ import {
 
 import { MyAccountLayout } from 'src/components/account'
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
-import RenderSections, {
-  RenderSectionsBase,
-} from 'src/components/cms/RenderSections'
+import RenderSections from 'src/components/cms/RenderSections'
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
@@ -28,11 +26,10 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
 }
 
 type Props = {
-  page: PageContentType
   globalSections: GlobalSectionsData
 }
 
-function Page({ page: { sections }, globalSections }: Props) {
+function Page({ globalSections }: Props) {
   return (
     <RenderSections
       globalSections={globalSections.sections}
@@ -87,8 +84,8 @@ export const getStaticProps: GetStaticProps<
   const [page, globalSections, globalSectionsHeader, globalSectionsFooter] =
     await Promise.all([
       getPage<PageContentType>({
-        ...(previewData?.contentType === '404' && previewData),
-        contentType: '404',
+        ...(previewData?.contentType === '403' && previewData),
+        contentType: '403',
       }),
       globalSectionsPromise,
       globalSectionsHeaderPromise,
@@ -102,7 +99,11 @@ export const getStaticProps: GetStaticProps<
   })
 
   return {
-    props: { page, globalSections: globalSectionsResult },
+    props: {
+      // The sections from the CMS page are not utilized here for the My Account page.
+      // page,
+      globalSections: globalSectionsResult,
+    },
   }
 }
 

--- a/packages/core/src/pages/account/orders/403.tsx
+++ b/packages/core/src/pages/account/orders/403.tsx
@@ -1,0 +1,109 @@
+import type { Locator } from '@vtex/client-cms'
+import type { GetStaticProps } from 'next'
+import { NextSeo } from 'next-seo'
+import type { ComponentType } from 'react'
+import {
+  type GlobalSectionsData,
+  getGlobalSectionsData,
+} from 'src/components/cms/GlobalSections'
+
+import { MyAccountLayout } from 'src/components/account'
+import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
+import RenderSections, {
+  RenderSectionsBase,
+} from 'src/components/cms/RenderSections'
+import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
+import CUSTOM_COMPONENTS from 'src/customizations/src/components'
+import PLUGINS_COMPONENTS from 'src/plugins'
+import { type PageContentType, getPage } from 'src/server/cms'
+import { injectGlobalSections } from 'src/server/cms/global'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
+import { Button } from '@faststore/components'
+
+/* A list of components that can be used in the CMS. */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  ...GLOBAL_COMPONENTS,
+  ...PLUGINS_COMPONENTS,
+  ...CUSTOM_COMPONENTS,
+}
+
+type Props = {
+  page: PageContentType
+  globalSections: GlobalSectionsData
+}
+
+function Page({ page: { sections }, globalSections }: Props) {
+  return (
+    <RenderSections
+      globalSections={globalSections.sections}
+      components={COMPONENTS}
+    >
+      <NextSeo noindex nofollow />
+
+      <MyAccountLayout>
+        <EmptyState
+          title="Unauthorized Access"
+          titleIcon={{ icon: 'ShoppingCart', alt: 'Shopping Cart' }}
+          subtitle="You don't have permission to access this page."
+          showLoader={false}
+        >
+          <Button
+            variant="secondary"
+            inverse={false}
+            size="regular"
+            onClick={() => {
+              window.location.href = '/account/orders'
+            }}
+          >
+            Back to Orders
+          </Button>
+        </EmptyState>
+      </MyAccountLayout>
+    </RenderSections>
+  )
+}
+
+export const getStaticProps: GetStaticProps<
+  Props,
+  Record<string, string>,
+  Locator
+> = async ({ previewData }) => {
+  // TODO validate permissions here
+
+  const { isFaststoreMyAccountEnabled, redirect } = getMyAccountRedirect({
+    query: {},
+  })
+
+  if (!isFaststoreMyAccountEnabled) {
+    return { redirect }
+  }
+
+  const [
+    globalSectionsPromise,
+    globalSectionsHeaderPromise,
+    globalSectionsFooterPromise,
+  ] = getGlobalSectionsData(previewData)
+
+  const [page, globalSections, globalSectionsHeader, globalSectionsFooter] =
+    await Promise.all([
+      getPage<PageContentType>({
+        ...(previewData?.contentType === '404' && previewData),
+        contentType: '404',
+      }),
+      globalSectionsPromise,
+      globalSectionsHeaderPromise,
+      globalSectionsFooterPromise,
+    ])
+
+  const globalSectionsResult = injectGlobalSections({
+    globalSections,
+    globalSectionsHeader,
+    globalSectionsFooter,
+  })
+
+  return {
+    props: { page, globalSections: globalSectionsResult },
+  }
+}
+
+export default Page

--- a/packages/core/src/pages/account/orders/[id].tsx
+++ b/packages/core/src/pages/account/orders/[id].tsx
@@ -729,7 +729,7 @@ export const getServerSideProps: GetServerSideProps<
     const statusCode: number = (orderDetails.errors[0] as any)?.extensions
       ?.status
     const destination: string =
-      statusCode === 403 ? '/account/orders/403' : '/account/404'
+      statusCode === 403 ? '/account/403' : '/account/404'
 
     return {
       redirect: {

--- a/packages/core/src/pages/account/orders/[id].tsx
+++ b/packages/core/src/pages/account/orders/[id].tsx
@@ -726,9 +726,14 @@ export const getServerSideProps: GetServerSideProps<
   ])
 
   if (orderDetails.errors) {
+    const statusCode: number = (orderDetails.errors[0] as any)?.extensions
+      ?.status
+    const destination: string =
+      statusCode === 403 ? '/account/orders/403' : '/account/404'
+
     return {
       redirect: {
-        destination: '/account/404',
+        destination,
         permanent: false,
       },
     }


### PR DESCRIPTION
## What's the purpose of this pull request?

Add 403 (Forbidden) error page to My Account module to handle unauthorized access attempts.

## What was done?

- If call error is "acesso negado" returns status code 403
- Created 403 error page for MyAccount

## How to test it?

1. Open
2. Try to access a protected My Account route without proper authentication
3. Verify that you are redirected to the 403 error page
4. Check that the page:
   - Shows a forbidden access message
   - Uses the standard My Account layout
   - Displays navigation menu correctly
   - Maintains consistent styling with other account pages
   
   ## Preview
   - https://github.com/vtex-sites/faststoreqa.store/pull/804
   - https://sfj-792c1d5--faststoreqa.preview.vtex.app/

## References

- [SFS-2408](https://vtex-dev.atlassian.net/browse/SFS-2408)


![image](https://github.com/user-attachments/assets/b4b9b038-60a8-414a-b8e2-0f374d7eb9db)
![image](https://github.com/user-attachments/assets/f7a2064e-5d3b-45cb-8bff-148d963ec3cc)


[SFS-2408]: https://vtex-dev.atlassian.net/browse/SFS-2408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ