### PR TITLE
fix: default delivery estimate labels

### DIFF
--- a/packages/core/src/sdk/deliveryPromise/useDeliveryPromise.ts
+++ b/packages/core/src/sdk/deliveryPromise/useDeliveryPromise.ts
@@ -408,12 +408,12 @@ export function useDeliveryPromise({
   function getDynamicEstimateLabel(value: string) {
     if (value === 'next-day') {
       return (
-        deliveryPromiseSettings?.dynamicEstimate?.nextDay ?? 'Receive Today'
+        deliveryPromiseSettings?.dynamicEstimate?.nextDay ?? 'Receive Tomorrow'
       )
     }
     if (value === 'same-day') {
       return (
-        deliveryPromiseSettings?.dynamicEstimate?.sameDay ?? 'Receive Tomorrow'
+        deliveryPromiseSettings?.dynamicEstimate?.sameDay ?? 'Receive Today'
       )
     }
     return value


### PR DESCRIPTION
## What's the purpose of this pull request?
  - nextDay = 'Receive Tomorrow'
  - sameDay = 'Receive Today'
    
The default labels were inverted 😬 