### PR TITLE
feat: use shopper first name in user details from session

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -396,7 +396,7 @@ export const VtexCommerce = (
 
       params.set(
         'items',
-        'profile.id,profile.email,profile.firstName,profile.lastName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol,authentication.customerId,authentication.storeUserId,authentication.storeUserEmail,authentication.unitId,authentication.unitName,checkout.regionId,'
+        'profile.id,profile.email,profile.firstName,profile.lastName,shopper.firstName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol,authentication.customerId,authentication.storeUserId,authentication.storeUserEmail,authentication.unitId,authentication.unitName,checkout.regionId'
       )
 
       const headers: HeadersInit = withCookie({

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
@@ -5,6 +5,7 @@ export interface Session {
 
 export interface Namespaces {
   profile?: Profile
+  shopper?: Shopper
   store?: Store
   checkout?: Checkout
   public?: Public
@@ -36,6 +37,10 @@ export interface Profile {
   email?: Value
   firstName?: Value
   lastName?: Value
+}
+
+export interface Shopper {
+  firstName?: Value
 }
 
 export interface Checkout {

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -514,11 +514,11 @@ export const Query = {
     // const params = new URLSearchParams()
     const sessionData = await commerce.session('').catch(() => null)
 
-    const profile = sessionData?.namespaces.profile ?? null
+    const shopper = sessionData?.namespaces.shopper ?? null
     const authentication = sessionData?.namespaces.authentication ?? null
 
     return {
-      name: `${(profile?.firstName?.value ?? '').trim()} ${(profile?.lastName?.value ?? '').trim()}`.trim(), // TODO change when implemented shopper from MD
+      name: shopper?.firstName?.value ?? '',
       email: authentication?.storeUserEmail.value ?? '',
       role: ['Admin'], // TODO change when implemented roles,
       orgUnit: authentication?.unitName?.value ?? '',

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -100,6 +100,7 @@ export const validateSession = async (
     .catch(() => null)
 
   const profile = sessionData?.namespaces.profile ?? null
+  const shopper = sessionData?.namespaces.shopper ?? null
   const store = sessionData?.namespaces.store ?? null
   const authentication = sessionData?.namespaces.authentication ?? null
   const checkout = sessionData?.namespaces.checkout ?? null
@@ -138,8 +139,7 @@ export const validateSession = async (
           unitId: authentication?.unitId?.value ?? unitId ?? '', // organization id
           firstName: profile?.firstName?.value ?? '', // contract name for b2b
           lastName: profile?.lastName?.value ?? '',
-          userName:
-            `${profile?.firstName?.value ?? ''} ${profile?.lastName?.value ?? ''}`.trim(), // shopper
+          userName: shopper?.firstName?.value ?? '', // shopper
           userEmail: authentication?.storeUserEmail.value ?? '',
         }
       : null,


### PR DESCRIPTION
## What's the purpose of this pull request?

Show user name instead of contract name in user details

## How it works?

Use `shopper.firstName` from session

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

[SFS-2575](https://vtex-dev.atlassian.net/browse/SFS-2575?atlOrigin=eyJpIjoiOGFlMGExZDIyOTYwNDBiYmFiYzdiY2I1NDU5NWRlMzEiLCJwIjoiaiJ9)

![image](https://github.com/user-attachments/assets/515b299f-60ac-4bfa-93cf-07f89cf12a19)


[SFS-2575]: https://vtex-dev.atlassian.net/browse/SFS-2575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