### PR TITLE
feat: Allow unavailable items on cart

### DIFF
--- a/packages/api/src/platforms/vtex/index.ts
+++ b/packages/api/src/platforms/vtex/index.ts
@@ -45,6 +45,7 @@ export interface Options {
 
 interface FeatureFlags {
   enableOrderFormSync?: boolean
+  enableUnavailableItemsOnCart?: boolean
 }
 
 export interface Context {

--- a/packages/api/src/platforms/vtex/loaders/sku.ts
+++ b/packages/api/src/platforms/vtex/loaders/sku.ts
@@ -6,7 +6,7 @@ import type { EnhancedSku } from '../utils/enhanceSku'
 import type { Options } from '..'
 import type { Clients } from '../clients'
 
-export const getSkuLoader = (_: Options, clients: Clients) => {
+export const getSkuLoader = ({ flags }: Options, clients: Clients) => {
   const loader = async (keys: readonly string[]) => {
     const skuIds = keys.map((key) => key.split('-')[0])
     const showInvisibleItems = keys.some(
@@ -18,6 +18,9 @@ export const getSkuLoader = (_: Options, clients: Clients) => {
       page: 0,
       count: skuIds.length,
       showInvisibleItems,
+      ...(flags?.enableUnavailableItemsOnCart && {
+        hideUnavailableItems: false,
+      }),
     })
 
     const skuBySkuId = products.reduce(

--- a/packages/api/test/integration/mutations.test.ts
+++ b/packages/api/test/integration/mutations.test.ts
@@ -29,6 +29,7 @@ const apiOptions = {
   incrementAddress: false,
   flags: {
     enableOrderFormSync: true,
+    enableUnavailableItemsOnCart: false,
   },
 } as Options
 

--- a/packages/api/test/integration/queries.test.ts
+++ b/packages/api/test/integration/queries.test.ts
@@ -53,6 +53,7 @@ const apiOptions = {
   incrementAddress: false,
   flags: {
     enableOrderFormSync: true,
+    enableUnavailableItemsOnCart: false,
   },
 } as Options
 

--- a/packages/api/test/integration/schema.test.ts
+++ b/packages/api/test/integration/schema.test.ts
@@ -97,6 +97,7 @@ beforeAll(async () => {
     showSponsored: false,
     flags: {
       enableOrderFormSync: true,
+      enableUnavailableItemsOnCart: false,
     },
   })
 })

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -38,6 +38,7 @@ module.exports = {
     hideUnavailableItems: false,
     showSponsored: false,
     incrementAddress: true,
+    enableUnavailableItemsOnCart: false,
   },
 
   // Default session

--- a/packages/core/src/server/options.ts
+++ b/packages/core/src/server/options.ts
@@ -16,5 +16,7 @@ export const apiOptions: APIOptions = {
   locale: storeConfig.session.locale,
   flags: {
     enableOrderFormSync: true,
+    enableUnavailableItemsOnCart:
+      storeConfig.api?.enableUnavailableItemsOnCart ?? false,
   },
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

The intention of this PR is to add the `enableUnavailableItemsOnCart` feature flag to enable merchants to handle scenarios where items become unavailable for some reason (e.g. after changing pickup point) on the client-side.

## How it works?

It adds the feature flag to be read from `discovery.config` API flags, but with default value set to `false`.

## How to test it?

- Check if all `@faststore/api` tests are passing;
- Perform cart actions (add/remove items) and it should behave as before, nothing should change with `enableUnavailableItemsOnCart: false`;
- The `enableUnavailableItemsOnCart: true` scenario will not work for FastStore for now because our default behavior is to let the backend handle unavailable itens on cart.

### Starters Deploy Preview

vtex-sites/faststoreqa.store#837