### PR TITLE
fix: output generation on monorepo

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -383,14 +383,17 @@ function checkDependencies(basePath: string, packagesToCheck: string[]) {
 }
 
 function updateNextConfig(basePath: string) {
-  const { tmpDir } = withBasePath(basePath)
+  // outputFileTracingRoot is used  on next.js/packages/next/src/build/utils.ts:1917
+  // this makes the generated path be under packages/discovery/etc on the generated. I'll attempt
+  // to change this to userDir (from process.cwd())
+  const { tmpDir, userDir } = withBasePath(basePath)
 
   const nextConfigPath = path.join(tmpDir, 'next.config.js')
 
   let nextConfigData = String(readFileSync(nextConfigPath))
   nextConfigData = nextConfigData.replace(
     /outputFileTracingRoot\:\s+(.*),/,
-    `outputFileTracingRoot: '${process.cwd()}',`
+    `outputFileTracingRoot: '${userDir}',`
   )
 
   writeFileSync(nextConfigPath, nextConfigData)


### PR DESCRIPTION
## What's the purpose of this pull request?

When replacing the outputFileTracingDir to `process.cwd()` we made the build process brake in the monorepo structure, where the command is not being run from the `userDir`. This makes the generated server file to be put under `.next/standalone/ARBITRARY_PATH/`. Setting it to `userDir` ensures that it will work.

## How to test it?

If the build on starter.store works, and the monorepo works, this PR works.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**

- [ ] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [ ] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [x] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [x] PR description
- [x] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)
