### PR TITLE
chore: Pickup All config

### DIFF
--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -140,7 +140,7 @@
                             },
                             "enabled": {
                               "title": "Display filter",
-                              "description": "Display the pickup all filter in the PLP/Search page",
+                              "description": "Display the pickup all filter in the PLP/Search page. This is recommended only for B2B stores.",
                               "type": "boolead",
                               "default": false
                             }

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -136,7 +136,7 @@
                             "label": {
                               "title": "Label",
                               "type": "string",
-                              "default": "Pickup All"
+                              "default": "Pickup Anywhere"
                             },
                             "enabled": {
                               "title": "Display filter",

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -110,8 +110,8 @@
                         }
                       }
                     },
-                    "deliveryCustomLabels": {
-                      "title": "Filter options labels",
+                    "deliveryMethods": {
+                      "title": "Delivery methods filter",
                       "type": "object",
                       "properties": {
                         "delivery": {
@@ -130,9 +130,21 @@
                           "default": "Pickup Nearby"
                         },
                         "pickupAll": {
-                          "title": "Pickup Anywhere label",
-                          "type": "string",
-                          "default": "Pickup Anywhere"
+                          "title": "Pickup All",
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "title": "Label",
+                              "type": "string",
+                              "default": "Pickup All"
+                            },
+                            "enabled": {
+                              "title": "Display filter",
+                              "description": "Display the pickup all filter in the PLP/Search page",
+                              "type": "boolead",
+                              "default": false
+                            }
+                          }
                         }
                       }
                     }

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -141,7 +141,7 @@
                             "enabled": {
                               "title": "Display filter",
                               "description": "Display the pickup all filter in the PLP/Search page. This is recommended only for B2B stores.",
-                              "type": "boolead",
+                              "type": "boolean",
                               "default": false
                             }
                           }

--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -133,17 +133,17 @@
                           "title": "Pickup All",
                           "type": "object",
                           "properties": {
+                            "enabled": {
+                              "title": "Display pickup all filter",
+                              "description": "Display the pickup all filter in the PLP/Search page. This is recommended only for B2B stores.",
+                              "type": "boolean",
+                              "default": false
+                            },
                             "label": {
                               "title": "Label",
                               "type": "string",
                               "default": "Pickup Anywhere"
                             },
-                            "enabled": {
-                              "title": "Display filter",
-                              "description": "Display the pickup all filter in the PLP/Search page. This is recommended only for B2B stores.",
-                              "type": "boolean",
-                              "default": false
-                            }
                           }
                         }
                       }

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1913,53 +1913,6 @@
                   "default": "Apply"
                 }
               }
-            },
-            "deliverySettings": {
-              "title": "Delivery Settings",
-              "type": "object",
-              "properties": {
-                "title": {
-                  "title": "Delivery section title",
-                  "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                  "type": "string"
-                },
-                "description": {
-                  "title": "Delivery section description",
-                  "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                  "type": "string"
-                },
-                "setLocationButtonLabel": {
-                  "title": "Call to Action label",
-                  "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                  "type": "string"
-                },
-                "deliveryCustomLabels": {
-                  "title": "Delivery Custom labels",
-                  "type": "object",
-                  "properties": {
-                    "delivery": {
-                      "title": "Shipping label",
-                      "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                      "type": "string"
-                    },
-                    "pickupInPoint": {
-                      "title": "Pickup in point label",
-                      "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                      "type": "string"
-                    },
-                    "pickupNearby": {
-                      "title": "Pickup Nearby label",
-                      "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                      "type": "string"
-                    },
-                    "pickupAll": {
-                      "title": "Pickup Anywhere label",
-                      "description": "[Deprecated] Use the fields from the Settings tab in Global Sections",
-                      "type": "string"
-                    }
-                  }
-                }
-              }
             }
           }
         },

--- a/packages/core/src/components/search/Filter/FilterDeliveryOption.tsx
+++ b/packages/core/src/components/search/Filter/FilterDeliveryOption.tsx
@@ -74,9 +74,5 @@ export default function FilterDeliveryOption({
     )
   }
 
-  if (item.value === 'pickup-all' && !deliveryMethods?.pickupAll?.enabled) {
-    return null
-  }
-
   return <>{mapDeliveryMethodLabel[item.value]}</>
 }

--- a/packages/core/src/components/search/Filter/FilterDeliveryOption.tsx
+++ b/packages/core/src/components/search/Filter/FilterDeliveryOption.tsx
@@ -1,14 +1,8 @@
-import { Button as UIButton, useUI, regionSliderTypes } from '@faststore/ui'
+import { regionSliderTypes, Button as UIButton, useUI } from '@faststore/ui'
 import { RegionSlider } from 'src/components/region/RegionSlider'
 import { sessionStore } from 'src/sdk/session'
+import type { RegionalizationCmsData } from 'src/utils/globalSettings'
 import { textToTitleCase } from 'src/utils/utilities'
