### PR TITLE
fix: search cookie domain

### DIFF
--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -24,9 +24,7 @@ const createOrRefreshCookie = (key: string, expiresSecond: number) => {
       ? '.localhost'
       : config.secureSubdomain
         ? getBaseDomain([config.storeUrl, config.secureSubdomain])
-        : `${new URL(config.storeUrl).hostname}`
-
-  console.log(urlDomain)
+        : `.${new URL(config.storeUrl).hostname}`
 
   return () => {
     let currentValue = getCookie(key)

--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -22,8 +22,11 @@ const createOrRefreshCookie = (key: string, expiresSecond: number) => {
   const urlDomain =
     process.env.NODE_ENV === 'development'
       ? '.localhost'
-      : getBaseDomain([config.storeUrl, config.secureSubdomain]) ||
-        `.${new URL(config.storeUrl).hostname}`
+      : config.secureSubdomain
+        ? getBaseDomain([config.storeUrl, config.secureSubdomain])
+        : `${new URL(config.storeUrl).hostname}`
+
+  console.log(urlDomain)
 
   return () => {
     let currentValue = getCookie(key)

--- a/packages/core/src/sdk/analytics/platform/vtex/search.ts
+++ b/packages/core/src/sdk/analytics/platform/vtex/search.ts
@@ -4,8 +4,9 @@
 import type { AnalyticsEvent } from '@faststore/sdk'
 import type { SearchEvents } from '../../types'
 
+import { getBaseDomain } from 'src/utils/getBaseDomain'
+import { getCookie } from 'src/utils/getCookie'
 import config from '../../../../../discovery.config'
-import { getCookie } from '../../../../utils/getCookie'
 
 const THIRTY_MINUTES_S = 30 * 60
 const ONE_YEAR_S = 365 * 24 * 3600
@@ -21,7 +22,8 @@ const createOrRefreshCookie = (key: string, expiresSecond: number) => {
   const urlDomain =
     process.env.NODE_ENV === 'development'
       ? '.localhost'
-      : `.${new URL(config.storeUrl).hostname}`
+      : getBaseDomain([config.storeUrl, config.secureSubdomain]) ||
+        `.${new URL(config.storeUrl).hostname}`
 
   return () => {
     let currentValue = getCookie(key)

--- a/packages/core/src/utils/getBaseDomain.ts
+++ b/packages/core/src/utils/getBaseDomain.ts
@@ -1,0 +1,50 @@
+import config from '../../discovery.config'
+
+export const getBaseDomain = (urls: string[]) => {
+  const extractHostname = (url: string) => {
+    try {
+      const hostname = new URL(url).hostname
+      const subDomainPrefixes = config.api.subDomainPrefix || []
+
+      // Remove subdomain prefixes
+      // e.g. 'www.', 'shop.', 'loja.' from the hostname
+      const prefixRegex = new RegExp(
+        `^(${['www', ...subDomainPrefixes].join('|')})\\.`
+      )
+
+      return hostname.replace(prefixRegex, '')
+    } catch {
+      return ''
+    }
+  }
+
+  const hostnames = urls.map(extractHostname)
+
+  // Find common parts
+  const splitHostnames = hostnames.map((hostname) =>
+    hostname.split('.').reverse()
+  )
+
+  const minLength = Math.min(...splitHostnames.map((parts) => parts.length))
+
+  const commonParts = []
+  for (let i = 0; i < minLength; i++) {
+    const partSet = new Set(splitHostnames.map((parts) => parts[i]))
+    if (partSet.size === 1) {
+      commonParts.push(splitHostnames[0][i])
+    } else {
+      break
+    }
+  }
+
+  if (commonParts.length < 2) {
+    // If we cannot find at least domain + tld, fallback to ''
+    const err = `No common domain found for URLs: ${urls.join(', ')}`
+    console.warn(
+      `${err}. Please check the Production URLs in the discovery.config file.`
+    )
+    return ''
+  }
+
+  return '.' + commonParts.reverse().join('.')
+}

--- a/packages/core/src/utils/getBaseDomain.ts
+++ b/packages/core/src/utils/getBaseDomain.ts
@@ -3,7 +3,7 @@ import config from '../../discovery.config'
 export const getBaseDomain = (urls: string[]) => {
   // Check if all hostnames are the same (unified domain scenario)
   if (urls[0] === urls[1]) {
-    return `${new URL(config.storeUrl).hostname}`
+    return `.${new URL(config.storeUrl).hostname}`
   }
 
   const extractHostname = (url: string) => {
@@ -15,9 +15,6 @@ export const getBaseDomain = (urls: string[]) => {
       const prefixRegex = new RegExp(
         `^(${['www', ...subDomainPrefixes].join('|')})\\.`
       )
-
-      console.log('Extracted hostname:', hostname.replace(prefixRegex, ''))
-
       return hostname.replace(prefixRegex, '')
     } catch {
       return ''

--- a/packages/core/src/utils/getBaseDomain.ts
+++ b/packages/core/src/utils/getBaseDomain.ts
@@ -1,16 +1,22 @@
 import config from '../../discovery.config'
 
 export const getBaseDomain = (urls: string[]) => {
+  // Check if all hostnames are the same (unified domain scenario)
+  if (urls[0] === urls[1]) {
+    return `${new URL(config.storeUrl).hostname}`
+  }
+
   const extractHostname = (url: string) => {
     try {
       const hostname = new URL(url).hostname
-      const subDomainPrefixes = config.api.subDomainPrefix || []
-
+      const subDomainPrefixes = (config.api as any).subDomainPrefix || []
       // Remove subdomain prefixes
       // e.g. 'www.', 'shop.', 'loja.' from the hostname
       const prefixRegex = new RegExp(
-        `^(${['www', ...subDomainPrefixes].join('|')})\\.`
+        `^(${['wwww', ...subDomainPrefixes].join('|')})\\.`
       )
+
+      console.log('Extracted hostname:', hostname.replace(prefixRegex, ''))
 
       return hostname.replace(prefixRegex, '')
     } catch {

--- a/packages/core/src/utils/getBaseDomain.ts
+++ b/packages/core/src/utils/getBaseDomain.ts
@@ -13,7 +13,7 @@ export const getBaseDomain = (urls: string[]) => {
       // Remove subdomain prefixes
       // e.g. 'www.', 'shop.', 'loja.' from the hostname
       const prefixRegex = new RegExp(
-        `^(${['wwww', ...subDomainPrefixes].join('|')})\\.`
+        `^(${['www', ...subDomainPrefixes].join('|')})\\.`
       )
 
       console.log('Extracted hostname:', hostname.replace(prefixRegex, ''))


### PR DESCRIPTION
## What's the purpose of this pull request?

- Re-applies changes from https://github.com/vtex/faststore/pull/2811
- Consider unified domain (store / secure) and when no secureDomain

How to test?
- This version is currently being used in https://homebrewqa.fast.store
- Open https://homebrewqa.fast.store in an incognito tab or remove all the cookies in the browser 
- Type anything in the SearchInput
- Check if `vtex-search-session` and `vtex-search-anonymous` cookies are being created with `.homebrewqa.fast.store` domain

<img width="637" alt="image" src="https://github.com/user-attachments/assets/7b409307-2c97-4301-879c-f51e0bf6b71a" />

