### PR TITLE
fix: discovery config import

### DIFF
--- a/packages/core/src/sdk/error/MissingContentError/MissingContentError.ts
+++ b/packages/core/src/sdk/error/MissingContentError/MissingContentError.ts
@@ -1,6 +1,6 @@
-import type { Options } from 'src/server/cms'
 import type { EntryPathParams } from '@vtex/client-cp'
-import { contentSource } from 'discovery.config.default'
+import { contentSource } from 'discovery.config'
+import type { Options } from 'src/server/cms'
 
 export default class MissingContentError extends Error {
   constructor(params: Options | EntryPathParams) {

--- a/packages/core/src/sdk/error/MultipleContentError/MultipleContentError.ts
+++ b/packages/core/src/sdk/error/MultipleContentError/MultipleContentError.ts
@@ -1,6 +1,6 @@
-import type { Options } from 'src/server/cms'
 import type { EntryPathParams } from '@vtex/client-cp'
-import { contentSource } from 'discovery.config.default'
+import { contentSource } from 'discovery.config'
+import type { Options } from 'src/server/cms'
 
 export default class MultipleContentError extends Error {
   constructor(params: Options | EntryPathParams) {


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix discovery.config import

## How it works?

It was being imported as `discovery.config.default`, but it should get from `discovery.config` otherwise it won't get the store configurations.
