### PR TITLE
fix(ui): use aria-valuetext and disabled attributes on Slider

### DIFF
--- a/packages/components/src/atoms/Slider/Slider.tsx
+++ b/packages/components/src/atoms/Slider/Slider.tsx
@@ -44,6 +44,10 @@ export interface SliderProps
    */
   absoluteValuesLabel: RangeLabel
   /**
+   * Disables interactions.
+   */
+  disabled?: boolean
+  /**
    * Callback that fires when the slider value changes.
    */
   onChange?: (value: { min: number; max: number }) => void
@@ -86,6 +90,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
       minValueLabelComponent,
       maxValueLabelComponent,
       'aria-labelledby': ariaLabelledBy,
+      disabled,
       ...otherProps
     },
     ref
@@ -149,6 +154,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
             max={Math.round(max.absolute)}
             value={minVal}
             step={step}
+            disabled={disabled}
             onMouseUp={() => onEnd?.({ min: minVal, max: maxVal })}
             onTouchEnd={() => onEnd?.({ min: minVal, max: maxVal })}
             onChange={(event) => {
@@ -185,6 +191,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
             max={Math.round(max.absolute)}
             value={maxVal}
             step={step}
+            disabled={disabled}
             onMouseUp={() => onEnd?.({ min: minVal, max: maxVal })}
             onTouchEnd={() => onEnd?.({ min: minVal, max: maxVal })}
             onChange={(event) => {

--- a/packages/components/src/atoms/Slider/Slider.tsx
+++ b/packages/components/src/atoms/Slider/Slider.tsx
@@ -85,6 +85,7 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
       step,
       minValueLabelComponent,
       maxValueLabelComponent,
+      'aria-labelledby': ariaLabelledBy,
       ...otherProps
     },
     ref
@@ -161,8 +162,9 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
             aria-valuemin={min.absolute}
             aria-valuemax={max.absolute}
             aria-valuenow={minVal}
+            aria-valuetext={getAriaValueText?.(minVal, 'min')}
             aria-label={String(minVal)}
-            aria-labelledby={getAriaValueText?.(minVal, 'min')}
+            aria-labelledby={ariaLabelledBy}
           />
           {minValueLabelComponent && (
             <span
@@ -196,8 +198,9 @@ const Slider = forwardRef<SliderRefType | undefined, SliderProps>(
             aria-valuemin={min.absolute}
             aria-valuemax={max.absolute}
             aria-valuenow={maxVal}
+            aria-valuetext={getAriaValueText?.(maxVal, 'max')}
             aria-label={String(maxVal)}
-            aria-labelledby={getAriaValueText?.(maxVal, 'max')}
+            aria-labelledby={ariaLabelledBy}
           />
           {maxValueLabelComponent && (
             <span


### PR DESCRIPTION
## What's the purpose of this pull request?

<!--- Considering the context, what is the problem we'll solve? Where in VTEX's big picture our issue fits in? Write a tweet about the context and the problem itself. --->
- Fixes an issue where screen readers wouldn't announce the value text provided by the prop `getAriaValueText`.
- Adds the missing `disabled` prop to both inputs.

## How it works?

<!--- Tell us the role of the new feature, or component, in its context. Provide details about what you have implemented and 
screenshots if applicable.  --->
Currently, screen readers announce the elements's role (e.g. "horizontal slider", or "slider at") and then the input value. The prop `getAriaValueText` was supposed to allow a human-readable text containing the current value to be announced instead. However, it was assigned to the `aria-labelledby` prop instead of `aria-valuetext`. `aria-labelledby` should only be used to reference _other_ elements (via `id`s) that will act as labels, instead of receiving formatted texts for the input values.

After the fix, screen readers should announce the slider's role and then the formatted text provided by the function `getAriaValueText`.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->
Aria Attributes
- Follow the `Local Install Instructions` from the [CodeSandbox CI](https://ci.codesandbox.io/status/vtex/faststore/pr/3083/builds/649072) to update the package.json of a store;
- Import the Slider atom in a component following the docs: https://developers.vtex.com/docs/guides/faststore/atoms-slider
- Assign a function to the `getAriaValueText` prop that returns a custom value text;
- Enable your operating system's screen reader;
- Open the store in development mode;
- Click or move slider thumbs and verify that the screen reader announces your custom value text.

Disabled Attribute
- Pass the `disabled` prop to the Slider atom;
- Verify that the slider interaction is disabled.

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->
[MDN - aria-labelledby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby)

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
