### PR TITLE
fix: Hide `Placed by` column from orders list and filters

### DIFF
--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountListOrders.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountListOrders.tsx
@@ -103,11 +103,12 @@ function getAllFacets({
         value: status.toLowerCase(),
       })),
     },
+    /* FIXME: Removing this facet until we have a cost-effective way to get the shopper name
     {
       __typename: 'StoreFacetPlacedBy',
       key: 'purchaseAgentId',
       label: 'Placed by',
-    } as any,
+    } as any, */
     {
       __typename: 'StoreFacetRange',
       key: 'dateRange',
@@ -245,7 +246,8 @@ export default function MyAccountListOrders({
           status: filters.status,
           dateInitial: filters.dateInitial,
           dateFinal: filters.dateFinal,
-          purchaseAgentId: filters.purchaseAgentId,
+          // FIXME: Removing this filter until we have a cost-effective way to get the shopper name
+          // purchaseAgentId: filters.purchaseAgentId,
         }}
         onClearAll={() => {
           window.location.href = '/pvt/account/orders'

--- a/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountListOrdersTable/MyAccountListOrdersTable.tsx
+++ b/packages/core/src/components/account/orders/MyAccountListOrders/MyAccountListOrdersTable/MyAccountListOrdersTable.tsx
@@ -152,7 +152,6 @@ export default function MyAccountListOrdersTable({
             const creationDate = item.creationDate
               ? formatOrderDate(item.creationDate, locale)
               : '-'
-            const clientName = item.clientName ? item.clientName : '-'
             const totalPrice = formatPrice(item.totalValue, item.currencyCode)
             const deliveryBy = item.ShippingEstimatedDate
               ? `Delivery by ${formatOrderDate(
@@ -228,6 +227,7 @@ export default function MyAccountListOrdersTable({
                               {shippingEstimatedDate}
                             </p>
                           </div>
+                          {/* FIXME: Removing this info until we have a cost-effective way to get the shopper name
                           <div data-fs-list-orders-table-product-info>
                             <p data-fs-list-orders-table-product-info-label>
                               Placed by
@@ -238,7 +238,7 @@ export default function MyAccountListOrdersTable({
                             >
                               {clientName}
                             </p>
-                          </div>
+                          </div> */}
                         </>
                       )}
                     </td>
@@ -257,6 +257,7 @@ export default function MyAccountListOrdersTable({
                             </p>
                           </div>
                         </td>
+                        {/* FIXME: Removing this info until we have a cost-effective way to get the shopper name
                         <td data-fs-list-orders-table-cell>
                           <div data-fs-list-orders-table-product-info>
                             <p data-fs-list-orders-table-product-info-label>
@@ -269,7 +270,7 @@ export default function MyAccountListOrdersTable({
                               {clientName}
                             </p>
                           </div>
-                        </td>
+                        </td> */}
                       </>
                     )}
                     {hasOrderOrItemCustomFields && (


### PR DESCRIPTION
## What's the purpose of this pull request?

With these changes, we are hiding the `Placed by` column from Orders list and filters for now until we have a cost-effective way to get the shopper name from API.

## How to test it?

- Check the orders list and its filters, they should not display any info or perform any actions related to the purchaser.