### PR TITLE
feat: add mutation to set new password

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -370,6 +370,20 @@ export type IProcessOrderAuthorization = {
   ruleId: Scalars['String'];
 };
 
+/** Input type for setting a new password. */
+export type ISetPassword = {
+  /** Optional access key for the user, used in some authentication flows. */
+  accesskey?: Maybe<Scalars['String']>;
+  /** The current password of the user, required for verification before changing to the new password. */
+  currentPassword: Scalars['String'];
+  /** The email of the user for whom the password is being set. */
+  email: Scalars['String'];
+  /** The new password to be set for the user. */
+  newPassword: Scalars['String'];
+  /** Optional reCAPTCHA token for security verification. */
+  recaptcha?: Maybe<Scalars['String']>;
+};
+
 /** Shipping Simulation item input. */
 export type IShippingItem = {
   /** ShippingItem ID / Sku. */
@@ -627,6 +641,11 @@ export type Mutation = {
   cancelOrder?: Maybe<UserOrderCancel>;
   /** Process Order Authorization */
   processOrderAuthorization?: Maybe<ProcessOrderAuthorizationResponse>;
+  /**
+   * Sets a new password for the user.
+   * This mutation is used to change the user's password, typically after a password reset or when the user wants to update their password.
+   */
+  setPassword?: Maybe<SetPasswordResponse>;
   /** Subscribes a new person to the newsletter list. */
   subscribeToNewsletter?: Maybe<PersonNewsletter>;
   /** Checks for changes between the cart presented in the UI and the cart stored in the ecommerce platform. If changes are detected, it returns the cart stored on the platform. Otherwise, it returns `null`. */
@@ -643,6 +662,11 @@ export type MutationCancelOrderArgs = {
 
 export type MutationProcessOrderAuthorizationArgs = {
   data: IProcessOrderAuthorization;
+};
+
+
+export type MutationSetPasswordArgs = {
+  data: ISetPassword;
 };
 
 
@@ -919,6 +943,15 @@ export type SellersData = {
   id?: Maybe<Scalars['String']>;
   /** List of sellers. */
   sellers?: Maybe<Array<Maybe<SellerInfo>>>;
+};
+
+/** Response type for setting a new password. */
+export type SetPasswordResponse = {
+  __typename?: 'SetPasswordResponse';
+  /** Message providing additional information about the operation. */
+  message?: Maybe<Scalars['String']>;
+  /** Indicates whether the password was successfully set. */
+  success: Scalars['Boolean'];
 };
 
 /** Shipping Simulation information. */

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -679,44 +679,47 @@ export const VtexCommerce = (
           { storeCookies }
         )
       },
-    },
-    setPassword: async ({
-      email,
-      newPassword,
-      currentPassword,
-      accesskey,
-      recaptcha,
-    }: {
-      email: string
-      newPassword: string
-      currentPassword: string
-      accesskey?: string
-      recaptcha?: string
-    }): Promise<{ success: boolean; message?: string }> => {
-      const headers: HeadersInit = withAutCookie(forwardedHost, account)
-
-      const body = buildFormData({
-        login: email,
+      setPassword: async ({
+        email,
         newPassword,
         currentPassword,
         accesskey,
         recaptcha,
-      })
+      }: {
+        email: string
+        newPassword: string
+        currentPassword: string
+        accesskey?: string
+        recaptcha?: string
+      }): Promise<{ success: boolean; message?: string }> => {
+        const headers: HeadersInit = withAutCookie(forwardedHost, account)
 
-      const result = await fetchAPI(
-        `${base}/api/vtexid/pub/authentication/classic/setpassword?expireSessions=true`,
-        {
-          method: 'POST',
-          headers,
-          body,
-        },
-        { storeCookies }
-      )
+        const body = buildFormData({
+          login: email,
+          newPassword,
+          currentPassword,
+          accesskey,
+          recaptcha,
+        })
 
-      if ((result?.authStatus ?? '').toLowerCase() === 'success') {
-        return { success: true }
-      }
-      return { success: false, message: result?.authStatus ?? 'Unknown error' }
+        const result = await fetchAPI(
+          `${base}/api/vtexid/pub/authentication/classic/setpassword?expireSessions=true`,
+          {
+            method: 'POST',
+            headers,
+            body,
+          },
+          { storeCookies }
+        )
+
+        if ((result?.authStatus ?? '').toLowerCase() === 'success') {
+          return { success: true }
+        }
+        return {
+          success: false,
+          message: result?.authStatus ?? 'Unknown error',
+        }
+      },
     },
   }
 }

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -39,6 +39,7 @@ import type {
 } from './types/Simulation'
 import type { ScopesByUnit, UnitResponse } from './types/Unit'
 import type { VtexIdResponse } from './types/VtexId'
