### PR TITLE
feat: [CP-407] Add support for rendering components based on their $componentKey

### DIFF
--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -19,11 +19,20 @@ import ViewportObserver from './ViewportObserver'
 interface Props {
   components?: Record<string, ComponentType<any>>
   globalSections?: Array<{ name: string; data: any }>
-  sections?: Array<{ name: string; data: any }>
+  sections?: Array<{ name: string; data: any; $componentKey?: string }>
   isInteractive?: boolean
 }
 
 const SECTIONS_OUT_OF_VIEWPORT = ['CartSidebar', 'RegionModal', 'RegionSlider']
+
+export type ComponentTypeWithComponentKey<T> = ComponentType<T> & {
+  $componentKey?: string
+}
+
+export const getComponentKey = (
+  Component: ComponentTypeWithComponentKey<any>,
+  name: string
+) => Component.$componentKey ?? name
 
 const Toast = dynamic(
   () => import(/* webpackChunkName: "Toast" */ '../common/Toast'),
@@ -106,13 +115,19 @@ export const RenderSectionsBase = ({
 }: Props) => {
   return (
     <>
-      {sections.map(({ name, data = {} }, index) => {
-        const Component = components[name]
+      {sections.map(({ name, data = {}, $componentKey }, index) => {
+        const key = $componentKey ?? name // Changes need to made here:
+        // [X] 1. The `section.name` being should be replaced by `$componentKey`
+        // 2. Find every reference of the `COMPONENTS` list and change the index
+        //    from just the component name to the component's `$componentKey`.
+        // 3. Every component that is configured via CMS, needs to have the
+        //    `$componentKey` property added to it.
+        const Component = components[key]
 
         if (!Component) {
           // TODO: add a documentation link to help to do this
           console.warn(
-            `${name} not found. Add a new component for this section or remove it from the CMS`
+            `${key} not found. Add a new component for this section or remove it from the CMS`
           )
 
           return null

--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -117,11 +117,6 @@ export const RenderSectionsBase = ({
     <>
       {sections.map(({ name, data = {}, $componentKey }, index) => {
         const key = $componentKey ?? name // Changes need to made here:
-        // [X] 1. The `section.name` being should be replaced by `$componentKey`
-        // 2. Find every reference of the `COMPONENTS` list and change the index
-        //    from just the component name to the component's `$componentKey`.
-        // 3. Every component that is configured via CMS, needs to have the
-        //    `$componentKey` property added to it.
         const Component = components[key]
 
         if (!Component) {

--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -107,7 +107,7 @@ export const RenderSectionsBase = ({
   return (
     <>
       {sections.map(({ name, data = {}, $componentKey }, index) => {
-        const key = $componentKey ?? name // Changes need to made here:
+        const key = $componentKey ?? name
         const Component = components[key]
 
         if (!Component) {

--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -25,15 +25,6 @@ interface Props {
 
 const SECTIONS_OUT_OF_VIEWPORT = ['CartSidebar', 'RegionModal', 'RegionSlider']
 
-export type ComponentTypeWithComponentKey<T> = ComponentType<T> & {
-  $componentKey?: string
-}
-
-export const getComponentKey = (
-  Component: ComponentTypeWithComponentKey<any>,
-  name: string
-) => Component.$componentKey ?? name
-
 const Toast = dynamic(
   () => import(/* webpackChunkName: "Toast" */ '../common/Toast'),
   { ssr: false }

--- a/packages/core/src/components/cms/global/Components.ts
+++ b/packages/core/src/components/cms/global/Components.ts
@@ -8,8 +8,7 @@ import { OverriddenDefaultRegionBar as RegionBar } from 'src/components/sections
 
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
-
-import { getComponentKey } from '../RenderSections'
+import { getComponentKey } from 'src/utils/cms'
 
 const CartSidebar = dynamic(
   () =>

--- a/packages/core/src/components/cms/global/Components.ts
+++ b/packages/core/src/components/cms/global/Components.ts
@@ -9,6 +9,8 @@ import { OverriddenDefaultRegionBar as RegionBar } from 'src/components/sections
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
 
+import { getComponentKey } from '../RenderSections'
+
 const CartSidebar = dynamic(
   () =>
     import(
@@ -37,14 +39,14 @@ const RegionSlider = dynamic(
 )
 
 const COMPONENTS: Record<string, ComponentType<any>> = {
-  Alert,
-  Navbar,
-  RegionBar,
-  RegionPopover,
-  CartSidebar, // out of viewport
-  RegionModal, // out of viewport
-  RegionSlider, // out of viewport
-  Footer, // out of viewport
+  [getComponentKey(Alert, 'Alert')]: Alert,
+  [getComponentKey(Navbar, 'Navbar')]: Navbar,
+  [getComponentKey(RegionBar, 'RegionBar')]: RegionBar,
+  [getComponentKey(RegionPopover, 'RegionPopover')]: RegionPopover,
+  [getComponentKey(CartSidebar, 'CartSidebar')]: CartSidebar, // out of viewport
+  [getComponentKey(RegionModal, 'RegionModal')]: RegionModal, // out of viewport
+  [getComponentKey(RegionSlider, 'RegionSlider')]: RegionSlider, // out of viewport
+  [getComponentKey(Footer, 'Footer')]: Footer, // out of viewport
   ...PLUGINS_COMPONENTS,
   ...CUSTOM_COMPONENTS,
 }

--- a/packages/core/src/components/cms/home/Components.ts
+++ b/packages/core/src/components/cms/home/Components.ts
@@ -4,6 +4,7 @@ import type { ComponentType } from 'react'
 import { OverriddenDefaultHero as Hero } from 'src/components/sections/Hero/OverriddenDefaultHero'
 import Incentives from 'src/components/sections/Incentives'
 import { default as GLOBAL_COMPONENTS } from '../global/Components'
+import { getComponentKey } from '../RenderSections'
 
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
@@ -43,12 +44,12 @@ const ProductTiles = dynamic(
  */
 const COMPONENTS: Record<string, ComponentType<any>> = {
   ...GLOBAL_COMPONENTS,
-  Hero,
-  Incentives,
-  BannerText,
-  Newsletter,
-  ProductShelf,
-  ProductTiles,
+  [getComponentKey(Hero, 'Hero')]: Hero,
+  [getComponentKey(Incentives, 'Incentives')]: Incentives,
+  [getComponentKey(BannerText, 'BannerText')]: BannerText,
+  [getComponentKey(Newsletter, 'Newsletter')]: Newsletter,
+  [getComponentKey(ProductShelf, 'ProductShelf')]: ProductShelf,
+  [getComponentKey(ProductTiles, 'ProductTiles')]: ProductTiles,
   ...PLUGINS_COMPONENTS,
   ...CUSTOM_COMPONENTS,
 }

--- a/packages/core/src/components/cms/home/Components.ts
+++ b/packages/core/src/components/cms/home/Components.ts
@@ -4,7 +4,7 @@ import type { ComponentType } from 'react'
 import { OverriddenDefaultHero as Hero } from 'src/components/sections/Hero/OverriddenDefaultHero'
 import Incentives from 'src/components/sections/Incentives'
 import { default as GLOBAL_COMPONENTS } from '../global/Components'
-import { getComponentKey } from '../RenderSections'
+import { getComponentKey } from 'src/utils/cms'
 
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'

--- a/packages/core/src/components/cms/plp/Components.ts
+++ b/packages/core/src/components/cms/plp/Components.ts
@@ -7,7 +7,7 @@ import { OverriddenDefaultProductGallery as ProductGallery } from 'src/component
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
 import { default as GLOBAL_COMPONENTS } from '../global/Components'
-import { getComponentKey } from '../RenderSections'
+import { getComponentKey } from 'src/utils/cms'
 
 const BannerText = dynamic(
   () =>

--- a/packages/core/src/components/cms/plp/Components.ts
+++ b/packages/core/src/components/cms/plp/Components.ts
@@ -7,6 +7,7 @@ import { OverriddenDefaultProductGallery as ProductGallery } from 'src/component
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
 import { default as GLOBAL_COMPONENTS } from '../global/Components'
+import { getComponentKey } from '../RenderSections'
 
 const BannerText = dynamic(
   () =>
@@ -47,13 +48,13 @@ const ProductTiles = dynamic(
  */
 const COMPONENTS: Record<string, ComponentType<any>> = {
   ...GLOBAL_COMPONENTS,
-  Breadcrumb,
-  Hero,
-  ProductGallery,
-  BannerText,
-  Newsletter,
-  ProductShelf,
-  ProductTiles,
+  [getComponentKey(Hero, 'Hero')]: Hero,
+  [getComponentKey(Breadcrumb, 'Breadcrumb')]: Breadcrumb,
+  [getComponentKey(ProductGallery, 'ProductGallery')]: ProductGallery,
+  [getComponentKey(BannerText, 'BannerText')]: BannerText,
+  [getComponentKey(Newsletter, 'Newsletter')]: Newsletter,
+  [getComponentKey(ProductShelf, 'ProductShelf')]: ProductShelf,
+  [getComponentKey(ProductTiles, 'ProductTiles')]: ProductTiles,
   ...PLUGINS_COMPONENTS,
   ...CUSTOM_COMPONENTS,
 }

--- a/packages/core/src/components/cms/search/Components.ts
+++ b/packages/core/src/components/cms/search/Components.ts
@@ -7,6 +7,7 @@ import { OverriddenDefaultProductGallery as ProductGallery } from 'src/component
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
 import { default as GLOBAL_COMPONENTS } from '../global/Components'
+import { getComponentKey } from '../RenderSections'
 
 const BannerText = dynamic(
   () =>
@@ -55,14 +56,14 @@ const ProductTiles = dynamic(
  */
 const COMPONENTS: Record<string, ComponentType<any>> = {
   ...GLOBAL_COMPONENTS,
-  Breadcrumb,
-  Hero,
-  ProductGallery,
-  BannerText,
-  BannerNewsletter,
-  Newsletter,
-  ProductShelf,
-  ProductTiles,
+  [getComponentKey(Hero, 'Hero')]: Hero,
+  [getComponentKey(Breadcrumb, 'Breadcrumb')]: Breadcrumb,
+  [getComponentKey(ProductGallery, 'ProductGallery')]: ProductGallery,
+  [getComponentKey(BannerText, 'BannerText')]: BannerText,
+  [getComponentKey(BannerNewsletter, 'BannerNewsletter')]: BannerNewsletter,
+  [getComponentKey(Newsletter, 'Newsletter')]: Newsletter,
+  [getComponentKey(ProductShelf, 'ProductShelf')]: ProductShelf,
+  [getComponentKey(ProductTiles, 'ProductTiles')]: ProductTiles,
   ...PLUGINS_COMPONENTS,
   ...CUSTOM_COMPONENTS,
 }

--- a/packages/core/src/components/cms/search/Components.ts
+++ b/packages/core/src/components/cms/search/Components.ts
@@ -7,7 +7,7 @@ import { OverriddenDefaultProductGallery as ProductGallery } from 'src/component
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
 import { default as GLOBAL_COMPONENTS } from '../global/Components'
-import { getComponentKey } from '../RenderSections'
+import { getComponentKey } from 'src/utils/cms'
 
 const BannerText = dynamic(
   () =>

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -143,4 +143,6 @@ function RegionModal(regionModalProps: RegionModalProps) {
   )
 }
 
+RegionModal.$componentKey = 'RegionModal'
+
 export default RegionModal

--- a/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
+++ b/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
@@ -186,4 +186,6 @@ function RegionPopover(regionPopoverProps: RegionPopoverProps) {
   )
 }
 
+RegionPopover.$componentKey = 'RegionPopover'
+
 export default RegionPopover

--- a/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
+++ b/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
@@ -404,4 +404,6 @@ function RegionSlider() {
   )
 }
 
+RegionSlider.$componentKey = 'RegionSlider'
+
 export default RegionSlider

--- a/packages/core/src/components/sections/Alert/Alert.tsx
+++ b/packages/core/src/components/sections/Alert/Alert.tsx
@@ -37,6 +37,8 @@ function Alert({ icon, content, link: { text, to }, dismissible }: AlertProps) {
   )
 }
 
+Alert.$componentKey = 'Alert'
+
 const OverridableAlert = getOverridableSection<typeof Alert>(
   'Alert',
   Alert,

--- a/packages/core/src/components/sections/BannerNewsletter/BannerNewsletter.tsx
+++ b/packages/core/src/components/sections/BannerNewsletter/BannerNewsletter.tsx
@@ -44,4 +44,6 @@ function BannerNewsletter({
   )
 }
 
+BannerNewsletter.$componentKey = 'BannerNewsletter'
+
 export default BannerNewsletter

--- a/packages/core/src/components/sections/BannerText/BannerText.tsx
+++ b/packages/core/src/components/sections/BannerText/BannerText.tsx
@@ -57,6 +57,8 @@ function BannerText({
   )
 }
 
+BannerText.$componentKey = 'BannerText'
+
 const OverridableBannerText = getOverridableSection<typeof BannerText>(
   'BannerText',
   BannerText,

--- a/packages/core/src/components/sections/Breadcrumb/Breadcrumb.tsx
+++ b/packages/core/src/components/sections/Breadcrumb/Breadcrumb.tsx
@@ -41,6 +41,8 @@ function BreadcrumbSection({ ...otherProps }: BreadcrumbSectionProps) {
   )
 }
 
+BreadcrumbSection.$componentKey = 'Breadcrumb'
+
 const OverridableBreadcrumbSection = getOverridableSection<
   typeof BreadcrumbSection
 >('Breadcrumb', BreadcrumbSection, BreadcrumbDefaultComponents)

--- a/packages/core/src/components/sections/CrossSellingShelf/CrossSellingShelf.tsx
+++ b/packages/core/src/components/sections/CrossSellingShelf/CrossSellingShelf.tsx
@@ -51,6 +51,8 @@ const CrossSellingShelf = ({
   )
 }
 
+CrossSellingShelf.$componentKey = 'CrossSellingShelf'
+
 const OverridableCrossSellingShelf = getOverridableSection<
   typeof CrossSellingShelf
 >('CrossSellingShelf', CrossSellingShelf, CrossSellingShelfDefaultComponents)

--- a/packages/core/src/components/sections/EmptyState/EmptyState.tsx
+++ b/packages/core/src/components/sections/EmptyState/EmptyState.tsx
@@ -107,6 +107,8 @@ function EmptyState({
   )
 }
 
+EmptyState.$componentKey = 'EmptyState'
+
 const OverridableEmptyState = getOverridableSection<typeof EmptyState>(
   'EmptyState',
   EmptyState,

--- a/packages/core/src/components/sections/Footer/Footer.tsx
+++ b/packages/core/src/components/sections/Footer/Footer.tsx
@@ -90,4 +90,6 @@ const Footer = ({
   )
 }
 
+Footer.$componentKey = 'Footer'
+
 export default Footer

--- a/packages/core/src/components/sections/Hero/Hero.tsx
+++ b/packages/core/src/components/sections/Hero/Hero.tsx
@@ -77,6 +77,8 @@ const Hero = ({
   )
 }
 
+Hero.$componentKey = 'Hero'
+
 const OverridableHero = getOverridableSection<typeof Hero>(
   'Hero',
   Hero,

--- a/packages/core/src/components/sections/Incentives/Incentives.tsx
+++ b/packages/core/src/components/sections/Incentives/Incentives.tsx
@@ -18,4 +18,6 @@ function Incentives({ incentives, label }: Props) {
   )
 }
 
+Incentives.$componentKey = 'Incentives'
+
 export default Incentives

--- a/packages/core/src/components/sections/Navbar/Navbar.tsx
+++ b/packages/core/src/components/sections/Navbar/Navbar.tsx
@@ -110,6 +110,8 @@ function NavbarSection({
   )
 }
 
+NavbarSection.$componentKey = 'Navbar'
+
 const OverridableNavbar = getOverridableSection<typeof NavbarSection>(
   'Navbar',
   NavbarSection,

--- a/packages/core/src/components/sections/Newsletter/Newsletter.tsx
+++ b/packages/core/src/components/sections/Newsletter/Newsletter.tsx
@@ -113,6 +113,8 @@ function Newsletter({
   )
 }
 
+Newsletter.$componentKey = 'Newsletter'
+
 const OverridableNewsletter = getOverridableSection<typeof Newsletter>(
   'Newsletter',
   Newsletter,

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -336,6 +336,8 @@ function ProductDetails({
   )
 }
 
+ProductDetails.$componentKey = 'ProductDetails'
+
 export const fragment = gql(`
   fragment ProductDetailsFragment_product on StoreProduct {
     id: productID

--- a/packages/core/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/packages/core/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -68,6 +68,8 @@ function ProductGallerySection({
   )
 }
 
+ProductGallerySection.$componentKey = 'ProductGallery'
+
 const OverridableProductGallery = getOverridableSection<
   typeof ProductGallerySection
 >('ProductGallery', ProductGallerySection, ProductGalleryDefaultComponents)

--- a/packages/core/src/components/sections/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/sections/ProductShelf/ProductShelf.tsx
@@ -23,6 +23,8 @@ function ProductShelfSection({
   )
 }
 
+ProductShelfSection.$componentKey = 'ProductShelf'
+
 const OverridableProductShelf = getOverridableSection<typeof ProductShelf>(
   'ProductShelf',
   ProductShelfSection,

--- a/packages/core/src/components/sections/ProductTiles/ProductTiles.tsx
+++ b/packages/core/src/components/sections/ProductTiles/ProductTiles.tsx
@@ -115,4 +115,6 @@ const ProductTiles = ({
   )
 }
 
+ProductTiles.$componentKey = 'ProductTiles'
+
 export default ProductTiles

--- a/packages/core/src/components/sections/RegionBar/RegionBar.tsx
+++ b/packages/core/src/components/sections/RegionBar/RegionBar.tsx
@@ -43,6 +43,8 @@ function RegionBarSection({ ...otherProps }: RegionBarSectionProps) {
   )
 }
 
+RegionBarSection.$componentKey = 'RegionBar'
+
 const OverridableRegionBar = getOverridableSection<typeof RegionBarSection>(
   'RegionBar',
   RegionBarSection,

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -2,9 +2,8 @@ import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
 import type { ComponentType } from 'react'
 
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
-import RenderSections, {
-  getComponentKey,
-} from 'src/components/cms/RenderSections'
+import RenderSections from 'src/components/cms/RenderSections'
+import { getComponentKey } from 'src/utils/cms'
 import BannerNewsletter from 'src/components/sections/BannerNewsletter/BannerNewsletter'
 import { OverriddenDefaultBannerText as BannerText } from 'src/components/sections/BannerText/OverriddenDefaultBannerText'
 import { OverriddenDefaultCrossSellingShelf as CrossSellingShelf } from 'src/components/sections/CrossSellingShelf/OverriddenDefaultCrossSellingShelf'

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -2,7 +2,9 @@ import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
 import type { ComponentType } from 'react'
 
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
-import RenderSections from 'src/components/cms/RenderSections'
+import RenderSections, {
+  getComponentKey,
+} from 'src/components/cms/RenderSections'
 import BannerNewsletter from 'src/components/sections/BannerNewsletter/BannerNewsletter'
 import { OverriddenDefaultBannerText as BannerText } from 'src/components/sections/BannerText/OverriddenDefaultBannerText'
 import { OverriddenDefaultCrossSellingShelf as CrossSellingShelf } from 'src/components/sections/CrossSellingShelf/OverriddenDefaultCrossSellingShelf'
@@ -24,14 +26,14 @@ import type { PreviewData } from 'src/server/content/types'
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
   ...GLOBAL_COMPONENTS,
-  Hero,
-  BannerText,
-  BannerNewsletter,
-  CrossSellingShelf,
-  Incentives,
-  Newsletter,
-  ProductShelf,
-  ProductTiles,
+  [getComponentKey(Hero, 'Hero')]: Hero,
+  [getComponentKey(BannerText, 'BannerText')]: BannerText,
+  [getComponentKey(BannerNewsletter, 'BannerNewsletter')]: BannerNewsletter,
+  [getComponentKey(Incentives, 'Incentives')]: Incentives,
+  [getComponentKey(CrossSellingShelf, 'CrossSellingShelf')]: CrossSellingShelf,
+  [getComponentKey(Newsletter, 'Newsletter')]: Newsletter,
+  [getComponentKey(ProductShelf, 'ProductShelf')]: ProductShelf,
+  [getComponentKey(ProductTiles, 'ProductTiles')]: ProductTiles,
   ...PLUGINS_COMPONENTS,
   ...CUSTOM_COMPONENTS,
 }

--- a/packages/core/src/pages/404.tsx
+++ b/packages/core/src/pages/404.tsx
@@ -7,7 +7,9 @@ import {
 } from 'src/components/cms/GlobalSections'
 
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
-import RenderSections from 'src/components/cms/RenderSections'
+import RenderSections, {
+  getComponentKey,
+} from 'src/components/cms/RenderSections'
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
@@ -20,7 +22,7 @@ import type { PreviewData } from 'src/server/content/types'
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
   ...GLOBAL_COMPONENTS,
-  EmptyState,
+  [getComponentKey(EmptyState, 'EmptyState')]: EmptyState,
   ...PLUGINS_COMPONENTS,
   ...CUSTOM_COMPONENTS,
 }

--- a/packages/core/src/pages/404.tsx
+++ b/packages/core/src/pages/404.tsx
@@ -7,9 +7,8 @@ import {
 } from 'src/components/cms/GlobalSections'
 
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
-import RenderSections, {
-  getComponentKey,
-} from 'src/components/cms/RenderSections'
+import RenderSections from 'src/components/cms/RenderSections'
+import { getComponentKey } from 'src/utils/cms'
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'

--- a/packages/core/src/pages/500.tsx
+++ b/packages/core/src/pages/500.tsx
@@ -7,7 +7,9 @@ import {
 } from 'src/components/cms/GlobalSections'
 
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
-import RenderSections from 'src/components/cms/RenderSections'
+import RenderSections, {
+  getComponentKey,
+} from 'src/components/cms/RenderSections'
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
@@ -20,7 +22,7 @@ import type { PreviewData } from 'src/server/content/types'
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
   ...GLOBAL_COMPONENTS,
-  EmptyState,
+  [getComponentKey(EmptyState, 'EmptyState')]: EmptyState,
   ...PLUGINS_COMPONENTS,
   ...CUSTOM_COMPONENTS,
 }

--- a/packages/core/src/pages/500.tsx
+++ b/packages/core/src/pages/500.tsx
@@ -7,9 +7,8 @@ import {
 } from 'src/components/cms/GlobalSections'
 
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
-import RenderSections, {
-  getComponentKey,
-} from 'src/components/cms/RenderSections'
+import RenderSections from 'src/components/cms/RenderSections'
+import { getComponentKey } from 'src/utils/cms'
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -11,7 +11,9 @@ import type {
   ServerProductQueryQueryVariables,
 } from '@generated/graphql'
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
-import RenderSections from 'src/components/cms/RenderSections'
+import RenderSections, {
+  getComponentKey,
+} from 'src/components/cms/RenderSections'
 import BannerNewsletter from 'src/components/sections/BannerNewsletter/BannerNewsletter'
 import { OverriddenDefaultBannerText as BannerText } from 'src/components/sections/BannerText/OverriddenDefaultBannerText'
 import { OverriddenDefaultBreadcrumb as Breadcrumb } from 'src/components/sections/Breadcrumb/OverriddenDefaultBreadcrumb'
@@ -53,15 +55,15 @@ type StoreConfig = typeof storeConfig & {
  */
 const COMPONENTS: Record<string, ComponentType<any>> = {
   ...GLOBAL_COMPONENTS,
-  Breadcrumb,
-  BannerNewsletter,
-  Newsletter,
-  BannerText,
-  Hero,
-  ProductDetails,
-  ProductShelf,
-  ProductTiles,
-  CrossSellingShelf,
+  [getComponentKey(Breadcrumb, 'Breadcrumb')]: Breadcrumb,
+  [getComponentKey(BannerNewsletter, 'BannerNewsletter')]: BannerNewsletter,
+  [getComponentKey(Newsletter, 'Newsletter')]: Newsletter,
+  [getComponentKey(BannerText, 'BannerText')]: BannerText,
+  [getComponentKey(Hero, 'Hero')]: Hero,
+  [getComponentKey(ProductDetails, 'ProductDetails')]: ProductDetails,
+  [getComponentKey(ProductShelf, 'ProductShelf')]: ProductShelf,
+  [getComponentKey(ProductTiles, 'ProductTiles')]: ProductTiles,
+  [getComponentKey(CrossSellingShelf, 'CrossSellingShelf')]: CrossSellingShelf,
   ...PLUGINS_COMPONENTS,
   ...CUSTOM_COMPONENTS,
 }

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -11,9 +11,8 @@ import type {
   ServerProductQueryQueryVariables,
 } from '@generated/graphql'
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
-import RenderSections, {
-  getComponentKey,
-} from 'src/components/cms/RenderSections'
+import RenderSections from 'src/components/cms/RenderSections'
+import { getComponentKey } from 'src/utils/cms'
 import BannerNewsletter from 'src/components/sections/BannerNewsletter/BannerNewsletter'
 import { OverriddenDefaultBannerText as BannerText } from 'src/components/sections/BannerText/OverriddenDefaultBannerText'
 import { OverriddenDefaultBreadcrumb as Breadcrumb } from 'src/components/sections/Breadcrumb/OverriddenDefaultBreadcrumb'

--- a/packages/core/src/pages/login.tsx
+++ b/packages/core/src/pages/login.tsx
@@ -8,7 +8,9 @@ import {
   type GlobalSectionsData,
   getGlobalSectionsData,
 } from 'src/components/cms/GlobalSections'
-import RenderSections from 'src/components/cms/RenderSections'
+import RenderSections, {
+  getComponentKey,
+} from 'src/components/cms/RenderSections'
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
@@ -22,7 +24,7 @@ import storeConfig from '../../discovery.config'
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
   ...GLOBAL_COMPONENTS,
-  EmptyState,
+  [getComponentKey(EmptyState, 'EmptyState')]: EmptyState,
   ...PLUGINS_COMPONENTS,
   ...CUSTOM_COMPONENTS,
 }

--- a/packages/core/src/pages/login.tsx
+++ b/packages/core/src/pages/login.tsx
@@ -8,9 +8,8 @@ import {
   type GlobalSectionsData,
   getGlobalSectionsData,
 } from 'src/components/cms/GlobalSections'
-import RenderSections, {
-  getComponentKey,
-} from 'src/components/cms/RenderSections'
+import RenderSections from 'src/components/cms/RenderSections'
+import { getComponentKey } from 'src/utils/cms'
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'

--- a/packages/core/src/utils/cms.ts
+++ b/packages/core/src/utils/cms.ts
@@ -1,0 +1,10 @@
+import type { ComponentType } from 'react'
+
+export type ComponentTypeWithComponentKey<T> = ComponentType<T> & {
+  $componentKey?: string
+}
+
+export const getComponentKey = (
+  Component: ComponentTypeWithComponentKey<any>,
+  name: string
+) => Component.$componentKey ?? name


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR makes it so FastStore Core is capable of rendering components based on data from the CMS, using `$componentKey`s to identity each component. It also adds the `$componentKey`s to each component, based on their new schemas (for Content Platform) added in [this PR](https://github.com/vtex/faststore/pull/2742).

## How it works?

The implementation here is backwards compatible, so during the existing rendering flow a new check was added to look for the `$componentKey` property in a section's data. Also, for each component that renders a section, the `$componentKey` property was added, then, when indexing all available components, the new property will now be used if its present. To keep backwards compatibility, the `$componentKey`s are matching the names of the components.

## How to test it?

Since this change should be totally backwards compatible, if you're testing this branch with any current store, fetching data from hCMS, you should see no change in behaviour and everything should still render normally. Running `@faststore/core` locally also should look normal.

You can also test this by using this branch alongside the new CP client being used in https://github.com/vtex/faststore/pull/2807. 
