### PR TITLE
chore: Change gtin to use ean when it exists

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -147,7 +147,7 @@ export const StoreProduct: Record<string, Resolver<Root>> & {
     return filteredImages.slice(0, limit)
   },
   sku: ({ itemId }) => itemId,
-  gtin: ({ referenceId }) => referenceId[0]?.Value ?? '',
+  gtin: ({ ean, referenceId }) => (ean ? ean : (referenceId[0]?.Value ?? '')),
   review: () => [],
   aggregateRating: () => ({}),
   offers: (root) =>


### PR DESCRIPTION
## What's the purpose of this pull request?

As the title says, change `gtin` to use `ean` when it exists, so in the product structured data this will be the value used.

## How it works?

Use `ean` when it's not an empty string, otherwise continue as it was.

## How to test it?

I've added a value (`123`) to EAN in the account `storeframework` for the SKU 9009169.
So in the preview is possible to see that the gtin value in the product structured data will match this value I've added.
<img width="1175" height="643" alt="Screenshot 2025-09-15 at 12 01 19" src="https://github.com/user-attachments/assets/5aa14bf8-b314-4259-8e33-b87d4283ced5" />

### Starters Deploy Preview
https://github.com/vtex-sites/faststoreqa.store/pull/867
- Before the change: https://storeframework-cm652ufll028lmgv665a6xv0g-111qh27dk.b.vtex.app/
- After the change: https://storeframework-cm652ufll028lmgv665a6xv0g-o0o8ntomd.b.vtex.app/

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SO-518)