-
-interface DeliveryCustomLabels {
-  delivery?: string
-  pickupInPoint?: string
-  pickupNearby?: string
-  pickupAll?: string
-}
 
 interface FacetValue {
   value: string
@@ -19,13 +13,13 @@ interface FacetValue {
 
 interface FilterDeliveryOptionProps {
   item: FacetValue
-  deliveryCustomLabels: DeliveryCustomLabels
+  deliveryMethods: RegionalizationCmsData['deliverySettings']['deliveryMethods']
   cmsData: Record<string, any>
 }
 
 export default function FilterDeliveryOption({
   item,
-  deliveryCustomLabels,
+  deliveryMethods,
   cmsData,
 }: FilterDeliveryOptionProps) {
   const { city, postalCode } = sessionStore.read()
@@ -35,17 +29,17 @@ export default function FilterDeliveryOption({
   } = useUI()
 
   const location = city ? `${textToTitleCase(city)}, ${postalCode}` : postalCode
-  const mapDeliveryCustomLabel: Record<string, string> = {
-    delivery: deliveryCustomLabels?.delivery ?? 'Shipping to',
-    'pickup-in-point': deliveryCustomLabels?.pickupInPoint ?? 'Pickup at',
-    'pickup-nearby': deliveryCustomLabels?.pickupNearby ?? 'Pickup Nearby',
-    'pickup-all': deliveryCustomLabels?.pickupAll ?? 'Pickup Anywhere',
+  const mapDeliveryMethodLabel: Record<string, string> = {
+    delivery: deliveryMethods?.delivery ?? 'Shipping to',
+    'pickup-in-point': deliveryMethods?.pickupInPoint ?? 'Pickup at',
+    'pickup-nearby': deliveryMethods?.pickupNearby ?? 'Pickup Nearby',
+    'pickup-all': deliveryMethods?.pickupAll?.label ?? 'Pickup Anywhere',
   }
 
   if (item.value === 'delivery') {
     return (
       <>
-        {mapDeliveryCustomLabel[item.value]}
+        {mapDeliveryMethodLabel[item.value]}
         <UIButton
           data-fs-filter-list-item-button
           size="small"
@@ -65,7 +59,7 @@ export default function FilterDeliveryOption({
   if (item.value === 'pickup-in-point') {
     return (
       <>
-        {mapDeliveryCustomLabel[item.value]}
+        {mapDeliveryMethodLabel[item.value]}
         <UIButton
           data-fs-filter-list-item-button
           size="small"
@@ -80,5 +74,9 @@ export default function FilterDeliveryOption({
     )
   }
 
-  return <>{mapDeliveryCustomLabel[item.value]}</>
+  if (item.value === 'pickup-all' && !deliveryMethods?.pickupAll?.enabled) {
+    return null
+  }
+
+  return <>{mapDeliveryMethodLabel[item.value]}</>
 }

--- a/packages/core/src/components/search/Filter/FilterDesktop.tsx
+++ b/packages/core/src/components/search/Filter/FilterDesktop.tsx
@@ -129,9 +129,7 @@ function FilterDesktop({
                       isDeliveryFacet ? (
                         <FilterDeliveryOption
                           item={item}
-                          deliveryCustomLabels={
-                            deliverySettingsData.deliveryCustomLabels
-                          }
+                          deliveryMethods={deliverySettingsData.deliveryMethods}
                           cmsData={regionalizationData}
                         />
                       ) : (

--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -218,9 +218,7 @@ function FilterSlider({
                         isDeliveryFacet ? (
                           <FilterDeliveryOption
                             item={item}
-                            deliveryCustomLabels={
-                              deliverySettings?.deliveryCustomLabels
-                            }
+                            deliveryMethods={deliverySettings?.deliveryMethods}
                             cmsData={regionalizationData}
                           />
                         ) : (

--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -62,7 +62,6 @@ import {
   getRegionalizationSettings,
   type RegionalizationCmsData,
 } from 'src/utils/globalSettings'
-import { filterFacets } from './FilterDesktop'
 import styles from './section.module.scss'
 
 export interface FilterSliderProps {
@@ -116,10 +115,12 @@ function FilterSlider({
 
   const { postalCode } = sessionStore.read()
   const shouldDisplayDeliveryButton = deliveryPromise.enabled && !postalCode
-  const filteredFacets = filterFacets(
-    facets,
+  const filteredFacets = deliveryPromise.enabled
+    ? facets
+    : facets.filter((facet) => facet.key !== 'shipping')
+
+  const isPickupAllEnabled =
     deliverySettingsData?.deliveryMethods?.pickupAll?.enabled ?? false
-  )
 
   return (
     <UIFilterSlider
@@ -204,32 +205,37 @@ function FilterSlider({
             >
               {type === 'StoreFacetBoolean' && isExpanded && (
                 <UIFilterFacetBoolean>
-                  {facet.values.map((item) => (
-                    <UIFilterFacetBooleanItem
-                      key={`${testId}-${facet.label}-${item.label}`}
-                      id={`${testId}-${facet.label}-${item.label}`}
-                      testId={`mobile-${testId}`}
-                      onFacetChange={(facet) =>
-                        dispatch({ type: 'toggleFacet', payload: facet })
-                      }
-                      selected={item.selected}
-                      value={item.value}
-                      quantity={item.quantity}
-                      facetKey={facet.key}
-                      label={
-                        isDeliveryFacet ? (
-                          <FilterDeliveryOption
-                            item={item}
-                            deliveryMethods={deliverySettings?.deliveryMethods}
-                            cmsData={regionalizationData}
-                          />
-                        ) : (
-                          item.label
-                        )
-                      }
-                      type={isDeliveryFacet ? 'radio' : 'checkbox'}
-                    />
-                  ))}
+                  {facet.values.map(
+                    (item) =>
+                      (item.value !== 'pickup-all' || isPickupAllEnabled) && (
+                        <UIFilterFacetBooleanItem
+                          key={`${testId}-${facet.label}-${item.label}`}
+                          id={`${testId}-${facet.label}-${item.label}`}
+                          testId={`mobile-${testId}`}
+                          onFacetChange={(facet) =>
+                            dispatch({ type: 'toggleFacet', payload: facet })
+                          }
+                          selected={item.selected}
+                          value={item.value}
+                          quantity={item.quantity}
+                          facetKey={facet.key}
+                          label={
+                            isDeliveryFacet ? (
+                              <FilterDeliveryOption
+                                item={item}
+                                deliveryMethods={
+                                  deliverySettings?.deliveryMethods
+                                }
+                                cmsData={regionalizationData}
+                              />
+                            ) : (
+                              item.label
+                            )
+                          }
+                          type={isDeliveryFacet ? 'radio' : 'checkbox'}
+                        />
+                      )
+                  )}
                 </UIFilterFacetBoolean>
               )}
               {type === 'StoreFacetRange' && isExpanded && (

--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -62,6 +62,7 @@ import {
   getRegionalizationSettings,
   type RegionalizationCmsData,
 } from 'src/utils/globalSettings'
+import { filterFacets } from './FilterDesktop'
 import styles from './section.module.scss'
 
 export interface FilterSliderProps {
@@ -115,9 +116,10 @@ function FilterSlider({
 
   const { postalCode } = sessionStore.read()
   const shouldDisplayDeliveryButton = deliveryPromise.enabled && !postalCode
-  const filteredFacets = deliveryPromise.enabled
-    ? facets
-    : facets.filter((facet) => facet.key !== 'shipping')
+  const filteredFacets = filterFacets(
+    facets,
+    deliverySettingsData?.deliveryMethods?.pickupAll?.enabled ?? false
+  )
 
   return (
     <UIFilterSlider

--- a/packages/core/src/utils/globalSettings.ts
+++ b/packages/core/src/utils/globalSettings.ts
@@ -28,11 +28,14 @@ export type RegionalizationCmsData = {
       setLocation?: string
       changeLocation?: string
     }
-    deliveryCustomLabels?: {
+    deliveryMethods?: {
       delivery?: string
       pickupInPoint?: string
       pickupNearby?: string
-      pickupAll?: string
+      pickupAll?: {
+        label?: string
+        enabled?: boolean
+      }
     }
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

In the PLP filters, the option for delivery method "pickup anywhere" should only be displayed when the store has configured it to be shown. 

## How it works?

It'll be configurable through hCMS and its default is false. We'll recommend to enable it for B2B stores.

## How to test it?

You can change the config through the hCMS, it is in the Global Sections > Settings tab:
![Screenshot 2025-05-19 at 15 21 14](https://github.com/user-attachments/assets/94682f75-4ff3-4710-be77-d0184652b2dd)

In the preview you should see the Pickup all filter (remember to set a postal code to see the filters) in the PLP only if the config is **true**.

#### False
https://vendemo-cm9sir9v900u7z6llkl62l70j-7cu2o2niz.b.vtex.app/
| Desktop | Mobile |
| ---- | ---- |
| <img width="560" alt="Screenshot 2025-05-19 at 20 57 35" src="https://github.com/user-attachments/assets/0ad25c8d-0ebb-45a6-9d34-ff8e353648eb" /> | <img width="215" alt="Screenshot 2025-05-19 at 20 57 52" src="https://github.com/user-attachments/assets/e6c41b80-9708-4408-b73e-5feef3c22690" /> |

#### True
https://vendemo-cm9sir9v900u7z6llkl62l70j-4s9fqs7hg.b.vtex.app/
| Desktop | Mobile |
| ---- | ---- |
| <img width="490" alt="Screenshot 2025-05-19 at 21 43 02" src="https://github.com/user-attachments/assets/1c8a7864-ef2e-4916-b36f-fb6b1286ac10" /> | <img width="221" alt="Screenshot 2025-05-19 at 21 43 25" src="https://github.com/user-attachments/assets/4c41fca4-f557-4b1c-8abd-90aec187e1e5" /> |

### Starters Deploy Preview

[PR](https://github.com/dp-faststore-org/vendemo-dp/pull/20)

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SFS-2446)
