### PR TITLE
fix: validate cart should consider coupon in marketingData

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -1,5 +1,6 @@
 import deepEquals from 'fast-deep-equal'
 
+import { parse } from 'cookie'
 import { mutateChannelContext, mutateLocaleContext } from '../utils/contex'
 import { md5 } from '../utils/md5'
 import {
@@ -7,7 +8,6 @@ import {
   getPropertyId,
   VALUE_REFERENCES,
 } from '../utils/propertyValue'
-import { parse } from 'cookie'
 
 import type { Context } from '..'
 import type {
@@ -23,10 +23,10 @@ import type {
   OrderFormInputItem,
   OrderFormItem,
 } from '../clients/commerce/types/OrderForm'
-import { shouldUpdateShippingData } from '../utils/shouldUpdateShippingData'
-import { getAddressOrderForm } from '../utils/getAddressOrderForm'
 import type { SelectedAddress } from '../clients/commerce/types/ShippingData'
 import { createNewAddress } from '../utils/createNewAddress'
+import { getAddressOrderForm } from '../utils/getAddressOrderForm'
+import { shouldUpdateShippingData } from '../utils/shouldUpdateShippingData'
 
 type Indexed<T> = T & { index?: number }
 
@@ -453,9 +453,14 @@ export const validateCart = async (
     // update marketingData
     .then((form: OrderForm) => {
       if (session?.marketingData) {
+        const updatedMarketingData = {
+          ...form.marketingData,
+          ...session.marketingData,
+        }
+
         return commerce.checkout.marketingData({
           id: orderForm.orderFormId,
-          marketingData: session.marketingData,
+          marketingData: updatedMarketingData,
         })
       }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Validate cart was not considering coupon info when updating marketing data.

## How it works?

It was only considering the info that comes from Session, but Session only identifies UTMs. Therefore, when running the POST req to checkout without the coupon info, the marketing data in the Orderform was deleting the coupon that was present in the Orderform and the marketing data was updated to have only UTMs info.

## How to test it?

Get the orderform id and [add a coupon to the orderform through Checkout API](https://developers.vtex.com/docs/api-reference/checkout-api#post-/api/checkout/pub/orderForm/-orderFormId-/coupons):
`curl --location 'https://storeframework.vtexcommercestable.com.br/api/checkout/pub/orderForm/<ORDERFORM_ID>/coupons' \
--header 'Content-Type: application/json' \
--data '{
    "text": "teste-1"
}'`
> This is an example using the `storeframework` account (faststoreqa.store) and the `teste-1` coupon that corresponds to a $5 discount. Feel free to test using another account and/or coupon.

Then, go back to the store page, the ValidateCartMutation should run and the minicart should be updated.

If you test the production domain, you'll see that the coupon is added but quickly it's also deleted.

### Starters Deploy Preview

PR: https://github.com/vtex-sites/faststoreqa.store/pull/840
https://storeframework-cm652ufll028lmgv665a6xv0g-8x30tg94s.b.vtex.app/

Preview: https://storeframework-cm652ufll028lmgv665a6xv0g-8x30tg94s.b.vtex.app/

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SO-499)