### PR TITLE
fix: Remove `productClusterIds` facet if it is present on `vtex_segment` cookie

### DIFF
--- a/packages/api/src/platforms/vtex/utils/cookies.ts
+++ b/packages/api/src/platforms/vtex/utils/cookies.ts
@@ -142,6 +142,13 @@ export const getAuthCookie = (cookies: string, account: string) => {
   return authCookie || ''
 }
 
+export const getSegmentCookie = (cookies: string) => {
+  const normalizedCookies = normalizeCookies(cookies)
+  const parsedCookies = parse(normalizedCookies)
+  const segmentCookie = parsedCookies['vtex_segment']
+  return segmentCookie || ''
+}
+
 export const getWithAutCookie = (ctx: ContextForCookies) => {
   const withCookie = getWithCookie(ctx)
 
@@ -195,4 +202,12 @@ export function parseJwt(token: string) {
     return null
   }
   return JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString())
+}
+
+export function parseJwtHeader(token: string) {
+  if (!token) {
+    return null
+  }
+
+  return JSON.parse(Buffer.from(token.split('.')[0], 'base64').toString())
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

With these changes, the `productClusterIds` facet will be removed from Intelligent Search request pathname if the `vtex_segment` cookie already has a defined value for it.

## How it works?

## How to test it?

### Starters Deploy Preview