### PR TITLE
feat: Add appkey and apptoken to VtexCommerce and Page components

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -716,7 +716,7 @@ export const VtexCommerce = (
         const userIdNormalized = userId.replace(/-/g, '') // Normalize userId by removing hyphens
 
         return fetchAPI(
-          `${base}/api/dataentities/shopper/search?_where=(userId=${userIdNormalized})&_fields=_all&_schema=v1`,
+          `${base}/api/dataentities/shopper/search?_where=(userId=${userIdNormalized} OR userId=${userId})&_fields=_all&_schema=v1`,
           {
             method: 'GET',
             headers,

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -698,8 +698,8 @@ export const VtexCommerce = (
           throw new Error('Missing userId to fetch shopper name')
         }
 
-        const appkey = process.env.FS_DISCOVERY_APP_KEY
-        const apptoken = process.env.FS_DISCOVERY_APP_TOKEN
+        const appkey = process.env.FS_DISCOVERY_APP_KEY ?? ''
+        const apptoken = process.env.FS_DISCOVERY_APP_TOKEN ?? ''
 
         console.log('🚀 ~ FS API process.env.FS_DISCOVERY_APP_KEY:', appkey)
         console.log('🚀 ~ FS API process.env.FS_DISCOVERY_APP_TOKEN:', apptoken)

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -701,12 +701,22 @@ export const VtexCommerce = (
         const appkey = process.env.FS_DISCOVERY_APP_KEY ?? ''
         const apptoken = process.env.FS_DISCOVERY_APP_TOKEN ?? ''
 
+        if (!appkey || !apptoken) {
+          throw new Error('No authentication AppKey and AppToken passed.')
+        }
+
+        const headers: HeadersInit = {
+          Accept: 'application/json',
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+          'X-VTEX-API-AppKey': appkey,
+          'X-VTEX-API-AppToken': apptoken,
+        }
+
         console.log('🚀 ~ FS API process.env.FS_DISCOVERY_APP_KEY:', appkey)
         console.log('🚀 ~ FS API process.env.FS_DISCOVERY_APP_TOKEN:', apptoken)
 
         const userIdNormalized = userId.replace(/-/g, '') // Normalize userId by removing hyphens
-
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
 
         return fetchAPI(
           `${base}/api/dataentities/shopper/search?_where=(userId=${userIdNormalized})&_fields=_all&_schema=v1`,

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -713,9 +713,6 @@ export const VtexCommerce = (
           'X-VTEX-API-AppToken': apptoken,
         }
 
-        console.log('🚀 ~ FS API process.env.FS_DISCOVERY_APP_KEY:', appkey)
-        console.log('🚀 ~ FS API process.env.FS_DISCOVERY_APP_TOKEN:', apptoken)
-
         const userIdNormalized = userId.replace(/-/g, '') // Normalize userId by removing hyphens
 
         return fetchAPI(

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -698,6 +698,12 @@ export const VtexCommerce = (
           throw new Error('Missing userId to fetch shopper name')
         }
 
+        const appkey = process.env.FS_DISCOVERY_APP_KEY
+        const apptoken = process.env.FS_DISCOVERY_APP_TOKEN
+
+        console.log('🚀 ~ FS API process.env.FS_DISCOVERY_APP_KEY:', appkey)
+        console.log('🚀 ~ FS API process.env.FS_DISCOVERY_APP_TOKEN:', apptoken)
+
         const userIdNormalized = userId.replace(/-/g, '') // Normalize userId by removing hyphens
 
         const headers: HeadersInit = withAutCookie(forwardedHost, account)

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -20,19 +20,13 @@ type Props = {
   page: PageContentType
   globalSections: GlobalSectionsData
   serverData?: unknown
-  appkey?: string
-  apptoken?: string
 }
 
 function Page({
   page: { sections, settings },
   globalSections: globalSectionsProp,
   serverData,
-  appkey,
-  apptoken,
 }: Props) {
-  console.log('🚀 ~ PAGE appkey:', appkey)
-  console.log('🚀 ~ PAGE apptoken:', apptoken)
   const { sections: globalSections, settings: globalSettings } =
     globalSectionsProp ?? {}
   const context = {
@@ -157,15 +151,6 @@ export const getStaticProps: GetStaticProps<
   Record<string, string>,
   PreviewData
 > = async ({ previewData }) => {
-  const appkey = process.env.FS_DISCOVERY_APP_KEY ?? ''
-  const apptoken = process.env.FS_DISCOVERY_APP_TOKEN ?? ''
-
-  console.log('🚀 ~ getStaticProps process.env.FS_DISCOVERY_APP_KEY:', appkey)
-  console.log(
-    '🚀 ~ getStaticProps process.env.FS_DISCOVERY_APP_TOKEN:',
-    apptoken
-  )
-
   const [
     globalSectionsPromise,
     globalSectionsHeaderPromise,
@@ -217,8 +202,6 @@ export const getStaticProps: GetStaticProps<
       page,
       globalSections: globalSectionsResult,
       serverData,
-      appkey,
-      apptoken,
     },
   }
 }

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -157,8 +157,8 @@ export const getStaticProps: GetStaticProps<
   Record<string, string>,
   PreviewData
 > = async ({ previewData }) => {
-  const appkey = process.env.FS_DISCOVERY_APP_KEY
-  const apptoken = process.env.FS_DISCOVERY_APP_TOKEN
+  const appkey = process.env.FS_DISCOVERY_APP_KEY ?? ''
+  const apptoken = process.env.FS_DISCOVERY_APP_TOKEN ?? ''
 
   console.log('🚀 ~ getStaticProps process.env.FS_DISCOVERY_APP_KEY:', appkey)
   console.log(

--- a/packages/core/src/pages/index.tsx
+++ b/packages/core/src/pages/index.tsx
@@ -20,13 +20,19 @@ type Props = {
   page: PageContentType
   globalSections: GlobalSectionsData
   serverData?: unknown
+  appkey?: string
+  apptoken?: string
 }
 
 function Page({
   page: { sections, settings },
   globalSections: globalSectionsProp,
   serverData,
+  appkey,
+  apptoken,
 }: Props) {
+  console.log('🚀 ~ PAGE appkey:', appkey)
+  console.log('🚀 ~ PAGE apptoken:', apptoken)
   const { sections: globalSections, settings: globalSettings } =
     globalSectionsProp ?? {}
   const context = {
@@ -151,6 +157,15 @@ export const getStaticProps: GetStaticProps<
   Record<string, string>,
   PreviewData
 > = async ({ previewData }) => {
+  const appkey = process.env.FS_DISCOVERY_APP_KEY
+  const apptoken = process.env.FS_DISCOVERY_APP_TOKEN
+
+  console.log('🚀 ~ getStaticProps process.env.FS_DISCOVERY_APP_KEY:', appkey)
+  console.log(
+    '🚀 ~ getStaticProps process.env.FS_DISCOVERY_APP_TOKEN:',
+    apptoken
+  )
+
   const [
     globalSectionsPromise,
     globalSectionsHeaderPromise,
@@ -198,7 +213,13 @@ export const getStaticProps: GetStaticProps<
   })
 
   return {
-    props: { page, globalSections: globalSectionsResult, serverData },
+    props: {
+      page,
+      globalSections: globalSectionsResult,
+      serverData,
+      appkey,
+      apptoken,
+    },
   }
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Uses AppKey and AppToken in the Masterdata Shopper entity API.
It also improves shopper search to include userId normalized (without hiphens) and normal.

## How it works?

Follow [this doc](https://docs.google.com/document/d/1cGxnlFxtO4bzZL0PBBOyjd4F6v8cRzKmn2K-KWDhDPY/edit?tab=t.0) to create roles + app key/token + secrets.

## How to test it?

You can just enter the order details page and check if you can see the page normally.

### Starters Deploy Preview
reach out to me :) 

## References
Doc: https://docs.google.com/document/d/1cGxnlFxtO4bzZL0PBBOyjd4F6v8cRzKmn2K-KWDhDPY/edit?tab=t.0