### PR TITLE
chore: Export Delivery Promise features

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -26,3 +26,12 @@ export { default as ProductGallerySection } from './src/components/sections/Prod
 export { default as ProductShelfSection } from './src/components/sections/ProductShelf'
 export { default as RegionBarSection } from './src/components/sections/RegionBar'
 export { default as Section } from './src/components/sections/Section'
+
+// Delivery Promise
+export {
+  PICKUP_IN_POINT_FACET_VALUE,
+  PICKUP_POINT_FACET_KEY,
+  SHIPPING_FACET_KEY,
+  PICKUP_ALL_FACET_VALUE,
+  getPickupPoints,
+} from './src/sdk/deliveryPromise'

--- a/packages/core/src/experimental/index.ts
+++ b/packages/core/src/experimental/index.ts
@@ -45,3 +45,9 @@ export { ProfileChallenge as ProfileChallenge_unstable } from '../../src/compone
 export { ButtonSignIn as ButtonSignIn_unstable } from '../../src/components/ui/Button'
 export { Image as Image_unstable } from '../../src/components/ui/Image'
 export { default as Selectors_unstable } from '../../src/components/ui/SkuSelector'
+
+// Delivery Promise
+export {
+  useDeliveryPromise as useDeliveryPromise_unstable,
+  deliveryPromiseStore as deliveryPromiseStore_unstable,
+} from 'src/sdk/deliveryPromise'


### PR DESCRIPTION
## What's the purpose of this pull request?

With these changes, Delivery Promise 1.2 stable and experimental features will be available from `@faststore/core` and `@faststore/core/experimental` import.