### PR TITLE
fix: theme styles import

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -314,7 +314,7 @@ async function copyTheme(basePath: string) {
           storeConfig.theme
         } theme was added to the config file but the ${
           storeConfig.theme
-        }.scss file does not exist in the themes folder. Read more: https://www.faststore.dev/docs/themes/overview`
+        }.scss file does not exist in the themes folder. Read more: https://developers.vtex.com/docs/guides/faststore/themes-overview`
       )
     }
   } else if (

--- a/packages/core/src/pages/_app.tsx
+++ b/packages/core/src/pages/_app.tsx
@@ -7,9 +7,7 @@ import useGeolocation from 'src/sdk/geolocation/useGeolocation'
 import SEO from '../../next-seo.config'
 
 // FastStore UI's base styles
-import '../customizations/src/themes/index.scss'
-import '../plugins/index.scss'
-import '../styles/global/index.scss'
+import '../styles/main.scss'
 
 import { DefaultSeo } from 'next-seo'
 

--- a/packages/core/src/styles/main.scss
+++ b/packages/core/src/styles/main.scss
@@ -1,0 +1,5 @@
+// The import order of these stylesheets does affect in the layers override
+// global/index.scss should be import before themes/index.scss
+@import "./global/index.scss";
+@import "../customizations/src/themes/index.scss";
+@import "../plugins/index.scss";


### PR DESCRIPTION
## What's the purpose of this pull request?

`@layer theme` was not being recognized and was getting overridden. The order of the stylesheet imports was affecting this behavior, so I extracted the imports into a separate file to prevent further issues.

|before|after|
|-|-|
|<img width="895" alt="image" src="https://github.com/user-attachments/assets/ba987dd3-1fcf-4576-8ce2-5a6f0b89a7bc" />|<img width="1795" alt="image" src="https://github.com/user-attachments/assets/56ad5ef7-c0b4-4a43-9233-0dcabfa692b5" />|


## How to test it?
- Check this [preview](https://sfj-a2c90e3--faststoreqa.preview.vtex.app), the theme should be applied and override the base styles.

### Starters Deploy Preview

[PR](https://github.com/vtex-sites/faststoreqa.store/pull/814) 

