### PR TITLE
feat: Add Region Slider to set/change location

### DIFF
--- a/packages/components/src/hooks/UIProvider.tsx
+++ b/packages/components/src/hooks/UIProvider.tsx
@@ -13,7 +13,13 @@ export interface Popover {
   triggerRef?: RefObject<HTMLElement>
 }
 
-type RegionSliderType = 'setLocation' | 'changeLocation'
+export const regionSliderTypes = {
+  setLocation: 'setLocation',
+  changeLocation: 'changeLocation',
+} as const
+
+type RegionSliderType =
+  (typeof regionSliderTypes)[keyof typeof regionSliderTypes]
 
 export type RegionSlider = {
   type: RegionSliderType | 'none'

--- a/packages/components/src/hooks/UIProvider.tsx
+++ b/packages/components/src/hooks/UIProvider.tsx
@@ -13,6 +13,12 @@ export interface Popover {
   triggerRef?: RefObject<HTMLElement>
 }
 
+type RegionSliderType = 'setLocation' | 'changeLocation'
+
+export type RegionSlider = {
+  type: RegionSliderType | 'none'
+}
+
 interface State {
   /** Cart sidebar */
   cart: boolean
@@ -26,6 +32,8 @@ interface State {
   toasts: Toast[]
   /** Region Popover */
   popover: Popover
+  /** Region slider */
+  regionSlider: RegionSlider
 }
 
 type UIElement = 'navbar' | 'cart' | 'modal' | 'filter'
@@ -55,6 +63,13 @@ type Action =
     }
   | {
       type: 'closePopover'
+    }
+  | {
+      type: 'openRegionSlider'
+      payload: RegionSliderType
+    }
+  | {
+      type: 'closeRegionSlider'
     }
 
 const reducer = (state: State, action: Action): State => {
@@ -127,6 +142,22 @@ const reducer = (state: State, action: Action): State => {
       }
     }
 
+    case 'openRegionSlider': {
+      return {
+        ...state,
+        regionSlider: {
+          type: action.payload,
+        },
+      }
+    }
+    case 'closeRegionSlider':
+      return {
+        ...state,
+        regionSlider: {
+          type: 'none',
+        },
+      }
+
     default:
       throw new Error(`Action ${type} not implemented`)
   }
@@ -141,6 +172,9 @@ const initializer = (): State => ({
   popover: {
     isOpen: false,
     triggerRef: undefined,
+  },
+  regionSlider: {
+    type: 'none',
   },
 })
 
@@ -157,6 +191,8 @@ interface Context extends State {
   popToast: () => void
   openPopover: (popover: Popover) => void
   closePopover: () => void
+  openRegionSlider: (type: RegionSliderType) => void
+  closeRegionSlider: () => void
 }
 
 const UIContext = createContext<Context | undefined>(undefined)
@@ -180,6 +216,9 @@ function UIProvider({ children }: PropsWithChildren<unknown>) {
       openPopover: (popover: Popover) =>
         dispatch({ type: 'openPopover', payload: popover }),
       closePopover: () => dispatch({ type: 'closePopover' }),
+      openRegionSlider: (type: RegionSliderType) =>
+        dispatch({ type: 'openRegionSlider', payload: type }),
+      closeRegionSlider: () => dispatch({ type: 'closeRegionSlider' }),
     }),
     []
   )

--- a/packages/components/src/hooks/index.ts
+++ b/packages/components/src/hooks/index.ts
@@ -1,15 +1,20 @@
-export { default as UIProvider, Toast as ToastProps, useUI } from './UIProvider'
+export {
+  regionSliderTypes,
+  Toast as ToastProps,
+  default as UIProvider,
+  useUI,
+} from './UIProvider'
 export { useFadeEffect } from './useFadeEffect'
 export { useOnClickOutside } from './useOnClickOutside'
+export { useScrollDirection } from './useScrollDirection'
 export { useSearch } from './useSearch'
 export { useSKUMatrix } from './useSKUMatrix'
-export { useScrollDirection } from './useScrollDirection'
 export { useSlider } from './useSlider'
 export type {
-  UseSliderArgs,
-  SliderState,
-  SliderDispatch,
   SlideDirection,
+  SliderDispatch,
+  SliderState,
+  UseSliderArgs,
 } from './useSlider'
 export { useSlideVisibility } from './useSlideVisibility'
 export { useTrapFocus } from './useTrapFocus'

