### PR TITLE
fix: update buying policy alert message to include dynamic description SFS-2861

### DIFF
--- a/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountBuyingPolicyAlert/MyAccountBuyingPolicyAlert.tsx
+++ b/packages/core/src/components/account/orders/MyAccountOrderDetails/MyAccountBuyingPolicyAlert/MyAccountBuyingPolicyAlert.tsx
@@ -14,6 +14,9 @@ interface MyAccountBuyingPolicyAlertProps {
   onAuthorizationComplete?: () => void
 }
 
+export const BUYING_POLICY_APPROVAL_REQUIRED_MESSAGE =
+  'This buying policy requires your approval before the order can proceed.'
+
 export default function MyAccountBuyingPolicyAlert({
   ruleForAuthorization,
   onAuthorizationComplete,
@@ -90,7 +93,7 @@ export default function MyAccountBuyingPolicyAlert({
           <h3 data-fs-buying-policy-title>{ruleForAuthorization.rule.name}</h3>
           <p data-fs-buying-policy-description>
             {ruleForAuthorization?.rule?.trigger?.condition?.description ??
-              'This buying policy requires your approval before the order can proceed.'}
+              BUYING_POLICY_APPROVAL_REQUIRED_MESSAGE}
           </p>
         </div>
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Include the message from the condition description of the buying policy

<img width="830" height="535" alt="Screenshot 2025-10-21 at 19 32 55" src="https://github.com/user-attachments/assets/29bd6723-92d0-4b9f-a1c8-1249ab9d7b97" />


## How to test it?

Enter a new order with buying policies that your user is an approver, and check the title and description from the buying policy inside the order details page.

pvt/account/orders/1570540796225-01 from the well-known user :)
