### PR TITLE
fix: don't require restart when switching themes

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -280,9 +280,15 @@ async function copyTheme(basePath: string) {
 
   let storeConfig
 
+  // Because of how node caches imports, if we don't delete the cache
+  // for the {discovery|faststore}.config.js files we will return a
+  // cached version and not reflect the theme change until a restart
+  // happens. Deleting before importing clears the cache
   if (existsSync(userStoreConfigFile)) {
+    delete require.cache[path.resolve(userStoreConfigFile)]
     storeConfig = await import(path.resolve(userStoreConfigFile))
   } else if (existsSync(userLegacyStoreConfigFile)) {
+    delete require.cache[path.resolve(userLegacyStoreConfigFile)]
     storeConfig = await import(path.resolve(userLegacyStoreConfigFile))
   } else {
     logger.info(


### PR DESCRIPTION
## What's the purpose of this pull request?

Current versions of `@faststore/cli` require a restart so a theme switch can be applied. This fixes the issue, by cleaning the node require cache before importing the discovery.config file on the `generate` function.

## How to test it?

Install the `@faststore/cli` preview version from this PR, run `yarn dev` and change the theme on `discovery.config.js` file.

### Starters Deploy Preview

TBD

## References

Old school: [Stack Overflow](https://stackoverflow.com/questions/15666144/how-to-remove-module-after-require-in-node-js)

I'll ping @mariana-caetano when this goes live to update the documentation 