--- a/packages/components/src/organisms/Filter/FilterSlider.tsx
+++ b/packages/components/src/organisms/Filter/FilterSlider.tsx
@@ -42,6 +42,11 @@ export interface FilterSliderProps extends HTMLAttributes<HTMLDivElement> {
    * Function called when Close Button is clicked.
    */
   onClose: () => void
+  /**
+   * Display FilterSlider footer with buttons.
+   * @default true
+   */
+  footer?: boolean
 }
 
 function FilterSlider({
@@ -53,10 +58,11 @@ function FilterSlider({
   clearBtnProps,
   overlayProps,
   onClose,
+  footer = true,
   ...otherProps
 }: PropsWithChildren<FilterSliderProps>) {
   const { fade, fadeOut } = useFadeEffect()
-  const { closeFilter } = useUI()
+  const { closeFilter, closeRegionSlider } = useUI()
 
   return (
     <SlideOver
@@ -66,7 +72,12 @@ function FilterSlider({
       onDismiss={fadeOut}
       size={size}
       direction={direction}
-      onTransitionEnd={() => fade === 'out' && closeFilter()}
+      onTransitionEnd={() => {
+        if (fade === 'out') {
+          closeFilter()
+          closeRegionSlider()
+        }
+      }}
       overlayProps={overlayProps}
       {...otherProps}
     >
@@ -81,18 +92,23 @@ function FilterSlider({
         </SlideOverHeader>
         {children}
       </div>
-      <footer data-fs-filter-slider-footer>
-        <Button data-fs-filter-slider-footer-button-clear {...clearBtnProps} />
-        <Button
-          data-fs-filter-slider-footer-button-apply
-          data-testid="filter-slider-button-apply"
-          {...applyBtnProps}
-          onClick={(e) => {
-            applyBtnProps?.onClick?.(e)
-            fadeOut()
-          }}
-        />
-      </footer>
+      {footer && (
+        <footer data-fs-filter-slider-footer>
+          <Button
+            data-fs-filter-slider-footer-button-clear
+            {...clearBtnProps}
+          />
+          <Button
+            data-fs-filter-slider-footer-button-apply
+            data-testid="filter-slider-button-apply"
+            {...applyBtnProps}
+            onClick={(e) => {
+              applyBtnProps?.onClick?.(e)
+              fadeOut()
+            }}
+          />
+        </footer>
+      )}
     </SlideOver>
   )
 }

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -110,8 +110,8 @@
                         }
                       }
                     },
-                    "deliveryCustomLabels": {
-                      "title": "Filter options labels",
+                    "deliveryMethods": {
+                      "title": "Delivery methods filter",
                       "type": "object",
                       "properties": {
                         "delivery": {
@@ -130,9 +130,21 @@
                           "default": "Pickup Nearby"
                         },
                         "pickupAll": {
-                          "title": "Pickup Anywhere label",
-                          "type": "string",
-                          "default": "Pickup Anywhere"
+                          "title": "Pickup All",
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "title": "Display pickup all filter",
+                              "description": "Display the pickup all filter in the PLP/Search page. This is recommended only for B2B stores.",
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "label": {
+                              "title": "Label",
+                              "type": "string",
+                              "default": "Pickup Anywhere"
+                            },
+                          }
                         }
                       }
                     }

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -94,6 +94,22 @@
                       "type": "string",
                       "default": "Set Location"
                     },
+                    "postalCodeEditSlider": {
+                      "title": "Postal Code Edit SlideOver",
+                      "type": "object",
+                      "properties": {
+                        "chooseDeliveryMethod": {
+                          "title": "Choose delivery method label",
+                          "type": "string",
+                          "default": "Choose a delivery method"
+                        },
+                        "changeLocation": {
+                          "title": "Change Postal Code",
+                          "type": "string",
+                          "default": "Change location"
+                        }
+                      }
+                    },
                     "deliveryCustomLabels": {
                       "title": "Filter options labels",
                       "type": "object",

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -87,7 +87,7 @@
                     "description": {
                       "title": "Description",
                       "type": "string",
-                      "default": "Offers and availability vary by location"
+                      "default": "Offers and availability vary by location."
                     },
                     "setLocationButtonLabel": {
                       "title": "Call to Action label",

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -143,7 +143,7 @@
                               "title": "Label",
                               "type": "string",
                               "default": "Pickup Anywhere"
-                            },
+                            }
                           }
                         }
                       }

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -87,7 +87,7 @@
                     "description": {
                       "title": "Description",
                       "type": "string",
-                      "default": "Offers and delivery options vary based on region."
+                      "default": "Offers and availability vary by location"
                     },
                     "setLocationButtonLabel": {
                       "title": "Call to Action label",
@@ -98,15 +98,15 @@
                       "title": "Postal Code Edit SlideOver",
                       "type": "object",
                       "properties": {
-                        "chooseDeliveryMethod": {
-                          "title": "Choose delivery method label",
+                        "setLocation": {
+                          "title": "Set Location label",
                           "type": "string",
-                          "default": "Choose a delivery method"
+                          "default": "Set Location"
                         },
                         "changeLocation": {
                           "title": "Change Postal Code",
                           "type": "string",
-                          "default": "Change location"
+                          "default": "Change Location"
                         }
                       }
                     },

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1913,53 +1913,6 @@
                   "default": "Apply"
                 }
               }
-            },
-            "deliverySettings": {
-              "title": "Delivery Settings",
-              "type": "object",
-              "properties": {
-                "title": {
-                  "title": "Delivery section title",
-                  "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                  "type": "string"
-                },
-                "description": {
-                  "title": "Delivery section description",
-                  "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                  "type": "string"
-                },
-                "setLocationButtonLabel": {
-                  "title": "Call to Action label",
-                  "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                  "type": "string"
-                },
-                "deliveryCustomLabels": {
-                  "title": "Delivery Custom labels",
-                  "type": "object",
-                  "properties": {
-                    "delivery": {
-                      "title": "Shipping label",
-                      "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                      "type": "string"
-                    },
-                    "pickupInPoint": {
-                      "title": "Pickup in point label",
-                      "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                      "type": "string"
-                    },
-                    "pickupNearby": {
-                      "title": "Pickup Nearby label",
-                      "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                      "type": "string"
-                    },
-                    "pickupAll": {
-                      "title": "Pickup Anywhere label",
-                      "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                      "type": "string"
-                    }
-                  }
-                }
-              }
             }
           }
         },

--- a/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
+++ b/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
@@ -99,32 +99,34 @@ function RegionSlider({ cmsData }: RegionSliderProps) {
       onClose={() => {}}
       footer={false}
     >
-      <span data-fs-filter-region-slider-description>
-        {cmsData?.deliverySettings?.description}
-      </span>
-      <UIInputField
-        id="region-slider-input-field"
-        inputRef={inputRef}
-        label={inputField?.label}
-        actionable
-        value={input}
-        buttonActionText={loading ? '...' : inputField?.buttonActionText}
-        onInput={(e) => {
-          regionError !== '' && setRegionError('')
-          setInput(e.currentTarget.value)
-        }}
-        onSubmit={() => {
-          handleSubmit()
-        }}
-        onClear={() => {
-          setInput('')
-          setRegionError('')
-        }}
-        error={regionError}
-      />
-      {idkPostalCodeLink?.to && (
-        <UILink data-fs-filter-delivery-link {...idkPostalCodeLinkProps} />
-      )}
+      <div data-fs-filter-region-slider-content>
+        <span data-fs-filter-region-slider-description>
+          {cmsData?.deliverySettings?.description}
+        </span>
+        <UIInputField
+          id="region-slider-input-field"
+          inputRef={inputRef}
+          label={inputField?.label}
+          actionable
+          value={input}
+          buttonActionText={loading ? '...' : inputField?.buttonActionText}
+          onInput={(e) => {
+            regionError !== '' && setRegionError('')
+            setInput(e.currentTarget.value)
+          }}
+          onSubmit={() => {
+            handleSubmit()
+          }}
+          onClear={() => {
+            setInput('')
+            setRegionError('')
+          }}
+          error={regionError}
+        />
+        {idkPostalCodeLink?.to && (
+          <UILink data-fs-filter-delivery-link {...idkPostalCodeLinkProps} />
+        )}
+      </div>
     </UIFilterSlider>
   )
 }

