### PR TITLE
fix: Use enhanceSku in allVariantProducts

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
+++ b/packages/api/src/platforms/vtex/resolvers/skuVariations.ts
@@ -1,12 +1,13 @@
 import type { Resolver } from '..'
 import type { PromiseType } from '../../../typings'
-import type { StoreProduct } from './product'
+import { enhanceSku } from '../utils/enhanceSku'
 import {
   createSlugsMap,
   getActiveSkuVariations,
   getFormattedVariations,
   getVariantsByName,
 } from '../utils/skuVariants'
+import type { StoreProduct } from './product'
 
 export type Root = PromiseType<ReturnType<typeof StoreProduct.isVariantOf>>
 
@@ -41,5 +42,6 @@ export const SkuVariants: Record<string, Resolver<Root>> = {
 
     return filteredFormattedVariations
   },
-  allVariantProducts: (root) => root.isVariantOf.items,
+  allVariantProducts: (root) =>
+    root.isVariantOf.items.map((item) => enhanceSku(item, root.isVariantOf)),
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the sku variants resolver, because the field `allVariantProducts` was not going through the `enhanceSku` function which adds the `isVariantOf` info, but this field triggers the StoreProduct resolver that uses the `isVariantOf`.

## How it works?

Just map through the items to ensure it has `isVariantOf`.

## How to test it?

Since in `StoreProduct.name` field we only use `isVariantOf` as a fallback, everything should look the same for almost everyone. In the slack thread there is a case in which this isn't true, check the explanation there.

## References

- [Slack thread](https://vtex.slack.com/archives/C051B6LL91U/p1757602464106739?thread_ts=1757507699.769859&cid=C051B6LL91U)
- [Jira task](https://vtex-dev.atlassian.net/browse/SO-526)