### PR TITLE
fix: Toggle unique facets only for Delivery Methods

### DIFF
--- a/packages/core/src/components/search/Filter/FilterDesktop.tsx
+++ b/packages/core/src/components/search/Filter/FilterDesktop.tsx
@@ -151,7 +151,7 @@ function FilterDesktop({
 
             selectedPickupInPointFacets.length !== 0
               ? togglePickupInPointFacet(selectedPickupInPointFacets)
-              : toggleFilterFacet(selectedShippingFacet)
+              : toggleFilterFacet(selectedShippingFacet, true)
           }
 
           facet.values = facet.values.filter(
@@ -244,7 +244,7 @@ function FilterDesktop({
                                 },
                               ])
                             } else {
-                              toggleFilterFacet(facet)
+                              toggleFilterFacet(facet, isDeliveryFacet)
                             }
 
                             resetInfiniteScroll(0)

--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -209,7 +209,7 @@ function FilterSlider({
 
             selectedPickupInPointFacets.length !== 0
               ? togglePickupInPointFacet(selectedPickupInPointFacets)
-              : toggleFilterFacets([selectedShippingFacet])
+              : toggleFilterFacets([selectedShippingFacet], true)
           }
 
           facet.values = facet.values.filter(
@@ -343,12 +343,15 @@ function FilterSlider({
                                   },
                                 ])
                               } else {
-                                toggleFilterFacets([
-                                  ...selected.filter(
-                                    ({ key }) => key === 'pickupPoint'
-                                  ),
-                                  facet,
-                                ])
+                                toggleFilterFacets(
+                                  [
+                                    ...selected.filter(
+                                      ({ key }) => key === 'pickupPoint'
+                                    ),
+                                    facet,
+                                  ],
+                                  isDeliveryFacet
+                                )
                               }
                             }}
                             selected={item.selected}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the wrong behavior of toggling only one facet (`unique` prop) for all the existing facets instead of just for the delivery methods.

## How to test it?

Navigate to a PLP that has some filter with multiple checkboxes and try to apply many of them, but for the `Delivery` facet you can only apply one value at time.

| Mobile | Desktop |
| --- | --- |
| ![Screenshot 2025-07-01 at 19 01 56](https://github.com/user-attachments/assets/efd07b51-0ac8-46fa-b035-9156ee802acf) | ![Screenshot 2025-07-01 at 18 46 38](https://github.com/user-attachments/assets/6acc696a-4ca4-4e03-b3c0-aab496dfd4fa) |

### Starters Deploy Preview

vtex-sites/faststoreqa.store#835