### PR TITLE
fix: avoids undefined data when deliverySettings is undefined

### DIFF
--- a/packages/core/src/utils/globalSettings.ts
+++ b/packages/core/src/utils/globalSettings.ts
@@ -48,11 +48,11 @@ export function getRegionalizationSettings(
   const regionalizationData =
     context?.globalSectionsSettings?.regionalization ?? {}
 
-  if (deliverySettings !== undefined) {
-    return deepmerge(regionalizationData, {
-      deliverySettings,
-    })
+  if (deliverySettings === undefined) {
+    return regionalizationData
   }
 
-  return regionalizationData
+  return deepmerge(regionalizationData, {
+    deliverySettings,
+  })
 }


### PR DESCRIPTION
If deliverySettings is undefined, we should just return the global sections available data (regionalizationData).

<img width="539" alt="image" src="https://github.com/user-attachments/assets/81105d40-12fe-49aa-92f0-910848645bed" />
