### PR TITLE
chore: use global settings in RegionPopover and RegionModal

### DIFF
--- a/packages/cli/src/utils/templates/myAccountPage.ts
+++ b/packages/cli/src/utils/templates/myAccountPage.ts
@@ -15,23 +15,26 @@ export const myAccountPageTemplate = (pagePath: string) => `
     type MyAccountProps,
   } from 'src/experimental/myAccountSeverSideProps'
   import DynamicPage from '${pagePath}';
+  import PageProvider from 'src/sdk/overrides/PageProvider'
   /* A list of components that can be used in the CMS. */
   const COMPONENTS: Record<string, ComponentType<any>> = {
     ...GLOBAL_COMPONENTS,
     ...CUSTOM_COMPONENTS,
   }
 
-  function Page({ globalSections, accountName }: MyAccountProps) {
+  function Page({ globalSections: { sections: globalSections, settings: globalSettings }, accountName }: MyAccountProps) {
 
     return (
-      <RenderSections
-        globalSections={globalSections}
-        components={COMPONENTS}
-      >
-        <MyAccountLayout accountName={accountName}>
-          <DynamicPage />
-        </MyAccountLayout>
-      </RenderSections>
+     <PageProvider context={{ globalSettings }}>
+        <RenderSections
+          globalSections={globalSections}
+          components={COMPONENTS}
+        >
+          <MyAccountLayout accountName={accountName}>
+            <DynamicPage />
+          </MyAccountLayout>
+        </RenderSections>
+      </PageProvider>
     )
   }
 

--- a/packages/cli/src/utils/templates/myAccountPage.ts
+++ b/packages/cli/src/utils/templates/myAccountPage.ts
@@ -22,7 +22,8 @@ export const myAccountPageTemplate = (pagePath: string) => `
     ...CUSTOM_COMPONENTS,
   }
 
