### PR TITLE
fix: Update search page when changing terms

### DIFF
--- a/packages/core/src/components/templates/SearchPage/SearchPage.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchPage.tsx
@@ -24,7 +24,9 @@ function SearchPage({
   globalSections,
   globalSettings,
 }: SearchPageProps) {
-  const { pages, useGalleryPage } = useCreateUseGalleryPage()
+  const { pages, useGalleryPage } = useCreateUseGalleryPage({
+    searchTerm: serverData?.searchTerm,
+  })
 
   const context = {
     data: {

--- a/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
+++ b/packages/core/src/components/templates/SearchPage/SearchWrapper.tsx
@@ -34,7 +34,7 @@ export default function SearchWrapper({
   } = useSearch()
 
   const { data: pageProductGalleryData } = useProductGalleryQuery({
-    term,
+    term: serverData?.searchTerm ?? term ?? '',
     sort,
     itemsPerPage,
     selectedFacets,

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -98,8 +98,9 @@ function generateSEOData(storeConfig: StoreConfig, searchTerm?: string) {
 function Page({
   page: searchContentType,
   globalSections: globalSectionsProp,
-  searchTerm,
+  searchTerm: serverSearchTerm,
 }: SearchPageProps) {
+  const router = useRouter()
   const { sections: globalSections, settings: globalSettings } =
     globalSectionsProp ?? {}
   const { settings } = searchContentType
@@ -109,6 +110,11 @@ function Page({
   })
 
   const itemsPerPage = settings?.productGallery?.itemsPerPage ?? ITEMS_PER_PAGE
+  const searchTerm =
+    serverSearchTerm ??
+    (router.query?.q as string) ??
+    searchParams.term ??
+    undefined
 
   if (!searchParams) {
     return null
@@ -144,10 +150,7 @@ function Page({
       <SearchWrapper
         itemsPerPage={itemsPerPage}
         searchContentType={searchContentType}
-        serverData={{
-          title: seoData.title,
-          searchTerm: searchTerm ?? searchParams.term ?? undefined,
-        }}
+        serverData={{ title: seoData.title, searchTerm }}
         globalSections={globalSections}
         globalSettings={globalSettings}
       />

--- a/packages/core/src/sdk/product/usePageProductsQuery.ts
+++ b/packages/core/src/sdk/product/usePageProductsQuery.ts
@@ -18,6 +18,7 @@ import { useQuery } from 'src/sdk/graphql/useQuery'
 import { generatedBuildTime } from '../../../next-seo.config'
 import { useLocalizedVariables } from './useLocalizedVariables'
 import { useShouldFetchFirstPage } from './useShouldFetchFirstPage'
+import { useSession } from 'src/sdk/session'
 
 export const UseGalleryPageContext = createContext<
   ReturnType<typeof useCreateUseGalleryPage>['useGalleryPage']
@@ -68,8 +69,9 @@ export const query = gql(`
 const getKey = (object: any) => JSON.stringify(object)
 
 interface UseCreateUseGalleryPageProps {
-  initialPages: ClientManyProductsQueryQuery
-  serverManyProductsVariables: ClientManyProductsQueryQueryVariables
+  initialPages?: ClientManyProductsQueryQuery
+  serverManyProductsVariables?: ClientManyProductsQueryQueryVariables
+  searchTerm?: string
 }
 
 /**
@@ -78,6 +80,7 @@ interface UseCreateUseGalleryPageProps {
 export const useCreateUseGalleryPage = (
   params?: UseCreateUseGalleryPageProps
 ) => {
+  const { postalCode: sessionPostalCode } = useSession()
   const initialPages = params?.initialPages?.search ? [params.initialPages] : []
   const initialVariables = params?.serverManyProductsVariables
     ? [getKey(params.serverManyProductsVariables)]
@@ -88,73 +91,86 @@ export const useCreateUseGalleryPage = (
   // We create pagesRef as a mirror of the pages state so we don't have to add pages as a dependency of the useGalleryPage hook
   const pagesRef = useRef<ClientManyProductsQueryQuery[]>(initialPages)
   const pagesCache = useRef<string[]>(initialVariables)
+  const postalCodeRef = useRef<string>(sessionPostalCode)
 
-  const useGalleryPage = useCallback(function useGalleryPage(page: number) {
-    const {
-      state: { sort, term, selectedFacets },
-      itemsPerPage,
-    } = useSearch()
+  const useGalleryPage = useCallback(
+    function useGalleryPage(page: number) {
+      const {
+        state: { sort, term, selectedFacets },
+        itemsPerPage,
+      } = useSearch()
 
-    const localizedVariables = useLocalizedVariables({
-      first: itemsPerPage,
-      after: (itemsPerPage * page).toString(),
-      sort,
-      term: term ?? '',
-      selectedFacets,
-    })
+      const localizedVariables = useLocalizedVariables({
+        first: itemsPerPage,
+        after: (itemsPerPage * page).toString(),
+        sort,
+        term: params?.searchTerm ?? term ?? '',
+        selectedFacets,
+      })
 
-    const hasSameVariables = deepEquals(
-      pagesCache.current[page],
-      getKey(localizedVariables)
-    )
+      const hasSameVariables = deepEquals(
+        pagesCache.current[page],
+        getKey(localizedVariables)
+      )
 
-    const shouldFetchFirstPage = useShouldFetchFirstPage({
-      page,
-      generatedBuildTime,
-    })
+      const shouldFetchFirstPage = useShouldFetchFirstPage({
+        page,
+        generatedBuildTime,
+      })
 
-    const shouldFetch = !hasSameVariables || shouldFetchFirstPage
+      const shouldFetch =
+        !hasSameVariables || shouldFetchFirstPage || !!sessionPostalCode
 
-    const { data } = useQuery<
-      ClientManyProductsQueryQuery,
-      ClientManyProductsQueryQueryVariables
-    >(query, localizedVariables, {
-      fallbackData: null,
-      suspense: true,
-      doNotRun: !shouldFetch,
-    })
+      const { data, mutate } = useQuery<
+        ClientManyProductsQueryQuery,
+        ClientManyProductsQueryQueryVariables
+      >(query, localizedVariables, {
+        fallbackData: null,
+        suspense: true,
+        doNotRun: !shouldFetch,
+      })
 
-    const shouldUpdatePages = data !== null
+      const shouldUpdatePages = data !== null
 
-    if (shouldUpdatePages) {
-      pagesCache.current[page] = getKey(localizedVariables)
-
-      // Update refs
-      const newPages = [...pagesRef.current]
-      newPages[page] = data
-      pagesRef.current = newPages
-    }
-
-    // Prevents error: Cannot update a component (`ProductListing`) while rendering a different component (`ProductGalleryPage`).
-    useEffect(() => {
       if (shouldUpdatePages) {
-        // Update state
-        setPages((oldPages) => {
-          const newPages = [...oldPages]
-          newPages[page] = data
-          return newPages
-        })
-      }
-    }, [data, page, shouldUpdatePages])
+        pagesCache.current[page] = getKey(localizedVariables)
 
-    return useMemo(() => {
-      if (hasSameVariables) {
-        return { data: pagesRef.current[page] }
+        // Update refs
+        const newPages = [...pagesRef.current]
+        newPages[page] = data
+        pagesRef.current = newPages
       }
 
-      return { data }
-    }, [hasSameVariables, data, page])
-  }, [])
+      // Prevents error: Cannot update a component (`ProductListing`) while rendering a different component (`ProductGalleryPage`).
+      useEffect(() => {
+        if (shouldUpdatePages) {
+          // Update state
+          setPages((oldPages) => {
+            const newPages = [...oldPages]
+            newPages[page] = data
+            return newPages
+          })
+        }
+      }, [data, page, shouldUpdatePages])
+
+      // Refetch query with updated regionId
+      useEffect(() => {
+        if (sessionPostalCode !== postalCodeRef.current) {
+          mutate()
+          postalCodeRef.current = sessionPostalCode
+        }
+      }, [sessionPostalCode])
+
+      return useMemo(() => {
+        if (hasSameVariables) {
+          return { data: pagesRef.current[page] }
+        }
+
+        return { data }
+      }, [hasSameVariables, data, page])
+    },
+    [params?.searchTerm, sessionPostalCode]
+  )
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## What's the purpose of this pull request?

Currently, after performing a new search, when the shopper is already in the search page, the results are not changing. Also, the results are not being updated when the zip code is changed.

With these changes, the search page will consider the correct term when performing the search and will refetch the query when the zip code is changed.

## How to test it?

- Search for `apple`. You should see `apple` results;
- On the search page, search again for `unbranded` and the results should be different (showing results for `unbranded`);

### Starters Deploy Preview