+import { buildFormData } from '../../utils/buildFormData'
 
 type ValueOf<T> = T extends Record<string, infer K> ? K : never
 
@@ -678,6 +679,44 @@ export const VtexCommerce = (
           { storeCookies }
         )
       },
+    },
+    setPassword: async ({
+      email,
+      newPassword,
+      currentPassword,
+      accesskey,
+      recaptcha,
+    }: {
+      email: string
+      newPassword: string
+      currentPassword: string
+      accesskey?: string
+      recaptcha?: string
+    }): Promise<{ success: boolean; message?: string }> => {
+      const headers: HeadersInit = withAutCookie(forwardedHost, account)
+
+      const body = buildFormData({
+        login: email,
+        newPassword,
+        currentPassword,
+        accesskey,
+        recaptcha,
+      })
+
+      const result = await fetchAPI(
+        `${base}/api/vtexid/pub/authentication/classic/setpassword?expireSessions=true`,
+        {
+          method: 'POST',
+          headers,
+          body,
+        },
+        { storeCookies }
+      )
+
+      if ((result?.authStatus ?? '').toLowerCase() === 'success') {
+        return { success: true }
+      }
+      return { success: false, message: result?.authStatus ?? 'Unknown error' }
     },
   }
 }

--- a/packages/api/src/platforms/vtex/resolvers/mutation.ts
+++ b/packages/api/src/platforms/vtex/resolvers/mutation.ts
@@ -1,5 +1,6 @@
 import { cancelOrder } from './cancelOrder'
 import { processOrderAuthorization } from './processOrderAuthorization'
+import { setPassword } from './setPassword'
 import { subscribeToNewsletter } from './subscribeToNewsletter'
 import { validateCart } from './validateCart'
 import { validateSession } from './validateSession'
@@ -10,4 +11,5 @@ export const Mutation = {
   subscribeToNewsletter,
   cancelOrder,
   processOrderAuthorization,
+  setPassword,
 }

--- a/packages/api/src/platforms/vtex/resolvers/setPassword.ts
+++ b/packages/api/src/platforms/vtex/resolvers/setPassword.ts
@@ -1,0 +1,26 @@
+import type { Context } from '..'
+import type {
+  MutationSetPasswordArgs,
+  SetPasswordResponse,
+} from '../../../__generated__/schema'
+import { BadRequestError } from '../../errors'
+
+export const setPassword = async (
+  _: any,
+  { data }: MutationSetPasswordArgs,
+  { clients: { commerce } }: Context
+): Promise<SetPasswordResponse> => {
+  if (!data?.email) {
+    throw new BadRequestError('Missing email')
+  }
+
+  const response = await commerce.setPassword({
+    email: data.email,
+    newPassword: data.newPassword,
+    currentPassword: data.currentPassword,
+    accesskey: data?.accesskey ?? '',
+    recaptcha: data?.recaptcha ?? '',
+  })
+
+  return { success: response.success, message: response?.message ?? '' }
+}

--- a/packages/api/src/platforms/vtex/resolvers/setPassword.ts
+++ b/packages/api/src/platforms/vtex/resolvers/setPassword.ts
@@ -14,7 +14,7 @@ export const setPassword = async (
     throw new BadRequestError('Missing email')
   }
 
