### PR TITLE
PoC: Don't render pages during build

### DIFF
--- a/packages/core/src/experimental/searchServerSideFunctions/getStaticProps.ts
+++ b/packages/core/src/experimental/searchServerSideFunctions/getStaticProps.ts
@@ -1,5 +1,5 @@
 import storeConfig from 'discovery.config'
-import type { GetStaticProps } from 'next'
+import type { GetStaticPaths, GetStaticProps } from 'next'
 import {
   getGlobalSectionsData,
   type GlobalSectionsData,
@@ -88,5 +88,12 @@ export const getStaticProps: GetStaticProps<
       page,
       globalSections: globalSectionsResult,
     },
+  }
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
   }
 }

--- a/packages/core/src/pages/404.tsx
+++ b/packages/core/src/pages/404.tsx
@@ -1,4 +1,4 @@
-import type { GetStaticProps } from 'next'
+import type { GetStaticPaths, GetStaticProps } from 'next'
 import { NextSeo } from 'next-seo'
 import type { ComponentType } from 'react'
 import {
@@ -93,6 +93,13 @@ export const getStaticProps: GetStaticProps<
 
   return {
     props: { page, globalSections: globalSectionsResult },
+  }
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
   }
 }
 

--- a/packages/core/src/pages/500.tsx
+++ b/packages/core/src/pages/500.tsx
@@ -1,4 +1,4 @@
-import type { GetStaticProps } from 'next'
+import type { GetStaticPaths, GetStaticProps } from 'next'
 import { NextSeo } from 'next-seo'
 import type { ComponentType } from 'react'
 import {
@@ -94,6 +94,13 @@ export const getStaticProps: GetStaticProps<
 
   return {
     props: { page, globalSections: globalSectionsResult },
+  }
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
   }
 }
 

--- a/packages/core/src/pages/account/404.tsx
+++ b/packages/core/src/pages/account/404.tsx
@@ -1,5 +1,5 @@
 import type { Locator } from '@vtex/client-cms'
-import type { GetServerSideProps } from 'next'
+import type { GetServerSideProps, GetStaticPaths } from 'next'
 import { NextSeo } from 'next-seo'
 import type { ComponentType } from 'react'
 import {
@@ -135,6 +135,13 @@ export const getServerSideProps: GetServerSideProps<
       globalSections: globalSectionsResult,
       accountName: account.data.accountName,
     },
+  }
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
   }
 }
 

--- a/packages/core/src/pages/checkout.tsx
+++ b/packages/core/src/pages/checkout.tsx
@@ -2,7 +2,7 @@ import { NextSeo } from 'next-seo'
 import { useEffect } from 'react'
 
 import type { Locator } from '@vtex/client-cms'
-import type { GetStaticProps } from 'next'
+import type { GetStaticPaths, GetStaticProps } from 'next'
 import type { ComponentType } from 'react'
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
 import {
@@ -71,6 +71,13 @@ export const getStaticProps: GetStaticProps<
 
   return {
     props: { globalSections: globalSectionsResult },
+  }
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
   }
 }
 

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import type { GetStaticProps } from 'next'
+import type { GetStaticPaths, GetStaticProps } from 'next'
 import { NextSeo, OrganizationJsonLd, SiteLinksSearchBoxJsonLd } from 'next-seo'
 
 import RenderSections from 'src/components/cms/RenderSections'
@@ -199,6 +199,13 @@ export const getStaticProps: GetStaticProps<
 
   return {
     props: { page, globalSections: globalSectionsResult, serverData },
+  }
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
   }
 }
 

--- a/packages/core/src/pages/login.tsx
+++ b/packages/core/src/pages/login.tsx
@@ -2,7 +2,7 @@ import { NextSeo } from 'next-seo'
 import type { ComponentType } from 'react'
 import { useEffect } from 'react'
 
-import type { GetStaticProps } from 'next'
+import type { GetStaticPaths, GetStaticProps } from 'next'
 import { default as GLOBAL_COMPONENTS } from 'src/components/cms/global/Components'
 import {
   type GlobalSectionsData,
@@ -106,6 +106,13 @@ export const getStaticProps: GetStaticProps<
 
   return {
     props: { page, globalSections: globalSectionsResult },
+  }
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
   }
 }
 

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -18,6 +18,7 @@ import storeConfig from 'discovery.config'
 import { SearchWrapper } from 'src/components/templates/SearchPage'
 import {
   getStaticProps,
+  getStaticPaths,
   type SearchPageProps,
 } from 'src/experimental/searchServerSideFunctions'
 
@@ -155,6 +156,6 @@ function Page({
   )
 }
 
-export { getStaticProps }
+export { getStaticProps, getStaticPaths }
 
 export default Page


### PR DESCRIPTION
This PoC is to see if we can get rid of the build step when we're publishing CMS releaes by caching the image generated during yarn build.
