### PR TITLE
fix: Use `corporateName` in profile page

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -624,9 +624,9 @@ export const Query = {
         contractId: profile?.id?.value ?? '',
       })
 
-      const name = contract?.isCorporate
-        ? contract?.corporateName
-        : `${(profile?.firstName?.value ?? '').trim()} ${(profile?.lastName?.value ?? '').trim()}`.trim()
+      const name =
+        contract?.corporateName ??
+        `${(profile?.firstName?.value ?? '').trim()} ${(profile?.lastName?.value ?? '').trim()}`.trim()
 
       return {
         name: name || '',


### PR DESCRIPTION
## What's the purpose of this pull request?

With this change, if the profile/contract is corporate we will use the corporate name instead of profile first and last names.

## How to test it?

- Check if the `.../account/profile` shown data (FastStore) matches with the shown on `/admin/contracts-management/contract/{contractId}/profile` (Admin)

### Starters Deploy Preview

vtex-sites/faststoreqa.store#864