### PR TITLE
Feat/global sections settings

### DIFF
--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -3,7 +3,131 @@
     "id": "globalSections",
     "name": "Global Sections",
     "scopes": ["global"],
-    "configurationSchemaSets": [],
+    "configurationSchemaSets": [
+      {
+        "name": "Settings",
+        "configurations": [
+          {
+            "name": "regionalization",
+            "schema": {
+              "title": "Regionalization",
+              "description": "Regionalization options",
+              "type": "object",
+              "properties": {
+                "inputField": {
+                  "title": "Postal Code Input Field",
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "title": "Label",
+                      "type": "string",
+                      "default": "Postal Code"
+                    },
+                    "errorMessage": {
+                      "title": "Error message",
+                      "type": "string",
+                      "default": "You entered an invalid Postal Code"
+                    },
+                    "noProductsAvailableErrorMessage": {
+                      "title": "Error message for the scenario of no products available for a given location",
+                      "type": "string",
+                      "default": "There are no products available for %s.",
+                      "description": "The '%s' will be replaced by the postal code value."
+                    },
+                    "buttonActionText": {
+                      "title": "Action label to apply the postal code",
+                      "type": "string",
+                      "default": "Apply"
+                    }
+                  }
+                },
+                "idkPostalCodeLink": {
+                  "title": "I don't know my postal code link",
+                  "type": "object",
+                  "properties": {
+                    "text": {
+                      "type": "string",
+                      "title": "Link Text",
+                      "default": "I don't know my Postal Code"
+                    },
+                    "to": {
+                      "type": "string",
+                      "title": "Action link"
+                    },
+                    "icon": {
+                      "title": "Icon",
+                      "type": "object",
+                      "properties": {
+                        "icon": {
+                          "title": "Icon",
+                          "type": "string",
+                          "enumNames": ["Arrow Square Out"],
+                          "enum": ["ArrowSquareOut"],
+                          "default": "ArrowSquareOut"
+                        },
+                        "alt": {
+                          "title": "Alternative Label",
+                          "type": "string",
+                          "default": "Arrow Square Out icon"
+                        }
+                      }
+                    }
+                  }
+                },
+                "deliverySettings": {
+                  "title": "PLP/Search Filter: Delivery Settings",
+                  "type": "object",
+                  "required": ["title", "description"],
+                  "properties": {
+                    "title": {
+                      "title": "Title",
+                      "type": "string",
+                      "default": "Delivery"
+                    },
+                    "description": {
+                      "title": "Description",
+                      "type": "string",
+                      "default": "Offers and delivery options vary based on region."
+                    },
+                    "setLocationButtonLabel": {
+                      "title": "Call to Action label",
+                      "type": "string",
+                      "default": "Set Location"
+                    },
+                    "deliveryCustomLabels": {
+                      "title": "Filter options labels",
+                      "type": "object",
+                      "properties": {
+                        "delivery": {
+                          "title": "Shipping label",
+                          "type": "string",
+                          "default": "Shipping to"
+                        },
+                        "pickupInPoint": {
+                          "title": "Pickup in point label",
+                          "type": "string",
+                          "default": "Pickup at"
+                        },
+                        "pickupNearby": {
+                          "title": "Pickup Nearby label",
+                          "type": "string",
+                          "default": "Pickup Nearby"
+                        },
+                        "pickupAll": {
+                          "title": "Pickup Anywhere label",
+                          "type": "string",
+                          "default": "Pickup Anywhere"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ],
     "isSingleton": true
   },
   {

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1917,22 +1917,21 @@
             "deliverySettings": {
               "title": "Delivery Settings",
               "type": "object",
-              "required": ["title", "description"],
               "properties": {
                 "title": {
                   "title": "Delivery section title",
-                  "type": "string",
-                  "default": "Delivery"
+                  "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+                  "type": "string"
                 },
                 "description": {
                   "title": "Delivery section description",
-                  "type": "string",
-                  "default": "Offers and delivery options vary based on region."
+                  "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+                  "type": "string"
                 },
                 "setLocationButtonLabel": {
                   "title": "Call to Action label",
-                  "type": "string",
-                  "default": "Set Location"
+                  "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+                  "type": "string"
                 },
                 "deliveryCustomLabels": {
                   "title": "Delivery Custom labels",
@@ -1940,23 +1939,23 @@
                   "properties": {
                     "delivery": {
                       "title": "Shipping label",
-                      "type": "string",
-                      "default": "Shipping to"
+                      "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+                      "type": "string"
                     },
                     "pickupInPoint": {
                       "title": "Pickup in point label",
-                      "type": "string",
-                      "default": "Pickup at"
+                      "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+                      "type": "string"
                     },
                     "pickupNearby": {
                       "title": "Pickup Nearby label",
-                      "type": "string",
-                      "default": "Pickup Nearby"
+                      "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+                      "type": "string"
                     },
                     "pickupAll": {
                       "title": "Pickup Anywhere label",
-                      "type": "string",
-                      "default": "Pickup Anywhere"
+                      "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+                      "type": "string"
                     }
                   }
                 }
@@ -2267,24 +2266,23 @@
           "properties": {
             "label": {
               "title": "Input field label",
-              "type": "string",
-              "default": "Postal Code"
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+              "type": "string"
             },
             "errorMessage": {
               "title": "Input field error message",
-              "type": "string",
-              "default": "You entered an invalid Postal Code"
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+              "type": "string"
             },
             "noProductsAvailableErrorMessage": {
               "title": "Input field error message for the scenario of no products available for a given location",
-              "type": "string",
-              "default": "There are no products available for %s.",
-              "description": "The '%s' will be replaced by the postal code value."
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used. The '%s' is replaced by the postal code value.",
+              "type": "string"
             },
             "buttonActionText": {
               "title": "Input field action button label",
-              "type": "string",
-              "default": "Apply"
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+              "type": "string"
             }
           }
         },
@@ -2295,11 +2293,12 @@
             "text": {
               "type": "string",
               "title": "Link Text",
-              "default": "I don't know my Postal Code"
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used."
             },
             "to": {
               "type": "string",
-              "title": "Action link"
+              "title": "Action link",
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used."
             },
             "icon": {
               "title": "Icon",
@@ -2307,15 +2306,15 @@
               "properties": {
                 "icon": {
                   "title": "Icon",
+                  "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
                   "type": "string",
                   "enumNames": ["Arrow Square Out"],
-                  "enum": ["ArrowSquareOut"],
-                  "default": "ArrowSquareOut"
+                  "enum": ["ArrowSquareOut"]
                 },
                 "alt": {
                   "title": "Alternative Label",
-                  "type": "string",
-                  "default": "Arrow Square Out icon"
+                  "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+                  "type": "string"
                 }
               }
             }
@@ -2348,24 +2347,23 @@
           "properties": {
             "label": {
               "title": "Input field label",
-              "type": "string",
-              "default": "Postal Code"
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+              "type": "string"
             },
             "errorMessage": {
               "title": "Input field error message",
-              "type": "string",
-              "default": "You entered an invalid Postal Code"
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+              "type": "string"
             },
             "noProductsAvailableErrorMessage": {
               "title": "Input field error message for the scenario of no products available for a given location",
-              "type": "string",
-              "default": "There are no products available for %s.",
-              "description": "The '%s' will be replaced by the postal code value."
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used. The '%s' is replaced by the postal code value.",
+              "type": "string"
             },
             "buttonActionText": {
               "title": "Input field action button label",
-              "type": "string",
-              "default": "Apply"
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+              "type": "string"
             }
           }
         },
@@ -2393,11 +2391,12 @@
             "text": {
               "type": "string",
               "title": "Link Text",
-              "default": "I don't know my Postal Code"
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used."
             },
             "to": {
               "type": "string",
-              "title": "Action link"
+              "title": "Action link",
+              "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used."
             },
             "icon": {
               "title": "Icon",
@@ -2405,15 +2404,15 @@
               "properties": {
                 "icon": {
                   "title": "Icon",
+                  "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
                   "type": "string",
                   "enumNames": ["Arrow Square Out"],
-                  "enum": ["ArrowSquareOut"],
-                  "default": "ArrowSquareOut"
+                  "enum": ["ArrowSquareOut"]
                 },
                 "alt": {
                   "title": "Alternative Label",
-                  "type": "string",
-                  "default": "Arrow Square Out icon"
+                  "description": "[DEPRECATED] Use the Settings tab in the Global Sections to configure this message. This field will be removed in the future. Leave it blank so the one in Global Sections Settings tab is used.",
+                  "type": "string"
                 }
               }
             }

--- a/packages/core/src/components/cms/GlobalSections.tsx
+++ b/packages/core/src/components/cms/GlobalSections.tsx
@@ -10,6 +10,7 @@ export const GLOBAL_SECTIONS_FOOTER_CONTENT_TYPE = 'globalFooterSections'
 
 export type GlobalSectionsData = {
   sections: Section[]
+  settings?: Record<string, unknown>
 }
 
 export const getGlobalSectionsByType = async (

--- a/packages/core/src/components/search/Filter/FilterDesktop.tsx
+++ b/packages/core/src/components/search/Filter/FilterDesktop.tsx
@@ -15,6 +15,12 @@ import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import type { useFilter } from 'src/sdk/search/useFilter'
 import type { FilterSliderProps } from './FilterSlider'
 
+import deepmerge from 'deepmerge'
+import {
+  type PLPContext,
+  type SearchPageContext,
+  usePage,
+} from 'src/sdk/overrides/PageProvider'
 import { sessionStore } from 'src/sdk/session'
 import FilterDeliveryOption from './FilterDeliveryOption'
 
@@ -34,9 +40,13 @@ function FilterDesktop({
 }: FilterDesktopProps & ReturnType<typeof useFilter>) {
   const { resetInfiniteScroll, state, setState } = useSearch()
 
-  const deliveryLabel = deliverySettings?.title ?? 'Delivery'
-  const { postalCode } = sessionStore.read()
+  const context = usePage<SearchPageContext | PLPContext>()
+  const globalDeliverySettingsData =
+    context?.globalSectionsSettings?.regionalization?.deliverySettings
+  const cmsData = deepmerge(globalDeliverySettingsData, deliverySettings)
+  const deliveryLabel = cmsData?.title ?? 'Delivery'
 
+  const { postalCode } = sessionStore.read()
   const shouldDisplayDeliveryButton = deliveryPromise.enabled && !postalCode
   const filteredFacets = deliveryPromise.enabled
     ? facets
@@ -58,7 +68,7 @@ function FilterDesktop({
           index={0}
           type=""
           label={deliveryLabel}
-          description={deliverySettings?.description}
+          description={cmsData?.description}
         >
           <UIButton
             data-fs-filter-list-delivery-button
@@ -68,7 +78,7 @@ function FilterDesktop({
             }}
             icon={<UIIcon name="MapPin" />}
           >
-            {deliverySettings?.setLocationButtonLabel ?? 'Set Location'}
+            {cmsData?.setLocationButtonLabel ?? 'Set Location'}
           </UIButton>
         </UIFilterFacets>
       )}
@@ -85,9 +95,7 @@ function FilterDesktop({
             index={index}
             type={type}
             label={isDeliveryFacet ? deliveryLabel : label}
-            description={
-              isDeliveryFacet ? deliverySettings.description : undefined
-            }
+            description={isDeliveryFacet ? cmsData.description : undefined}
           >
             {type === 'StoreFacetBoolean' && isExpanded && (
               <UIFilterFacetBoolean>
@@ -116,9 +124,7 @@ function FilterDesktop({
                       isDeliveryFacet ? (
                         <FilterDeliveryOption
                           item={item}
-                          deliveryCustomLabels={
-                            deliverySettings.deliveryCustomLabels
-                          }
+                          deliveryCustomLabels={cmsData.deliveryCustomLabels}
                         />
                       ) : (
                         item.label

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -1,6 +1,7 @@
 import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
 import type { ComponentType } from 'react'
 
+import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
 import RenderSections from 'src/components/cms/RenderSections'
 import BannerNewsletter from 'src/components/sections/BannerNewsletter/BannerNewsletter'
 import { OverriddenDefaultBannerText as BannerText } from 'src/components/sections/BannerText/OverriddenDefaultBannerText'
@@ -10,16 +11,15 @@ import Incentives from 'src/components/sections/Incentives'
 import { OverriddenDefaultNewsletter as Newsletter } from 'src/components/sections/Newsletter/OverriddenDefaultNewsletter'
 import { OverriddenDefaultProductShelf as ProductShelf } from 'src/components/sections/ProductShelf/OverriddenDefaultProductShelf'
 import ProductTiles from 'src/components/sections/ProductTiles'
-import PLUGINS_COMPONENTS from 'src/plugins'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
-import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
+import PLUGINS_COMPONENTS from 'src/plugins'
 import MissingContentError from 'src/sdk/error/MissingContentError/MissingContentError'
 import PageProvider from 'src/sdk/overrides/PageProvider'
 import type { PageContentType } from 'src/server/cms'
 
 import storeConfig from 'discovery.config'
-import type { PreviewData } from 'src/server/content/types'
 import { contentService } from 'src/server/content/service'
+import type { PreviewData } from 'src/server/content/types'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -41,6 +41,7 @@ export type LandingPageProps = {
   slug?: string
   serverData?: unknown
   globalSections?: Array<{ name: string; data: any }>
+  globalSectionsSettings?: Record<string, any>
 }
 
 export default function LandingPage({
@@ -48,9 +49,11 @@ export default function LandingPage({
   slug,
   serverData,
   globalSections,
+  globalSectionsSettings,
 }: LandingPageProps) {
   const context = {
     data: serverData,
+    globalSectionsSettings,
   }
 
   return (

--- a/packages/core/src/components/templates/ProductListingPage/ProductListing.tsx
+++ b/packages/core/src/components/templates/ProductListingPage/ProductListing.tsx
@@ -15,6 +15,7 @@ import RenderSections, {
 } from 'src/components/cms/RenderSections'
 import type { PLPContentType } from 'src/server/cms/plp'
 
+import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import PageProvider, { type PLPContext } from 'src/sdk/overrides/PageProvider'
 import {
@@ -23,7 +24,6 @@ import {
 } from 'src/sdk/product/usePageProductsQuery'
 import { useProductGalleryQuery } from 'src/sdk/product/useProductGalleryQuery'
 import { useApplySearchState } from 'src/sdk/search/state'
-import { useRouter } from 'next/router'
 import { isContentPlatformSource } from 'src/server/content/utils'
 
 const ScrollToTopButton = dynamic(
@@ -39,6 +39,7 @@ export type ProductListingPageProps = {
   serverManyProductsVariables: ServerManyProductsQueryQueryVariables
   page: PLPContentType
   globalSections?: Array<{ name: string; data: any }>
+  globalSectionsSettings?: Record<string, any>
 }
 
 // Array merging strategy from deepmerge that makes client arrays overwrite server array
@@ -50,6 +51,7 @@ export default function ProductListing({
   data: server,
   serverManyProductsVariables,
   globalSections,
+  globalSectionsSettings,
 }: ProductListingPageProps) {
   const router = useRouter()
   const { state } = useSearch()
@@ -86,6 +88,7 @@ export default function ProductListing({
       ),
       pages,
     },
+    globalSectionsSettings,
   } as PLPContext
 
   return (

--- a/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
+++ b/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
@@ -26,6 +26,7 @@ export type ProductListingPageProps = {
   serverManyProductsVariables: ServerManyProductsQueryQueryVariables
   page: PLPContentType
   globalSections?: Array<{ name: string; data: any }>
+  globalSectionsSettings?: Record<string, any>
 }
 
 type UseSearchParams = {
@@ -76,6 +77,7 @@ export default function ProductListingPage({
   data: server,
   serverManyProductsVariables,
   globalSections,
+  globalSectionsSettings,
 }: ProductListingPageProps) {
   const { settings } = plpContentType
   const collection = server.collection
@@ -134,6 +136,7 @@ export default function ProductListingPage({
 
       <ProductListing
         globalSections={globalSections}
+        globalSectionsSettings={globalSectionsSettings}
         page={plpContentType}
         data={server}
         serverManyProductsVariables={serverManyProductsVariables}

--- a/packages/core/src/components/templates/SearchPage/SearchPage.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchPage.tsx
@@ -15,12 +15,14 @@ export type SearchPageProps = {
   data: SearchPageContextType & ClientProductGalleryQuery
   page: SearchContentType
   globalSections?: Array<{ name: string; data: any }>
+  globalSectionsSettings?: Record<string, any>
 }
 
 function SearchPage({
   page: { sections },
   data: serverData,
   globalSections,
+  globalSectionsSettings,
 }: SearchPageProps) {
   const { pages, useGalleryPage } = useCreateUseGalleryPage()
 
@@ -29,6 +31,7 @@ function SearchPage({
       ...serverData,
       pages,
     },
+    globalSectionsSettings,
   } as SearchPageContext
 
   return (

--- a/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
@@ -15,6 +15,7 @@ export type SearchWrapperProps = {
   searchContentType: SearchContentType
   serverData: SearchPageContextType
   globalSections?: Array<{ name: string; data: any }>
+  globalSectionsSettings?: Record<string, any>
 }
 
 export default function SearchWrapper({
@@ -22,6 +23,7 @@ export default function SearchWrapper({
   searchContentType,
   serverData,
   globalSections,
+  globalSectionsSettings,
 }: SearchWrapperProps) {
   const router = useRouter()
   const {
@@ -81,6 +83,7 @@ export default function SearchWrapper({
       page={searchContentType}
       data={{ ...serverData, ...pageProductGalleryData }}
       globalSections={globalSections}
+      globalSectionsSettings={globalSectionsSettings}
     />
   )
 }

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -28,10 +28,10 @@ import { getRedirect } from 'src/sdk/redirects'
 import type { PageContentType } from 'src/server/cms'
 import { injectGlobalSections } from 'src/server/cms/global'
 import type { PLPContentType } from 'src/server/cms/plp'
-import { getDynamicContent } from 'src/utils/dynamicContent'
-import { fetchServerManyProducts } from 'src/utils/fetchProductGallerySSR'
 import { contentService } from 'src/server/content/service'
 import type { PreviewData } from 'src/server/content/types'
+import { getDynamicContent } from 'src/utils/dynamicContent'
+import { fetchServerManyProducts } from 'src/utils/fetchProductGallerySSR'
 
 const LandingPage = dynamic(
   () => import('src/components/templates/LandingPage')
@@ -63,12 +63,14 @@ function Page({ globalSections, type, ...otherProps }: Props) {
       {type === 'plp' && (
         <ProductListingPage
           globalSections={globalSections.sections}
+          globalSectionsSettings={globalSections.settings}
           {...(otherProps as ProductListingPageProps)}
         />
       )}
       {type === 'page' && (
         <LandingPage
           globalSections={globalSections.sections}
+          globalSectionsSettings={globalSections.settings}
           {...(otherProps as LandingPageProps)}
         />
       )}

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -147,6 +147,7 @@ function Page({
           searchTerm: searchTerm ?? searchParams.term ?? undefined,
         }}
         globalSections={globalSections.sections}
+        globalSectionsSettings={globalSections.settings}
       />
     </SearchProvider>
   )

--- a/packages/core/src/sdk/overrides/PageProvider.tsx
+++ b/packages/core/src/sdk/overrides/PageProvider.tsx
@@ -19,6 +19,7 @@ export interface PLPContext {
     ClientProductGalleryQueryQuery & {
       pages: ClientManyProductsQueryQuery[]
     }
+  globalSectionsSettings?: Record<string, any>
 }
 
 export interface SearchPageContext {
@@ -26,6 +27,7 @@ export interface SearchPageContext {
     ClientProductGalleryQueryQuery & {
       pages: ClientManyProductsQueryQuery[]
     }
+  globalSectionsSettings?: Record<string, any>
 }
 
 export interface DynamicContent<T> {


### PR DESCRIPTION
## What's the purpose of this pull request?

It creates a new tab inside the Global Sections CMS. In this new Settings tab will be possible to configure settings related to regionalization, which will be used by some components/sections like Region Modal and Region Popover. 
This PR doesn't update all components/sections, it'll be done after. In this PR there is the update of `FilterDesktop` so we can validate the change.

## How it works?

The merchant will be able to configure their regionalization-related message in a single place (Global Sections Settings tab) instead of duplicate messages through sections.
To not introduce breaking change I didn't remove the messages from the sections yet - this will be done in the v4. I've added a deprecation notice in every field that was created in the Settings tab.

In v3: the components/sections will use the messages defined in the sections CMS, if they're blank they will use the messages in Global Sections Settings tab. 

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

- [Slack discussion thread](https://vtex.slack.com/archives/C03L3CRCDC4/p1747248599365189)