### PR TITLE
fix: B2B session info

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -398,7 +398,7 @@ export const VtexCommerce = (
 
       params.set(
         'items',
-        'profile.id,profile.email,profile.firstName,profile.lastName,shopper.firstName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol,authentication.customerId,authentication.storeUserId,authentication.storeUserEmail,authentication.unitId,authentication.unitName,checkout.regionId,public.postalCode'
+        'profile.id,profile.email,profile.firstName,profile.lastName,shopper.firstName,shopper.lastName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol,authentication.customerId,authentication.storeUserId,authentication.storeUserEmail,authentication.unitId,authentication.unitName,checkout.regionId,public.postalCode'
       )
 
       const headers: HeadersInit = withCookie({

--- a/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Session.ts
@@ -41,6 +41,7 @@ export interface Profile {
 
 export interface Shopper {
   firstName?: Value
+  lastName?: Value
 }
 
 export interface Checkout {

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -132,15 +132,22 @@ export const validateSession = async (
       seller: seller?.id,
       hasOnlyDefaultSalesChannel: !store?.channel?.value,
     }),
+    /**
+     * B2B data structure in Session:
+     * - Logged user data (shopper): `shopper` namespace
+     * - Unit data: `authentication` namespace
+     * - Contract data: `profile` namespace (those info will be available inside Faststore's Session `person` object)
+     */
     b2b: isRepresentative
       ? {
           isRepresentative: isRepresentative ?? false,
-          customerId: authentication?.customerId?.value ?? customerId ?? '', //contract
-          unitName: authentication?.unitName?.value ?? '', // organization name
-          unitId: authentication?.unitId?.value ?? unitId ?? '', // organization id
-          firstName: profile?.firstName?.value ?? '', // contract name for b2b
-          lastName: profile?.lastName?.value ?? '',
-          userName: shopper?.firstName?.value ?? '', // shopper
+          customerId: authentication?.customerId?.value ?? customerId ?? '',
+          unitName: authentication?.unitName?.value ?? '',
+          unitId: authentication?.unitId?.value ?? unitId ?? '',
+          firstName: shopper?.firstName?.value ?? '',
+          lastName: shopper?.lastName?.value ?? '',
+          userName:
+            `${shopper?.firstName?.value ?? ''} ${shopper?.lastName?.value ?? ''}`.trim(),
           userEmail: authentication?.storeUserEmail.value ?? '',
           savedPostalCode: publicData?.postalCode?.value ?? '',
         }

--- a/packages/core/src/components/account/MyAccountDrawer/OrganizationDrawer/OrganizationDrawer.tsx
+++ b/packages/core/src/components/account/MyAccountDrawer/OrganizationDrawer/OrganizationDrawer.tsx
@@ -1,11 +1,11 @@
 import { SlideOver, useFadeEffect } from '@faststore/ui'
 
 import { useSession } from 'src/sdk/session'
+import storeConfig from '../../../../../discovery.config'
 import { ProfileSummary } from '../ProfileSummary/ProfileSummary'
 import { OrganizationDrawerBody } from './OrganizationDrawerBody'
 import { OrganizationDrawerHeader } from './OrganizationDrawerHeader'
 import styles from './section.module.scss'
-import storeConfig from '../../../../../discovery.config'
 
 type OrganizationDrawerProps = {
   isOpen: boolean
@@ -26,9 +26,9 @@ export const OrganizationDrawer = ({
   isRepresentative,
 }: OrganizationDrawerProps) => {
   const { fade, fadeOut } = useFadeEffect()
-  const { b2b } = useSession()
+  const { b2b, person } = useSession()
 
-  const contractName = b2b?.firstName ?? ''
+  const contractName = person?.givenName ?? ''
 
   return (
     <SlideOver
@@ -55,8 +55,8 @@ export const OrganizationDrawer = ({
           bordered={true}
           onLogoutClick={doLogout}
           person={{
-            name: b2b?.userName ?? '',
-            email: b2b?.userEmail ?? '',
+            name: person?.givenName ?? '',
+            email: person?.email ?? '',
           }}
           orgName={b2b?.unitName ?? ''}
         />

--- a/packages/core/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/core/src/components/navigation/Navbar/Navbar.tsx
@@ -101,7 +101,7 @@ function Navbar({
   const scrollDirection = useScrollDirection()
   const { openNavbar, navbar: displayNavbar } = useUI()
   const { isDesktop, isMobile } = useScreenResize()
-  const { person, b2b } = useSession()
+  const { b2b } = useSession()
 
   const searchMobileRef = useRef<SearchInputRef>(null)
   const [searchExpanded, setSearchExpanded] = useState(false)


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix from where we're getting B2B session info. There were some misunderstandings regarding session namespaces (shopper, profile, unit).

## How it works?

`firstName`, `lastName` and `userName` should use the `shopper` namespace.
I've added a comment to make it explicit the B2B structure in Session:
- **Logged user** data (shopper) comes from the`shopper` namespace
- **Unit** data comes from the `authentication` namespace
- **Contract** data comes from the `profile` namespace

I've also did some changes on MyAccount's `OrganizationDrawer` because it was using `profile?.firstName` as contract name, but the contract name comes from `profile`, so it should get from our session `person` object. 
Also, I've changed back `userName` to be the concat between 1st and last name, so I believe `ProfileSummary` wanted to use `person.givenName`, to follow those changes I changed `ProfileSummary` to use `person.email` - but tell me if I misunderstood and it should use the shopper info and not contract!

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

- [Bug report](https://vtex.slack.com/archives/C08QH7W3C2Y/p1752591970934119)