--- a/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
+++ b/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
@@ -1,0 +1,136 @@
+import {
+  useUI,
+  type FilterSliderProps as UIFilterSliderProps,
+  type IconProps as UIIconProps,
+  type InputFieldProps as UIInputFieldProps,
+} from '@faststore/ui'
+import dynamic from 'next/dynamic'
+import { useRef, useState } from 'react'
+import useRegion from 'src/components/region/RegionModal/useRegion'
+import { useSession } from 'src/sdk/session'
+import type { RegionalizationCmsData } from 'src/utils/globalSettings'
+import styles from './section.module.scss'
+
+const UIFilterSlider = dynamic<UIFilterSliderProps>(
+  () =>
+    /* webpackChunkName: "UIFilterSlider" */
+    import('@faststore/ui').then((mod) => mod.FilterSlider),
+  { ssr: false }
+)
+const UIInputField = dynamic<UIInputFieldProps>(() =>
+  /* webpackChunkName: "UIInputField" */
+  import('@faststore/ui').then((mod) => mod.InputField)
+)
+const UIIcon = dynamic<UIIconProps>(() =>
+  /* webpackChunkName: "UIIcon" */
+  import('@faststore/ui').then((mod) => mod.Icon)
+)
+const UILink = dynamic(() =>
+  /* webpackChunkName: "UILink" */
+  import('@faststore/ui').then((mod) => mod.Link)
+)
+
+type RegionSliderProps = {
+  cmsData: RegionalizationCmsData
+}
+
+function RegionSlider({ cmsData }: RegionSliderProps) {
+  const {
+    regionSlider: { type: regionSliderType },
+    closeRegionSlider,
+  } = useUI()
+  const { isValidating, ...session } = useSession()
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const inputField = cmsData?.inputField
+
+  const idkPostalCodeLink = cmsData?.idkPostalCodeLink
+
+  const [input, setInput] = useState<string>('')
+
+  const { loading, setRegion, regionError, setRegionError } = useRegion()
+
+  const handleSubmit = async () => {
+    if (isValidating) {
+      return
+    }
+
+    await setRegion({
+      session,
+      onSuccess: () => {
+        setInput('')
+        closeRegionSlider()
+      },
+      postalCode: input,
+      errorMessage: inputField?.errorMessage,
+      noProductsAvailableErrorMessage:
+        inputField?.noProductsAvailableErrorMessage,
+    })
+  }
+
+  const idkPostalCodeLinkProps = {
+    href: idkPostalCodeLink?.to,
+    children: (
+      <>
+        {idkPostalCodeLink?.text}
+        {!!idkPostalCodeLink?.icon?.icon && (
+          <UIIcon
+            name={idkPostalCodeLink?.icon?.icon}
+            aria-label={idkPostalCodeLink?.icon?.alt}
+            width={20}
+            height={20}
+          />
+        )}
+      </>
+    ),
+  }
+
+  return (
+    <UIFilterSlider
+      data-fs-filter-region-slider
+      overlayProps={{
+        className: `section ${styles.section} section-filter-slider`,
+      }}
+      title={
+        cmsData?.deliverySettings?.postalCodeEditSlider?.[
+          regionSliderType === 'setLocation'
+            ? 'chooseDeliveryMethod'
+            : 'changeLocation'
+        ]
+      }
+      size="partial"
+      direction="rightSide"
+      onClose={() => {}}
+      footer={false}
+    >
+      <span data-fs-filter-region-slider-description>
+        {cmsData?.deliverySettings?.description}
+      </span>
+      <UIInputField
+        id={'region-slideover-input-field'}
+        inputRef={inputRef}
+        label={inputField?.label}
+        actionable
+        value={input}
+        buttonActionText={loading ? '...' : inputField?.buttonActionText}
+        onInput={(e) => {
+          regionError !== '' && setRegionError('')
+          setInput(e.currentTarget.value)
+        }}
+        onSubmit={() => {
+          handleSubmit()
+        }}
+        onClear={() => {
+          setInput('')
+          setRegionError('')
+        }}
+        error={regionError}
+      />
+      {idkPostalCodeLink?.to && (
+        <UILink data-fs-filter-delivery-link {...idkPostalCodeLinkProps} />
+      )}
+    </UIFilterSlider>
+  )
+}
+
+export default RegionSlider

--- a/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
+++ b/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
@@ -1,5 +1,4 @@
 import {
-  regionSliderTypes,
   useUI,
   type FilterSliderProps as UIFilterSliderProps,
   type IconProps as UIIconProps,
@@ -91,11 +90,9 @@ function RegionSlider({ cmsData }: RegionSliderProps) {
         className: `section ${styles.section} section-filter-slider`,
       }}
       title={
-        cmsData?.deliverySettings?.postalCodeEditSlider?.[
-          regionSliderType === regionSliderTypes.setLocation
-            ? 'chooseDeliveryMethod'
-            : 'changeLocation'
-        ]
+        regionSliderType !== 'none'
+          ? cmsData?.deliverySettings?.postalCodeEditSlider?.[regionSliderType]
+          : ''
       }
       size="partial"
       direction="rightSide"

