### PR TITLE
fix: Quick Order typings

### DIFF
--- a/packages/components/src/organisms/SKUMatrix/SKUMatrixSidebar.tsx
+++ b/packages/components/src/organisms/SKUMatrix/SKUMatrixSidebar.tsx
@@ -20,8 +20,8 @@ interface VariationProductColumn {
     label: string
     stockDisplaySettings: 'showStockQuantity' | 'showAvailability'
   }
-  price: number
-  quantitySelector: number
+  price: string
+  quantitySelector: string
 }
 
 const ImageComponentFallback: SKUMatrixSidebarProps['ImageComponent'] = ({

--- a/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
+++ b/packages/core/src/components/search/SearchDropdown/SearchDropdown.tsx
@@ -24,7 +24,7 @@ interface SearchDropdownProps {
   sort: SearchState['sort']
   quickOrderSettings?: NavbarProps['searchInput']['quickOrderSettings']
   [key: string]: any
-  onChangeCustomSearchDropdownVisible: Dispatch<SetStateAction<boolean>>
+  onChangeCustomSearchDropdownVisible?: Dispatch<SetStateAction<boolean>>
 }
 
 export function sendAutocompleteClickEvent({

--- a/packages/core/src/components/search/SearchProductItem/SearchProductItem.tsx
+++ b/packages/core/src/components/search/SearchProductItem/SearchProductItem.tsx
@@ -33,11 +33,11 @@ type SearchProductItemProps = {
   /**
    * Quick Order settings.
    */
-  quickOrderSettings: NavbarProps['searchInput']['quickOrderSettings']
+  quickOrderSettings?: NavbarProps['searchInput']['quickOrderSettings']
   /**
    * Method to manage the visibility state of the dropdown when SKU Matrix is active.
    */
-  onChangeCustomSearchDropdownVisible: Dispatch<SetStateAction<boolean>>
+  onChangeCustomSearchDropdownVisible?: Dispatch<SetStateAction<boolean>>
 }
 
 function SearchProductItem({

--- a/packages/core/src/components/sections/Navbar/Navbar.tsx
+++ b/packages/core/src/components/sections/Navbar/Navbar.tsx
@@ -23,15 +23,15 @@ export interface NavbarProps {
   searchInput: {
     placeholder?: string
     sort: string
-    quickOrderSettings: {
+    quickOrderSettings?: {
       quickOrder: boolean
       skuMatrix: {
         triggerButtonLabel: string
         columns: {
           name: string
           additionalColumns: Array<{ label: string; value: string }>
-          price: number
-          quantitySelector: number
+          price: string
+          quantitySelector: string
           availability: {
             label: string
             stockDisplaySettings: 'showAvailability' | 'showStockQuantity'


### PR DESCRIPTION
## What's the purpose of this pull request?

With these changes, all Quick Order props should be optional.