### PR TITLE
feat: integrate `cacheControlDirective` and remove `graphqlCacheControl` config

### DIFF
--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -147,10 +147,6 @@ module.exports = {
     enableSearchSSR: false,
     enableFaststoreMyAccount: false,
     enableVtexAssetsLoader: false,
-    graphqlCacheControl: {
-      maxAge: 0, // 0 disables cache, 5 * 60 enable cache control maxAge 5 minutes
-      staleWhileRevalidate: 60,
-    },
     refreshToken: false,
   },
 }

--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -149,22 +149,7 @@ const handler: NextApiHandler = async (request, response) => {
         ? stringifyCacheControl(extensions.cacheControl)
         : 'no-cache, no-store'
 
-    if (
-      request.method === 'GET' &&
-      discoveryConfig?.experimental?.graphqlCacheControl?.maxAge
-    ) {
-      const maxAge = discoveryConfig.experimental.graphqlCacheControl.maxAge
-      const staleWhileRevalidate =
-        discoveryConfig?.experimental?.graphqlCacheControl
-          ?.staleWhileRevalidate ?? ONE_MINUTE
-
-      response.setHeader(
-        'cache-control',
-        `public, s-maxage=${maxAge}, stale-while-revalidate=${staleWhileRevalidate}`
-      )
-    } else {
-      response.setHeader('cache-control', cacheControl)
-    }
+    response.setHeader('cache-control', cacheControl)
 
     const setCookieValues = Array.from(extensions.cookies.values())
     if (setCookieValues.length > 0 && !hasErrors) {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -12,6 +12,7 @@ import { useValidationCache } from '@envelop/validation-cache'
 import type { CacheControl, Maybe } from '@faststore/api'
 import {
   authDirective,
+  cacheControlDirective,
   BadRequestError,
   getContextFactory,
   getResolvers,
@@ -68,8 +69,7 @@ function getFinalAPISchema() {
   })
 
   // Apply directive transformations
-  // TODO: include cacheControlDirective in the future and remove graphqlCacheControl config from discovery.config
-  const directives = [authDirective]
+  const directives = [cacheControlDirective, authDirective]
   return directives.reduce((s, d) => d.transformer(s), schema)
 }
 


### PR DESCRIPTION
Depends on
- https://github.com/vtex/faststore/pull/3065

## What's the purpose of this pull request?
Enable cache control from the directive instead of the config.

## How it works?

<!--- Tell us the role of the new feature, or component, in its context. Provide details about what you have implemented and screenshots if applicable.  --->

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**

- [ ] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [ ] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [ ] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [ ] PR description
- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)