--- a/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
+++ b/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
@@ -1,4 +1,5 @@
 import {
+  regionSliderTypes,
   useUI,
   type FilterSliderProps as UIFilterSliderProps,
   type IconProps as UIIconProps,
@@ -39,16 +40,14 @@ function RegionSlider({ cmsData }: RegionSliderProps) {
     regionSlider: { type: regionSliderType },
     closeRegionSlider,
   } = useUI()
-  const { isValidating, ...session } = useSession()
   const inputRef = useRef<HTMLInputElement>(null)
-
-  const inputField = cmsData?.inputField
-
-  const idkPostalCodeLink = cmsData?.idkPostalCodeLink
+  const { isValidating, ...session } = useSession()
+  const { loading, setRegion, regionError, setRegionError } = useRegion()
 
   const [input, setInput] = useState<string>('')
 
-  const { loading, setRegion, regionError, setRegionError } = useRegion()
+  const inputField = cmsData?.inputField
+  const idkPostalCodeLink = cmsData?.idkPostalCodeLink
 
   const handleSubmit = async () => {
     if (isValidating) {
@@ -93,7 +92,7 @@ function RegionSlider({ cmsData }: RegionSliderProps) {
       }}
       title={
         cmsData?.deliverySettings?.postalCodeEditSlider?.[
-          regionSliderType === 'setLocation'
+          regionSliderType === regionSliderTypes.setLocation
             ? 'chooseDeliveryMethod'
             : 'changeLocation'
         ]
@@ -107,7 +106,7 @@ function RegionSlider({ cmsData }: RegionSliderProps) {
         {cmsData?.deliverySettings?.description}
       </span>
       <UIInputField
-        id={'region-slideover-input-field'}
+        id="region-slider-input-field"
         inputRef={inputRef}
         label={inputField?.label}
         actionable

--- a/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
+++ b/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
@@ -5,7 +5,7 @@ import {
   type InputFieldProps as UIInputFieldProps,
 } from '@faststore/ui'
 import dynamic from 'next/dynamic'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import useRegion from 'src/components/region/RegionModal/useRegion'
 import { useSession } from 'src/sdk/session'
 import type { RegionalizationCmsData } from 'src/utils/globalSettings'
@@ -82,6 +82,10 @@ function RegionSlider({ cmsData }: RegionSliderProps) {
       </>
     ),
   }
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
 
   return (
     <UIFilterSlider

--- a/packages/core/src/components/region/RegionSlider/index.ts
+++ b/packages/core/src/components/region/RegionSlider/index.ts
@@ -1,0 +1,1 @@
+export { default as RegionSlider } from './RegionSlider'

--- a/packages/core/src/components/region/RegionSlider/section.module.scss
+++ b/packages/core/src/components/region/RegionSlider/section.module.scss
@@ -1,0 +1,40 @@
+.section {
+  @import "@faststore/ui/src/components/atoms/Button/styles.scss";
+  @import "@faststore/ui/src/components/atoms/Icon/styles.scss";
+  @import "@faststore/ui/src/components/atoms/Input/styles.scss";
+  @import "@faststore/ui/src/components/atoms/Link/styles.scss";
+  @import "@faststore/ui/src/components/molecules/InputField/styles.scss";
+  @import "@faststore/ui/src/components/molecules/Modal/styles.scss";
+  @import "@faststore/ui/src/components/organisms/FilterSlider/styles.scss";
+  @import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
+
+  [data-fs-filter-region-slider] [data-fs-filter-slider-content] {
+    @include media(">=notebook") {
+      padding-right: var(--fs-spacing-6);
+      padding-left: var(--fs-spacing-6);
+    }
+
+    [data-fs-slide-over-header] {
+      padding: 0;
+    }
+  }
+
+  [data-fs-filter-region-slider-description] {
+    display: flex;
+    padding: var(--fs-spacing-2) 0;
+    font-size: var(--fs-text-size-2);
+    line-height: 1.25;
+  }
+
+  // Duplicate from data-fs-region-modal-link
+  [data-fs-filter-delivery-link] {
+    display: flex;
+    flex-direction: row;
+    column-gap: var(--fs-filter-link-column-gap);
+    align-content: flex-start;
+    align-items: center;
+    justify-content: flex-start;
+    padding: var(--fs-filter-link-padding);
+    color: var(--fs-filter-link-color);
+  }
+}

--- a/packages/core/src/components/region/RegionSlider/section.module.scss
+++ b/packages/core/src/components/region/RegionSlider/section.module.scss
@@ -8,33 +8,45 @@
   @import "@faststore/ui/src/components/organisms/FilterSlider/styles.scss";
   @import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
 
-  [data-fs-filter-region-slider] [data-fs-filter-slider-content] {
-    @include media(">=notebook") {
-      padding-right: var(--fs-spacing-6);
-      padding-left: var(--fs-spacing-6);
+  [data-fs-filter-region-slider] {
+    [data-fs-filter-slider-title] {
+      font-size: var(--fs-text-size-3);
+      font-weight: var(--fs-text-weight-semibold);
     }
 
     [data-fs-slide-over-header] {
-      padding: 0;
+      @include media(">=notebook") {
+        padding-right: var(--fs-spacing-6);
+        padding-left: var(--fs-spacing-6);
+      }
     }
-  }
 
-  [data-fs-filter-region-slider-description] {
-    display: flex;
-    padding: var(--fs-spacing-2) 0;
-    font-size: var(--fs-text-size-2);
-    line-height: 1.25;
-  }
+    [data-fs-filter-region-slider-content] {
+      padding: 0 var(--fs-spacing-3);
 
-  // Duplicate from data-fs-region-modal-link
-  [data-fs-filter-delivery-link] {
-    display: flex;
-    flex-direction: row;
-    column-gap: var(--fs-filter-link-column-gap);
-    align-content: flex-start;
-    align-items: center;
-    justify-content: flex-start;
-    padding: var(--fs-filter-link-padding);
-    color: var(--fs-filter-link-color);
+      @include media(">=notebook") {
+        padding: 0 var(--fs-spacing-6);
+      }
+    }
+
+    [data-fs-filter-region-slider-description] {
+      display: flex;
+      padding: var(--fs-spacing-4) 0;
+      font-size: var(--fs-text-size-2);
+      line-height: 1.25;
+    }
+
+    // Duplicate from data-fs-region-modal-link
+    [data-fs-filter-delivery-link] {
+      display: flex;
+      flex-direction: row;
+      column-gap: var(--fs-filter-link-column-gap);
+      align-content: flex-start;
+      align-items: center;
+      justify-content: flex-start;
+      padding: var(--fs-filter-link-padding);
+      margin-top: var(--fs-spacing-2);
+      color: var(--fs-filter-link-color);
+    }
   }
 }

--- a/packages/core/src/components/search/Filter/FilterDeliveryOption.tsx
+++ b/packages/core/src/components/search/Filter/FilterDeliveryOption.tsx
@@ -1,4 +1,5 @@
-import { Button as UIButton } from '@faststore/ui'
+import { Button as UIButton, useUI } from '@faststore/ui'
+import { RegionSlider } from 'src/components/region/RegionSlider'
 import { sessionStore } from 'src/sdk/session'
 import { textToTitleCase } from 'src/utils/utilities'
 
@@ -19,15 +20,21 @@ interface FacetValue {
 interface FilterDeliveryOptionProps {
   item: FacetValue
   deliveryCustomLabels: DeliveryCustomLabels
+  cmsData: Record<string, any>
 }
 
 export default function FilterDeliveryOption({
   item,
   deliveryCustomLabels,
+  cmsData,
 }: FilterDeliveryOptionProps) {
   const { city, postalCode } = sessionStore.read()
-  const location = city ? `${textToTitleCase(city)}, ${postalCode}` : postalCode
+  const {
+    regionSlider: { type: regionSliderType },
+    openRegionSlider,
+  } = useUI()
 
+  const location = city ? `${textToTitleCase(city)}, ${postalCode}` : postalCode
   const mapDeliveryCustomLabel: Record<string, string> = {
     delivery: deliveryCustomLabels?.delivery ?? 'Shipping to',
     'pickup-in-point': deliveryCustomLabels?.pickupInPoint ?? 'Pickup at',
@@ -35,6 +42,7 @@ export default function FilterDeliveryOption({
     'pickup-all': deliveryCustomLabels?.pickupAll ?? 'Pickup Anywhere',
   }
 
+  const changeLocation = 'changeLocation'
   if (item.value === 'delivery') {
     return (
       <>
@@ -43,12 +51,14 @@ export default function FilterDeliveryOption({
           data-fs-filter-list-item-button
           size="small"
           onClick={() => {
-            // TODO: open edit local slideOver
-            window.alert('Open Modal')
+            openRegionSlider(changeLocation)
           }}
         >
           {location}
         </UIButton>
+        {regionSliderType === changeLocation && (
+          <RegionSlider cmsData={cmsData} />
+        )}
       </>
     )
   }

--- a/packages/core/src/components/search/Filter/FilterDeliveryOption.tsx
+++ b/packages/core/src/components/search/Filter/FilterDeliveryOption.tsx
@@ -1,4 +1,4 @@
-import { Button as UIButton, useUI } from '@faststore/ui'
+import { Button as UIButton, useUI, regionSliderTypes } from '@faststore/ui'
 import { RegionSlider } from 'src/components/region/RegionSlider'
 import { sessionStore } from 'src/sdk/session'
 import { textToTitleCase } from 'src/utils/utilities'
@@ -42,7 +42,6 @@ export default function FilterDeliveryOption({
     'pickup-all': deliveryCustomLabels?.pickupAll ?? 'Pickup Anywhere',
   }
 
-  const changeLocation = 'changeLocation'
   if (item.value === 'delivery') {
     return (
       <>
@@ -51,12 +50,12 @@ export default function FilterDeliveryOption({
           data-fs-filter-list-item-button
           size="small"
           onClick={() => {
-            openRegionSlider(changeLocation)
+            openRegionSlider(regionSliderTypes.changeLocation)
           }}
         >
           {location}
         </UIButton>
-        {regionSliderType === changeLocation && (
+        {regionSliderType === regionSliderTypes.changeLocation && (
           <RegionSlider cmsData={cmsData} />
         )}
       </>

--- a/packages/core/src/components/search/Filter/FilterDeliveryOption.tsx
+++ b/packages/core/src/components/search/Filter/FilterDeliveryOption.tsx
@@ -1,14 +1,8 @@
-import { Button as UIButton, useUI, regionSliderTypes } from '@faststore/ui'
+import { regionSliderTypes, Button as UIButton, useUI } from '@faststore/ui'
 import { RegionSlider } from 'src/components/region/RegionSlider'
 import { sessionStore } from 'src/sdk/session'
+import type { RegionalizationCmsData } from 'src/utils/globalSettings'
 import { textToTitleCase } from 'src/utils/utilities'
-
-interface DeliveryCustomLabels {
-  delivery?: string
-  pickupInPoint?: string
-  pickupNearby?: string
-  pickupAll?: string
-}
 
 interface FacetValue {
   value: string
@@ -19,13 +13,13 @@ interface FacetValue {
 
 interface FilterDeliveryOptionProps {
   item: FacetValue
-  deliveryCustomLabels: DeliveryCustomLabels
+  deliveryMethods: RegionalizationCmsData['deliverySettings']['deliveryMethods']
   cmsData: Record<string, any>
 }
 
 export default function FilterDeliveryOption({
   item,
-  deliveryCustomLabels,
+  deliveryMethods,
   cmsData,
 }: FilterDeliveryOptionProps) {
   const { city, postalCode } = sessionStore.read()
@@ -35,17 +29,17 @@ export default function FilterDeliveryOption({
   } = useUI()
 
   const location = city ? `${textToTitleCase(city)}, ${postalCode}` : postalCode
-  const mapDeliveryCustomLabel: Record<string, string> = {
-    delivery: deliveryCustomLabels?.delivery ?? 'Shipping to',
-    'pickup-in-point': deliveryCustomLabels?.pickupInPoint ?? 'Pickup at',
-    'pickup-nearby': deliveryCustomLabels?.pickupNearby ?? 'Pickup Nearby',
-    'pickup-all': deliveryCustomLabels?.pickupAll ?? 'Pickup Anywhere',
+  const mapDeliveryMethodLabel: Record<string, string> = {
+    delivery: deliveryMethods?.delivery ?? 'Shipping to',
+    'pickup-in-point': deliveryMethods?.pickupInPoint ?? 'Pickup at',
+    'pickup-nearby': deliveryMethods?.pickupNearby ?? 'Pickup Nearby',
+    'pickup-all': deliveryMethods?.pickupAll?.label ?? 'Pickup Anywhere',
   }
 
   if (item.value === 'delivery') {
     return (
       <>
-        {mapDeliveryCustomLabel[item.value]}
+        {mapDeliveryMethodLabel[item.value]}
         <UIButton
           data-fs-filter-list-item-button
           size="small"
@@ -65,7 +59,7 @@ export default function FilterDeliveryOption({
   if (item.value === 'pickup-in-point') {
     return (
       <>
-        {mapDeliveryCustomLabel[item.value]}
+        {mapDeliveryMethodLabel[item.value]}
         <UIButton
           data-fs-filter-list-item-button
           size="small"
@@ -80,5 +74,5 @@ export default function FilterDeliveryOption({
     )
   }
 
-  return <>{mapDeliveryCustomLabel[item.value]}</>
+  return <>{mapDeliveryMethodLabel[item.value]}</>
 }

--- a/packages/core/src/components/search/Filter/FilterDesktop.tsx
+++ b/packages/core/src/components/search/Filter/FilterDesktop.tsx
@@ -1,6 +1,7 @@
 import { setFacet, toggleFacet, useSearch } from '@faststore/sdk'
 
 import {
+  regionSliderTypes,
   Button as UIButton,
   Filter as UIFilter,
   FilterFacetBoolean as UIFilterFacetBoolean,
@@ -51,8 +52,6 @@ function FilterDesktop({
     ? facets
     : facets.filter((facet) => facet.key !== 'shipping')
 
-  const setLocation = 'setLocation'
-
   return (
     <UIFilter
       testId={`desktop-${testId}`}
@@ -75,7 +74,7 @@ function FilterDesktop({
             data-fs-filter-list-delivery-button
             variant="secondary"
             onClick={() => {
-              openRegionSlider(setLocation)
+              openRegionSlider(regionSliderTypes.setLocation)
             }}
             icon={<UIIcon name="MapPin" />}
           >
@@ -83,7 +82,7 @@ function FilterDesktop({
           </UIButton>
         </UIFilterFacets>
       )}
-      {regionSliderType === setLocation && (
+      {regionSliderType === regionSliderTypes.setLocation && (
         <RegionSlider cmsData={regionalizationData} />
       )}
       {filteredFacets.map((facet, idx) => {

--- a/packages/core/src/components/search/Filter/FilterDesktop.tsx
+++ b/packages/core/src/components/search/Filter/FilterDesktop.tsx
@@ -52,6 +52,9 @@ function FilterDesktop({
     ? facets
     : facets.filter((facet) => facet.key !== 'shipping')
 
+  const isPickupAllEnabled =
+    deliverySettingsData?.deliveryMethods?.pickupAll?.enabled ?? false
+
   return (
     <UIFilter
       testId={`desktop-${testId}`}
@@ -104,43 +107,46 @@ function FilterDesktop({
           >
             {type === 'StoreFacetBoolean' && isExpanded && (
               <UIFilterFacetBoolean>
-                {facet.values.map((item) => (
-                  <UIFilterFacetBooleanItem
-                    key={`${testId}-${facet.label}-${item.label}`}
-                    id={`${testId}-${facet.label}-${item.label}`}
-                    testId={testId}
-                    onFacetChange={(facet) => {
-                      setState({
-                        ...state,
-                        selectedFacets: toggleFacet(
-                          state.selectedFacets,
-                          facet,
-                          true
-                        ),
-                        page: 0,
-                      })
-                      resetInfiniteScroll(0)
-                    }}
-                    selected={item.selected}
-                    value={item.value}
-                    quantity={item.quantity}
-                    facetKey={facet.key}
-                    label={
-                      isDeliveryFacet ? (
-                        <FilterDeliveryOption
-                          item={item}
-                          deliveryCustomLabels={
-                            deliverySettingsData.deliveryCustomLabels
-                          }
-                          cmsData={regionalizationData}
-                        />
-                      ) : (
-                        item.label
-                      )
-                    }
-                    type={isDeliveryFacet ? 'radio' : 'checkbox'}
-                  />
-                ))}
+                {facet.values.map(
+                  (item) =>
+                    (item.value !== 'pickup-all' || isPickupAllEnabled) && (
+                      <UIFilterFacetBooleanItem
+                        key={`${testId}-${facet.label}-${item.label}`}
+                        id={`${testId}-${facet.label}-${item.label}`}
+                        testId={testId}
+                        onFacetChange={(facet) => {
+                          setState({
+                            ...state,
+                            selectedFacets: toggleFacet(
+                              state.selectedFacets,
+                              facet,
+                              true
+                            ),
+                            page: 0,
+                          })
+                          resetInfiniteScroll(0)
+                        }}
+                        selected={item.selected}
+                        value={item.value}
+                        quantity={item.quantity}
+                        facetKey={facet.key}
+                        label={
+                          isDeliveryFacet ? (
+                            <FilterDeliveryOption
+                              item={item}
+                              deliveryMethods={
+                                deliverySettingsData.deliveryMethods
+                              }
+                              cmsData={regionalizationData}
+                            />
+                          ) : (
+                            item.label
+                          )
+                        }
+                        type={isDeliveryFacet ? 'radio' : 'checkbox'}
+                      />
+                    )
+                )}
               </UIFilterFacetBoolean>
             )}
             {type === 'StoreFacetRange' && isExpanded && (

--- a/packages/core/src/components/search/Filter/FilterDesktop.tsx
+++ b/packages/core/src/components/search/Filter/FilterDesktop.tsx
@@ -8,6 +8,7 @@ import {
   FilterFacetRange as UIFilterFacetRange,
   FilterFacets as UIFilterFacets,
   Icon as UIIcon,
+  useUI,
 } from '@faststore/ui'
 import { gql } from '@generated/gql'
 import { deliveryPromise } from 'discovery.config'
@@ -17,6 +18,7 @@ import type { FilterSliderProps } from './FilterSlider'
 
 import { sessionStore } from 'src/sdk/session'
 import { getRegionalizationSettings } from 'src/utils/globalSettings'
+import RegionSlider from '../../region/RegionSlider/RegionSlider'
 import FilterDeliveryOption from './FilterDeliveryOption'
 
 interface FilterDesktopProps
@@ -34,9 +36,13 @@ function FilterDesktop({
   deliverySettings,
 }: FilterDesktopProps & ReturnType<typeof useFilter>) {
   const { resetInfiniteScroll, state, setState } = useSearch()
+  const {
+    regionSlider: { type: regionSliderType },
+    openRegionSlider,
+  } = useUI()
 
-  const { deliverySettings: deliverySettingsData } =
-    getRegionalizationSettings(deliverySettings)
+  const regionalizationData = getRegionalizationSettings(deliverySettings)
+  const { deliverySettings: deliverySettingsData } = regionalizationData
   const deliveryLabel = deliverySettingsData?.title ?? 'Delivery'
 
   const { postalCode } = sessionStore.read()
@@ -44,6 +50,8 @@ function FilterDesktop({
   const filteredFacets = deliveryPromise.enabled
     ? facets
     : facets.filter((facet) => facet.key !== 'shipping')
+
+  const setLocation = 'setLocation'
 
   return (
     <UIFilter
@@ -67,13 +75,16 @@ function FilterDesktop({
             data-fs-filter-list-delivery-button
             variant="secondary"
             onClick={() => {
-              // TODO: open edit local slideOver
+              openRegionSlider(setLocation)
             }}
             icon={<UIIcon name="MapPin" />}
           >
             {deliverySettingsData?.setLocationButtonLabel ?? 'Set Location'}
           </UIButton>
         </UIFilterFacets>
+      )}
+      {regionSliderType === setLocation && (
+        <RegionSlider cmsData={regionalizationData} />
       )}
       {filteredFacets.map((facet, idx) => {
         const index = shouldDisplayDeliveryButton ? idx + 1 : idx
@@ -122,6 +133,7 @@ function FilterDesktop({
                           deliveryCustomLabels={
                             deliverySettingsData.deliveryCustomLabels
                           }
+                          cmsData={regionalizationData}
                         />
                       ) : (
                         item.label

--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -119,6 +119,9 @@ function FilterSlider({
     ? facets
     : facets.filter((facet) => facet.key !== 'shipping')
 
+  const isPickupAllEnabled =
+    deliverySettingsData?.deliveryMethods?.pickupAll?.enabled ?? false
+
   return (
     <UIFilterSlider
       overlayProps={{
@@ -202,34 +205,37 @@ function FilterSlider({
             >
               {type === 'StoreFacetBoolean' && isExpanded && (
                 <UIFilterFacetBoolean>
-                  {facet.values.map((item) => (
-                    <UIFilterFacetBooleanItem
-                      key={`${testId}-${facet.label}-${item.label}`}
-                      id={`${testId}-${facet.label}-${item.label}`}
-                      testId={`mobile-${testId}`}
-                      onFacetChange={(facet) =>
-                        dispatch({ type: 'toggleFacet', payload: facet })
-                      }
-                      selected={item.selected}
-                      value={item.value}
-                      quantity={item.quantity}
-                      facetKey={facet.key}
-                      label={
-                        isDeliveryFacet ? (
-                          <FilterDeliveryOption
-                            item={item}
-                            deliveryCustomLabels={
-                              deliverySettings?.deliveryCustomLabels
-                            }
-                            cmsData={regionalizationData}
-                          />
-                        ) : (
-                          item.label
-                        )
-                      }
-                      type={isDeliveryFacet ? 'radio' : 'checkbox'}
-                    />
-                  ))}
+                  {facet.values.map(
+                    (item) =>
+                      (item.value !== 'pickup-all' || isPickupAllEnabled) && (
+                        <UIFilterFacetBooleanItem
+                          key={`${testId}-${facet.label}-${item.label}`}
+                          id={`${testId}-${facet.label}-${item.label}`}
+                          testId={`mobile-${testId}`}
+                          onFacetChange={(facet) =>
+                            dispatch({ type: 'toggleFacet', payload: facet })
+                          }
+                          selected={item.selected}
+                          value={item.value}
+                          quantity={item.quantity}
+                          facetKey={facet.key}
+                          label={
+                            isDeliveryFacet ? (
+                              <FilterDeliveryOption
+                                item={item}
+                                deliveryMethods={
+                                  deliverySettings?.deliveryMethods
+                                }
+                                cmsData={regionalizationData}
+                              />
+                            ) : (
+                              item.label
+                            )
+                          }
+                          type={isDeliveryFacet ? 'radio' : 'checkbox'}
+                        />
+                      )
+                  )}
                 </UIFilterFacetBoolean>
               )}
               {type === 'StoreFacetRange' && isExpanded && (

--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -108,8 +108,8 @@ function FilterSlider({
     openRegionSlider,
   } = useUI()
 
-  const { reginalizationMergedData, deliverySettingsData } =
-    getRegionalizationSettings(deliverySettings)
+  const regionalizationData = getRegionalizationSettings(deliverySettings)
+  const { deliverySettings: deliverySettingsData } = regionalizationData
   const deliveryLabel = deliverySettingsData?.title ?? 'Delivery'
 
   const { postalCode } = sessionStore.read()
@@ -182,7 +182,7 @@ function FilterSlider({
           </UIFilterFacets>
         )}
         {regionSliderType === setLocation && (
-          <RegionSlider cmsData={reginalizationMergedData} />
+          <RegionSlider cmsData={regionalizationData} />
         )}
         {filteredFacets.map((facet, idx) => {
           const index = shouldDisplayDeliveryButton ? idx + 1 : idx
@@ -222,7 +222,7 @@ function FilterSlider({
                             deliveryCustomLabels={
                               deliverySettings?.deliveryCustomLabels
                             }
-                            cmsData={reginalizationMergedData}
+                            cmsData={regionalizationData}
                           />
                         ) : (
                           item.label

--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -2,6 +2,7 @@ import dynamic from 'next/dynamic'
 
 import { useSearch } from '@faststore/sdk'
 import {
+  regionSliderTypes,
   useUI,
   type ButtonProps as UIButtonProps,
   type FilterFacetBooleanItemProps as UIFilterFacetBooleanItemProps,
@@ -118,8 +119,6 @@ function FilterSlider({
     ? facets
     : facets.filter((facet) => facet.key !== 'shipping')
 
-  const setLocation = 'setLocation'
-
   return (
     <UIFilterSlider
       overlayProps={{
@@ -173,7 +172,7 @@ function FilterSlider({
               data-fs-filter-list-delivery-button
               variant="secondary"
               onClick={() => {
-                openRegionSlider(setLocation)
+                openRegionSlider(regionSliderTypes.setLocation)
               }}
               icon={<UIIcon name="MapPin" />}
             >
@@ -181,7 +180,7 @@ function FilterSlider({
             </UIButton>
           </UIFilterFacets>
         )}
-        {regionSliderType === setLocation && (
+        {regionSliderType === regionSliderTypes.setLocation && (
           <RegionSlider cmsData={regionalizationData} />
         )}
         {filteredFacets.map((facet, idx) => {

--- a/packages/core/src/utils/globalSettings.ts
+++ b/packages/core/src/utils/globalSettings.ts
@@ -28,11 +28,14 @@ export type RegionalizationCmsData = {
       setLocation?: string
       changeLocation?: string
     }
-    deliveryCustomLabels?: {
+    deliveryMethods?: {
       delivery?: string
       pickupInPoint?: string
       pickupNearby?: string
-      pickupAll?: string
+      pickupAll?: {
+        label?: string
+        enabled?: boolean
+      }
     }
   }
 }

--- a/packages/core/src/utils/globalSettings.ts
+++ b/packages/core/src/utils/globalSettings.ts
@@ -24,6 +24,10 @@ export type RegionalizationCmsData = {
     title?: string
     description?: string
     setLocationButtonLabel?: string
+    postalCodeEditSlider?: {
+      changeLocation?: string
+      chooseDeliveryMethod?: string
+    }
     deliveryCustomLabels?: {
       delivery?: string
       pickupInPoint?: string

--- a/packages/core/src/utils/globalSettings.ts
+++ b/packages/core/src/utils/globalSettings.ts
@@ -25,8 +25,8 @@ export type RegionalizationCmsData = {
     description?: string
     setLocationButtonLabel?: string
     postalCodeEditSlider?: {
+      setLocation?: string
       changeLocation?: string
-      chooseDeliveryMethod?: string
     }
     deliveryCustomLabels?: {
       delivery?: string

--- a/packages/ui/src/components/organisms/FilterSlider/styles.scss
+++ b/packages/ui/src/components/organisms/FilterSlider/styles.scss
@@ -8,8 +8,8 @@
   --fs-filter-slider-content-padding                  : var(--fs-spacing-3) var(--fs-spacing-3) calc(var(--fs-filter-slider-footer-height) + var(--fs-spacing-3));
 
   // Title
-  --fs-filter-slider-title-font-size                  : var(--fs-text-size-4);
-  --fs-filter-slider-title-font-weight                : var(--fs-text-weight-bold);
+  --fs-filter-slider-title-font-size                  : var(--fs-text-size-3);
+  --fs-filter-slider-title-font-weight                : var(--fs-text-weight-semibold);
   --fs-filter-slider-title-line-height                : 1.12;
 
   // Footer

--- a/packages/ui/src/components/organisms/FilterSlider/styles.scss
+++ b/packages/ui/src/components/organisms/FilterSlider/styles.scss
@@ -7,7 +7,7 @@
   --fs-filter-slider-content-height                   : calc(100vh - var(--fs-filter-slider-footer-height));
   --fs-filter-slider-content-padding                  : var(--fs-spacing-3) var(--fs-spacing-3) calc(var(--fs-filter-slider-footer-height) + var(--fs-spacing-3));
 
-  // Title 
+  // Title
   --fs-filter-slider-title-font-size                  : var(--fs-text-size-4);
   --fs-filter-slider-title-font-weight                : var(--fs-text-weight-bold);
   --fs-filter-slider-title-line-height                : 1.12;
@@ -24,6 +24,11 @@
   --fs-filter-slider-footer-button-clear-margin-right : var(--fs-spacing-3);
 
   --fs-filter-slider-footer-button-apply-width        : 60%;
+
+  // Link
+  --fs-filter-link-padding                            : 0;
+  --fs-filter-link-column-gap                         : var(--fs-spacing-0);
+  --fs-filter-link-color                              : var(--fs-color-link);
 
   [data-fs-filter-slider-content] {
     height: var(--fs-filter-slider-content-height);

--- a/packages/ui/src/components/organisms/FilterSlider/styles.scss
+++ b/packages/ui/src/components/organisms/FilterSlider/styles.scss
@@ -5,7 +5,7 @@
 
   // Content
   --fs-filter-slider-content-height                   : calc(100vh - var(--fs-filter-slider-footer-height));
-  --fs-filter-slider-content-padding                  : var(--fs-spacing-3) var(--fs-spacing-3) calc(var(--fs-filter-slider-footer-height) + var(--fs-spacing-3));
+  --fs-filter-slider-content-padding                  : 0 var(--fs-spacing-3);
 
   // Title
   --fs-filter-slider-title-font-size                  : var(--fs-text-size-3);
@@ -32,18 +32,33 @@
 
   [data-fs-filter-slider-content] {
     height: var(--fs-filter-slider-content-height);
-    padding: var(--fs-filter-slider-content-padding);
+    padding-bottom: calc(var(--fs-filter-slider-footer-height) + var(--fs-spacing-3));
     overflow-y: auto;
+
+    [data-fs-slide-over-header] {
+      position: relative;
+
+      &::after {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        display: block;
+        width: 100%;
+        height: 1px;
+        content: "";
+        background-color: var(--fs-border-color-light);
+      }
+    }
+  }
+
+  [data-fs-filter] {
+    padding: var(--fs-filter-slider-content-padding);
   }
 
   [data-fs-filter-slider-title] {
     font-size: var(--fs-filter-slider-title-font-size);
     font-weight: var(--fs-filter-slider-title-font-weight);
     line-height: var(--fs-filter-slider-title-line-height);
-  }
-
-  [data-fs-slide-over-header] {
-    padding: 0;
   }
 
   [data-fs-filter-slider-footer] {


### PR DESCRIPTION
## What's the purpose of this pull request?

Create the Region Slider component to be used for setting and changing the location (postal code).

## How it works?

It's triggered when the shopper clicks on the "Set location" button in the PLP filters and when they click on the postal code link in the PLP filters. The first one is the set location type of this Region Slider, and the second is the change location type.
I've added a new state in the UIProvider and functions to handle its change for the Region Slider.

## How to test it?

In the preview, test both the set and change location scenarios:
#### Set location
When no postal code is defined yet, the "Set location" button is displayed in the PLP filters.
When the shopper clicks this button, a slideover is displayed to set the postal code.
| Desktop | Mobile |
| ---- | ---- |
| <img width="1505" alt="Screenshot 2025-05-19 at 13 42 54" src="https://github.com/user-attachments/assets/06abcd1e-f963-4746-ad45-6003c675f49a" /> | <img width="218" alt="Screenshot 2025-05-19 at 13 47 14" src="https://github.com/user-attachments/assets/75db72a0-7f3b-45a1-ba6d-4c27617c5e55" /> |
| <img width="1507" alt="Screenshot 2025-05-19 at 13 44 04" src="https://github.com/user-attachments/assets/3cf4a05d-a58b-47dc-bf19-bac99a53be55" /> | <img width="216" alt="Screenshot 2025-05-19 at 13 47 50" src="https://github.com/user-attachments/assets/bd87d1ed-9fdd-40f7-b009-e6480d10c89d" /> |

#### Change location
When a postal code was previously set, this postal code is displayed as a link in the PLP filters.
When the shopper clicks this link, a slideover is displayed to change the postal code.
| Desktop | Mobile |
| ---- | ---- |
| <img width="1503" alt="Screenshot 2025-05-19 at 13 44 24" src="https://github.com/user-attachments/assets/f2f5cbe7-5c11-47b1-9769-f1223a1a3339" /> | <img width="216" alt="Screenshot 2025-05-19 at 13 48 14" src="https://github.com/user-attachments/assets/9b1b513f-e3be-4f81-8328-7728dec1e876" /> |
| <img width="1506" alt="Screenshot 2025-05-19 at 13 44 45" src="https://github.com/user-attachments/assets/06a8e8dc-d7b7-41d0-80f8-2462abd52058" /> | <img width="218" alt="Screenshot 2025-05-19 at 13 48 29" src="https://github.com/user-attachments/assets/62f1fc05-f24e-4fbb-83de-4c90d2342d63" /> |

### Starters Deploy Preview

[Preview](https://vendemo-cm9sir9v900u7z6llkl62l70j-k5r6r35q4.b.vtex.app/)
[PR](https://github.com/dp-faststore-org/vendemo-dp/pull/19)

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SFS-2449)