### PR TITLE
fix: Prevent PLPs' specific facets being cleared

### DIFF
--- a/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
+++ b/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
@@ -111,7 +111,7 @@ function ProductGallery({
   const hasProductsLoaded = Boolean(data?.search?.products)
   const initialSelectedFacets =
     (data as PLPContext['data'])?.collection?.meta?.selectedFacets ?? []
-  const filter = useFilter(facets, initiallySelectedFacets)
+  const filter = useFilter(facets, initialSelectedFacets)
 
   return (
     <section data-testid="product-gallery" data-fs-product-listing>

--- a/packages/core/src/sdk/search/useFilter.ts
+++ b/packages/core/src/sdk/search/useFilter.ts
@@ -90,7 +90,7 @@ const reducer = (state: State, action: Action) => {
 
 export const useFilter = (
   allFacets: Filter_FacetsFragment[],
-  initiallySelectedFacets?: IStoreSelectedFacet[]
+  initialSelectedFacets?: IStoreSelectedFacet[]
 ) => {
   const {
     state: { selectedFacets },
@@ -139,13 +139,13 @@ export const useFilter = (
 
   // Restore initial PLP facets after clearing filters (e.g. { key: category-n, value: 'electronics' })
   useEffect(() => {
-    if (initiallySelectedFacets && selected.length === 0) {
+    if (initialSelectedFacets && selected.length === 0) {
       dispatch({
         type: 'selectFacets',
-        payload: initiallySelectedFacets,
+        payload: initialSelectedFacets,
       })
     }
-  }, [initiallySelectedFacets, selected])
+  }, [initialSelectedFacets, selected])
 
   useEffect(() => {
     dispatch({


### PR DESCRIPTION
## What's the purpose of this pull request?

With these changes, the PLPs will not lose their specific facets (e.g. { key: 'category-n', value: 'electronics' }) anymore after the shopper clear filters using the `FilterSlider` component (mobile-only).

<img width="440" height="853" alt="image" src="https://github.com/user-attachments/assets/8d7d13f7-cd24-4020-a5d6-9d9e92011da9" />

## How it works?

It ensures the `initiallySelectedFacets` (from server data) will be always considered as selected facets after the shopper clear all filters using the `FilterSlider` component (mobile-only).

## How to test it?

You will need to navigate through the store using the mobile version, then:
- Open any PLP;
- Click on `Filters`;
- Click on `Clear all` (even if you hadn't applied any filter) then on `Apply`;
- After loading, the button `Filters` should be still visible and the PLP's specific facet should be present in the url (as a query string `category-n=...`)

### Starters Deploy Preview

vtex-sites/faststoreqa.store#853