### PR TITLE
fix: Add Delivery Options `enabled` prop

### DIFF
--- a/packages/core/cms/faststore/content-types.json
+++ b/packages/core/cms/faststore/content-types.json
@@ -239,6 +239,11 @@
                   "title": "PLP/Search Filter: Delivery Options",
                   "type": "object",
                   "properties": {
+                    "enabled": {
+                      "title": "Should enable Delivery Options?",
+                      "type": "boolean",
+                      "default": true
+                    },
                     "title": {
                       "title": "Delivery Options title",
                       "type": "string",

--- a/packages/core/src/sdk/deliveryPromise/useDeliveryPromise.ts
+++ b/packages/core/src/sdk/deliveryPromise/useDeliveryPromise.ts
@@ -109,7 +109,9 @@ export function useDeliveryPromise({
 
   const isDeliveryPromiseEnabled = deliveryPromiseConfig.enabled
   const isDynamicEstimateEnabled =
-    deliveryPromiseSettings?.dynamicEstimate?.enabled ?? false
+    deliveryPromiseSettings?.dynamicEstimate?.enabled ?? true
+  const isDeliveryOptionsEnabled =
+    deliveryPromiseSettings?.deliveryOptions?.enabled ?? true
 
   const selectedFacets = useMemo(
     () => selectedFilterFacets ?? searchState.selectedFacets,
@@ -303,9 +305,17 @@ export function useDeliveryPromise({
       )
     }
 
-    const filteredFacets = !isDynamicEstimateEnabled
-      ? allFacets.filter(({ key }) => key !== DYNAMIC_ESTIMATE_FACET_KEY)
-      : allFacets
+    const filteredFacets = allFacets.filter(({ key }) => {
+      if (!isDeliveryOptionsEnabled && key === DELIVERY_OPTIONS_FACET_KEY) {
+        return false
+      }
+
+      if (!isDynamicEstimateEnabled && key === DYNAMIC_ESTIMATE_FACET_KEY) {
+        return false
+      }
+
+      return true
+    })
 
     return filteredFacets
       .map((facet) => {

--- a/packages/core/src/utils/globalSettings.ts
+++ b/packages/core/src/utils/globalSettings.ts
@@ -59,6 +59,7 @@ type DeliveryPromiseCmsData = {
     }
   }
   deliveryOptions?: {
+    enabled?: boolean
     title?: string
     allDeliveryOptions?: string
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

With these changes, Delivery Options will have an enabled prop as we have for Dynamic Estimates, then we can control wether the facets should be displayed or not.

### Starters Deploy Preview

