### PR TITLE
fix(cli): Listen to $PORT env var on `dev` command.

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -152,7 +152,7 @@ export default class Dev extends Command {
   async run() {
     const { args, flags } = await this.parse(Dev)
     const basePath = args.path ?? process.cwd()
-    const port = args.port ?? 3000
+    const port = args.port ?? process.env.PORT ?? 3000
     const watchPlugins = flags['watch-plugins']
 
     const { getRoot, tmpDir, coreDir } = withBasePath(basePath)

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -528,6 +528,7 @@ export async function generate(options: GenerateOptions) {
       copyCoreFiles(basePath),
       copyCypressFiles(basePath),
       copyPublicFiles(basePath),
+      updateNextConfig(basePath),
     ])
   }
 
@@ -539,7 +540,6 @@ export async function generate(options: GenerateOptions) {
     copyUserStarterToCustomizations(basePath),
     copyTheme(basePath),
     createCmsWebhookUrlsJsonFile(basePath),
-    updateNextConfig(basePath),
     enableRedirectsMiddleware(basePath),
 
     installPlugins(basePath),


### PR DESCRIPTION
## What's the purpose of this pull request?

Depends on the improvement from https://github.com/vtex/faststore/pull/2983. 

This feature is a requirement for the fast preview environment, which runs the store on `dev` mode in our infrastructure. Our infrastructure selects a PORT at random at attributes it to the pod.

## How it works?

Instead of using the hardcoded port number (3000) as a fallback, we try to fallback to the $PORT env var before.

## How to test it?

Run `PORT=4242 yarn dev` and see that the server runs on port 4242.

### Starters Deploy Preview

N/A