### PR TITLE
fix: validate mutations after offline network

### DIFF
--- a/packages/sdk/src/store/optimistic.ts
+++ b/packages/sdk/src/store/optimistic.ts
@@ -23,7 +23,9 @@ export const optimistic = <T>(onValidate: Validator<T> = trivial) => {
         }
       }
 
-      queue = queue.then(handler)
+      queue = queue.then(handler).catch((_) => {
+        console.error('Error in optimistic validation:', _)
+      })
 
       return () => {
         cancel = true

--- a/packages/sdk/src/store/optimistic.ts
+++ b/packages/sdk/src/store/optimistic.ts
@@ -18,7 +18,7 @@ export const optimistic = <T>(onValidate: Validator<T> = trivial) => {
 
         const validated = await onValidate(value)
 
-        if (!cancel && validated !== null) {
+        if (!cancel && validated !== null && validated !== undefined) {
           store.set(validated)
         }
       }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes the validation cart and session mutations behavior after some errors, such as internet connection issues.

Before:
https://vtex.slack.com/archives/C051B6LL91U/p1755264051698289?thread_ts=1755264007.074619&cid=C051B6LL91U

After:
https://vtex.slack.com/archives/C051B6LL91U/p1755807381785019?thread_ts=1755264007.074619&cid=C051B6LL91U

## How it works?

`validateCart` depends on the session in its request.
`validateSession` sometimes becomes `undefined` when there is an error, such as internet connection issues.

That way, the mutation becomes desynchronized and stops working.
Also, looks like when an error exists in the `queue.then(handler)`, the `store.subscribe` method breaks, making the validateCart stop running. Just including a catch makes it work as expected.

## How to test it?

You can test locally, simulating an offline network, and after online, double-check if both mutations work in the network panel of devtools.

Also, you can use the version generated from this PR in some store.

### Starters Deploy Preview

TBD
