### PR TITLE
fix: Pickup Point ID that IS expects

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -179,7 +179,7 @@ export const IntelligentSearch = (
     }
 
     if (pickupPointFacet) {
-      params.append(PICKUP_POINT_KEY, `${account}_${pickupPointFacet.value}`)
+      params.append(PICKUP_POINT_KEY, pickupPointFacet.value)
     }
   }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

When filtering by pickup in point no results were being returned. It was due to the pickup point ID format we were sending to IS.

## How it works?

Checkout returns `<seller>_<pickupppoint_id>` as the Pickup Point ID when we use the Checkout's API for Pickup Points.
IS expects the Pickup Point ID to be `<account>_<pickuppoint_id>` or the Checkout format `<seller>_<pickupppoint_id>`. It doesn't expect it to be like we're sending (`<account>_<seller>_<pickuppoint_id>`). 
Therefore, now we'll send to IS as the Checkout sends to us and let IS deal with this format.

## How to test it?

If you want to test the core, remember to change `discovery.config.default.js` to use the `vendemo` config and also change the `hideUnavailableItems` to `true`.
You can also test it using the `vendemo` previews.
Using a Recife CEP, in a PLP/Search page (example `/apparel` page), filter by pickup point `VTEX Recife` - it should return results and not a empty search page.
<img width="1499" alt="Screenshot 2025-06-23 at 17 45 56" src="https://github.com/user-attachments/assets/511231be-e3b8-40d2-8c42-70fe035b4c98" />

### Starters Deploy Preview

- Preview without the fix - https://vendemo-cm9sir9v900u7z6llkl62l70j-9qgb9e563.b.vtex.app/
- Preview with the fix - https://vendemo-cm9sir9v900u7z6llkl62l70j-1kljpmw47.b.vtex.app/

[PR](https://github.com/dp-faststore-org/vendemo-dp/pull/37)

## References

- [Slack thread](https://vtex.slack.com/archives/C069YM7R73P/p1750701754802599)