### PR TITLE
fix: update allowed prefix pages to include '/pvt/account'

### DIFF
--- a/packages/cli/src/utils/createNextjsPages.ts
+++ b/packages/cli/src/utils/createNextjsPages.ts
@@ -1,10 +1,10 @@
-import path from 'path'
 import fs from 'fs'
+import path from 'path'
 
 import { withBasePath } from './directory'
 import { myAccountPageTemplate } from './templates/myAccountPage'
 
-const ALLOWED_PREFIX_PAGES = ['/account']
+const ALLOWED_PREFIX_PAGES = ['/pvt/account']
 
 type CreateExternalPagesArgs = {
   customizationPagesDir: string


### PR DESCRIPTION
## What's the purpose of this pull request?

fix: update allowed prefix pages to include '/pvt/account'
