### PR TITLE
fix: Remove `RegionSlider` section props

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -2377,18 +2377,11 @@
   },
   {
     "name": "RegionSlider",
-    "requiredScopes": [],
     "schema": {
       "title": "Region Slider",
       "type": "object",
       "description": "Region Slider configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Should enable Region Slider?",
-          "default": true
-        }
-      }
+      "properties": {}
     }
   },
   {

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -2376,15 +2376,6 @@
     }
   },
   {
-    "name": "RegionSlider",
-    "schema": {
-      "title": "Region Slider",
-      "type": "object",
-      "description": "Region Slider configuration",
-      "properties": {}
-    }
-  },
-  {
     "name": "EmptyState",
     "schema": {
       "title": "Empty State",

--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -23,7 +23,7 @@ interface Props {
   isInteractive?: boolean
 }
 
-const SECTIONS_OUT_OF_VIEWPORT = ['CartSidebar', 'RegionModal']
+const SECTIONS_OUT_OF_VIEWPORT = ['CartSidebar', 'RegionModal', 'RegionSlider']
 
 const Toast = dynamic(
   () => import(/* webpackChunkName: "Toast" */ '../common/Toast'),


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to remove `RegionSlider` section props as we won't use it.

