### PR TITLE
chore: Renames to avoid mixing delivery methods with delivery option

### DIFF
--- a/packages/core/src/components/search/Filter/FilterDeliveryMethodFacet.tsx
+++ b/packages/core/src/components/search/Filter/FilterDeliveryMethodFacet.tsx
@@ -10,15 +10,15 @@ interface FacetValue {
   quantity: number
 }
 
-interface FilterDeliveryOptionProps {
+interface FilterDeliveryMethodFacetProps {
   item: FacetValue
   deliveryMethods: RegionalizationCmsData['deliverySettings']['deliveryMethods']
 }
 
-export default function FilterDeliveryOption({
+export default function FilterDeliveryMethodFacet({
   item,
   deliveryMethods,
-}: FilterDeliveryOptionProps) {
+}: FilterDeliveryMethodFacetProps) {
   const { city, postalCode } = sessionStore.read()
   const { openRegionSlider } = useUI()
 

--- a/packages/core/src/components/search/Filter/FilterDesktop.tsx
+++ b/packages/core/src/components/search/Filter/FilterDesktop.tsx
@@ -22,7 +22,7 @@ import { sessionStore } from 'src/sdk/session'
 import { getRegionalizationSettings } from 'src/utils/globalSettings'
 
 import { RegionSlider } from 'src/components/region/RegionSlider'
-import FilterDeliveryOption from './FilterDeliveryOption'
+import FilterDeliveryMethodFacet from './FilterDeliveryMethodFacet'
 
 interface FilterDesktopProps
   extends Omit<
@@ -233,7 +233,7 @@ function FilterDesktop({
                           facetKey={facet.key}
                           label={
                             isDeliveryFacet ? (
-                              <FilterDeliveryOption
+                              <FilterDeliveryMethodFacet
                                 item={item}
                                 deliveryMethods={
                                   deliverySettingsData?.deliveryMethods

--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -19,7 +19,7 @@ import { usePickupPoints } from 'src/sdk/shipping/usePickupPoints'
 import { deliveryPromise } from 'discovery.config'
 
 import type { Filter_FacetsFragment } from '@generated/graphql'
-import FilterDeliveryOption from './FilterDeliveryOption'
+import FilterDeliveryMethodFacet from './FilterDeliveryMethodFacet'
 
 import type { useFilter } from 'src/sdk/search/useFilter'
 import { sessionStore } from 'src/sdk/session'
@@ -338,7 +338,7 @@ function FilterSlider({
                             facetKey={facet.key}
                             label={
                               isDeliveryFacet ? (
-                                <FilterDeliveryOption
+                                <FilterDeliveryMethodFacet
                                   item={item}
                                   deliveryMethods={
                                     deliverySettings?.deliveryMethods


### PR DESCRIPTION
## What's the purpose of this pull request?

Renames the `FilterDeliveryOption` component to clarify that it relates to delivery methods.