### PR TITLE
fix: Shipping Simulation table style

### DIFF
--- a/packages/ui/src/components/molecules/Table/styles.scss
+++ b/packages/ui/src/components/molecules/Table/styles.scss
@@ -26,21 +26,22 @@
   --fs-table-bordered-border-width      : var(--fs-border-width);
   --fs-table-bordered-border-color      : var(--fs-border-color-light);
 
+  display: block;
 
   // --------------------------------------------------------
   // Structural Styles
   // --------------------------------------------------------
 
   width: 100%;
-  display: block;
   overflow-x: auto;
   white-space: nowrap;
 
   [data-fs-table-cell="header"],
   [data-fs-table-cell="data"] {
-    text-align: center;
-    padding-left: var(--fs-table-cell-padding-x);
     padding-right: var(--fs-table-cell-padding-x);
+    padding-left: var(--fs-table-cell-padding-x);
+    overflow-x: auto;
+    text-align: center;
     &[data-fs-table-cell-align="left"] { text-align: left; }
     &[data-fs-table-cell-align="center"] { text-align: center; }
     &[data-fs-table-cell-align="right"] { text-align: right; }
@@ -82,15 +83,16 @@
   }
 
   [data-fs-table-content] {
-    width: 100%;
     display: table;
+    width: 100%;
+    table-layout: fixed;
     border-collapse: collapse;
   }
 
   [data-fs-icon] {
-    margin-right: var(--fs-spacing-2);
     width: var(--fs-spacing-3);
     height: var(--fs-spacing-3);
+    margin-right: var(--fs-spacing-2);
   }
 
   // --------------------------------------------------------
@@ -121,5 +123,4 @@
       border-bottom: var(--fs-table-bordered-border-width) solid var(--fs-table-bordered-border-color);
     }
   }
-
 }

--- a/packages/ui/src/components/molecules/Table/styles.scss
+++ b/packages/ui/src/components/molecules/Table/styles.scss
@@ -26,12 +26,11 @@
   --fs-table-bordered-border-width      : var(--fs-border-width);
   --fs-table-bordered-border-color      : var(--fs-border-color-light);
 
-  display: block;
-
   // --------------------------------------------------------
   // Structural Styles
   // --------------------------------------------------------
 
+  display: block;
   width: 100%;
   overflow-x: auto;
   white-space: nowrap;


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the Shipping Simulation table style that was breaking when the text in a cell was too big.

## How it works?

Fixing the table width and setting an overflow-x of auto fixed the issue.

## How to test it?

An example of this was happening in the `vendemo` account. There is a pickup point configured there with a long ID.

| Before | After |
| ---- | ---- |
| <img width="320" alt="Screenshot 2025-07-02 at 11 46 19" src="https://github.com/user-attachments/assets/2e5aa477-7ad0-4e36-89b5-bdf1fa435e2e" /> | <img width="326" alt="Screenshot 2025-07-02 at 11 44 56" src="https://github.com/user-attachments/assets/485baa5d-98bb-4483-86dd-d8fea5eb585a" /> |

#### Before
https://github.com/user-attachments/assets/108bfa35-cc5a-4529-9e36-12aac23fe878

#### After
https://github.com/user-attachments/assets/2a3a1faf-644c-4721-b465-534fd372beb6


### Starters Deploy Preview

- Preview: https://vendemo-cm9sir9v900u7z6llkl62l70j-e0h3ge2vg.b.vtex.app/whole-watermelon-mini-fresh-19/p
- PR: https://github.com/dp-faststore-org/vendemo-dp/pull/42

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SFS-2581)