### PR TITLE
fix(ui): update slider variable for border-radius in the mozilla rules

### DIFF
--- a/packages/ui/src/components/atoms/Slider/styles.scss
+++ b/packages/ui/src/components/atoms/Slider/styles.scss
@@ -81,7 +81,7 @@
     cursor: col-resize;
     background-color: var(--fs-slider-thumb-bkg-color);
     border: var(--fs-slider-thumb-border-width) solid var(--fs-slider-thumb-border-color);
-    border-radius: var(--fs-slider-thumb-radius);
+    border-radius: var(--fs-slider-thumb-border-radius);
   }
 
   [data-fs-slider-thumb] {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes the `border-radius` of the Slider thumb in Firefox. The current CSS rule for Mozilla uses an inexistent variable, making the browser render a square instead of a circle:

<img width="1028" height="181" alt="image" src="https://github.com/user-attachments/assets/50c08d79-a6a9-4d31-b2e7-5ef9e287080f" />

## How it works?

The `--fs-slider-thumb-radius` variable is replaced by `--fs-slider-thumb-border-radius`, the one that is defined in the default thumb variables.

## How to test it?

- Use the `Local Install Instructions` from the [CodeSandbox CI](https://ci.codesandbox.io/status/vtex/faststore/pr/3077) to add this version in the `package.json` of a store.
- Import the `Slider` atom (and styles) in a component following the docs: https://developers.vtex.com/docs/guides/faststore/atoms-slider
- Run the store in development mode and browse it in Mozilla Firefox.

### Starters Deploy Preview

I'm unable to generate a preview link but here's a screenshot from localhost:

<img width="1287" height="617" alt="image" src="https://github.com/user-attachments/assets/f0a5a5e9-d657-41db-9415-303b5d17fefd" />

## Checklist

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [ ] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..
_(No permissions. It's a bug though.)_

**Dependencies**

- [N/A] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [x] PR description
- [N/A] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)
