### PR TITLE
fix: remove facets parameter from validate session

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -59,6 +59,12 @@ export const validateSession = async (
    * This is used by Checkout (checkout-session) and Intelligent Search (search-session)
    */
   const params = new URLSearchParams(search)
+
+  // Remove facets parameter if it exists so that it does not interfere with session data and prioritize vtex_segment
+  if (params.has('facets')) {
+    params.delete('facets')
+  }
+
   const salesChannel = params.get('sc') ?? channel.salesChannel
   params.set('sc', salesChannel)
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to remove the facets from the search params sent to `validateSession`.

[reference](https://vtex.slack.com/archives/C069MDTR51Q/p1756378519479289)