### PR TITLE
fix: integer default values

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -959,7 +959,7 @@
         "after": {
           "type": "integer",
           "title": "After",
-          "default": "0",
+          "default": 0,
           "description": "Initial pagination item"
         },
         "sort": {
@@ -1122,7 +1122,7 @@
         "after": {
           "title": "After",
           "type": "integer",
-          "default": "0",
+          "default": 0,
           "description": "Initial pagination item"
         },
         "sort": {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes default values for integer fields. Currently, it's using a string for integer input.

https://github.com/vtex/faststore/pull/3071

## How it works?

<!--- Tell us the role of the new feature, or component, in its context. Provide details about what you have implemented and screenshots if applicable.  --->

## How to test it?

Sync the schema in a test account and test it with hCMS and the new CMS.
