### PR TITLE
chore: add Pickup Point's address state back

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -743,6 +743,8 @@ export type PickupPointAddress = {
   number?: Maybe<Scalars['String']>;
   /** Address postal code. */
   postalCode?: Maybe<Scalars['String']>;
+  /** Address state. */
+  state?: Maybe<Scalars['String']>;
   /** Address street. */
   street?: Maybe<Scalars['String']>;
 };

--- a/packages/api/src/platforms/vtex/clients/commerce/types/PickupPoints.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/PickupPoints.ts
@@ -16,6 +16,7 @@ interface Address {
   number: string
   postalCode: string
   street: string
+  state: string
 }
 
 interface BusinessHour {

--- a/packages/api/src/typeDefs/pickupPoints.graphql
+++ b/packages/api/src/typeDefs/pickupPoints.graphql
@@ -19,6 +19,10 @@ type PickupPointAddress {
   Address street.
   """
   street: String
+  """
+  Address state.
+  """
+  state: String
 }
 
 type BusinessHour {

--- a/packages/core/@generated/gql.ts
+++ b/packages/core/@generated/gql.ts
@@ -62,7 +62,7 @@ const documents = {
     types.ValidateUserDocument,
   '\n  mutation ValidateCartMutation($cart: IStoreCart!, $session: IStoreSession!) {\n    validateCart(cart: $cart, session: $session) {\n      order {\n        orderNumber\n        acceptedOffer {\n          ...CartItem\n        }\n        shouldSplitItem\n      }\n      messages {\n        ...CartMessage\n      }\n    }\n  }\n\n  fragment CartMessage on StoreCartMessage {\n    text\n    status\n  }\n\n  fragment CartItem on StoreOffer {\n    seller {\n      identifier\n    }\n    quantity\n    price\n    priceWithTaxes\n    listPrice\n    listPriceWithTaxes\n    itemOffered {\n      ...CartProductItem\n    }\n  }\n\n  fragment CartProductItem on StoreProduct {\n    sku\n    name\n    unitMultiplier\n    image {\n      url\n      alternateName\n    }\n    brand {\n      name\n    }\n    isVariantOf {\n      productGroupID\n      name\n      skuVariants {\n        activeVariations\n        slugsMap\n        availableVariations\n      }\n    }\n    gtin\n    additionalProperty {\n      propertyID\n      name\n      value\n      valueReference\n    }\n  }\n':
     types.ValidateCartMutationDocument,
-  '\n  query ClientPickupPointsQuery(\n    $geoCoordinates: IStoreGeoCoordinates\n  ) {\n    pickupPoints(geoCoordinates: $geoCoordinates) {\n      pickupPointDistances {\n        pickupId\n        distance\n        pickupName\n        isActive\n        address {\n          city\n          number\n          postalCode\n          street\n        }\n      }\n    }\n  }\n':
+  '\n  query ClientPickupPointsQuery(\n    $geoCoordinates: IStoreGeoCoordinates\n  ) {\n    pickupPoints(geoCoordinates: $geoCoordinates) {\n      pickupPointDistances {\n        pickupId\n        distance\n        pickupName\n        isActive\n        address {\n          city\n          state\n          number\n          postalCode\n          street\n        }\n      }\n    }\n  }\n':
     types.ClientPickupPointsQueryDocument,
   '\n  mutation SubscribeToNewsletter($data: IPersonNewsletter!) {\n    subscribeToNewsletter(data: $data) {\n      id\n    }\n  }\n':
     types.SubscribeToNewsletterDocument,
@@ -244,7 +244,7 @@ export function gql(
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function gql(
-  source: '\n  query ClientPickupPointsQuery(\n    $geoCoordinates: IStoreGeoCoordinates\n  ) {\n    pickupPoints(geoCoordinates: $geoCoordinates) {\n      pickupPointDistances {\n        pickupId\n        distance\n        pickupName\n        isActive\n        address {\n          city\n          number\n          postalCode\n          street\n        }\n      }\n    }\n  }\n'
+  source: '\n  query ClientPickupPointsQuery(\n    $geoCoordinates: IStoreGeoCoordinates\n  ) {\n    pickupPoints(geoCoordinates: $geoCoordinates) {\n      pickupPointDistances {\n        pickupId\n        distance\n        pickupName\n        isActive\n        address {\n          city\n          state\n          number\n          postalCode\n          street\n        }\n      }\n    }\n  }\n'
 ): typeof import('./graphql').ClientPickupPointsQueryDocument
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -731,6 +731,8 @@ export type PickupPointAddress = {
   number: Maybe<Scalars['String']['output']>
   /** Address postal code. */
   postalCode: Maybe<Scalars['String']['output']>
+  /** Address state. */
+  state: Maybe<Scalars['String']['output']>
   /** Address street. */
   street: Maybe<Scalars['String']['output']>
 }
@@ -3030,6 +3032,7 @@ export type ClientPickupPointsQueryQuery = {
       isActive: boolean | null
       address: {
         city: string | null
+        state: string | null
         number: string | null
         postalCode: string | null
         street: string | null
@@ -4052,7 +4055,7 @@ export const ValidateCartMutationDocument = {
 export const ClientPickupPointsQueryDocument = {
   __meta__: {
     operationName: 'ClientPickupPointsQuery',
-    operationHash: '1ea72f41b367e482251e186b4128a4a91f3a4d56',
+    operationHash: '3fa04e88c811fcb5ece7206fd5aa745bdbc143a8',
   },
 } as unknown as TypedDocumentString<
   ClientPickupPointsQueryQuery,

--- a/packages/core/src/components/ui/PickupPoints/PickupPointCard.tsx
+++ b/packages/core/src/components/ui/PickupPoints/PickupPointCard.tsx
@@ -24,7 +24,9 @@ function PickupPointCard({ store }: PickupPointCardProps) {
           <span>
             {store?.address?.street}, {store?.address?.number}
           </span>
-          <span>{store?.address?.city}</span>
+          <span>
+            {store?.address?.city} - {store?.address?.state}
+          </span>
         </p>
         <span data-fs-pickup-point-card-distance>
           {store?.distance !== undefined ? formatDistance(store.distance) : ''}

--- a/packages/core/src/sdk/deliveryPromise/queries.ts
+++ b/packages/core/src/sdk/deliveryPromise/queries.ts
@@ -19,6 +19,7 @@ const pickupPointsQuery = gql(`
         isActive
         address {
           city
+          state
           number
           postalCode
           street
@@ -70,6 +71,7 @@ export const getPickupPoints = async ({
         number: pickupPoint?.address?.number,
         postalCode: pickupPoint?.address?.postalCode,
         city: pickupPoint?.address?.city,
+        state: pickupPoint?.address?.state,
       },
       distance: pickupPoint?.distance,
     }))

--- a/packages/core/src/sdk/deliveryPromise/useDeliveryPromise.ts
+++ b/packages/core/src/sdk/deliveryPromise/useDeliveryPromise.ts
@@ -37,6 +37,7 @@ export type PickupPoint = {
     number?: string
     postalCode?: string
     city?: string
+    state?: string
   }
   distance?: number
   totalItems?: number


### PR DESCRIPTION
## What's the purpose of this pull request?

When we changed the API (from Checkout to Logistics) we removed the info related to the address state of the pickup points, because Logistics wasn't returning this info. But in the latest deploy they added this info so we can add it back!

## How it works?

Just adding state back 

## How to test it?

Check that the state appears in the Pickup Point Card in the list:
<img width="406" height="424" alt="Screenshot 2025-07-25 at 11 28 43" src="https://github.com/user-attachments/assets/8c810e30-d368-4b7b-a368-8bffaf3d1d93" />

### Starters Deploy Preview

PR:
Preview:

## References

[Jira task](https://vtex-dev.atlassian.net/browse/SFS-2678)