### PR TITLE
fix: Prevent `checkDeps` error

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -129,33 +129,46 @@ async function copyResources(basePath: string) {
   }
 }
 
-async function checkDeps(basePath: string): Promise<Array<string>> {
+async function checkDeps(basePath: string): Promise<string[]> {
   const packageJsonPath = `${basePath}/package.json`
-  if (!existsSync(packageJsonPath))
-    throw new Error(`package.json not found at ${packageJsonPath}`)
+  if (!existsSync(packageJsonPath)) {
+    console.log(
+      `${chalk.yellow(
+        'warning'
+      )} - package.json not found at ${packageJsonPath}`
+    )
+  }
 
-  const {
-    devDependencies = {},
-    dependencies = {},
-    peerDependencies = {},
-  } = await import(packageJsonPath)
+  try {
+    const {
+      devDependencies = {},
+      dependencies = {},
+      peerDependencies = {},
+    } = await import(packageJsonPath)
 
-  const allDeps: Record<string, string> = Object.assign(
-    {},
-    peerDependencies,
-    devDependencies,
-    dependencies
-  )
+    const allDeps: Record<string, string> = Object.assign(
+      {},
+      peerDependencies,
+      devDependencies,
+      dependencies
+    )
 
-  const invalidPackages: Array<string> = []
+    const invalidPackages: Array<string> = []
 
-  Object.entries(allDeps).forEach(([pkg, version]) => {
-    if (/^@faststore\/.+/i.test(pkg) === false) return
+    Object.entries(allDeps).forEach(([pkg, version]) => {
+      if (/^@faststore\/.+/i.test(pkg) === false) return
 
-    if (version && /^(http|https|git):.+/.test(version) === true) {
-      invalidPackages.push(pkg)
-    }
-  })
+      if (version && /^(http|https|git):.+/.test(version) === true) {
+        invalidPackages.push(pkg)
+      }
+    })
 
-  return invalidPackages
+    return invalidPackages
+  } catch (err) {
+    console.log(
+      `${chalk.yellow('warning')} - unable to check dependencies. Error: ${err}`
+    )
+
+    return []
+  }
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -166,7 +166,7 @@ async function checkDeps(basePath: string): Promise<string[]> {
     return invalidPackages
   } catch (err) {
     console.log(
-      `${chalk.yellow('warning')} - unable to check dependencies. Error: ${err}`
+      `${chalk.yellow('warning')} - unable to check @faststore dependencies: ${err}`
     )
 
     return []

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -129,7 +129,7 @@ async function copyResources(basePath: string) {
   }
 }
 
-async function checkDeps(basePath: string): Promise<string[]> {
+async function checkDeps(basePath: string): Promise<Array<string>> {
   const packageJsonPath = `${basePath}/package.json`
   if (!existsSync(packageJsonPath)) {
     console.log(


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to prevent errors to happen when checking `@faststore` dependencies on starters.

## How it works?

It throws warnings instead errors to the CLI execution.