### PR TITLE
fix: avoid unnecessary server restarts by moving updateNextConfig to setup only

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -528,6 +528,7 @@ export async function generate(options: GenerateOptions) {
       copyCoreFiles(basePath),
       copyCypressFiles(basePath),
       copyPublicFiles(basePath),
+      updateNextConfig(basePath),
     ])
   }
 
@@ -539,7 +540,6 @@ export async function generate(options: GenerateOptions) {
     copyUserStarterToCustomizations(basePath),
     copyTheme(basePath),
     createCmsWebhookUrlsJsonFile(basePath),
-    updateNextConfig(basePath),
     enableRedirectsMiddleware(basePath),
 
     installPlugins(basePath),


### PR DESCRIPTION
## What's the purpose of this pull request?

Currently, every time a modification is made while developing with the FastStore CLI, the entire Next.js server is restarted.  
This happens because `updateNextConfig` is called on every `generate` execution, which forces a rebuild whenever `next.config.js` changes.  

Since `next.config.js` doesn’t need to be updated constantly during development, this behavior negatively impacts DX by making hot reload slower than necessary.  

This PR adjusts the logic so that `updateNextConfig` runs **only during setup**, avoiding unnecessary server restarts and significantly improving development performance.  

## How it works?

- Previously, `updateNextConfig(basePath)` was called in the main `Promise.all` for every generate run, forcing a Next.js restart.
- Now, it’s only called inside the `if (setup)` block, meaning it will run only when the initial project setup happens.
- This keeps the same behavior for initial configuration but removes the constant server restarts during normal development iterations.

**Before:**
```ts
...
await Promise.all([
  setupPromise,
  ...
  updateNextConfig(basePath),
  ...
])
```

**After:**
```ts
...
if (setup) {
  setupPromise = Promise.all([
    ...
    updateNextConfig(basePath),
  ])
}
...
```

**Impact on Developer Experience:**
- Hot reload from Next.js works properly again.
- Component and application state are preserved between reloads.
- No need to refresh the entire page after every change.
- Faster feedback loop during development.
- Less memory and CPU usage from unnecessary server restarts.

📹 **Before**  

https://github.com/user-attachments/assets/eef60d65-cd98-4eee-bb41-ea630c111cb7



📹 **After**  


https://github.com/user-attachments/assets/0c73dba6-46ed-49a5-b7dd-b4f374f7af28


## How to test it?

- Start a FastStore project in dev mode.
- Make a change to any file that does **not** require `next.config.js` updates.
- Observe that:
  - The server no longer restarts — only hot reload is triggered.
  - Application state is preserved after reload.
  - The page is not fully reloaded.
- Run the CLI with `setup` enabled to confirm that `next.config.js` is still updated when needed.

## Starters Deploy Preview

N/A — CLI-only change.

## References

- Original behavior introduced in [#2500](link-to-pr-2500)  
- Discussion with @guila confirming the change is not needed in dev mode

## Checklist

**PR Title and Commit Messages**
- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification  
  - e.g. `fix(cli): avoid unnecessary server restarts by moving updateNextConfig to setup only`

**PR Description**
- [x] Added a label according to the PR goal - `performance`

**Dependencies**
- [x] No dependency changes

**Documentation**
- [x] PR description complete
