### PR TITLE
fix: selectedFacets value for ProductShelf and ProductTiles

### DIFF
--- a/packages/core/src/components/sections/ProductTiles/ProductTiles.tsx
+++ b/packages/core/src/components/sections/ProductTiles/ProductTiles.tsx
@@ -11,8 +11,8 @@ import { useProductsQuery } from 'src/sdk/product/useProductsQuery'
 import Section from '../Section'
 
 import deepmerge from 'deepmerge'
-import { useDeliveryPromiseFacets } from 'src/sdk/deliveryPromise/useDeliveryPromiseFacets'
-import { overwriteMerge, toArray } from 'src/utils/utilities'
+import { useDeliveryPromiseGlobalFacets } from 'src/sdk/deliveryPromise/useDeliveryPromiseFacets'
+import { toArray } from 'src/utils/utilities'
 import styles from './section.module.scss'
 
 interface ProductTilesProps
@@ -68,16 +68,13 @@ const ProductTiles = ({
 }: ProductTilesProps) => {
   const viewedOnce = useRef(false)
   const { ref, inView } = useInView()
-  const { deliveryFacets } = useDeliveryPromiseFacets()
+  const { globalDeliveryFacets } = useDeliveryPromiseGlobalFacets()
 
   const data = useProductsQuery({
     ...variables,
     selectedFacets: deepmerge(
       toArray(variables.selectedFacets),
-      deliveryFacets,
-      {
-        arrayMerge: overwriteMerge,
-      }
+      globalDeliveryFacets
     ),
   })
   const products = data?.search?.products

--- a/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
+++ b/packages/core/src/components/ui/ProductShelf/ProductShelf.tsx
@@ -3,10 +3,10 @@ import { useEffect, useId, useRef } from 'react'
 import deepmerge from 'deepmerge'
 import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
 import { useViewItemListEvent } from 'src/sdk/analytics/hooks/useViewItemListEvent'
-import { useDeliveryPromiseFacets } from 'src/sdk/deliveryPromise/useDeliveryPromiseFacets'
+import { useDeliveryPromiseGlobalFacets } from 'src/sdk/deliveryPromise/useDeliveryPromiseFacets'
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 import { useProductsQuery } from 'src/sdk/product/useProductsQuery'
-import { overwriteMerge, textToKebabCase } from 'src/utils/utilities'
+import { textToKebabCase, toArray } from 'src/utils/utilities'
 
 type Sort =
   | 'discount_desc'
@@ -57,14 +57,15 @@ function ProductShelf({
   const titleId = textToKebabCase(title)
   const id = useId()
   const viewedOnce = useRef(false)
-  const { deliveryFacets } = useDeliveryPromiseFacets()
+  const { globalDeliveryFacets } = useDeliveryPromiseGlobalFacets()
 
   const data = useProductsQuery({
     ...otherProps,
     first: numberOfItems,
-    selectedFacets: deepmerge(otherProps.selectedFacets, deliveryFacets, {
-      arrayMerge: overwriteMerge,
-    }),
+    selectedFacets: deepmerge(
+      toArray(otherProps.selectedFacets),
+      globalDeliveryFacets
+    ),
   })
 
   const products = data?.search?.products

--- a/packages/core/src/sdk/deliveryPromise/useDeliveryPromiseFacets.ts
+++ b/packages/core/src/sdk/deliveryPromise/useDeliveryPromiseFacets.ts
@@ -1,4 +1,10 @@
 import { useSearch } from '@faststore/sdk'
+import {
+  PICKUP_IN_POINT_FACET_VALUE,
+  PICKUP_POINT_FACET_KEY,
+  SHIPPING_FACET_KEY,
+  useDeliveryPromiseContext,
+} from '.'
 
 export function useDeliveryPromiseFacets() {
   const { state: searchState } = useSearch()
@@ -11,6 +17,25 @@ export function useDeliveryPromiseFacets() {
     pickupPoint: searchState.selectedFacets.filter(
       pickByKey(['pickupPoint'])
     )?.[0],
+  }
+}
+
+export function useDeliveryPromiseGlobalFacets() {
+  const { globalPickupPoint } = useDeliveryPromiseContext()
+
+  return {
+    globalDeliveryFacets: globalPickupPoint
+      ? [
+          {
+            key: PICKUP_POINT_FACET_KEY,
+            value: globalPickupPoint.id,
+          },
+          {
+            key: SHIPPING_FACET_KEY,
+            value: PICKUP_IN_POINT_FACET_VALUE,
+          },
+        ]
+      : [],
   }
 }
 

--- a/packages/core/src/utils/utilities.ts
+++ b/packages/core/src/utils/utilities.ts
@@ -108,10 +108,3 @@ export const buildFormData = (
 
 export const toArray = <T>(x: T[] | T | undefined) =>
   Array.isArray(x) ? x : x ? [x] : []
-
-/**
- * Array merging strategy from deepmerge that makes source arrays overwrite destination array
- *
- * @see https://www.npmjs.com/package/deepmerge
- */
-export const overwriteMerge = (_: any[], sourceArray: any[]) => sourceArray


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix bugs on `ProductShelf` and `ProductTiles`:
- Facets configured in hCMS for those components were being overwritten.
- For DP stores: when those components are present in the PLP they were inheriting the shipping method selected in the filter tab, but it should only use the global facet (pickup point) if present.

## How it works?

- Removed the overwrite merge from `deepmerge` in `ProductShelf` and `ProductTiles`.
- Created a `useDeliveryPromiseGlobalFacets` that returns the global facets, if existent.

## How to test it?

Navigate through the previews seeing if the ClientManyProducts query is using the right selected facets:
- for the 1st bug you should check if the `productClusterIds` is present
- for the 2nd one check if changing the facets in the PLP filters alters the variables sent in the query - it should only change when there is a change in the global pickup point

You can also check that the product results are meeting the store's collection config.

Examples of tests:
- `ProductShelf` showing the configured collection
<img height="250" alt="Screenshot 2025-10-17 at 14 25 59" src="https://github.com/user-attachments/assets/f67b74d2-11cf-48fb-97e4-bbec2be0be2a" />

- `ProductShelf` on PLP using the global facet instead of using the one selected in the filters
<img height="250" alt="Screenshot 2025-10-17 at 14 27 16" src="https://github.com/user-attachments/assets/357e54e8-255c-47ad-b034-9d2b5b79fc51" />

| Before | After |
| ---- | ---- |
| <img width="1499" height="809" alt="Screenshot 2025-10-17 at 14 32 05" src="https://github.com/user-attachments/assets/af79648b-620e-4467-9736-86255bf34027" /> | <img width="1499" height="806" alt="Screenshot 2025-10-17 at 14 30 12" src="https://github.com/user-attachments/assets/c9dfd022-1f8b-4dae-98a1-b111a6eec5ea" /> |
| `productClusterIds` being ignored | Collections being displayed correctly |

### Starters Deploy Preview

- `faststoreqa` preview: https://storeframework-cm652ufll028lmgv665a6xv0g-2kq9jkspr.b.vtex.app/ ([PR](https://github.com/vtex-sites/faststoreqa.store/pull/879))
- `vendemo` preview (Delivery Promise): https://vendemo-cm9sir9v900u7z6llkl62l70j-71zdm0dwr.b.vtex.app/ ([PR](https://github.com/dp-faststore-org/vendemo-dp/pull/108))

## References

- [Slack thread](https://vtex.slack.com/archives/C051B6LL91U/p1760555671910629) - Bug in ProductShelf
- [Slack thread](https://vtex.slack.com/archives/C08SZUBMFDK/p1760634785223889) - Product views on ProductShelf and ProductTiles in DP