### PR TITLE
fix: Prevent displaying `pickup-all` facet when there are no pickup points

### DIFF
--- a/packages/core/src/components/search/Filter/FilterDesktop.tsx
+++ b/packages/core/src/components/search/Filter/FilterDesktop.tsx
@@ -17,7 +17,10 @@ import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import type { useFilter } from 'src/sdk/search/useFilter'
 import type { FilterSliderProps } from './FilterSlider'
 
-import { useDeliveryPromise } from 'src/sdk/deliveryPromise'
+import {
+  useDeliveryPromise,
+  PICKUP_ALL_FACET_VALUE,
+} from 'src/sdk/deliveryPromise'
 import { getGlobalSettings } from 'src/utils/globalSettings'
 import FilterDeliveryMethodFacet from './FilterDeliveryMethodFacet'
 
@@ -108,7 +111,8 @@ function FilterDesktop({
                 <UIFilterFacetBoolean>
                   {facet.values.map(
                     (item) =>
-                      (item.value !== 'pickup-all' || isPickupAllEnabled) && (
+                      (item.value !== PICKUP_ALL_FACET_VALUE ||
+                        isPickupAllEnabled) && (
                         <UIFilterFacetBooleanItem
                           key={`${testId}-${facet.label}-${item.value}`}
                           id={`${testId}-${facet.label}-${item.value}`}

--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -19,7 +19,10 @@ import type { Filter_FacetsFragment } from '@generated/graphql'
 import FilterDeliveryMethodFacet from './FilterDeliveryMethodFacet'
 
 import type { useFilter } from 'src/sdk/search/useFilter'
-import { useDeliveryPromise } from 'src/sdk/deliveryPromise'
+import {
+  useDeliveryPromise,
+  PICKUP_ALL_FACET_VALUE,
+} from 'src/sdk/deliveryPromise'
 import { getGlobalSettings } from 'src/utils/globalSettings'
 
 import styles from './section.module.scss'
@@ -206,7 +209,8 @@ function FilterSlider({
                   <UIFilterFacetBoolean>
                     {facet.values.map(
                       (item) =>
-                        (item.value !== 'pickup-all' || isPickupAllEnabled) && (
+                        (item.value !== PICKUP_ALL_FACET_VALUE ||
+                          isPickupAllEnabled) && (
                           <UIFilterFacetBooleanItem
                             key={`${testId}-${facet.label}-${item.value}`}
                             id={`${testId}-${facet.label}-${item.value}`}

--- a/packages/core/src/sdk/deliveryPromise/index.ts
+++ b/packages/core/src/sdk/deliveryPromise/index.ts
@@ -4,6 +4,7 @@ export {
   PICKUP_IN_POINT_FACET_VALUE,
   PICKUP_POINT_FACET_KEY,
   SHIPPING_FACET_KEY,
+  PICKUP_ALL_FACET_VALUE,
 } from './useDeliveryPromise'
 export type { PickupPoint, DeliveryPromiseStore } from './useDeliveryPromise'
 

--- a/packages/core/src/sdk/deliveryPromise/useDeliveryPromise.ts
+++ b/packages/core/src/sdk/deliveryPromise/useDeliveryPromise.ts
@@ -25,6 +25,7 @@ export const PICKUP_POINT_FACET_KEY = 'pickupPoint' as const
 export const SHIPPING_FACET_KEY = 'shipping' as const
 export const PICKUP_IN_POINT_FACET_VALUE = 'pickup-in-point' as const
 export const ALL_DELIVERY_METHODS_FACET_VALUE = 'all-delivery-methods' as const
+export const PICKUP_ALL_FACET_VALUE = 'pickup-all' as const
 
 type Facet = SearchState['selectedFacets'][number]
 
@@ -395,7 +396,8 @@ export function useDeliveryPromise({
     deliveryLabel:
       deliveryPromiseSettings?.deliveryMethods?.title ?? 'Delivery',
     isPickupAllEnabled:
-      deliveryPromiseSettings?.deliveryMethods?.pickupAll?.enabled ?? false,
+      pickupPoints?.length > 0 &&
+      (deliveryPromiseSettings?.deliveryMethods?.pickupAll?.enabled ?? false),
     shouldDisplayDeliveryButton: isDeliveryPromiseEnabled && !postalCode,
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

With these changes the `pickup-all` facet will be displayed only when there are pickup points available.

## How to test it?

- Enable `Pickup All` in the Global Sections on Headless CMS;

<img width="729" height="358" alt="Screenshot 2025-07-18 at 17 27 46" src="https://github.com/user-attachments/assets/c7b86013-030e-4c31-b67a-20fdcc9c395c" />

- Set a postal code without pickup points, `55014-740`;
- The `pickup-all` facet should not be displayed on PLP.

### Starters Deploy Preview

https://vendemo-cm9sir9v900u7z6llkl62l70j-icpdr5ohx.b.vtex.app/