-  const response = await commerce.setPassword({
+  const response = await commerce.vtexid.setPassword({
     email: data.email,
     newPassword: data.newPassword,
     currentPassword: data.currentPassword,

--- a/packages/api/src/platforms/vtex/utils/buildFormData.ts
+++ b/packages/api/src/platforms/vtex/utils/buildFormData.ts
@@ -1,0 +1,12 @@
+export const buildFormData = (
+  valueObject: Record<string, string | number | boolean | null | undefined>
+) => {
+  const form = new FormData()
+
+  Object.keys(valueObject).forEach((key) => {
+    const value = valueObject[key]
+    form.append(key, value == null ? '' : String(value))
+  })
+
+  return form
+}

--- a/packages/api/src/typeDefs/mutation.graphql
+++ b/packages/api/src/typeDefs/mutation.graphql
@@ -21,4 +21,9 @@ type Mutation {
   processOrderAuthorization(
     data: IProcessOrderAuthorization!
   ): ProcessOrderAuthorizationResponse
+  """
+  Sets a new password for the user.
+  This mutation is used to change the user's password, typically after a password reset or when the user wants to update their password.
+  """
+  setPassword(data: ISetPassword!): SetPasswordResponse
 }

--- a/packages/api/src/typeDefs/password.graphql
+++ b/packages/api/src/typeDefs/password.graphql
@@ -1,0 +1,43 @@
+"""
+Input type for setting a new password.
+"""
+input ISetPassword {
+  """
+  The email of the user for whom the password is being set.
+  """
+  email: String!
+
+  """
+  The new password to be set for the user.
+  """
+  newPassword: String!
+
+  """
+  The current password of the user, required for verification before changing to the new password.
+  """
+  currentPassword: String!
+
+  """
+  Optional access key for the user, used in some authentication flows.
+  """
+  accesskey: String
+
+  """
+  Optional reCAPTCHA token for security verification.
+  """
+  recaptcha: String
+}
+
+"""
+Response type for setting a new password.
+"""
+type SetPasswordResponse {
+  """
+  Indicates whether the password was successfully set.
+  """
+  success: Boolean!
+  """
+  Message providing additional information about the operation.
+  """
+  message: String
+}

--- a/packages/api/test/integration/schema.test.ts
+++ b/packages/api/test/integration/schema.test.ts
@@ -83,6 +83,7 @@ const MUTATIONS = [
   'subscribeToNewsletter',
   'cancelOrder',
   'processOrderAuthorization',
+  'setPassword',
 ]
 
 let schema: GraphQLSchema

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -373,6 +373,20 @@ export type IProcessOrderAuthorization = {
   ruleId: Scalars['String']['input']
 }
 
+/** Input type for setting a new password. */
+export type ISetPassword = {
+  /** Optional access key for the user, used in some authentication flows. */
+  accesskey: InputMaybe<Scalars['String']['input']>
+  /** The current password of the user, required for verification before changing to the new password. */
+  currentPassword: Scalars['String']['input']
+  /** The email of the user for whom the password is being set. */
+  email: Scalars['String']['input']
+  /** The new password to be set for the user. */
+  newPassword: Scalars['String']['input']
+  /** Optional reCAPTCHA token for security verification. */
+  recaptcha: InputMaybe<Scalars['String']['input']>
+}
+
 /** Shipping Simulation item input. */
 export type IShippingItem = {
   /** ShippingItem ID / Sku. */
@@ -625,6 +639,11 @@ export type Mutation = {
   cancelOrder: Maybe<UserOrderCancel>
   /** Process Order Authorization */
   processOrderAuthorization: Maybe<ProcessOrderAuthorizationResponse>
+  /**
+   * Sets a new password for the user.
+   * This mutation is used to change the user's password, typically after a password reset or when the user wants to update their password.
+   */
+  setPassword: Maybe<SetPasswordResponse>
   /** Subscribes a new person to the newsletter list. */
   subscribeToNewsletter: Maybe<PersonNewsletter>
   /** Checks for changes between the cart presented in the UI and the cart stored in the ecommerce platform. If changes are detected, it returns the cart stored on the platform. Otherwise, it returns `null`. */
@@ -639,6 +658,10 @@ export type MutationCancelOrderArgs = {
 
 export type MutationProcessOrderAuthorizationArgs = {
   data: IProcessOrderAuthorization
+}
+
+export type MutationSetPasswordArgs = {
+  data: ISetPassword
 }
 
 export type MutationSubscribeToNewsletterArgs = {
@@ -888,6 +911,14 @@ export type SellersData = {
   id: Maybe<Scalars['String']['output']>
   /** List of sellers. */
   sellers: Maybe<Array<Maybe<SellerInfo>>>
+}
+
+/** Response type for setting a new password. */
+export type SetPasswordResponse = {
+  /** Message providing additional information about the operation. */
+  message: Maybe<Scalars['String']['output']>
+  /** Indicates whether the password was successfully set. */
+  success: Scalars['Boolean']['output']
 }
 
 /** Shipping Simulation information. */

--- a/packages/core/test/server/index.test.ts
+++ b/packages/core/test/server/index.test.ts
@@ -88,6 +88,7 @@ const MUTATIONS = [
   'subscribeToNewsletter',
   'cancelOrder',
   'processOrderAuthorization',
+  'setPassword',
 ]
 
 describe('FastStore GraphQL Layer', () => {


### PR DESCRIPTION

This pull request introduces a new feature to enable users to set or update their passwords, along with the necessary GraphQL schema updates, resolver implementation, and utility functions. The changes span multiple files and include updates to the API, client, and test layers.

#### API Implementation:
* Implemented the `setPassword` resolver to handle password update requests, validate inputs, and call the corresponding client method.
* Registered the `setPassword` resolver in the `Mutation` object.

#### Client and Utility Enhancements:
* Added a `setPassword` method to the `VtexCommerce` client for making API requests to update user passwords.
* Created a utility function `buildFormData` to construct form data from key-value pairs, used in the `setPassword` client method.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [x] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [ ] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [x] PR description
- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)
