### PR TITLE
fix: prevent new carts from being marked as stale in validateCart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,7 @@ packages/core/@generated/persisted-documents.json
 oclif.manifest.json
 
 *storybook.log
+
+# FastStore development files
+.faststore/
+packages/*/.husky/_/

--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -222,8 +222,9 @@ const isOrderFormStale = (form: OrderForm) => {
 
   const oldEtag = faststoreData?.fields?.cartEtag
 
+  // If there's no etag, it's a new cart, so it's not stale
   if (oldEtag == null) {
-    return true
+    return false
   }
 
   const newEtag = getOrderFormEtag(form)


### PR DESCRIPTION
## What's the purpose of this pull request?

Fixes a critical UX issue where the cart count in the minicart icon doesn't update immediately after adding products to the cart. This was causing confusion for users who couldn't see their cart updates in real-time, leading to a poor shopping experience.

## How it works?

The issue was in the `isOrderFormStale` function within the `validateCart` resolver. When a new cart was created (without an existing `cartEtag`), the function was incorrectly marking it as stale by returning `true` when `oldEtag == null`. This caused the `validateCart` mutation to return the server's cart state instead of `null`, which overrode the optimistic cart updates.

**The fix:**
- Modified the `isOrderFormStale` function to treat new carts (without etag) as not stale
- Changed the logic from returning `true` to `false` when `oldEtag == null`
- This allows optimistic updates to persist through validation

**Before:**
```typescript
if (oldEtag == null) {
  return true  // ❌ New carts were marked as stale
}
```

**After:**
```typescript
if (oldEtag == null) {
  return false  // ✅ New carts are not stale
}
```

## How to test it?

### Manual Testing Steps:
1. **Open a FastStore store** (e.g., `http://localhost:3000`)
2. **Navigate to a product page**
3. **Add a product to cart** using the "Add to Cart" button
4. **Check the minicart icon** - it should immediately show the updated count
5. **Add another product** - the count should increment properly
6. **Open the cart** - verify the items are there

### Expected Behavior:
- ✅ **Before fix**: Cart count wouldn't update immediately after adding items
- ✅ **After fix**: Cart count should update instantly and persist

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

## References

- **Related Issue**: Cart count in minicart icon doesn't update after adding products to cart
- **Files Changed**: `packages/api/src/platforms/vtex/resolvers/validateCart.ts`
- **Impact**: Better user experience with responsive cart feedback

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [ ] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [ ] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [x] PR description
- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)