### PR TITLE
feat: add flag --watch-plugins on dev command

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,4 +1,4 @@
-import { Command } from '@oclif/core'
+import { Command, Flags } from '@oclif/core'
 import { spawn } from 'child_process'
 import chalk from 'chalk'
 import chokidar from 'chokidar'
@@ -26,11 +26,15 @@ const defaultIgnored = [
   'README.md',
   '.gitignore',
   'package.json',
-  'node_modules/**',
-  '**/node_modules/**',
   '.git/**',
   '.faststore/**',
   '**/.faststore/**',
+]
+
+const defaultNodeModulesIgnored = ['node_modules/**', '**/node_modules/**']
+
+const defaultNodeModulesIgnoredExceptVtexPackages = [
+  '**/node_modules/!(@vtex)/**',
 ]
 
 const devAbortController = new AbortController()
@@ -125,10 +129,18 @@ export default class Dev extends Command {
     },
   ]
 
+  static flags = {
+    'watch-plugins': Flags.boolean({
+      description: 'Enable watching for plugin changes',
+      default: false,
+    }),
+  }
+
   async run() {
-    const { args } = await this.parse(Dev)
+    const { args, flags } = await this.parse(Dev)
     const basePath = args.path ?? process.cwd()
     const port = args.port ?? 3000
+    const watchPlugins = flags['watch-plugins']
 
     const { getRoot, tmpDir, coreDir } = withBasePath(basePath)
 
@@ -143,7 +155,12 @@ export default class Dev extends Command {
       },
       cwd: getRoot(),
       ignoreInitial: true,
-      ignored: defaultIgnored,
+      ignored: [
+        ...defaultIgnored,
+        ...(watchPlugins
+          ? defaultNodeModulesIgnoredExceptVtexPackages
+          : defaultNodeModulesIgnored),
+      ],
       persistent: true,
       usePolling: process.platform === 'win32',
     })


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds a new flag `--watch-plugins` to the FastStore CLI's dev command to improve the developer experience when developing FastStore plugins. Currently, developers need to manually restart the server after each plugin modification, which is time-consuming and interrupts the development flow. This enhancement allows for automatic server restarts when changes are detected in plugin files.

## How it works?

The PR introduces a new optional flag `--watch-plugins` to the `faststore dev` command. When enabled, it configures the file watcher to monitor files inside `node_modules/@vtex` directory, which is where FastStore plugins are typically installed.

Key implementation details:
- Added a new boolean flag `--watch-plugins` (default: false) to the dev command
- Modified the chokidar watcher configuration to conditionally watch `node_modules/@vtex` files
- Server automatically restarts when plugin files are modified

This change is completely opt-in and won't affect existing FastStore development workflows unless explicitly enabled.

## How to test it?

1. Install a FastStore plugin in your project
2. Start the development server with the new flag:
```bash
faststore dev --watch-plugins
```
3. Modify any file inside `node_modules/@vtex`
4. Verify that the server automatically restarts and applies the changes

## References
- [feat: Adds Plugins feature #2563](https://github.com/vtex/faststore/pull/2563)
- [Chokidar Watch Patterns Documentation](https://github.com/paulmillr/chokidar#path-filtering)
- [OCLIF Command Flags Documentation](https://oclif.io/docs/flags)

## Checklist

**PR Title and Commit Messages**
- [x] PR title and commit messages follow the Conventional Commits specification
  - Using prefix: `feat`

**PR Description**
- [x] Added labels: `enhancement`

**Dependencies**
- [x] No changes to dependencies required

**Documentation**
- [x] PR description completed
