### PR TITLE
feat: order list placed by filter-SFS-2702

### DIFF
--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPlacedBy/MyAccountFilterFacetPlacedBy.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPlacedBy/MyAccountFilterFacetPlacedBy.tsx
@@ -26,6 +26,9 @@ export interface MyAccountFilterFacetPlacedByProps {
   dispatch: (action: { type: 'toggleFacet' | 'setFacet'; payload: any }) => void
 }
 
+// TODO: Integration: Replace `mockShoppers` with an API call to the entity "shopper"
+// filtering by firstName OR lastName, restricted to the current user's unit. Also
+// debounced as the user types to reduce requests.
 const mockShoppers: Shopper[] = [
   {
     purchase_agent_id: '1',

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPlacedBy/MyAccountFilterFacetPlacedBy.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPlacedBy/MyAccountFilterFacetPlacedBy.tsx
@@ -1,0 +1,203 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { Input, IconButton, Icon } from '@faststore/ui'
+import type { SelectedFacet } from 'src/sdk/search/useMyAccountFilter'
+
+type Shopper = {
+  purchase_agent_id: string
+  name: string
+  email: string
+}
+
+export interface MyAccountFilterFacetPlacedByProps {
+  /**
+   * Current selected facets from filter context
+   */
+  selected: SelectedFacet[]
+  /**
+   * Dispatch from filter context
+   */
+  dispatch: (action: { type: 'toggleFacet' | 'setFacet'; payload: any }) => void
+}
+
+const mockShoppers: Shopper[] = [
+  {
+    purchase_agent_id: '1',
+    name: 'Robert Fox',
+    email: 'robert.fox@example.com',
+  },
+  {
+    purchase_agent_id: '2',
+    name: 'Ronald Wilson',
+    email: 'ronald.wilson@example.com',
+  },
+  {
+    purchase_agent_id: '3',
+    name: 'Cameron Williamson',
+    email: 'cameron.williamson@example.com',
+  },
+  {
+    purchase_agent_id: '4',
+    name: 'Brooklyn Simmons',
+    email: 'brooklyn.simmons@example.com',
+  },
+]
+
+const MyAccountFilterFacetPlacedBy = forwardRef<
+  {
+    clear: () => void
+  },
+  MyAccountFilterFacetPlacedByProps
+>(function MyAccountFilterFacetPlacedBy({ selected, dispatch }, ref) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [query, setQuery] = useState('')
+  const [selectedShopper, setSelectedShopper] = useState<Shopper | null>(null)
+  const [isOpen, setIsOpen] = useState(false)
+
+  const selectedId = useMemo(
+    () => selected.find((f) => f.key === 'purchaseAgentId')?.value,
+    [selected]
+  )
+
+  useEffect(() => {
+    if (selectedId) {
+      if (!selectedShopper) {
+        const found = mockShoppers.find(
+          (s) => s.purchase_agent_id === selectedId
+        )
+        if (found) setSelectedShopper(found)
+      }
+    } else {
+      // Clear local when global selected cleared (e.g., Clear All)
+      setSelectedShopper(null)
+      setQuery('')
+      if (inputRef.current) inputRef.current.value = ''
+    }
+  }, [selectedId, selectedShopper])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return mockShoppers
+    return mockShoppers.filter(
+      (s) =>
+        s.name.toLowerCase().includes(q) || s.email.toLowerCase().includes(q)
+    )
+  }, [query])
+
+  useImperativeHandle(ref, () => ({
+    clear: () => {
+      setQuery('')
+      setSelectedShopper(null)
+      if (inputRef.current) inputRef.current.value = ''
+      if (selectedId) {
+        dispatch({
+          type: 'toggleFacet',
+          payload: { key: 'purchaseAgentId', value: selectedId },
+        })
+      }
+    },
+  }))
+
+  function handleSelect(shopper: Shopper) {
+    setSelectedShopper(shopper)
+    setIsOpen(false)
+    dispatch({
+      type: 'setFacet',
+      payload: {
+        facet: { key: 'purchaseAgentId', value: shopper.purchase_agent_id },
+        unique: true,
+      },
+    })
+  }
+
+  function handleClearTag() {
+    if (selectedShopper) {
+      dispatch({
+        type: 'toggleFacet',
+        payload: {
+          key: 'purchaseAgentId',
+          value: selectedShopper.purchase_agent_id,
+        },
+      })
+    }
+    setSelectedShopper(null)
+    setQuery('')
+    if (inputRef.current) inputRef.current.value = ''
+  }
+
+  return (
+    <div data-fs-list-orders-filters-placed-by>
+      <div data-fs-list-orders-filters-placed-by-input>
+        <Input
+          id="placed-by-input"
+          placeholder="Enter the shopper's name..."
+          ref={inputRef}
+          value={selectedShopper ? selectedShopper.name : query}
+          readOnly={Boolean(selectedShopper)}
+          onFocus={() => {
+            if (!selectedShopper) setIsOpen(true)
+          }}
+          onChange={(e) => {
+            if (selectedShopper) return
+            setQuery(e.target.value)
+            setIsOpen(true)
+          }}
+          onBlur={() => {
+            // delay close to allow click selection
+            setTimeout(() => {
+              setIsOpen(false)
+              if (!selectedShopper) {
+                setQuery('')
+                if (inputRef.current) inputRef.current.value = ''
+              }
+            }, 100)
+          }}
+          type="text"
+          inputMode="text"
+        />
+        {selectedShopper && (
+          <IconButton
+            size="small"
+            aria-label="Clear shopper"
+            data-fs-list-orders-filters-placed-by-clear
+            icon={<Icon name="X" />}
+            onClick={handleClearTag}
+          />
+        )}
+      </div>
+
+      {isOpen && filtered.length > 0 && (
+        <div
+          data-fs-list-orders-filters-placed-by-dropdown
+          role="listbox"
+          tabIndex={0}
+        >
+          <ul>
+            {filtered.map((s) => (
+              <li key={s.purchase_agent_id}>
+                <button
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => handleSelect(s)}
+                  data-fs-list-orders-filters-placed-by-option
+                >
+                  <span data-fs-list-orders-filters-placed-by-option-name>
+                    {s.name}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+})
+
+export default MyAccountFilterFacetPlacedBy

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPlacedBy/index.ts
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPlacedBy/index.ts
@@ -1,0 +1,2 @@
+export { default } from './MyAccountFilterFacetPlacedBy'
+export type { MyAccountFilterFacetPlacedByProps } from './MyAccountFilterFacetPlacedBy'

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPlacedBy/styles.scss
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPlacedBy/styles.scss
@@ -1,0 +1,66 @@
+[data-fs-list-orders-filters-placed-by] {
+  --fs-list-orders-filters-placed-by-dropdown-bkg                               : var(--fs-color-neutral-0);
+  --fs-list-orders-filters-placed-by-dropdown-border                            : 1px solid var(--fs-border-color-light);
+  --fs-list-orders-filters-placed-by-dropdown-radius                            : var(--fs-border-radius);
+  --fs-list-orders-filters-placed-by-option-padding                             : var(--fs-spacing-2) var(--fs-spacing-3);
+  --fs-list-orders-filters-placed-by-selected-height                            : var(--fs-control-height);
+  --fs-list-orders-filters-placed-by-selected-padding                           : 0 var(--fs-spacing-3);
+  --fs-list-orders-filters-placed-by-selected-border                            : var(--fs-input-border-width) solid var(--fs-input-border-color);
+  --fs-list-orders-filters-placed-by-selected-radius                            : var(--fs-input-border-radius);
+
+  position: relative;
+
+  // Clear icon inside input when actionable
+  [data-fs-list-orders-filters-placed-by-input] {
+    position: relative;
+
+    [data-fs-input] {
+      width: 100%;
+    }
+
+    [data-fs-icon-button] {
+      position: absolute;
+      top: 50%;
+      right: var(--fs-spacing-2);
+      transform: translateY(-50%);
+    }
+  }
+
+  [data-fs-list-orders-filters-placed-by-dropdown] {
+    position: absolute;
+    z-index: 10;
+    width: 100%;
+    margin-top: var(--fs-spacing-1);
+    background: var(--fs-list-orders-filters-placed-by-dropdown-bkg);
+    border: var(--fs-list-orders-filters-placed-by-dropdown-border);
+    border-radius: var(--fs-list-orders-filters-placed-by-dropdown-radius);
+    box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
+
+    ul {
+      max-height: 220px;
+      padding: 0;
+      margin: 0;
+      overflow: auto;
+      list-style: none;
+    }
+
+    [data-fs-list-orders-filters-placed-by-option] {
+      display: flex;
+      justify-content: flex-start;
+      width: 100%;
+      padding: var(--fs-list-orders-filters-placed-by-option-padding);
+      text-align: left;
+      cursor: pointer;
+      background: transparent;
+      border: 0;
+
+      &:hover, &:focus {
+        background: var(--fs-color-neutral-bkg);
+      }
+
+      [data-fs-list-orders-filters-placed-by-option-name] {
+        font-weight: var(--fs-text-weight-regular);
+      }
+    }
+  }
+}

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterSlider.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterSlider.tsx
@@ -13,6 +13,7 @@ import type {
   useMyAccountFilter,
 } from 'src/sdk/search/useMyAccountFilter'
 import FilterFacetDateRange from './MyAccountFilterFacetDateRange'
+import FilterFacetPlacedBy from './MyAccountFilterFacetPlacedBy'
 import styles from './section.module.scss'
 
 export interface FilterSliderProps {
@@ -89,6 +90,10 @@ function MyAccountFilterSlider({
           acc['status'] = Array.isArray(acc['status'])
             ? [...acc['status'], value]
             : [value]
+        }
+
+        if (key === 'purchaseAgentId') {
+          acc['purchaseAgentId'] = value
         }
 
         return acc
@@ -196,6 +201,9 @@ function MyAccountFilterSlider({
                     />
                   ))}
                 </UIFilterFacetBoolean>
+              )}
+              {type === 'StoreFacetPlacedBy' && isExpanded && (
+                <FilterFacetPlacedBy selected={selected} dispatch={dispatch} />
               )}
               {type === 'StoreFacetRange' && isExpanded && (
                 <FilterFacetDateRange

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/section.module.scss
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/section.module.scss
@@ -16,6 +16,7 @@
   @import "@faststore/ui/src/components/organisms/FilterSlider/styles.scss";
   @import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
   @import "./MyAccountFilterFacetDateRange/styles.scss";
+  @import "./MyAccountFilterFacetPlacedBy/styles.scss";
 
   [data-fs-badge] {
     display: none;

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountListOrders.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountListOrders.tsx
@@ -39,6 +39,7 @@ export type MyAccountListOrdersProps = {
     dateFinal: string
     text: string
     clientEmail: string
+    purchaseAgentId?: string
   }
 }
 
@@ -73,6 +74,11 @@ function getSelectedFacets({
         key: 'dateFinal',
         value: String(value),
       })
+    } else if (filter === 'purchaseAgentId' && value) {
+      acc.push({
+        key: 'purchaseAgentId',
+        value: String(value),
+      })
     }
 
     return acc
@@ -96,6 +102,11 @@ function getAllFacets({
         value: status.toLowerCase(),
       })),
     },
+    {
+      __typename: 'StoreFacetPlacedBy',
+      key: 'purchaseAgentId',
+      label: 'Placed by',
+    } as any,
     {
       __typename: 'StoreFacetRange',
       key: 'dateRange',
@@ -233,6 +244,7 @@ export default function MyAccountListOrders({
             status: filters.status,
             dateInitial: filters.dateInitial,
             dateFinal: filters.dateFinal,
+            purchaseAgentId: filters.purchaseAgentId,
           }}
           onClearAll={() => {
             window.location.href = '/account/orders'
@@ -247,6 +259,8 @@ export default function MyAccountListOrders({
             } else if (key === 'dateInitial' || key === 'dateFinal') {
               delete updatedFilters.dateInitial
               delete updatedFilters.dateFinal
+            } else if (key === 'purchaseAgentId') {
+              delete updatedFilters.purchaseAgentId
             } else {
               delete updatedFilters[key]
             }
@@ -258,6 +272,8 @@ export default function MyAccountListOrders({
             } else if (key === 'dateInitial' || key === 'dateFinal') {
               delete updatedFilters.dateInitial
               delete updatedFilters.dateFinal
+            } else if (key === 'purchaseAgentId') {
+              delete updatedFilters.purchaseAgentId
             } else {
               delete updatedFilters[key]
             }

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountSelectedTags/MyAccountSelectedTags.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountSelectedTags/MyAccountSelectedTags.tsx
@@ -7,10 +7,11 @@ type MyAccountSelectedTagsProps = {
     status?: string[]
     dateInitial?: string
     dateFinal?: string
+    purchaseAgentId?: string
   }
   onClearAll: () => void
   onRemoveFilter: (
-    key: 'status' | 'dateInitial' | 'dateFinal',
+    key: 'status' | 'dateInitial' | 'dateFinal' | 'purchaseAgentId',
     value: string
   ) => void
 }
@@ -40,7 +41,7 @@ function Tags({
   onRemoveFilter,
 }: Pick<MyAccountSelectedTagsProps, 'filters' | 'onRemoveFilter'>) {
   const { locale } = useSession()
-  const { dateInitial, dateFinal, status } = filters
+  const { dateInitial, dateFinal, status, purchaseAgentId } = filters
   const formattedDateInitial = dateInitial
     ? formatFilterDate(dateInitial, locale)
     : ''
@@ -85,10 +86,23 @@ function Tags({
     </div>
   ))
 
+  const placedByTag = purchaseAgentId && (
+    <div key={`placed-by-${purchaseAgentId}`} data-fs-list-orders-selected-tag>
+      <span>Placed by: {purchaseAgentId}</span>
+      <button
+        data-fs-list-orders-selected-tag-clear
+        onClick={() => onRemoveFilter('purchaseAgentId', purchaseAgentId)}
+      >
+        &times;
+      </button>
+    </div>
+  )
+
   return (
     <>
       {dateTag}
       {statusTags}
+      {placedByTag}
     </>
   )
 }
@@ -100,7 +114,10 @@ function MyAccountSelectedTags({
 }: MyAccountSelectedTagsProps) {
   const hasFilters = Object.entries(filters).some(
     ([key, values]) =>
-      (key === 'status' || key === 'dateInitial' || key === 'dateFinal') &&
+      (key === 'status' ||
+        key === 'dateInitial' ||
+        key === 'dateFinal' ||
+        key === 'purchaseAgentId') &&
       values &&
       (Array.isArray(values) ? values.length > 0 : true)
   )

--- a/packages/core/src/pages/account/orders/index.tsx
+++ b/packages/core/src/pages/account/orders/index.tsx
@@ -46,6 +46,7 @@ type ListOrdersPageProps = {
     dateFinal: string
     text: string
     clientEmail: string
+    purchaseAgentId?: string
   }
 } & MyAccountProps
 
@@ -171,6 +172,8 @@ export const getServerSideProps: GetServerSideProps<
   const dateFinal = (context.query.dateFinal as string | undefined) || ''
   const text = (context.query.text as string | undefined) || ''
   const clientEmail = (context.query.clientEmail as string | undefined) || ''
+  const purchaseAgentId =
+    (context.query.purchaseAgentId as string | undefined) || ''
 
   // Map labels from FastStore status to API status
   const groupedStatus = groupOrderStatusByLabel()
@@ -246,6 +249,7 @@ export const getServerSideProps: GetServerSideProps<
         dateFinal,
         text,
         clientEmail,
+        purchaseAgentId,
       },
       isRepresentative,
     },

--- a/packages/core/src/pages/account/orders/index.tsx
+++ b/packages/core/src/pages/account/orders/index.tsx
@@ -172,6 +172,8 @@ export const getServerSideProps: GetServerSideProps<
   const dateFinal = (context.query.dateFinal as string | undefined) || ''
   const text = (context.query.text as string | undefined) || ''
   const clientEmail = (context.query.clientEmail as string | undefined) || ''
+  // TODO: Integration: ensure `purchaseAgentId` is mapped to `purchase_agent_id`
+  // when calling the OMS API. Keep camelCase across the frontend.
   const purchaseAgentId =
     (context.query.purchaseAgentId as string | undefined) || ''
 

--- a/packages/core/src/sdk/search/useMyAccountFilter.ts
+++ b/packages/core/src/sdk/search/useMyAccountFilter.ts
@@ -49,9 +49,16 @@ export type MyAccountFilter_Facets_StoreFacetRange_Fragment = {
   to: string
 }
 
+export type MyAccountFilter_Facets_StoreFacetPlacedBy_Fragment = {
+  __typename: 'StoreFacetPlacedBy'
+  key: string
+  label: string
+}
+
 export type MyAccountFilter_FacetsFragment =
   | MyAccountFilter_Facets_StoreFacetBoolean_Fragment
   | MyAccountFilter_Facets_StoreFacetRange_Fragment
+  | MyAccountFilter_Facets_StoreFacetPlacedBy_Fragment
 
 const reducer = (state: State, action: Action) => {
   const { expanded, selected } = state


### PR DESCRIPTION
## What’s the purpose of this pull request?

- Add a new Placed by filter to My Account → Orders, enabling users to search and select a shopper before applying filters.
- Implement the feature with mock data, preparing for a future API integration.

## How it works?

- New facet in the Filters panel (between Status and Order date):
  - Autocomplete input using mock shoppers.
  - Type to filter by name/email (case-insensitive).
  - Selecting a shopper makes the input read-only and shows a clear X inside the field.
  - Clear X removes the selection and restores search mode.
  - If the user types but doesn’t select and blurs, the input auto-clears.
- Selected shopper appears as a tag inside the filter panel; Clear All removes it.
- Clicking View Results rebuilds the URL and reloads the page with:
  - purchaseAgentId=<id> when selected

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

[SFS-2702](https://vtex-dev.atlassian.net/browse/SFS-2702?atlOrigin=eyJpIjoiZmNjZmUwNWQxMjdjNDlhNDk0YTU5OTY4Y2NkMDBmYzciLCJwIjoiaiJ9)

[Figma](https://www.figma.com/design/JppevzwPSV58ud0JDCFE7o/My-Account-%E2%80%93-ODP?node-id=2975-182090&p=f&t=TUnyb1nRi7t0WYVV-0)
