### PR TITLE
feat(core): presentational components for AI Agents

### DIFF
--- a/packages/core/src/components/sections/ProductDetails/DefaultComponents.ts
+++ b/packages/core/src/components/sections/ProductDetails/DefaultComponents.ts
@@ -20,7 +20,10 @@ import { Image } from 'src/components/ui/Image'
 import LocalNotAvailableButton from 'src/components/product/NotAvailableButton'
 import LocalSKUMatrixSidebar from 'src/components/ui/SKUMatrix/SKUMatrixSidebar'
 import LocalProductDescription from 'src/components/ui/ProductDescription/ProductDescription'
-import { ProductDetailsSettings as LocalProductDetailsSettings } from 'src/components/ui/ProductDetails'
+import {
+  ProductDetailsSettings as LocalProductDetailsSettings,
+  ProductDetailsPresentational,
+} from 'src/components/ui/ProductDetails'
 
 export const ProductDetailsDefaultComponents = {
   ProductTitle: UIProductTitle,
@@ -36,6 +39,7 @@ export const ProductDetailsDefaultComponents = {
   SKUMatrix: UISKUMatrix,
   SKUMatrixTrigger: UISKUMatrixTrigger,
   SKUMatrixSidebar: UISKUMatrixSidebar,
+  ProductDetailsPresentational: ProductDetailsPresentational,
   __experimentalImageGalleryImage: Image,
   __experimentalImageGallery: LocalImageGallery,
   __experimentalShippingSimulation: LocalShippingSimulation,

--- a/packages/core/src/components/ui/ProductDetails/ProductDetailsPresentational.tsx
+++ b/packages/core/src/components/ui/ProductDetails/ProductDetailsPresentational.tsx
@@ -1,0 +1,3 @@
+export default function ProductDetailsPresentational({ children }: any) {
+  return <>{children}</>
+}

--- a/packages/core/src/components/ui/ProductDetails/index.ts
+++ b/packages/core/src/components/ui/ProductDetails/index.ts
@@ -1,2 +1,3 @@
 export { default as ProductDetailsSettings } from './ProductDetailsSettings'
 export { default as AddToCartLoadingSkeleton } from './AddToCartLoadingSkeleton'
+export { default as ProductDetailsPresentational } from './ProductDetailsPresentational'

--- a/packages/core/src/typings/overrides.ts
+++ b/packages/core/src/typings/overrides.ts
@@ -286,6 +286,7 @@ export type SectionsOverrides = {
         SKUMatrixSidebarProps,
         SKUMatrixSidebarProps
       >
+      ProductDetailsPresentational: ComponentOverrideDefinition<any, any>
       __experimentalImageGalleryImage: ComponentOverrideDefinition<any, any>
       __experimentalImageGallery: ComponentOverrideDefinition<any, any>
       __experimentalShippingSimulation: ComponentOverrideDefinition<any, any>


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR introduces presentational components for AI Agents, allowing for more flexible and dynamic product displays. This will enable AI agents to control the rendering of product details and shelves, paving the way for more personalized and intelligent user experiences.

## How it works?

- A new `ProductDetailsPresentational` component has been created to separate logic from presentation in the product details section.
- The `ProductShelf` component has been refactored to optionally accept a `products` prop, allowing for products to be passed in directly instead of being fetched within the component.
- The `useProductsQuery` within `ProductShelf` now uses `suspense: false` to better handle loading states.

## How to test it?

1. Go to a product page.
2. The product details should render as before.
3. Go to a page with a product shelf.
4. The product shelf should render as before.
5. It is now possible to pass a `products` prop to `ProductShelf` and have it render those products.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

## Checklist

*You may erase this after checking them all :wink:*

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [x] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [ ] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [x] PR description
- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)
Collapse








