### PR TITLE
fix: Using SEO product name and description input if available

### DIFF
--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -191,7 +191,7 @@ function Page({
         mainEntityOfPage={`${meta.canonical}${
           settings?.seo?.mainEntityOfPage ?? ''
         }`}
-        productName={product.name}
+        productName={meta.title}
         description={product.description}
         brand={product.brand.name}
         sku={product.sku}

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -191,8 +191,8 @@ function Page({
         mainEntityOfPage={`${meta.canonical}${
           settings?.seo?.mainEntityOfPage ?? ''
         }`}
-        productName={meta.title}
-        description={meta.description}
+        productName={title}
+        description={description}
         brand={product.brand.name}
         sku={product.sku}
         gtin={product.gtin}

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -192,7 +192,7 @@ function Page({
           settings?.seo?.mainEntityOfPage ?? ''
         }`}
         productName={meta.title}
-        description={product.description}
+        description={meta.description}
         brand={product.brand.name}
         sku={product.sku}
         gtin={product.gtin}


### PR DESCRIPTION
## What's the purpose of this pull request?

Instead of using the product name and product long description, we could use the SEO customized information that is filled in the Admin (if available)

We did this change to prioritize the SEO fields from IS before #2701
```
 title: isVariantOf.productTitle || isVariantOf.productName,
 description: isVariantOf.metaTagDescription || isVariantOf.description,
```

## How it works?

You should see the `productTitle`  and `metaTagDescription` if they exist instead of the description and productName in PDP SEO data.

## How to test it?
|before|after|
|-|-|
<img width="912" height="454" alt="image" src="https://github.com/user-attachments/assets/84d74584-76a9-46e1-944d-17d73f6b154c" />|<img width="894" height="298" alt="image" src="https://github.com/user-attachments/assets/f5398eff-2d14-4bef-ab87-7f5cf0388039" />


note: `productTitle` and `metaTagDescription` is not being returned from IS from all accounts.

### Starters Deploy Preview

TBD

## References

[slack ticket](https://vtex.slack.com/archives/C051B6LL91U/p1752072991619379)
