### PR TITLE
feat: add filter and selected tag for pending approval

### DIFF
--- a/packages/api/src/__generated__/schema.ts
+++ b/packages/api/src/__generated__/schema.ts
@@ -853,7 +853,7 @@ export type Query = {
   allProducts: StoreProductConnection;
   /** Returns the details of a collection based on the collection slug. */
   collection: StoreCollection;
-  /** Returns information about the list of Orders that the User can view. */
+  /** Returns the list of Orders that the User can view. */
   listUserOrders?: Maybe<UserOrderListMinimalResult>;
   /** Returns a list of pickup points near to the given geo coordinates. */
   pickupPoints?: Maybe<PickupPoints>;
@@ -902,6 +902,7 @@ export type QueryListUserOrdersArgs = {
   dateFinal?: Maybe<Scalars['String']>;
   dateInitial?: Maybe<Scalars['String']>;
   page?: Maybe<Scalars['Int']>;
+  pendingMyApproval?: Maybe<Scalars['Boolean']>;
   perPage?: Maybe<Scalars['Int']>;
   status?: Maybe<Array<Maybe<Scalars['String']>>>;
   text?: Maybe<Scalars['String']>;

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -488,6 +488,7 @@ export const VtexCommerce = (
         text,
         clientEmail,
         perPage,
+        pendingMyApproval,
       }: QueryListUserOrdersArgs): Promise<UserOrderListResult> => {
         const params = new URLSearchParams()
 
@@ -530,6 +531,14 @@ export const VtexCommerce = (
         if (clientEmail) params.append('clientEmail', clientEmail)
         if (page) params.append('page', page.toString())
         if (perPage) params.append('per_page', perPage.toString())
+
+        if (pendingMyApproval) {
+          console.log(
+            'Filtering orders with pending user approval:',
+            pendingMyApproval
+          )
+          // TODO: Implement actual filtering logic when API is ready
+        }
 
         const headers: HeadersInit = withCookie({
           'content-type': 'application/json',

--- a/packages/api/src/typeDefs/query.graphql
+++ b/packages/api/src/typeDefs/query.graphql
@@ -380,7 +380,7 @@ type Query {
     @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
 
   """
-  Returns information about the list of Orders that the User can view.
+  Returns the list of Orders that the User can view.
   """
   listUserOrders(
     """
@@ -411,6 +411,10 @@ type Query {
     Client email used to filter of the list of orders.
     """
     clientEmail: String
+    """
+    Filter orders that are pending user approval.
+    """
+    pendingMyApproval: Boolean
   ): UserOrderListMinimalResult
     @cacheControl(scope: "public", sMaxAge: 120, staleWhileRevalidate: 3600)
 

--- a/packages/core/@generated/graphql.ts
+++ b/packages/core/@generated/graphql.ts
@@ -833,7 +833,7 @@ export type Query = {
   allProducts: StoreProductConnection
   /** Returns the details of a collection based on the collection slug. */
   collection: StoreCollection
-  /** Returns information about the list of Orders that the User can view. */
+  /** Returns the list of Orders that the User can view. */
   listUserOrders: Maybe<UserOrderListMinimalResult>
   /** Returns a list of pickup points near to the given geo coordinates. */
   pickupPoints: Maybe<PickupPoints>
@@ -878,6 +878,7 @@ export type QueryListUserOrdersArgs = {
   dateFinal: InputMaybe<Scalars['String']['input']>
   dateInitial: InputMaybe<Scalars['String']['input']>
   page: InputMaybe<Scalars['Int']['input']>
+  pendingMyApproval: InputMaybe<Scalars['Boolean']['input']>
   perPage: InputMaybe<Scalars['Int']['input']>
   status: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
   text: InputMaybe<Scalars['String']['input']>

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPendingApproval/MyAccountFilterFacetPendingApproval.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPendingApproval/MyAccountFilterFacetPendingApproval.tsx
@@ -1,0 +1,62 @@
+import { Toggle } from '@faststore/ui'
+import { useMemo } from 'react'
+import type { SelectedFacet } from 'src/sdk/search/useMyAccountFilter'
+
+export interface MyAccountFilterFacetPendingApprovalProps {
+  /**
+   * Current selected facets from filter context
+   */
+  selected: SelectedFacet[]
+  /**
+   * Dispatch from filter context
+   */
+  dispatch: (action: { type: 'toggleFacet' | 'setFacet'; payload: any }) => void
+}
+
+function MyAccountFilterFacetPendingApproval({
+  selected,
+  dispatch,
+}: MyAccountFilterFacetPendingApprovalProps) {
+  const isSelected = useMemo(
+    () =>
+      selected.some((f) => f.key === 'pendingApproval' && f.value === 'true'),
+    [selected]
+  )
+
+  const handleToggleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const isChecked = event.target.checked
+
+    if (isChecked) {
+      dispatch({
+        type: 'setFacet',
+        payload: {
+          facet: { key: 'pendingApproval', value: 'true' },
+          unique: true,
+        },
+      })
+    } else {
+      dispatch({
+        type: 'toggleFacet',
+        payload: {
+          key: 'pendingApproval',
+          value: 'true',
+        },
+      })
+    }
+  }
+
+  return (
+    <div data-fs-my-account-filter-facet-pending-approval>
+      <Toggle
+        id="pending-approval-toggle"
+        testId="pending-approval-toggle"
+        checked={isSelected}
+        onChange={handleToggleChange}
+        aria-label="Filter orders pending approval"
+      />
+      <label htmlFor="pending-approval-toggle">Pending my approval</label>
+    </div>
+  )
+}
+
+export default MyAccountFilterFacetPendingApproval

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPendingApproval/MyAccountFilterFacetPendingApproval.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPendingApproval/MyAccountFilterFacetPendingApproval.tsx
@@ -19,7 +19,7 @@ function MyAccountFilterFacetPendingApproval({
 }: MyAccountFilterFacetPendingApprovalProps) {
   const isSelected = useMemo(
     () =>
-      selected.some((f) => f.key === 'pendingApproval' && f.value === 'true'),
+      selected.some((f) => f.key === 'pendingMyApproval' && f.value === 'true'),
     [selected]
   )
 
@@ -30,7 +30,7 @@ function MyAccountFilterFacetPendingApproval({
       dispatch({
         type: 'setFacet',
         payload: {
-          facet: { key: 'pendingApproval', value: 'true' },
+          facet: { key: 'pendingMyApproval', value: 'true' },
           unique: true,
         },
       })
@@ -38,7 +38,7 @@ function MyAccountFilterFacetPendingApproval({
       dispatch({
         type: 'toggleFacet',
         payload: {
-          key: 'pendingApproval',
+          key: 'pendingMyApproval',
           value: 'true',
         },
       })

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPendingApproval/index.ts
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPendingApproval/index.ts
@@ -1,0 +1,2 @@
+export { default } from './MyAccountFilterFacetPendingApproval'
+export type { MyAccountFilterFacetPendingApprovalProps } from './MyAccountFilterFacetPendingApproval'

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPendingApproval/styles.scss
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterFacetPendingApproval/styles.scss
@@ -1,0 +1,18 @@
+[data-fs-my-account-filter-facet-pending-approval] {
+  display: flex;
+  gap: var(--fs-spacing-2);
+  align-items: center;
+  padding: var(--fs-spacing-2) 0;
+
+  label {
+    font-size: var(--fs-text-size-body);
+    font-weight: var(--fs-text-weight-regular);
+    color: var(--fs-color-text);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  [data-fs-toggle] {
+    flex-shrink: 0;
+  }
+}

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterSlider.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterSlider.tsx
@@ -97,8 +97,8 @@ function MyAccountFilterSlider({
           acc['purchaseAgentId'] = value
         }
 
-        if (key === 'pendingApproval') {
-          acc['pendingApproval'] = value
+        if (key === 'pendingMyApproval') {
+          acc['pendingMyApproval'] = value
         }
 
         return acc

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterSlider.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/MyAccountFilterSlider.tsx
@@ -14,6 +14,7 @@ import type {
 } from 'src/sdk/search/useMyAccountFilter'
 import FilterFacetDateRange from './MyAccountFilterFacetDateRange'
 import FilterFacetPlacedBy from './MyAccountFilterFacetPlacedBy'
+import FilterFacetPendingApproval from './MyAccountFilterFacetPendingApproval'
 import styles from './section.module.scss'
 
 export interface FilterSliderProps {
@@ -94,6 +95,10 @@ function MyAccountFilterSlider({
 
         if (key === 'purchaseAgentId') {
           acc['purchaseAgentId'] = value
+        }
+
+        if (key === 'pendingApproval') {
+          acc['pendingApproval'] = value
         }
 
         return acc
@@ -198,6 +203,12 @@ function MyAccountFilterSlider({
                     />
                   ))}
                 </UIFilterFacetBoolean>
+              )}
+              {type === 'StoreFacetPendingApproval' && isExpanded && (
+                <FilterFacetPendingApproval
+                  selected={selected}
+                  dispatch={dispatch}
+                />
               )}
               {type === 'StoreFacetPlacedBy' && isExpanded && (
                 <FilterFacetPlacedBy selected={selected} dispatch={dispatch} />

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/section.module.scss
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountFilterSlider/section.module.scss
@@ -8,6 +8,7 @@
   @import "@faststore/ui/src/components/atoms/Link/styles.scss";
   @import "@faststore/ui/src/components/atoms/List/styles.scss";
   @import "@faststore/ui/src/components/atoms/Slider/styles.scss";
+  @import "@faststore/ui/src/components/molecules/Toggle/styles.scss";
   @import "@faststore/ui/src/components/molecules/DiscountBadge/styles.scss";
   @import "@faststore/ui/src/components/molecules/Accordion/styles.scss";
   @import "@faststore/ui/src/components/molecules/InputField/styles.scss";
@@ -18,6 +19,7 @@
   @import "@faststore/ui/src/components/organisms/SlideOver/styles.scss";
   @import "./MyAccountFilterFacetDateRange/styles.scss";
   @import "./MyAccountFilterFacetPlacedBy/styles.scss";
+  @import "./MyAccountFilterFacetPendingApproval/styles.scss";
 
   [data-fs-badge] {
     display: none;

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountListOrders.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountListOrders.tsx
@@ -40,7 +40,7 @@ export type MyAccountListOrdersProps = {
     text: string
     clientEmail: string
     purchaseAgentId?: string
-    pendingApproval?: string
+    pendingMyApproval?: boolean
   }
 }
 
@@ -80,9 +80,9 @@ function getSelectedFacets({
         key: 'purchaseAgentId',
         value: String(value),
       })
-    } else if (filter === 'pendingApproval' && value) {
+    } else if (filter === 'pendingMyApproval' && value) {
       acc.push({
-        key: 'pendingApproval',
+        key: 'pendingMyApproval',
         value: String(value),
       })
     }
@@ -99,7 +99,7 @@ function getAllFacets({
   return [
     {
       __typename: 'StoreFacetPendingApproval',
-      key: 'pendingApproval',
+      key: 'pendingMyApproval',
       label: 'Pending Approval',
     } as any,
     {
@@ -136,7 +136,7 @@ function hasActiveFilters(
     Boolean(filters.dateInitial) ||
     Boolean(filters.dateFinal) ||
     Boolean(filters.text) ||
-    Boolean(filters.pendingApproval)
+    Boolean(filters.pendingMyApproval)
   )
 }
 
@@ -274,7 +274,7 @@ export default function MyAccountListOrders({
 
             if (key === 'status' && Array.isArray(updatedFilters[key])) {
               updatedFilters[key] = updatedFilters[key].filter(
-                (v) => v.toLowerCase() !== value.toLowerCase()
+                (v) => v.toLowerCase() !== value.toString().toLowerCase()
               )
             } else if (key === 'dateInitial' || key === 'dateFinal') {
               delete updatedFilters.dateInitial

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountListOrders.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountListOrders.tsx
@@ -40,6 +40,7 @@ export type MyAccountListOrdersProps = {
     text: string
     clientEmail: string
     purchaseAgentId?: string
+    pendingApproval?: string
   }
 }
 
@@ -79,6 +80,11 @@ function getSelectedFacets({
         key: 'purchaseAgentId',
         value: String(value),
       })
+    } else if (filter === 'pendingApproval' && value) {
+      acc.push({
+        key: 'pendingApproval',
+        value: String(value),
+      })
     }
 
     return acc
@@ -91,6 +97,11 @@ function getAllFacets({
   filters: MyAccountListOrdersProps['filters']
 }): MyAccountFilter_FacetsFragment[] {
   return [
+    {
+      __typename: 'StoreFacetPendingApproval',
+      key: 'pendingApproval',
+      label: 'Pending Approval',
+    } as any,
     {
       __typename: 'StoreFacetBoolean',
       key: 'status',
@@ -124,7 +135,8 @@ function hasActiveFilters(
     filters.status.length > 0 ||
     Boolean(filters.dateInitial) ||
     Boolean(filters.dateFinal) ||
-    Boolean(filters.text)
+    Boolean(filters.text) ||
+    Boolean(filters.pendingApproval)
   )
 }
 
@@ -240,12 +252,7 @@ export default function MyAccountListOrders({
         </div>
 
         <SelectedFiltersTags
-          filters={{
-            status: filters.status,
-            dateInitial: filters.dateInitial,
-            dateFinal: filters.dateFinal,
-            purchaseAgentId: filters.purchaseAgentId,
-          }}
+          filters={filters}
           onClearAll={() => {
             window.location.href = '/account/orders'
           }}

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountSelectedTags/MyAccountSelectedTags.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountSelectedTags/MyAccountSelectedTags.tsx
@@ -8,7 +8,7 @@ type MyAccountSelectedTagsProps = {
     dateInitial?: string
     dateFinal?: string
     purchaseAgentId?: string
-    pendingApproval?: string
+    pendingMyApproval?: boolean
   }
   onClearAll: () => void
   onRemoveFilter: (
@@ -17,8 +17,8 @@ type MyAccountSelectedTagsProps = {
       | 'dateInitial'
       | 'dateFinal'
       | 'purchaseAgentId'
-      | 'pendingApproval',
-    value: string
+      | 'pendingMyApproval',
+    value: string | boolean
   ) => void
 }
 
@@ -47,7 +47,7 @@ function Tags({
   onRemoveFilter,
 }: Pick<MyAccountSelectedTagsProps, 'filters' | 'onRemoveFilter'>) {
   const { locale } = useSession()
-  const { dateInitial, dateFinal, status, purchaseAgentId, pendingApproval } =
+  const { dateInitial, dateFinal, status, purchaseAgentId, pendingMyApproval } =
     filters
 
   const formattedDateInitial = dateInitial
@@ -106,12 +106,12 @@ function Tags({
     </div>
   )
 
-  const pendingApprovalTag = pendingApproval && (
+  const pendingMyApprovalTag = pendingMyApproval && (
     <div key="pending-approval" data-fs-list-orders-selected-tag>
       <span>Pending my approval</span>
       <button
         data-fs-list-orders-selected-tag-clear
-        onClick={() => onRemoveFilter('pendingApproval', pendingApproval)}
+        onClick={() => onRemoveFilter('pendingMyApproval', pendingMyApproval)}
       >
         &times;
       </button>
@@ -120,7 +120,7 @@ function Tags({
 
   return (
     <>
-      {pendingApprovalTag}
+      {pendingMyApprovalTag}
       {placedByTag}
       {dateTag}
       {statusTags}
@@ -139,7 +139,7 @@ function MyAccountSelectedTags({
         key === 'dateInitial' ||
         key === 'dateFinal' ||
         key === 'purchaseAgentId' ||
-        key === 'pendingApproval') &&
+        key === 'pendingMyApproval') &&
       values &&
       (Array.isArray(values) ? values.length > 0 : true)
   )

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountSelectedTags/MyAccountSelectedTags.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountSelectedTags/MyAccountSelectedTags.tsx
@@ -8,10 +8,16 @@ type MyAccountSelectedTagsProps = {
     dateInitial?: string
     dateFinal?: string
     purchaseAgentId?: string
+    pendingApproval?: string
   }
   onClearAll: () => void
   onRemoveFilter: (
-    key: 'status' | 'dateInitial' | 'dateFinal' | 'purchaseAgentId',
+    key:
+      | 'status'
+      | 'dateInitial'
+      | 'dateFinal'
+      | 'purchaseAgentId'
+      | 'pendingApproval',
     value: string
   ) => void
 }
@@ -41,7 +47,9 @@ function Tags({
   onRemoveFilter,
 }: Pick<MyAccountSelectedTagsProps, 'filters' | 'onRemoveFilter'>) {
   const { locale } = useSession()
-  const { dateInitial, dateFinal, status, purchaseAgentId } = filters
+  const { dateInitial, dateFinal, status, purchaseAgentId, pendingApproval } =
+    filters
+
   const formattedDateInitial = dateInitial
     ? formatFilterDate(dateInitial, locale)
     : ''
@@ -98,8 +106,21 @@ function Tags({
     </div>
   )
 
+  const pendingApprovalTag = pendingApproval && (
+    <div key="pending-approval" data-fs-list-orders-selected-tag>
+      <span>Pending my approval</span>
+      <button
+        data-fs-list-orders-selected-tag-clear
+        onClick={() => onRemoveFilter('pendingApproval', pendingApproval)}
+      >
+        &times;
+      </button>
+    </div>
+  )
+
   return (
     <>
+      {pendingApprovalTag}
       {placedByTag}
       {dateTag}
       {statusTags}
@@ -117,7 +138,8 @@ function MyAccountSelectedTags({
       (key === 'status' ||
         key === 'dateInitial' ||
         key === 'dateFinal' ||
-        key === 'purchaseAgentId') &&
+        key === 'purchaseAgentId' ||
+        key === 'pendingApproval') &&
       values &&
       (Array.isArray(values) ? values.length > 0 : true)
   )

--- a/packages/core/src/pages/account/orders/index.tsx
+++ b/packages/core/src/pages/account/orders/index.tsx
@@ -176,6 +176,8 @@ export const getServerSideProps: GetServerSideProps<
   // when calling the OMS API. Keep camelCase across the frontend.
   const purchaseAgentId =
     (context.query.purchaseAgentId as string | undefined) || ''
+  const pendingApproval =
+    (context.query.pendingApproval as string | undefined) || ''
 
   // Map labels from FastStore status to API status
   const groupedStatus = groupOrderStatusByLabel()
@@ -252,6 +254,7 @@ export const getServerSideProps: GetServerSideProps<
         text,
         clientEmail,
         purchaseAgentId,
+        pendingApproval,
       },
       isRepresentative,
     },

--- a/packages/core/src/pages/account/orders/index.tsx
+++ b/packages/core/src/pages/account/orders/index.tsx
@@ -47,6 +47,7 @@ type ListOrdersPageProps = {
     text: string
     clientEmail: string
     purchaseAgentId?: string
+    pendingMyApproval?: boolean
   }
 } & MyAccountProps
 
@@ -176,8 +177,7 @@ export const getServerSideProps: GetServerSideProps<
   // when calling the OMS API. Keep camelCase across the frontend.
   const purchaseAgentId =
     (context.query.purchaseAgentId as string | undefined) || ''
-  const pendingApproval =
-    (context.query.pendingApproval as string | undefined) || ''
+  const pendingMyApproval = context.query.pendingMyApproval === 'true'
 
   // Map labels from FastStore status to API status
   const groupedStatus = groupOrderStatusByLabel()
@@ -254,7 +254,7 @@ export const getServerSideProps: GetServerSideProps<
         text,
         clientEmail,
         purchaseAgentId,
-        pendingApproval,
+        pendingMyApproval,
       },
       isRepresentative,
     },

--- a/packages/core/src/sdk/search/useMyAccountFilter.ts
+++ b/packages/core/src/sdk/search/useMyAccountFilter.ts
@@ -55,10 +55,17 @@ export type MyAccountFilter_Facets_StoreFacetPlacedBy_Fragment = {
   label: string
 }
 
+export type MyAccountFilter_Facets_StoreFacetPendingApproval_Fragment = {
+  __typename: 'StoreFacetPendingApproval'
+  key: string
+  label: string
+}
+
 export type MyAccountFilter_FacetsFragment =
   | MyAccountFilter_Facets_StoreFacetBoolean_Fragment
   | MyAccountFilter_Facets_StoreFacetRange_Fragment
   | MyAccountFilter_Facets_StoreFacetPlacedBy_Fragment
+  | MyAccountFilter_Facets_StoreFacetPendingApproval_Fragment
 
 const reducer = (state: State, action: Action) => {
   const { expanded, selected } = state


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds a new "Pending Approval" filter to the MyAccount orders page, allowing users to quickly filter orders that require their approval.

## How it works?

- New toggle filter: Added "Pending Approval" as the first filter option in the orders filter slider
- Toggle switch: Users can turn on/off the filter to show only pending approval orders
- URL integration: Filter state is reflected in the URL (?pendingApproval=true)
- Selected tag: When active, shows "Pending my approval" tag below the search bar

## How to test it?

- Go to /account/orders
- Open filter slider and verify "Pending Approval" is the first option
- Toggle the switch and click "Apply"
- Check URL - should include ?pendingApproval=true
- Verify tag appears - "Pending my approval" tag should show below search bar
- Test removal - click "×" on tag or "Clear All" to remove filter
- Test direct URL - navigate to /account/orders?pendingApproval=true and verify filter is active

## References

[SFS-2618](https://vtex-dev.atlassian.net/browse/SFS-2618)

| List                                                                                      | Filter                                                                                    |
|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| ![image](https://github.com/user-attachments/assets/70a02298-4461-4b21-926d-8d6b754a78bc) | ![image](https://github.com/user-attachments/assets/2d6afc76-7153-473a-b839-c141e4f0ca1f) |


[SFS-2618]: https://vtex-dev.atlassian.net/browse/SFS-2618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