### PR TITLE
fix: Search events params to track conversion

### DIFF
--- a/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
+++ b/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
@@ -1,4 +1,3 @@
-import type { Dispatch, SetStateAction } from 'react'
 import {
   SearchProducts,
   SearchAutoComplete as UISearchAutoComplete,
@@ -6,6 +5,7 @@ import {
   SearchDropdown as UISearchDropdown,
   useSearch,
 } from '@faststore/ui'
+import type { Dispatch, SetStateAction } from 'react'
 
 import { SearchHistory } from '../SearchHistory'
 import { SearchTop } from '../SearchTop'
@@ -13,12 +13,12 @@ import { SearchTop } from '../SearchTop'
 import type { SearchState } from '@faststore/sdk'
 import type { ProductSummary_ProductFragment } from '@generated/graphql'
 import SearchProductItem from 'src/components/search/SearchProductItem'
-import { formatSearchPath } from 'src/sdk/search/formatSearchPath'
+import type { NavbarProps } from 'src/components/sections/Navbar'
 import type {
   IntelligentSearchAutocompleteClickEvent,
   IntelligentSearchAutocompleteClickParams,
 } from 'src/sdk/analytics/types'
-import type { NavbarProps } from 'src/components/sections/Navbar'
+import { formatSearchPath } from 'src/sdk/search/formatSearchPath'
 
 interface SearchDropdownProps {
   sort: SearchState['sort']
@@ -68,11 +68,11 @@ function SearchDropdown({
               }),
               onClick: () => {
                 onSearchSelection?.(
-                  suggestion,
-                  formatSearchPath({ term: suggestion, sort })
+                  term,
+                  formatSearchPath({ term: term, sort })
                 )
                 sendAutocompleteClickEvent({
-                  term: suggestion,
+                  term: term,
                   url: window.location.href,
                 })
               },

--- a/packages/core/src/components/search/SearchInput/SearchInput.tsx
+++ b/packages/core/src/components/search/SearchInput/SearchInput.tsx
@@ -106,7 +106,6 @@ const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
       addToSearchHistory({ term, path })
       sendAnalytics(term)
       setSearchDropdownVisible(false)
-      setSearchQuery(term)
     }
 
     useOnClickOutside(searchRef, () =>

--- a/packages/core/src/components/search/SearchProductItem/SearchProductItem.tsx
+++ b/packages/core/src/components/search/SearchProductItem/SearchProductItem.tsx
@@ -1,4 +1,3 @@
-import { type Dispatch, type SetStateAction, useMemo, useState } from 'react'
 import {
   Icon,
   SearchProductItem as UISearchProductItem,
@@ -9,15 +8,16 @@ import {
   useSearch,
   useUI,
 } from '@faststore/ui'
+import { type Dispatch, type SetStateAction, useMemo, useState } from 'react'
 
+import type { ProductSummary_ProductFragment } from '@generated/graphql'
+import type { NavbarProps } from 'src/components/sections/Navbar'
 import { Image } from 'src/components/ui/Image'
+import { useBuyButton } from 'src/sdk/cart/useBuyButton'
+import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import { useProductLink } from 'src/sdk/product/useProductLink'
 import { sendAutocompleteClickEvent } from '../SearchDropdown'
-import type { ProductSummary_ProductFragment } from '@generated/graphql'
-import { useBuyButton } from 'src/sdk/cart/useBuyButton'
-import type { NavbarProps } from 'src/components/sections/Navbar'
-import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 
 import styles from 'src/components/sections/Navbar/section.module.scss'
 
@@ -48,7 +48,7 @@ function SearchProductItem({
   ...otherProps
 }: SearchProductItemProps) {
   const {
-    values: { onSearchSelection },
+    values: { term, onSearchSelection },
   } = useSearch()
   const { pushToast } = useUI()
 
@@ -96,7 +96,7 @@ function SearchProductItem({
       onSearchSelection?.(name, href)
       sendAutocompleteClickEvent({
         url: href,
-        term: name,
+        term: term,
         position: index,
         productId: product.isVariantOf.productGroupID ?? product.sku,
       })


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the params when sending events that affects the IS report conversion data.

- When sending `search.autocomplete.click` events, we were using the wrong `text` parameter. We should be sending the searched `term` instead.

## How it works?

1. Search for a term and clicks enter, you'll be redirected to a search page with the list of products (PLP), click on the product.
- type the term `headphone`

<img width="1804" alt="image" src="https://github.com/user-attachments/assets/0edef565-9bc4-4ad4-a1ec-5cea50cb9efd" />

- while typing some events `search.autocomplete.query` will be sent, when clicking on enter, `search.query` event should be sent with `text: "headphone"`
<img width="1622" alt="image" src="https://github.com/user-attachments/assets/616d3bde-dcd8-4c04-8741-6d6b20e4bc0d" />

- On the PLP page, clicking on the product `Aedle VK-1 L Headphone` should trigger a `search.click` event with `text: "headphone"` (where text should match the searched term)

<img width="1670" alt="image" src="https://github.com/user-attachments/assets/8df31db7-a948-44ff-b5da-4e1863d10781" />


2. Search for a term and clicks on a suggested product.

- type the term `awesome`, while typing some events `search.autocomplete.query` will be sent with the current term

<img width="1643" alt="image" src="https://github.com/user-attachments/assets/0288dfd4-373f-4c5d-ac72-838347adad61" />

- click on the **suggested product**  `Intelligent Steel Cheese Awesome` product
<img width="888" alt="image" src="https://github.com/user-attachments/assets/337875a7-ccd1-4dae-aa7f-591a76204d8b" />

- `search.autocomplete.click` should be sent , with `text: "awesome"` (where text should match the searched term)
<img width="1702" alt="image" src="https://github.com/user-attachments/assets/30278598-761c-46f1-bbfa-9d285acdc503" />


## How to test it?

- You can run locally or try on this preview [link](https://storeframework-cm652ufll028lmgv665a6xv0g-8onpmtolq.b.vtex.app).
- Reproduce the scenarios listed above, and you should have the same output.

### Starters Deploy Preview