### PR TITLE
fix: CMS Sync with default contentSource.project

### DIFF
--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -25,7 +25,7 @@ export default class CmsSync extends Command {
     const { tmpDir, userStoreConfigFile } = withBasePath(basePath)
 
     const userStoreConfig = await import(path.resolve(userStoreConfigFile))
-    const cmsProjectName = userStoreConfig.contentSource.project
+    const cmsProjectName = userStoreConfig.contentSource?.project ?? 'faststore'
 
     await generate({ setup: true, basePath })
     await mergeCMSFiles(basePath)

--- a/packages/cli/src/utils/hcms.ts
+++ b/packages/cli/src/utils/hcms.ts
@@ -121,7 +121,7 @@ export async function mergeCMSFile(fileName: string, basePath: string) {
   } = withBasePath(basePath)
 
   const userStoreConfig = await import(path.resolve(userStoreConfigFile))
-  const cmsProjectName = userStoreConfig.contentSource.project
+  const cmsProjectName = userStoreConfig.contentSource?.project ?? 'faststore'
 
   const coreFilePath = path.join(coreCMSDir, fileName)
   const customFilePath = path.join(userCMSDir, fileName)


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix default project name on CMS sync.

## How it works?

Uses the default 'faststore' project name whenever reading the `contentSource.project` from the config file.

## How to test it?

Use the version on this PR and run cms-sync locally.

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**

- [ ] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [ ] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [ ] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [ ] PR description
- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)
