### PR TITLE
fix: `ShippingSimulation` table SFS-2622

### DIFF
--- a/packages/components/src/organisms/ShippingSimulation/ShippingSimulation.tsx
+++ b/packages/components/src/organisms/ShippingSimulation/ShippingSimulation.tsx
@@ -204,8 +204,14 @@ function ShippingSimulation({
             <TableBody>
               {options.map((option) => (
                 <TableRow key={option.carrier}>
-                  <TableCell align="left">{option.carrier}</TableCell>
-                  <TableCell>{option.localizedEstimates}</TableCell>
+                  <TableCell align="left">
+                    <p data-fs-shipping-simulation-option-carrier>
+                      {option.carrier}
+                    </p>
+                    <span data-fs-shipping-simulation-option-estimate>
+                      {option.localizedEstimates}
+                    </span>
+                  </TableCell>
                   <TableCell align="right">
                     {option.price && (
                       <Price

--- a/packages/ui/src/components/organisms/ShippingSimulation/styles.scss
+++ b/packages/ui/src/components/organisms/ShippingSimulation/styles.scss
@@ -59,6 +59,39 @@
     line-height: var(--fs-shipping-simulation-subtitle-line-height);
   }
 
+  [data-fs-table-row] {
+    display: flex;
+    align-items: stretch;
+  }
+
+  [data-fs-table-cell] {
+    display: flex;
+    width: 100%;
+    font-size: var(--fs-text-size-1);
+
+    &:first-of-type { flex-direction: column; }
+
+    &:last-of-type {
+      align-items: center;
+      width: fit-content;
+      min-width: fit-content;
+    }
+
+    [data-fs-shipping-simulation-option-carrier] {
+      overflow: hidden;
+      font-weight: var(--fs-text-weight-medium);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    [data-fs-shipping-simulation-option-estimate] {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
   [data-fs-shipping-simulation-location] {
     padding-bottom: var(--fs-shipping-simulation-location-padding-bottom);
     font-size: var(--fs-shipping-simulation-location-font-size);


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR reorganizes `ShippingSimulation`'s table content to consider copy length and remove the need of the scroll.

## How it works?

|Before|After|
|-|-|
|<img width="415" height="696" alt="image" src="https://github.com/user-attachments/assets/cd8d702e-82ee-4c1b-984b-93b4d1561a94" />|<img width="415" height="696" alt="image" src="https://github.com/user-attachments/assets/f65fe411-3fcc-447c-8ec1-23a0eb9cf453" />|

## How to test it?

go to the [PDP](https://sfj-8e70c6a--faststoreqa.preview.vtex.app/intelligent-steel-ball-ergonomic-90306354/p) and search for a valid zipcode (eg `07008`) on the `Shipping` section

### Starters Deploy Preview
[PDP Preview](https://sfj-8e70c6a--faststoreqa.preview.vtex.app/intelligent-steel-ball-ergonomic-90306354/p)
