### PR TITLE
fix: refactor `ProductShelf` component to import directly

### DIFF
--- a/packages/core/src/components/cms/home/Components.ts
+++ b/packages/core/src/components/cms/home/Components.ts
@@ -3,8 +3,9 @@ import type { ComponentType } from 'react'
 
 import { OverriddenDefaultHero as Hero } from 'src/components/sections/Hero/OverriddenDefaultHero'
 import Incentives from 'src/components/sections/Incentives'
-import { default as GLOBAL_COMPONENTS } from '../global/Components'
+import { OverriddenDefaultProductShelf as ProductShelf } from 'src/components/sections/ProductShelf/OverriddenDefaultProductShelf'
 import { getComponentKey } from 'src/utils/cms'
+import { default as GLOBAL_COMPONENTS } from '../global/Components'
 
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
@@ -23,13 +24,7 @@ const Newsletter = dynamic(
     ).then((mod) => mod.OverriddenDefaultNewsletter),
   { ssr: false }
 )
-const ProductShelf = dynamic(
-  () =>
-    import(
-      /* webpackChunkName: "ProductShelf" */ 'src/components/sections/ProductShelf/OverriddenDefaultProductShelf'
-    ).then((mod) => mod.OverriddenDefaultProductShelf),
-  { ssr: false }
-)
+
 const ProductTiles = dynamic(
   () =>
     import(

--- a/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
@@ -1,18 +1,12 @@
-import dynamic from 'next/dynamic'
 import { useEffect, useId, useRef } from 'react'
 
 import deepmerge from 'deepmerge'
+import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
 import { useViewItemListEvent } from 'src/sdk/analytics/hooks/useViewItemListEvent'
 import { useDeliveryPromiseFacets } from 'src/sdk/deliveryPromise/useDeliveryPromiseFacets'
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 import { useProductsQuery } from 'src/sdk/product/useProductsQuery'
 import { overwriteMerge, textToKebabCase } from 'src/utils/utilities'
-
-const ProductShelfSkeleton = dynamic(
-  () =>
-    /* webpackChunkName: "ProductShelfSkeleton" */
-    import('src/components/skeletons/ProductShelfSkeleton')
-)
 
 type Sort =
   | 'discount_desc'


### PR DESCRIPTION
## What's the purpose of this pull request?

fix: refactor `ProductShelf` component to import directly and remove dynamic loading
attempts to fix this intermittent error:

<img width="1057" height="486" alt="Screenshot 2025-09-30 at 20 20 43" src="https://github.com/user-attachments/assets/b7114801-7d16-4951-977c-459f84c63847" />