-  function Page({ globalSections: { sections: globalSections, settings: globalSettings }, accountName }: MyAccountProps) {
+  function Page({ globalSections: globalSectionsProp, accountName }: MyAccountProps) {
+    const { sections: globalSections, settings: globalSettings } = globalSectionsProp ?? {}
 
     return (
      <PageProvider context={{ globalSettings }}>

--- a/packages/cli/src/utils/templates/myAccountPage.ts
+++ b/packages/cli/src/utils/templates/myAccountPage.ts
@@ -25,7 +25,7 @@ export const myAccountPageTemplate = (pagePath: string) => `
 
     return (
       <RenderSections
-        globalSections={globalSections.sections}
+        globalSections={globalSections}
         components={COMPONENTS}
       >
         <MyAccountLayout accountName={accountName}>

--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -9,16 +9,14 @@ import {
 import { useUI } from '@faststore/ui'
 import type { Section } from '@vtex/client-cms'
 import dynamic from 'next/dynamic'
-import PageProvider, { usePage } from 'src/sdk/overrides/PageProvider'
 import useTTI from 'src/sdk/performance/useTTI'
 import COMPONENTS from './global/Components'
-import type { GlobalSectionsData } from './GlobalSections'
 import SectionBoundary from './SectionBoundary'
 import ViewportObserver from './ViewportObserver'
 
 interface Props {
   components?: Record<string, ComponentType<any>>
-  globalSections?: Array<{ name: string; data: any }> | GlobalSectionsData
+  globalSections?: Array<{ name: string; data: any }>
   sections?: Array<{ name: string; data: any }>
   isInteractive?: boolean
 }
@@ -130,34 +128,18 @@ export const RenderSectionsBase = ({
 
 function RenderSections({
   children,
-  globalSections: global,
+  globalSections,
   sections,
   components = COMPONENTS,
 }: PropsWithChildren<Props>) {
-  const [globalSections, globalSettings] = Array.isArray(global)
-    ? [global, {}]
-    : [global?.sections ?? [], global?.settings ?? {}]
   const { firstSections, lastSections } = useDividedSections(
     globalSections ?? sections
   )
-  const outerContext = (() => {
-    try {
-      return usePage()
-    } catch {
-      // if there is no outer context (usePage throws an error), fallback to an empty object
-      return {}
-    }
-  })()
 
   const { isInteractive } = useTTI()
 
   return (
-    <PageProvider
-      context={{
-        ...outerContext,
-        globalSettings,
-      }}
-    >
+    <>
       {firstSections && (
         <RenderSectionsBase
           sections={firstSections}
@@ -184,7 +166,7 @@ function RenderSections({
           isInteractive={isInteractive}
         />
       )}
-    </PageProvider>
+    </>
   )
 }
 

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -47,18 +47,21 @@ function RegionModal(regionModalProps: RegionModalProps) {
   )
   const {
     inputField: {
-      label: inputFieldLabel,
-      errorMessage: inputFieldErrorMessage,
+      label: inputFieldLabel = '',
+      errorMessage: inputFieldErrorMessage = '',
       noProductsAvailableErrorMessage:
-        inputFieldNoProductsAvailableErrorMessage,
-      buttonActionText: inputButtonActionText,
-    },
+        inputFieldNoProductsAvailableErrorMessage = '',
+      buttonActionText: inputButtonActionText = '',
+    } = {},
     idkPostalCodeLink: {
-      text: idkPostalCodeLinkText,
-      to: idkPostalCodeLinkTo,
-      icon: { icon: idkPostalCodeLinkIcon, alt: idkPostalCodeLinkIconAlt },
-    },
-  } = regionalizationSettings
+      text: idkPostalCodeLinkText = '',
+      to: idkPostalCodeLinkTo = '',
+      icon: {
+        icon: idkPostalCodeLinkIcon = '',
+        alt: idkPostalCodeLinkIconAlt = '',
+      } = {},
+    } = {},
+  } = regionalizationSettings ?? {}
 
   const inputRef = useRef<HTMLInputElement>(null)
   const { isValidating, ...session } = useSession()

--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -9,6 +9,7 @@ import { useSession } from 'src/sdk/session'
 
 import useRegion from './useRegion'
 
+import { getRegionalizationSettings } from 'src/utils/globalSettings'
 import styles from './section.module.scss'
 
 const UIRegionModal = dynamic<UIRegionModalProps>(
@@ -38,22 +39,27 @@ interface RegionModalProps {
   }
 }
 
-function RegionModal({
-  title,
-  description,
-  closeButtonAriaLabel,
-  inputField: {
-    label: inputFieldLabel,
-    errorMessage: inputFieldErrorMessage,
-    noProductsAvailableErrorMessage: inputFieldNoProductsAvailableErrorMessage,
-    buttonActionText: inputButtonActionText,
-  },
-  idkPostalCodeLink: {
-    text: idkPostalCodeLinkText,
-    to: idkPostalCodeLinkTo,
-    icon: { icon: idkPostalCodeLinkIcon, alt: idkPostalCodeLinkIconAlt },
-  },
-}: RegionModalProps) {
+function RegionModal(regionModalProps: RegionModalProps) {
+  const { title, description, closeButtonAriaLabel, ...otherRegionModalProps } =
+    regionModalProps
+  const regionalizationSettings = getRegionalizationSettings(
+    otherRegionModalProps
+  )
+  const {
+    inputField: {
+      label: inputFieldLabel,
+      errorMessage: inputFieldErrorMessage,
+      noProductsAvailableErrorMessage:
+        inputFieldNoProductsAvailableErrorMessage,
+      buttonActionText: inputButtonActionText,
+    },
+    idkPostalCodeLink: {
+      text: idkPostalCodeLinkText,
+      to: idkPostalCodeLinkTo,
+      icon: { icon: idkPostalCodeLinkIcon, alt: idkPostalCodeLinkIconAlt },
+    },
+  } = regionalizationSettings
+
   const inputRef = useRef<HTMLInputElement>(null)
   const { isValidating, ...session } = useSession()
   const { modal: displayModal, closeModal } = useUI()

--- a/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
+++ b/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
@@ -60,18 +60,21 @@ function RegionPopover(regionPopoverProps: RegionPopoverProps) {
   )
   const {
     inputField: {
-      label: inputFieldLabel,
-      errorMessage: inputFieldErrorMessage,
+      label: inputFieldLabel = '',
+      errorMessage: inputFieldErrorMessage = '',
       noProductsAvailableErrorMessage:
-        inputFieldNoProductsAvailableErrorMessage,
-      buttonActionText: inputButtonActionText,
-    },
+        inputFieldNoProductsAvailableErrorMessage = '',
+      buttonActionText: inputButtonActionText = '',
+    } = {},
     idkPostalCodeLink: {
-      text: idkPostalCodeLinkText,
-      to: idkPostalCodeLinkTo,
-      icon: { icon: idkPostalCodeLinkIcon, alt: idkPostalCodeLinkIconAlt },
-    },
-  } = regionalizationSettings
+      text: idkPostalCodeLinkText = '',
+      to: idkPostalCodeLinkTo = '',
+      icon: {
+        icon: idkPostalCodeLinkIcon = '',
+        alt: idkPostalCodeLinkIconAlt = '',
+      } = {},
+    } = {},
+  } = regionalizationSettings ?? {}
 
   const inputRef = useRef<HTMLInputElement>(null)
   const { isValidating, ...session } = useSession()

--- a/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
+++ b/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
@@ -11,6 +11,7 @@ import { useRef, useState } from 'react'
 import useRegion from '../RegionModal/useRegion'
 
 import { sessionStore, useSession } from 'src/sdk/session'
+import { getRegionalizationSettings } from 'src/utils/globalSettings'
 import { textToTitleCase } from 'src/utils/utilities'
 import styles from './section.module.scss'
 
@@ -41,28 +42,37 @@ interface RegionPopoverProps {
   placement?: UIPopoverProps['placement']
 }
 
-function RegionPopover({
-  title = 'Set your location',
-  closeButtonAriaLabel,
-  inputField: {
-    label: inputFieldLabel,
-    errorMessage: inputFieldErrorMessage,
-    noProductsAvailableErrorMessage: inputFieldNoProductsAvailableErrorMessage,
-    buttonActionText: inputButtonActionText,
-  },
-  idkPostalCodeLink: {
-    text: idkPostalCodeLinkText,
-    to: idkPostalCodeLinkTo,
-    icon: { icon: idkPostalCodeLinkIcon, alt: idkPostalCodeLinkIconAlt },
-  },
-  textBeforeLocation = 'Your current location is:',
-  textAfterLocation = 'Use the field below to change it.',
-  description = 'Offers and availability vary by location.',
-  triggerRef,
-  offsetTop = 6,
-  offsetLeft,
-  placement = 'bottom-start',
-}: RegionPopoverProps) {
+function RegionPopover(regionPopoverProps: RegionPopoverProps) {
+  const {
+    title = 'Set your location',
+    closeButtonAriaLabel,
+    textBeforeLocation = 'Your current location is:',
+    textAfterLocation = 'Use the field below to change it.',
+    description = 'Offers and availability vary by location.',
+    triggerRef,
+    offsetTop = 6,
+    offsetLeft,
+    placement = 'bottom-start',
+    ...otherRegionPopoverProps
+  } = regionPopoverProps
+  const regionalizationSettings = getRegionalizationSettings(
+    otherRegionPopoverProps
+  )
+  const {
+    inputField: {
+      label: inputFieldLabel,
+      errorMessage: inputFieldErrorMessage,
+      noProductsAvailableErrorMessage:
+        inputFieldNoProductsAvailableErrorMessage,
+      buttonActionText: inputButtonActionText,
+    },
+    idkPostalCodeLink: {
+      text: idkPostalCodeLinkText,
+      to: idkPostalCodeLinkTo,
+      icon: { icon: idkPostalCodeLinkIcon, alt: idkPostalCodeLinkIconAlt },
+    },
+  } = regionalizationSettings
+
   const inputRef = useRef<HTMLInputElement>(null)
   const { isValidating, ...session } = useSession()
   const { popover: displayPopover, closePopover } = useUI()

--- a/packages/core/src/components/search/Filter/FilterDesktop.tsx
+++ b/packages/core/src/components/search/Filter/FilterDesktop.tsx
@@ -74,7 +74,7 @@ function FilterDesktop({
   }
 
   // Delivery Promise consts
-  const regionalizationData = getRegionalizationSettings(deliverySettings)
+  const regionalizationData = getRegionalizationSettings({ deliverySettings })
   const { deliverySettings: deliverySettingsData } = regionalizationData
   const deliveryLabel = deliverySettingsData?.title ?? 'Delivery'
   const isDeliveryPromiseEnabled = deliveryPromise.enabled

--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -137,7 +137,7 @@ function FilterSlider({
   }
 
   // Delivery Promise consts
-  const regionalizationData = getRegionalizationSettings(deliverySettings)
+  const regionalizationData = getRegionalizationSettings({ deliverySettings })
   const { deliverySettings: deliverySettingsData } = regionalizationData
   const deliveryLabel = deliverySettingsData?.title ?? 'Delivery'
   const isDeliveryPromiseEnabled = deliveryPromise.enabled

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -18,7 +18,6 @@ import PageProvider from 'src/sdk/overrides/PageProvider'
 import type { PageContentType } from 'src/server/cms'
 
 import storeConfig from 'discovery.config'
-import type { GlobalSectionsData } from 'src/components/cms/GlobalSections'
 import { contentService } from 'src/server/content/service'
 import type { PreviewData } from 'src/server/content/types'
 
@@ -41,7 +40,8 @@ export type LandingPageProps = {
   page: PageContentType
   slug?: string
   serverData?: unknown
-  globalSections?: Array<{ name: string; data: any }> | GlobalSectionsData
+  globalSections?: Array<{ name: string; data: any }>
+  globalSettings?: Record<string, unknown>
 }
 
 export default function LandingPage({
@@ -49,9 +49,11 @@ export default function LandingPage({
   slug,
   serverData,
   globalSections,
+  globalSettings,
 }: LandingPageProps) {
   const context = {
     data: serverData,
+    globalSettings,
   }
 
   return (

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -18,6 +18,7 @@ import PageProvider from 'src/sdk/overrides/PageProvider'
 import type { PageContentType } from 'src/server/cms'
 
 import storeConfig from 'discovery.config'
+import type { GlobalSectionsData } from 'src/components/cms/GlobalSections'
 import { contentService } from 'src/server/content/service'
 import type { PreviewData } from 'src/server/content/types'
 
@@ -40,8 +41,7 @@ export type LandingPageProps = {
   page: PageContentType
   slug?: string
   serverData?: unknown
-  globalSections?: Array<{ name: string; data: any }>
-  globalSectionsSettings?: Record<string, any>
+  globalSections?: Array<{ name: string; data: any }> | GlobalSectionsData
 }
 
 export default function LandingPage({
@@ -49,11 +49,9 @@ export default function LandingPage({
   slug,
   serverData,
   globalSections,
-  globalSectionsSettings,
 }: LandingPageProps) {
   const context = {
     data: serverData,
-    globalSectionsSettings,
   }
 
   return (

--- a/packages/core/src/components/templates/ProductListingPage/ProductListing.tsx
+++ b/packages/core/src/components/templates/ProductListingPage/ProductListing.tsx
@@ -17,6 +17,7 @@ import type { PLPContentType } from 'src/server/cms/plp'
 
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
+import type { GlobalSectionsData } from 'src/components/cms/GlobalSections'
 import PageProvider, { type PLPContext } from 'src/sdk/overrides/PageProvider'
 import {
   useCreateUseGalleryPage,
@@ -38,8 +39,7 @@ export type ProductListingPageProps = {
   data: ServerCollectionPageQueryQuery & ServerManyProductsQueryQuery
   serverManyProductsVariables: ServerManyProductsQueryQueryVariables
   page: PLPContentType
-  globalSections?: Array<{ name: string; data: any }>
-  globalSectionsSettings?: Record<string, any>
+  globalSections?: Array<{ name: string; data: any }> | GlobalSectionsData
 }
 
 // Array merging strategy from deepmerge that makes client arrays overwrite server array
@@ -51,7 +51,6 @@ export default function ProductListing({
   data: server,
   serverManyProductsVariables,
   globalSections,
-  globalSectionsSettings,
 }: ProductListingPageProps) {
   const router = useRouter()
   const { state } = useSearch()
@@ -88,7 +87,6 @@ export default function ProductListing({
       ),
       pages,
     },
-    globalSectionsSettings,
   } as PLPContext
 
   return (

--- a/packages/core/src/components/templates/ProductListingPage/ProductListing.tsx
+++ b/packages/core/src/components/templates/ProductListingPage/ProductListing.tsx
@@ -17,7 +17,6 @@ import type { PLPContentType } from 'src/server/cms/plp'
 
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
-import type { GlobalSectionsData } from 'src/components/cms/GlobalSections'
 import PageProvider, { type PLPContext } from 'src/sdk/overrides/PageProvider'
 import {
   useCreateUseGalleryPage,
@@ -39,7 +38,8 @@ export type ProductListingPageProps = {
   data: ServerCollectionPageQueryQuery & ServerManyProductsQueryQuery
   serverManyProductsVariables: ServerManyProductsQueryQueryVariables
   page: PLPContentType
-  globalSections?: Array<{ name: string; data: any }> | GlobalSectionsData
+  globalSections?: Array<{ name: string; data: any }>
+  globalSettings?: Record<string, unknown>
 }
 
 // Array merging strategy from deepmerge that makes client arrays overwrite server array
@@ -51,6 +51,7 @@ export default function ProductListing({
   data: server,
   serverManyProductsVariables,
   globalSections,
+  globalSettings,
 }: ProductListingPageProps) {
   const router = useRouter()
   const { state } = useSearch()
@@ -87,6 +88,7 @@ export default function ProductListing({
       ),
       pages,
     },
+    globalSettings,
   } as PLPContext
 
   return (

--- a/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
+++ b/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
@@ -20,13 +20,13 @@ import type { PLPContentType } from 'src/server/cms/plp'
 
 import storeConfig from '../../../../discovery.config'
 import ProductListing from './ProductListing'
+import type { GlobalSectionsData } from 'src/components/cms/GlobalSections'
 
 export type ProductListingPageProps = {
   data: ServerCollectionPageQueryQuery & ServerManyProductsQueryQuery
   serverManyProductsVariables: ServerManyProductsQueryQueryVariables
   page: PLPContentType
-  globalSections?: Array<{ name: string; data: any }>
-  globalSectionsSettings?: Record<string, any>
+  globalSections?: Array<{ name: string; data: any }> | GlobalSectionsData
 }
 
 type UseSearchParams = {
@@ -77,7 +77,6 @@ export default function ProductListingPage({
   data: server,
   serverManyProductsVariables,
   globalSections,
-  globalSectionsSettings,
 }: ProductListingPageProps) {
   const { settings } = plpContentType
   const collection = server.collection
@@ -136,7 +135,6 @@ export default function ProductListingPage({
 
       <ProductListing
         globalSections={globalSections}
-        globalSectionsSettings={globalSectionsSettings}
         page={plpContentType}
         data={server}
         serverManyProductsVariables={serverManyProductsVariables}

--- a/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
+++ b/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
@@ -20,13 +20,13 @@ import type { PLPContentType } from 'src/server/cms/plp'
 
 import storeConfig from '../../../../discovery.config'
 import ProductListing from './ProductListing'
-import type { GlobalSectionsData } from 'src/components/cms/GlobalSections'
 
 export type ProductListingPageProps = {
   data: ServerCollectionPageQueryQuery & ServerManyProductsQueryQuery
   serverManyProductsVariables: ServerManyProductsQueryQueryVariables
   page: PLPContentType
-  globalSections?: Array<{ name: string; data: any }> | GlobalSectionsData
+  globalSections?: Array<{ name: string; data: any }>
+  globalSettings?: Record<string, unknown>
 }
 
 type UseSearchParams = {
@@ -77,6 +77,7 @@ export default function ProductListingPage({
   data: server,
   serverManyProductsVariables,
   globalSections,
+  globalSettings,
 }: ProductListingPageProps) {
   const { settings } = plpContentType
   const collection = server.collection
@@ -135,6 +136,7 @@ export default function ProductListingPage({
 
       <ProductListing
         globalSections={globalSections}
+        globalSettings={globalSettings}
         page={plpContentType}
         data={server}
         serverManyProductsVariables={serverManyProductsVariables}

--- a/packages/core/src/components/templates/SearchPage/SearchPage.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchPage.tsx
@@ -1,4 +1,5 @@
 import type { ClientProductGalleryQueryQuery as ClientProductGalleryQuery } from '@generated/graphql'
+import type { GlobalSectionsData } from 'src/components/cms/GlobalSections'
 import RenderSections from 'src/components/cms/RenderSections'
 import COMPONENTS from 'src/components/cms/search/Components'
 import type { SearchPageContextType } from 'src/pages/s'
@@ -14,15 +15,13 @@ import type { SearchContentType } from 'src/server/cms'
 export type SearchPageProps = {
   data: SearchPageContextType & ClientProductGalleryQuery
   page: SearchContentType
-  globalSections?: Array<{ name: string; data: any }>
-  globalSectionsSettings?: Record<string, any>
+  globalSections?: Array<{ name: string; data: any }> | GlobalSectionsData
 }
 
 function SearchPage({
   page: { sections },
   data: serverData,
   globalSections,
-  globalSectionsSettings,
 }: SearchPageProps) {
   const { pages, useGalleryPage } = useCreateUseGalleryPage()
 
@@ -31,7 +30,6 @@ function SearchPage({
       ...serverData,
       pages,
     },
-    globalSectionsSettings,
   } as SearchPageContext
 
   return (

--- a/packages/core/src/components/templates/SearchPage/SearchPage.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchPage.tsx
@@ -1,5 +1,4 @@
 import type { ClientProductGalleryQueryQuery as ClientProductGalleryQuery } from '@generated/graphql'
-import type { GlobalSectionsData } from 'src/components/cms/GlobalSections'
 import RenderSections from 'src/components/cms/RenderSections'
 import COMPONENTS from 'src/components/cms/search/Components'
 import type { SearchPageContextType } from 'src/pages/s'
@@ -15,13 +14,15 @@ import type { SearchContentType } from 'src/server/cms'
 export type SearchPageProps = {
   data: SearchPageContextType & ClientProductGalleryQuery
   page: SearchContentType
-  globalSections?: Array<{ name: string; data: any }> | GlobalSectionsData
+  globalSections?: Array<{ name: string; data: any }>
+  globalSettings?: Record<string, unknown>
 }
 
 function SearchPage({
   page: { sections },
   data: serverData,
   globalSections,
+  globalSettings,
 }: SearchPageProps) {
   const { pages, useGalleryPage } = useCreateUseGalleryPage()
 
@@ -30,6 +31,7 @@ function SearchPage({
       ...serverData,
       pages,
     },
+    globalSettings,
   } as SearchPageContext
 
   return (

--- a/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
@@ -1,21 +1,22 @@
 import { useSearch } from '@faststore/sdk'
 import { useRouter } from 'next/router'
 
+import storeConfig from 'discovery.config'
 import type { SearchPageContextType } from 'src/pages/s'
 import { useProductGalleryQuery } from 'src/sdk/product/useProductGalleryQuery'
 import type { SearchContentType } from 'src/server/cms'
-import storeConfig from 'discovery.config'
 
 import RenderSections from 'src/components/cms/RenderSections'
+import PageProvider from 'src/sdk/overrides/PageProvider'
 import EmptySearch from './EmptySearch'
 import SearchPage from './SearchPage'
-import type { GlobalSectionsData } from 'src/components/cms/GlobalSections'
 
 export type SearchWrapperProps = {
   itemsPerPage: number
   searchContentType: SearchContentType
   serverData: SearchPageContextType
-  globalSections?: Array<{ name: string; data: any }> | GlobalSectionsData
+  globalSections?: Array<{ name: string; data: any }>
+  globalSettings?: Record<string, unknown>
 }
 
 export default function SearchWrapper({
@@ -23,6 +24,7 @@ export default function SearchWrapper({
   searchContentType,
   serverData,
   globalSections,
+  globalSettings,
 }: SearchWrapperProps) {
   const router = useRouter()
   const {
@@ -47,9 +49,11 @@ export default function SearchWrapper({
 
   if (!pageProductGalleryData) {
     return (
-      <RenderSections globalSections={globalSections}>
-        <EmptySearch {...emptySearchProps} />
-      </RenderSections>
+      <PageProvider context={{ globalSettings }}>
+        <RenderSections globalSections={globalSections}>
+          <EmptySearch {...emptySearchProps} />
+        </RenderSections>
+      </PageProvider>
     )
   }
 
@@ -60,9 +64,11 @@ export default function SearchWrapper({
     })
 
     return (
-      <RenderSections globalSections={globalSections}>
-        <EmptySearch {...emptySearchProps} />
-      </RenderSections>
+      <PageProvider context={{ globalSettings }}>
+        <RenderSections globalSections={globalSections}>
+          <EmptySearch {...emptySearchProps} />
+        </RenderSections>
+      </PageProvider>
     )
   }
 
@@ -82,6 +88,7 @@ export default function SearchWrapper({
       page={searchContentType}
       data={{ ...serverData, ...pageProductGalleryData }}
       globalSections={globalSections}
+      globalSettings={globalSettings}
     />
   )
 }

--- a/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
@@ -9,13 +9,13 @@ import storeConfig from 'discovery.config'
 import RenderSections from 'src/components/cms/RenderSections'
 import EmptySearch from './EmptySearch'
 import SearchPage from './SearchPage'
+import type { GlobalSectionsData } from 'src/components/cms/GlobalSections'
 
 export type SearchWrapperProps = {
   itemsPerPage: number
   searchContentType: SearchContentType
   serverData: SearchPageContextType
-  globalSections?: Array<{ name: string; data: any }>
-  globalSectionsSettings?: Record<string, any>
+  globalSections?: Array<{ name: string; data: any }> | GlobalSectionsData
 }
 
 export default function SearchWrapper({
@@ -23,7 +23,6 @@ export default function SearchWrapper({
   searchContentType,
   serverData,
   globalSections,
-  globalSectionsSettings,
 }: SearchWrapperProps) {
   const router = useRouter()
   const {
@@ -83,7 +82,6 @@ export default function SearchWrapper({
       page={searchContentType}
       data={{ ...serverData, ...pageProductGalleryData }}
       globalSections={globalSections}
-      globalSectionsSettings={globalSectionsSettings}
     />
   )
 }

--- a/packages/core/src/pages/404.tsx
+++ b/packages/core/src/pages/404.tsx
@@ -46,7 +46,7 @@ function Page({ page: { sections }, globalSections }: Props) {
       */}
       <RenderSections
         sections={sections}
-        globalSections={globalSections.sections}
+        globalSections={globalSections}
         components={COMPONENTS}
       />
     </>

--- a/packages/core/src/pages/404.tsx
+++ b/packages/core/src/pages/404.tsx
@@ -32,8 +32,11 @@ type Props = {
 
 function Page({
   page: { sections },
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
 }: Props) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   return (
     <>
       <NextSeo noindex nofollow />

--- a/packages/core/src/pages/404.tsx
+++ b/packages/core/src/pages/404.tsx
@@ -11,6 +11,7 @@ import RenderSections from 'src/components/cms/RenderSections'
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
+import PageProvider from 'src/sdk/overrides/PageProvider'
 import type { PageContentType } from 'src/server/cms'
 import { injectGlobalSections } from 'src/server/cms/global'
 import { contentService } from 'src/server/content/service'
@@ -29,7 +30,10 @@ type Props = {
   globalSections: GlobalSectionsData
 }
 
-function Page({ page: { sections }, globalSections }: Props) {
+function Page({
+  page: { sections },
+  globalSections: { sections: globalSections, settings: globalSettings },
+}: Props) {
   return (
     <>
       <NextSeo noindex nofollow />
@@ -44,11 +48,13 @@ function Page({ page: { sections }, globalSections }: Props) {
         If needed, wrap your component in a <Section /> component
         (not the HTML tag) before rendering it here.
       */}
-      <RenderSections
-        sections={sections}
-        globalSections={globalSections}
-        components={COMPONENTS}
-      />
+      <PageProvider context={{ globalSettings }}>
+        <RenderSections
+          sections={sections}
+          globalSections={globalSections}
+          components={COMPONENTS}
+        />
+      </PageProvider>
     </>
   )
 }

--- a/packages/core/src/pages/500.tsx
+++ b/packages/core/src/pages/500.tsx
@@ -11,6 +11,7 @@ import RenderSections from 'src/components/cms/RenderSections'
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
+import PageProvider from 'src/sdk/overrides/PageProvider'
 import type { PageContentType } from 'src/server/cms'
 import { injectGlobalSections } from 'src/server/cms/global'
 import { contentService } from 'src/server/content/service'
@@ -29,7 +30,10 @@ type Props = {
   globalSections: GlobalSectionsData
 }
 
-function Page({ page: { sections }, globalSections }: Props) {
+function Page({
+  page: { sections },
+  globalSections: { sections: globalSections, settings: globalSettings },
+}: Props) {
   return (
     <>
       <NextSeo noindex nofollow />
@@ -45,11 +49,13 @@ function Page({ page: { sections }, globalSections }: Props) {
         If needed, wrap your component in a <Section /> component
         (not the HTML tag) before rendering it here.
       */}
-      <RenderSections
-        sections={sections}
-        globalSections={globalSections}
-        components={COMPONENTS}
-      />
+      <PageProvider context={{ globalSettings }}>
+        <RenderSections
+          sections={sections}
+          globalSections={globalSections}
+          components={COMPONENTS}
+        />
+      </PageProvider>
     </>
   )
 }

--- a/packages/core/src/pages/500.tsx
+++ b/packages/core/src/pages/500.tsx
@@ -47,7 +47,7 @@ function Page({ page: { sections }, globalSections }: Props) {
       */}
       <RenderSections
         sections={sections}
-        globalSections={globalSections.sections}
+        globalSections={globalSections}
         components={COMPONENTS}
       />
     </>

--- a/packages/core/src/pages/500.tsx
+++ b/packages/core/src/pages/500.tsx
@@ -32,8 +32,11 @@ type Props = {
 
 function Page({
   page: { sections },
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
 }: Props) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   return (
     <>
       <NextSeo noindex nofollow />

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -58,10 +58,13 @@ type Props = BaseProps &
   )
 
 function Page({
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
   type,
   ...otherProps
 }: Props) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   return (
     <>
       {type === 'plp' && (

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -57,18 +57,24 @@ type Props = BaseProps &
       }
   )
 
-function Page({ globalSections, type, ...otherProps }: Props) {
+function Page({
+  globalSections: { sections: globalSections, settings: globalSettings },
+  type,
+  ...otherProps
+}: Props) {
   return (
     <>
       {type === 'plp' && (
         <ProductListingPage
           globalSections={globalSections}
+          globalSettings={globalSettings}
           {...(otherProps as ProductListingPageProps)}
         />
       )}
       {type === 'page' && (
         <LandingPage
           globalSections={globalSections}
+          globalSettings={globalSettings}
           {...(otherProps as LandingPageProps)}
         />
       )}

--- a/packages/core/src/pages/[...slug].tsx
+++ b/packages/core/src/pages/[...slug].tsx
@@ -62,15 +62,13 @@ function Page({ globalSections, type, ...otherProps }: Props) {
     <>
       {type === 'plp' && (
         <ProductListingPage
-          globalSections={globalSections.sections}
-          globalSectionsSettings={globalSections.settings}
+          globalSections={globalSections}
           {...(otherProps as ProductListingPageProps)}
         />
       )}
       {type === 'page' && (
         <LandingPage
-          globalSections={globalSections.sections}
-          globalSectionsSettings={globalSections.settings}
+          globalSections={globalSections}
           {...(otherProps as LandingPageProps)}
         />
       )}

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -87,7 +87,7 @@ function Page({
   data: server,
   sections,
   settings,
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
   offers,
   meta,
 }: Props) {
@@ -135,6 +135,8 @@ function Page({
         }
       })()
 
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
   const context = {
     data: {
       ...deepmerge(server, client, { arrayMerge: overwriteMerge }),

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -23,8 +23,8 @@ import { OverriddenDefaultProductShelf as ProductShelf } from 'src/components/se
 import ProductTiles from 'src/components/sections/ProductTiles'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
-import { useSession } from 'src/sdk/session'
 import { getRedirect } from 'src/sdk/redirects'
+import { useSession } from 'src/sdk/session'
 import { execute } from 'src/server'
 
 import storeConfig from 'discovery.config'
@@ -215,7 +215,7 @@ function Page({
       <PageProvider context={context}>
         <RenderSections
           sections={sections}
-          globalSections={globalSections.sections}
+          globalSections={globalSections}
           components={COMPONENTS}
         />
       </PageProvider>

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -87,7 +87,7 @@ function Page({
   data: server,
   sections,
   settings,
-  globalSections,
+  globalSections: { sections: globalSections, settings: globalSettings },
   offers,
   meta,
 }: Props) {
@@ -140,6 +140,7 @@ function Page({
       ...deepmerge(server, client, { arrayMerge: overwriteMerge }),
       isValidating,
     },
+    globalSettings,
   } as PDPContext
 
   return (

--- a/packages/core/src/pages/account/403.tsx
+++ b/packages/core/src/pages/account/403.tsx
@@ -8,22 +8,23 @@ import {
 } from 'src/components/cms/GlobalSections'
 
 import { LinkButton } from '@faststore/ui'
+import { gql } from '@generated/gql'
+import type {
+  ServerAccountPageQueryQuery,
+  ServerAccountPageQueryQueryVariables,
+} from '@generated/graphql'
 import { MyAccountLayout } from 'src/components/account'
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
 import RenderSections from 'src/components/cms/RenderSections'
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
+import { validateUser } from 'src/sdk/account/validateUser'
+import PageProvider from 'src/sdk/overrides/PageProvider'
+import { execute } from 'src/server'
 import { type PageContentType, getPage } from 'src/server/cms'
 import { injectGlobalSections } from 'src/server/cms/global'
 import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
-import { gql } from '@generated/gql'
-import { execute } from 'src/server'
-import type {
-  ServerAccountPageQueryQuery,
-  ServerAccountPageQueryQueryVariables,
-} from '@generated/graphql'
-import { validateUser } from 'src/sdk/account/validateUser'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -37,24 +38,29 @@ type Props = {
   accountName: ServerAccountPageQueryQuery['accountName']
 }
 
-function Page({ globalSections, accountName }: Props) {
+function Page({
+  globalSections: { sections: globalSections, settings: globalSettings },
+  accountName,
+}: Props) {
   return (
-    <RenderSections globalSections={globalSections} components={COMPONENTS}>
-      <NextSeo noindex nofollow />
+    <PageProvider context={{ globalSettings }}>
+      <RenderSections globalSections={globalSections} components={COMPONENTS}>
+        <NextSeo noindex nofollow />
 
-      <MyAccountLayout accountName={accountName}>
-        <EmptyState
-          title="Unauthorized Access"
-          titleIcon={{ icon: 'ShoppingCart', alt: 'Shopping Cart' }}
-          subtitle="You don't have permission to access this page."
-          showLoader={false}
-        >
-          <LinkButton variant="secondary" href="/account">
-            Back to Account
-          </LinkButton>
-        </EmptyState>
-      </MyAccountLayout>
-    </RenderSections>
+        <MyAccountLayout accountName={accountName}>
+          <EmptyState
+            title="Unauthorized Access"
+            titleIcon={{ icon: 'ShoppingCart', alt: 'Shopping Cart' }}
+            subtitle="You don't have permission to access this page."
+            showLoader={false}
+          >
+            <LinkButton variant="secondary" href="/account">
+              Back to Account
+            </LinkButton>
+          </EmptyState>
+        </MyAccountLayout>
+      </RenderSections>
+    </PageProvider>
   )
 }
 

--- a/packages/core/src/pages/account/403.tsx
+++ b/packages/core/src/pages/account/403.tsx
@@ -39,10 +39,7 @@ type Props = {
 
 function Page({ globalSections, accountName }: Props) {
   return (
-    <RenderSections
-      globalSections={globalSections.sections}
-      components={COMPONENTS}
-    >
+    <RenderSections globalSections={globalSections} components={COMPONENTS}>
       <NextSeo noindex nofollow />
 
       <MyAccountLayout accountName={accountName}>

--- a/packages/core/src/pages/account/403.tsx
+++ b/packages/core/src/pages/account/403.tsx
@@ -38,10 +38,10 @@ type Props = {
   accountName: ServerAccountPageQueryQuery['accountName']
 }
 
-function Page({
-  globalSections: { sections: globalSections, settings: globalSettings },
-  accountName,
-}: Props) {
+function Page({ globalSections: globalSectionsProp, accountName }: Props) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   return (
     <PageProvider context={{ globalSettings }}>
       <RenderSections globalSections={globalSections} components={COMPONENTS}>

--- a/packages/core/src/pages/account/404.tsx
+++ b/packages/core/src/pages/account/404.tsx
@@ -42,10 +42,7 @@ type Props = {
 
 function Page({ page: { sections }, globalSections, accountName }: Props) {
   return (
-    <RenderSections
-      globalSections={globalSections.sections}
-      components={COMPONENTS}
-    >
+    <RenderSections globalSections={globalSections} components={COMPONENTS}>
       <NextSeo noindex nofollow />
 
       <MyAccountLayout accountName={accountName}>

--- a/packages/core/src/pages/account/404.tsx
+++ b/packages/core/src/pages/account/404.tsx
@@ -7,6 +7,11 @@ import {
   getGlobalSectionsData,
 } from 'src/components/cms/GlobalSections'
 
+import { gql } from '@generated/gql'
+import type {
+  ServerAccountPageQueryQuery,
+  ServerAccountPageQueryQueryVariables,
+} from '@generated/graphql'
 import { MyAccountLayout } from 'src/components/account'
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
 import RenderSections, {
@@ -15,16 +20,12 @@ import RenderSections, {
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
+import { validateUser } from 'src/sdk/account/validateUser'
+import PageProvider from 'src/sdk/overrides/PageProvider'
+import { execute } from 'src/server'
 import { type PageContentType, getPage } from 'src/server/cms'
 import { injectGlobalSections } from 'src/server/cms/global'
 import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
-import { gql } from '@generated/gql'
-import { execute } from 'src/server'
-import type {
-  ServerAccountPageQueryQuery,
-  ServerAccountPageQueryQueryVariables,
-} from '@generated/graphql'
-import { validateUser } from 'src/sdk/account/validateUser'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -40,17 +41,23 @@ type Props = {
   accountName: ServerAccountPageQueryQuery['accountName']
 }
 
-function Page({ page: { sections }, globalSections, accountName }: Props) {
+function Page({
+  page: { sections },
+  globalSections: { sections: globalSections, settings: globalSettings },
+  accountName,
+}: Props) {
   return (
-    <RenderSections globalSections={globalSections} components={COMPONENTS}>
-      <NextSeo noindex nofollow />
+    <PageProvider context={{ globalSettings }}>
+      <RenderSections globalSections={globalSections} components={COMPONENTS}>
+        <NextSeo noindex nofollow />
 
-      <MyAccountLayout accountName={accountName}>
-        {sections && sections.length > 0 && (
-          <RenderSectionsBase sections={sections} components={COMPONENTS} />
-        )}
-      </MyAccountLayout>
-    </RenderSections>
+        <MyAccountLayout accountName={accountName}>
+          {sections && sections.length > 0 && (
+            <RenderSectionsBase sections={sections} components={COMPONENTS} />
+          )}
+        </MyAccountLayout>
+      </RenderSections>
+    </PageProvider>
   )
 }
 

--- a/packages/core/src/pages/account/404.tsx
+++ b/packages/core/src/pages/account/404.tsx
@@ -43,9 +43,12 @@ type Props = {
 
 function Page({
   page: { sections },
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
   accountName,
 }: Props) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   return (
     <PageProvider context={{ globalSettings }}>
       <RenderSections globalSections={globalSections} components={COMPONENTS}>

--- a/packages/core/src/pages/account/orders/[id].tsx
+++ b/packages/core/src/pages/account/orders/[id].tsx
@@ -34,10 +34,13 @@ type OrderDetailsPageProps = {
 } & MyAccountProps
 
 export default function OrderDetailsPage({
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
   order,
   accountName,
 }: OrderDetailsPageProps) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   return (
     <PageProvider context={{ globalSettings }}>
       <RenderSections globalSections={globalSections} components={COMPONENTS}>

--- a/packages/core/src/pages/account/orders/[id].tsx
+++ b/packages/core/src/pages/account/orders/[id].tsx
@@ -18,6 +18,7 @@ import type {
 import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'
 import { default as AfterSection } from 'src/customizations/src/myAccount/extensions/orders/[id]/after'
 import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/orders/[id]/before'
+import PageProvider from 'src/sdk/overrides/PageProvider'
 import { execute } from 'src/server'
 import { injectGlobalSections } from 'src/server/cms/global'
 import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
@@ -33,20 +34,22 @@ type OrderDetailsPageProps = {
 } & MyAccountProps
 
 export default function OrderDetailsPage({
-  globalSections,
+  globalSections: { sections: globalSections, settings: globalSettings },
   order,
   accountName,
 }: OrderDetailsPageProps) {
   return (
-    <RenderSections globalSections={globalSections} components={COMPONENTS}>
-      <NextSeo noindex nofollow />
+    <PageProvider context={{ globalSettings }}>
+      <RenderSections globalSections={globalSections} components={COMPONENTS}>
+        <NextSeo noindex nofollow />
 
-      <MyAccountLayout accountName={accountName}>
-        <BeforeSection />
-        <MyAccountOrderDetails order={order} />
-        <AfterSection />
-      </MyAccountLayout>
-    </RenderSections>
+        <MyAccountLayout accountName={accountName}>
+          <BeforeSection />
+          <MyAccountOrderDetails order={order} />
+          <AfterSection />
+        </MyAccountLayout>
+      </RenderSections>
+    </PageProvider>
   )
 }
 

--- a/packages/core/src/pages/account/orders/[id].tsx
+++ b/packages/core/src/pages/account/orders/[id].tsx
@@ -38,10 +38,7 @@ export default function OrderDetailsPage({
   accountName,
 }: OrderDetailsPageProps) {
   return (
-    <RenderSections
-      globalSections={globalSections.sections}
-      components={COMPONENTS}
-    >
+    <RenderSections globalSections={globalSections} components={COMPONENTS}>
       <NextSeo noindex nofollow />
 
       <MyAccountLayout accountName={accountName}>

--- a/packages/core/src/pages/account/orders/index.tsx
+++ b/packages/core/src/pages/account/orders/index.tsx
@@ -23,8 +23,9 @@ import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 import { groupOrderStatusByLabel } from 'src/utils/userOrderStatus'
 
 import { MyAccountListOrders } from 'src/components/account/orders/MyAccountListOrders'
-import { extractStatusFromError } from 'src/utils/utilities'
 import { validateUser } from 'src/sdk/account/validateUser'
+import PageProvider from 'src/sdk/overrides/PageProvider'
+import { extractStatusFromError } from 'src/utils/utilities'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -47,7 +48,7 @@ type ListOrdersPageProps = {
 } & MyAccountProps
 
 export default function ListOrdersPage({
-  globalSections,
+  globalSections: { sections: globalSections, settings: globalSettings },
   accountName,
   listOrders,
   total,
@@ -55,20 +56,22 @@ export default function ListOrdersPage({
   filters,
 }: ListOrdersPageProps) {
   return (
-    <RenderSections globalSections={globalSections} components={COMPONENTS}>
-      <NextSeo noindex nofollow />
+    <PageProvider context={{ globalSettings }}>
+      <RenderSections globalSections={globalSections} components={COMPONENTS}>
+        <NextSeo noindex nofollow />
 
-      <MyAccountLayout accountName={accountName}>
-        <BeforeSection />
-        <MyAccountListOrders
-          listOrders={listOrders}
-          filters={filters}
-          perPage={perPage}
-          total={total}
-        />
-        <AfterSection />
-      </MyAccountLayout>
-    </RenderSections>
+        <MyAccountLayout accountName={accountName}>
+          <BeforeSection />
+          <MyAccountListOrders
+            listOrders={listOrders}
+            filters={filters}
+            perPage={perPage}
+            total={total}
+          />
+          <AfterSection />
+        </MyAccountLayout>
+      </RenderSections>
+    </PageProvider>
   )
 }
 

--- a/packages/core/src/pages/account/orders/index.tsx
+++ b/packages/core/src/pages/account/orders/index.tsx
@@ -48,13 +48,16 @@ type ListOrdersPageProps = {
 } & MyAccountProps
 
 export default function ListOrdersPage({
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
   accountName,
   listOrders,
   total,
   perPage,
   filters,
 }: ListOrdersPageProps) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   return (
     <PageProvider context={{ globalSettings }}>
       <RenderSections globalSections={globalSections} components={COMPONENTS}>

--- a/packages/core/src/pages/account/orders/index.tsx
+++ b/packages/core/src/pages/account/orders/index.tsx
@@ -55,10 +55,7 @@ export default function ListOrdersPage({
   filters,
 }: ListOrdersPageProps) {
   return (
-    <RenderSections
-      globalSections={globalSections.sections}
-      components={COMPONENTS}
-    >
+    <RenderSections globalSections={globalSections} components={COMPONENTS}>
       <NextSeo noindex nofollow />
 
       <MyAccountLayout accountName={accountName}>

--- a/packages/core/src/pages/account/profile.tsx
+++ b/packages/core/src/pages/account/profile.tsx
@@ -36,10 +36,7 @@ export default function Profile({
   accountName,
 }: MyAccountProps) {
   return (
-    <RenderSections
-      globalSections={globalSections.sections}
-      components={COMPONENTS}
-    >
+    <RenderSections globalSections={globalSections} components={COMPONENTS}>
       <NextSeo noindex nofollow />
 
       <MyAccountLayout accountName={accountName}>

--- a/packages/core/src/pages/account/profile.tsx
+++ b/packages/core/src/pages/account/profile.tsx
@@ -33,9 +33,12 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
 }
 
 export default function Profile({
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
   accountName,
 }: MyAccountProps) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   return (
     <PageProvider context={{ globalSettings }}>
       <RenderSections globalSections={globalSections} components={COMPONENTS}>

--- a/packages/core/src/pages/account/profile.tsx
+++ b/packages/core/src/pages/account/profile.tsx
@@ -12,18 +12,19 @@ import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 
 import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'
 
-import { default as AfterSection } from 'src/customizations/src/myAccount/extensions/profile/after'
-import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/profile/before'
-import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
-import { injectGlobalSections } from 'src/server/cms/global'
-import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 import { gql } from '@generated/gql'
-import { execute } from 'src/server'
 import type {
   ServerProfileQueryQuery,
   ServerProfileQueryQueryVariables,
 } from '@generated/graphql'
+import { default as AfterSection } from 'src/customizations/src/myAccount/extensions/profile/after'
+import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/profile/before'
+import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
 import { validateUser } from 'src/sdk/account/validateUser'
+import PageProvider from 'src/sdk/overrides/PageProvider'
+import { execute } from 'src/server'
+import { injectGlobalSections } from 'src/server/cms/global'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -32,21 +33,23 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
 }
 
 export default function Profile({
-  globalSections,
+  globalSections: { sections: globalSections, settings: globalSettings },
   accountName,
 }: MyAccountProps) {
   return (
-    <RenderSections globalSections={globalSections} components={COMPONENTS}>
-      <NextSeo noindex nofollow />
+    <PageProvider context={{ globalSettings }}>
+      <RenderSections globalSections={globalSections} components={COMPONENTS}>
+        <NextSeo noindex nofollow />
 
-      <MyAccountLayout accountName={accountName}>
-        <BeforeSection />
-        <div>
-          <h1>Profile</h1>
-        </div>
-        <AfterSection />
-      </MyAccountLayout>
-    </RenderSections>
+        <MyAccountLayout accountName={accountName}>
+          <BeforeSection />
+          <div>
+            <h1>Profile</h1>
+          </div>
+          <AfterSection />
+        </MyAccountLayout>
+      </RenderSections>
+    </PageProvider>
   )
 }
 

--- a/packages/core/src/pages/account/security.tsx
+++ b/packages/core/src/pages/account/security.tsx
@@ -13,18 +13,19 @@ import type { GetServerSideProps } from 'next'
 
 import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'
 
-import { default as AfterSection } from 'src/customizations/src/myAccount/extensions/security/after'
-import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/security/before'
-import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
-import { injectGlobalSections } from 'src/server/cms/global'
-import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
-import { execute } from 'src/server'
 import { gql } from '@generated/gql'
 import type {
   ServerSecurityQueryQuery,
   ServerSecurityQueryQueryVariables,
 } from '@generated/graphql'
+import { default as AfterSection } from 'src/customizations/src/myAccount/extensions/security/after'
+import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/security/before'
+import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
 import { validateUser } from 'src/sdk/account/validateUser'
+import PageProvider from 'src/sdk/overrides/PageProvider'
+import { execute } from 'src/server'
+import { injectGlobalSections } from 'src/server/cms/global'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -37,21 +38,23 @@ type SecurityPageProps = {
 } & MyAccountProps
 
 export default function Page({
-  globalSections,
+  globalSections: { sections: globalSections, settings: globalSettings },
   accountName,
 }: SecurityPageProps) {
   return (
-    <RenderSections globalSections={globalSections} components={COMPONENTS}>
-      <NextSeo noindex nofollow />
+    <PageProvider context={{ globalSettings }}>
+      <RenderSections globalSections={globalSections} components={COMPONENTS}>
+        <NextSeo noindex nofollow />
 
-      <MyAccountLayout accountName={accountName}>
-        <BeforeSection />
-        <div>
-          <h1>Security</h1>
-        </div>
-        <AfterSection />
-      </MyAccountLayout>
-    </RenderSections>
+        <MyAccountLayout accountName={accountName}>
+          <BeforeSection />
+          <div>
+            <h1>Security</h1>
+          </div>
+          <AfterSection />
+        </MyAccountLayout>
+      </RenderSections>
+    </PageProvider>
   )
 }
 

--- a/packages/core/src/pages/account/security.tsx
+++ b/packages/core/src/pages/account/security.tsx
@@ -41,10 +41,7 @@ export default function Page({
   accountName,
 }: SecurityPageProps) {
   return (
-    <RenderSections
-      globalSections={globalSections.sections}
-      components={COMPONENTS}
-    >
+    <RenderSections globalSections={globalSections} components={COMPONENTS}>
       <NextSeo noindex nofollow />
 
       <MyAccountLayout accountName={accountName}>

--- a/packages/core/src/pages/account/security.tsx
+++ b/packages/core/src/pages/account/security.tsx
@@ -38,9 +38,12 @@ type SecurityPageProps = {
 } & MyAccountProps
 
 export default function Page({
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
   accountName,
 }: SecurityPageProps) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   return (
     <PageProvider context={{ globalSettings }}>
       <RenderSections globalSections={globalSections} components={COMPONENTS}>

--- a/packages/core/src/pages/account/user-details.tsx
+++ b/packages/core/src/pages/account/user-details.tsx
@@ -37,10 +37,7 @@ export default function UserDetails({
   accountName,
 }: MyAccountProps) {
   return (
-    <RenderSections
-      globalSections={globalSections.sections}
-      components={COMPONENTS}
-    >
+    <RenderSections globalSections={globalSections} components={COMPONENTS}>
       <NextSeo noindex nofollow />
 
       <MyAccountLayout accountName={accountName}>

--- a/packages/core/src/pages/account/user-details.tsx
+++ b/packages/core/src/pages/account/user-details.tsx
@@ -13,18 +13,19 @@ import type { GetServerSideProps } from 'next'
 
 import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'
 
-import { default as AfterSection } from 'src/customizations/src/myAccount/extensions/user-details/after'
-import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/user-details/before'
-import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
-import { injectGlobalSections } from 'src/server/cms/global'
-import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 import { gql } from '@generated/gql'
-import { execute } from 'src/server'
 import type {
   ServerUserDetailsQueryQuery,
   ServerUserDetailsQueryQueryVariables,
 } from '@generated/graphql'
+import { default as AfterSection } from 'src/customizations/src/myAccount/extensions/user-details/after'
+import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/user-details/before'
+import type { MyAccountProps } from 'src/experimental/myAccountSeverSideProps'
 import { validateUser } from 'src/sdk/account/validateUser'
+import PageProvider from 'src/sdk/overrides/PageProvider'
+import { execute } from 'src/server'
+import { injectGlobalSections } from 'src/server/cms/global'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -33,21 +34,23 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
 }
 
 export default function UserDetails({
-  globalSections,
+  globalSections: { sections: globalSections, settings: globalSettings },
   accountName,
 }: MyAccountProps) {
   return (
-    <RenderSections globalSections={globalSections} components={COMPONENTS}>
-      <NextSeo noindex nofollow />
+    <PageProvider context={{ globalSettings }}>
+      <RenderSections globalSections={globalSections} components={COMPONENTS}>
+        <NextSeo noindex nofollow />
 
-      <MyAccountLayout accountName={accountName}>
-        <BeforeSection />
-        <div>
-          <h1>User Details</h1>
-        </div>
-        <AfterSection />
-      </MyAccountLayout>
-    </RenderSections>
+        <MyAccountLayout accountName={accountName}>
+          <BeforeSection />
+          <div>
+            <h1>User Details</h1>
+          </div>
+          <AfterSection />
+        </MyAccountLayout>
+      </RenderSections>
+    </PageProvider>
   )
 }
 

--- a/packages/core/src/pages/account/user-details.tsx
+++ b/packages/core/src/pages/account/user-details.tsx
@@ -34,9 +34,12 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
 }
 
 export default function UserDetails({
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
   accountName,
 }: MyAccountProps) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   return (
     <PageProvider context={{ globalSettings }}>
       <RenderSections globalSections={globalSections} components={COMPONENTS}>

--- a/packages/core/src/pages/checkout.tsx
+++ b/packages/core/src/pages/checkout.tsx
@@ -12,6 +12,7 @@ import {
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 
 import RenderSections from 'src/components/cms/RenderSections'
+import PageProvider from 'src/sdk/overrides/PageProvider'
 import { injectGlobalSections } from 'src/server/cms/global'
 import storeConfig from '../../discovery.config'
 
@@ -25,17 +26,21 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
   ...CUSTOM_COMPONENTS,
 }
 
-function Page({ globalSections }: Props) {
+function Page({
+  globalSections: { sections: globalSections, settings: globalSettings },
+}: Props) {
   useEffect(() => {
     window.location.href = storeConfig.checkoutUrl
   }, [])
 
   return (
-    <RenderSections globalSections={globalSections} components={COMPONENTS}>
-      <NextSeo noindex nofollow />
+    <PageProvider context={{ globalSettings }}>
+      <RenderSections globalSections={globalSections} components={COMPONENTS}>
+        <NextSeo noindex nofollow />
 
-      <div>loading...</div>
-    </RenderSections>
+        <div>loading...</div>
+      </RenderSections>
+    </PageProvider>
   )
 }
 

--- a/packages/core/src/pages/checkout.tsx
+++ b/packages/core/src/pages/checkout.tsx
@@ -31,10 +31,7 @@ function Page({ globalSections }: Props) {
   }, [])
 
   return (
-    <RenderSections
-      globalSections={globalSections.sections}
-      components={COMPONENTS}
-    >
+    <RenderSections globalSections={globalSections} components={COMPONENTS}>
       <NextSeo noindex nofollow />
 
       <div>loading...</div>

--- a/packages/core/src/pages/checkout.tsx
+++ b/packages/core/src/pages/checkout.tsx
@@ -26,9 +26,10 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
   ...CUSTOM_COMPONENTS,
 }
 
-function Page({
-  globalSections: { sections: globalSections, settings: globalSettings },
-}: Props) {
+function Page({ globalSections: globalSectionsProp }: Props) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   useEffect(() => {
     window.location.href = storeConfig.checkoutUrl
   }, [])

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -24,11 +24,12 @@ type Props = {
 
 function Page({
   page: { sections, settings },
-  globalSections,
+  globalSections: { sections: globalSections, settings: globalSettings },
   serverData,
 }: Props) {
   const context = {
     data: serverData,
+    globalSettings,
   }
 
   const publisherId = settings?.seo?.publisherId ?? storeConfig.seo.publisherId

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -11,10 +11,10 @@ import {
 import COMPONENTS from 'src/components/cms/home/Components'
 import PageProvider from 'src/sdk/overrides/PageProvider'
 import { injectGlobalSections } from 'src/server/cms/global'
-import { getDynamicContent } from 'src/utils/dynamicContent'
-import storeConfig from '../../discovery.config'
 import { contentService } from 'src/server/content/service'
 import type { PreviewData } from 'src/server/content/types'
+import { getDynamicContent } from 'src/utils/dynamicContent'
+import storeConfig from '../../discovery.config'
 
 type Props = {
   page: PageContentType
@@ -134,7 +134,7 @@ function Page({
       */}
       <PageProvider context={context}>
         <RenderSections
-          globalSections={globalSections.sections}
+          globalSections={globalSections}
           sections={sections}
           components={COMPONENTS}
         />

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -24,9 +24,11 @@ type Props = {
 
 function Page({
   page: { sections, settings },
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
   serverData,
 }: Props) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
   const context = {
     data: serverData,
     globalSettings,

--- a/packages/core/src/pages/login.tsx
+++ b/packages/core/src/pages/login.tsx
@@ -59,7 +59,7 @@ function Page({ page: { sections }, globalSections }: Props) {
       */}
       <RenderSections
         sections={sections}
-        globalSections={globalSections.sections}
+        globalSections={globalSections}
         components={COMPONENTS}
       />
     </>

--- a/packages/core/src/pages/login.tsx
+++ b/packages/core/src/pages/login.tsx
@@ -34,8 +34,11 @@ type Props = {
 
 function Page({
   page: { sections },
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
 }: Props) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
+
   useEffect(() => {
     const loginUrl = new URL(storeConfig.loginUrl)
     const incomingParams = new URLSearchParams(window.location.search)

--- a/packages/core/src/pages/login.tsx
+++ b/packages/core/src/pages/login.tsx
@@ -12,11 +12,12 @@ import RenderSections from 'src/components/cms/RenderSections'
 import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sections/EmptyState/OverriddenDefaultEmptyState'
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
+import PageProvider from 'src/sdk/overrides/PageProvider'
 import type { PageContentType } from 'src/server/cms'
 import { injectGlobalSections } from 'src/server/cms/global'
-import storeConfig from '../../discovery.config'
 import { contentService } from 'src/server/content/service'
 import type { PreviewData } from 'src/server/content/types'
+import storeConfig from '../../discovery.config'
 
 /* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
@@ -31,7 +32,10 @@ type Props = {
   globalSections: GlobalSectionsData
 }
 
-function Page({ page: { sections }, globalSections }: Props) {
+function Page({
+  page: { sections },
+  globalSections: { sections: globalSections, settings: globalSettings },
+}: Props) {
   useEffect(() => {
     const loginUrl = new URL(storeConfig.loginUrl)
     const incomingParams = new URLSearchParams(window.location.search)
@@ -57,11 +61,13 @@ function Page({ page: { sections }, globalSections }: Props) {
         If needed, wrap your component in a <Section /> component
         (not the HTML tag) before rendering it here.
       */}
-      <RenderSections
-        sections={sections}
-        globalSections={globalSections}
-        components={COMPONENTS}
-      />
+      <PageProvider context={{ globalSettings }}>
+        <RenderSections
+          sections={sections}
+          globalSections={globalSections}
+          components={COMPONENTS}
+        />
+      </PageProvider>
     </>
   )
 }

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -146,8 +146,7 @@ function Page({
           title: seoData.title,
           searchTerm: searchTerm ?? searchParams.term ?? undefined,
         }}
-        globalSections={globalSections.sections}
-        globalSectionsSettings={globalSections.settings}
+        globalSections={globalSections}
       />
     </SearchProvider>
   )

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -97,7 +97,7 @@ function generateSEOData(storeConfig: StoreConfig, searchTerm?: string) {
 
 function Page({
   page: searchContentType,
-  globalSections,
+  globalSections: { sections: globalSections, settings: globalSettings },
   searchTerm,
 }: SearchPageProps) {
   const { settings } = searchContentType
@@ -147,6 +147,7 @@ function Page({
           searchTerm: searchTerm ?? searchParams.term ?? undefined,
         }}
         globalSections={globalSections}
+        globalSettings={globalSettings}
       />
     </SearchProvider>
   )

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -97,9 +97,11 @@ function generateSEOData(storeConfig: StoreConfig, searchTerm?: string) {
 
 function Page({
   page: searchContentType,
-  globalSections: { sections: globalSections, settings: globalSettings },
+  globalSections: globalSectionsProp,
   searchTerm,
 }: SearchPageProps) {
+  const { sections: globalSections, settings: globalSettings } =
+    globalSectionsProp ?? {}
   const { settings } = searchContentType
   const applySearchState = useApplySearchState()
   const searchParams = useSearchParams({

--- a/packages/core/src/sdk/overrides/PageProvider.tsx
+++ b/packages/core/src/sdk/overrides/PageProvider.tsx
@@ -9,30 +9,30 @@ import type { PropsWithChildren } from 'react'
 import { createContext, useContext, useMemo } from 'react'
 import type { SearchPageContextType } from 'src/pages/s'
 
-interface PageCommonContext {
+interface PageGlobalContext {
   globalSettings?: Record<string, unknown>
 }
 
-export interface PDPContext extends PageCommonContext {
+export interface PDPContext extends PageGlobalContext {
   data?: ServerProductQueryQuery &
     ClientProductQueryQuery['product'] & { isValidating?: boolean }
 }
 
-export interface PLPContext extends PageCommonContext {
+export interface PLPContext extends PageGlobalContext {
   data?: ServerCollectionPageQueryQuery &
     ClientProductGalleryQueryQuery & {
       pages: ClientManyProductsQueryQuery[]
     }
 }
 
-export interface SearchPageContext extends PageCommonContext {
+export interface SearchPageContext extends PageGlobalContext {
   data?: SearchPageContextType &
     ClientProductGalleryQueryQuery & {
       pages: ClientManyProductsQueryQuery[]
     }
 }
 
-export interface DynamicContent<T> extends PageCommonContext {
+export interface DynamicContent<T> extends PageGlobalContext {
   data?: T
 }
 
@@ -41,7 +41,7 @@ export interface PageProviderContextValue {
 }
 
 type PageProviderContext =
-  | PageCommonContext
+  | PageGlobalContext
   | PDPContext
   | PLPContext
   | SearchPageContext

--- a/packages/core/src/sdk/overrides/PageProvider.tsx
+++ b/packages/core/src/sdk/overrides/PageProvider.tsx
@@ -9,30 +9,30 @@ import type { PropsWithChildren } from 'react'
 import { createContext, useContext, useMemo } from 'react'
 import type { SearchPageContextType } from 'src/pages/s'
 
-interface WithGlobalSettings {
-  globalSettings?: Record<string, any>
+interface PageCommonContext {
+  globalSettings?: Record<string, unknown>
 }
 
-export interface PDPContext extends WithGlobalSettings {
+export interface PDPContext extends PageCommonContext {
   data?: ServerProductQueryQuery &
     ClientProductQueryQuery['product'] & { isValidating?: boolean }
 }
 
-export interface PLPContext extends WithGlobalSettings {
+export interface PLPContext extends PageCommonContext {
   data?: ServerCollectionPageQueryQuery &
     ClientProductGalleryQueryQuery & {
       pages: ClientManyProductsQueryQuery[]
     }
 }
 
-export interface SearchPageContext extends WithGlobalSettings {
+export interface SearchPageContext extends PageCommonContext {
   data?: SearchPageContextType &
     ClientProductGalleryQueryQuery & {
       pages: ClientManyProductsQueryQuery[]
     }
 }
 
-export interface DynamicContent<T> extends WithGlobalSettings {
+export interface DynamicContent<T> extends PageCommonContext {
   data?: T
 }
 
@@ -41,6 +41,7 @@ export interface PageProviderContextValue {
 }
 
 type PageProviderContext =
+  | PageCommonContext
   | PDPContext
   | PLPContext
   | SearchPageContext

--- a/packages/core/src/sdk/overrides/PageProvider.tsx
+++ b/packages/core/src/sdk/overrides/PageProvider.tsx
@@ -9,28 +9,30 @@ import type { PropsWithChildren } from 'react'
 import { createContext, useContext, useMemo } from 'react'
 import type { SearchPageContextType } from 'src/pages/s'
 
-export interface PDPContext {
+interface WithGlobalSettings {
+  globalSettings?: Record<string, any>
+}
+
+export interface PDPContext extends WithGlobalSettings {
   data?: ServerProductQueryQuery &
     ClientProductQueryQuery['product'] & { isValidating?: boolean }
 }
 
-export interface PLPContext {
+export interface PLPContext extends WithGlobalSettings {
   data?: ServerCollectionPageQueryQuery &
     ClientProductGalleryQueryQuery & {
       pages: ClientManyProductsQueryQuery[]
     }
-  globalSectionsSettings?: Record<string, any>
 }
 
-export interface SearchPageContext {
+export interface SearchPageContext extends WithGlobalSettings {
   data?: SearchPageContextType &
     ClientProductGalleryQueryQuery & {
       pages: ClientManyProductsQueryQuery[]
     }
-  globalSectionsSettings?: Record<string, any>
 }
 
-export interface DynamicContent<T> {
+export interface DynamicContent<T> extends WithGlobalSettings {
   data?: T
 }
 

--- a/packages/core/src/utils/globalSettings.ts
+++ b/packages/core/src/utils/globalSettings.ts
@@ -44,7 +44,7 @@ export type RegionalizationCmsData = {
 }
 
 export function getRegionalizationSettings(
-  sectionRegionalizationData?: RegionalizationCmsData['deliverySettings']
+  sectionRegionalizationData?: RegionalizationCmsData
 ): RegionalizationCmsData {
   const context = usePage()
   const globalRegionalizationData =
@@ -53,7 +53,5 @@ export function getRegionalizationSettings(
   if (sectionRegionalizationData === undefined) {
     return globalRegionalizationData
   }
-  return deepmerge(globalRegionalizationData, {
-    deliverySettings: sectionRegionalizationData,
-  })
+  return deepmerge(globalRegionalizationData, sectionRegionalizationData)
 }

--- a/packages/core/src/utils/globalSettings.ts
+++ b/packages/core/src/utils/globalSettings.ts
@@ -1,9 +1,5 @@
 import deepmerge from 'deepmerge'
-import {
-  type PLPContext,
-  type SearchPageContext,
-  usePage,
-} from 'src/sdk/overrides/PageProvider'
+import { usePage } from 'src/sdk/overrides/PageProvider'
 
 export type RegionalizationCmsData = {
   inputField?: {
@@ -48,17 +44,16 @@ export type RegionalizationCmsData = {
 }
 
 export function getRegionalizationSettings(
-  deliverySettings?: RegionalizationCmsData['deliverySettings']
+  sectionRegionalizationData?: RegionalizationCmsData['deliverySettings']
 ): RegionalizationCmsData {
-  const context = usePage<SearchPageContext | PLPContext>()
-  const regionalizationData =
-    context?.globalSectionsSettings?.regionalization ?? {}
+  const context = usePage()
+  const globalRegionalizationData =
+    context?.globalSettings?.regionalization ?? {}
 
-  if (deliverySettings === undefined) {
-    return regionalizationData
+  if (sectionRegionalizationData === undefined) {
+    return globalRegionalizationData
   }
-
-  return deepmerge(regionalizationData, {
-    deliverySettings,
+  return deepmerge(globalRegionalizationData, {
+    deliverySettings: sectionRegionalizationData,
   })
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Make `RegionModal` and `RegionPopover` have access to global settings (hCMS -> Global Sections -> Settings)

## How it works?

The Global Settings was created to remove duplications of messages in hCMS. `RegionModal`, `RegionPopover` and filter componentes have some messages in common that were being duplicated across sections and pages in hCMS.

`FilterDesktop` and `FilterSlider` had already been modified to use global settings in a previous PR, but they were only in the context of PLP and Search pages, which is different from `RegionModal` and `RegionPopover` that are global sections. Therefore, in this current PR was necessary some changes related to page context, which involved adding `PageProvider` to ALL pages (that's why there is a lot of modified files) passing the globalSettings as its context.

The prioritization order is: first check if there is the message inside the section, if not then use the message inside the global settings -- this avoids breaking changes.

## How to test it?

I've made some changes in the hCMS in `vendemo` admin so we can see the impact.
⚠️ Make sure to test all different types of pages, example: PLP, Search, PDP, Landing Page, 404, 500.
In Global Settings, the input field label is "Postal Code", the error message when there is no product available for the location has a "Oh no!" in the beginning, and there is a message for the "I don't know my postal code" link.
<img width="350" alt="global settings" src="https://github.com/user-attachments/assets/bd0c28a5-a1d3-4ce7-8551-6be703bb9a05" />

### Region Popover
<img width="350" alt="region popover" src="https://github.com/user-attachments/assets/69bc2aed-0019-441d-ae07-5bb92e46201f" />

Differences:
- The input field label has a "!" in the end.
- There is no message for the error of no product available

What should happen: Since it was defined some messages in the section, those messages should be gotten from the **section**. The only one that should be from **global settings** is the one for the error of no product available, therefore:
- The input field label should have a "!" in the end.
- The error message should be "Oh no! There are no products available for %s." %s being replaced by the inserted postal code.
 
| Desktop | Mobile | Error |
| ---- | ---- | ---- |
| <img width="607" alt="popover" src="https://github.com/user-attachments/assets/675da07d-20de-4fd0-8d8e-ac49b9c3b30c" /> | <img width="217" alt="popover mobile" src="https://github.com/user-attachments/assets/dcc731ea-4185-4162-ad2e-ec30341c1067" /> | <img width="600" alt="popover error" src="https://github.com/user-attachments/assets/2762ff82-46d7-44fb-ad3d-3808df24f93e" /> |

### Region Modal
<img width="350" alt="region modal" src="https://github.com/user-attachments/assets/f51c8bc5-c956-435a-9939-3ffca985b148" />

- The input field label has a "!" in the end.
- There is no message for the "I don't know my postal code" link.

What should happen: Since it was defined some messages in the section, those messages should be gotten from the **section**. The only one that should be from **global settings** is the one for the "I don't know my postal code" link, therefore:
- The input field label should have a "!" in the end.
- The "I don't know my postal code" link message should be "I don't know my Postal Code".

| Desktop | Mobile | Error |
| ---- | ---- | ---- |
| <img width="1232" alt="modal" src="https://github.com/user-attachments/assets/042d3e12-98e5-4e53-9713-cab24d5e0a10" /> | <img width="215" alt="modal mobile" src="https://github.com/user-attachments/assets/a1e0f277-d45f-4927-9aaf-b6f0311f8cdf" /> | <img width="1240" alt="modal error" src="https://github.com/user-attachments/assets/c1eb84a3-c7e0-45d6-acae-79ae38a5a6c5" /> |

### Starters Deploy Preview

- [Preview](https://vendemo-cm9sir9v900u7z6llkl62l70j-m66r5st5t.b.vtex.app/)
- [PR](https://github.com/dp-faststore-org/vendemo-dp/pull/39)

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SFS-2524)