### PR TITLE
fix: Handle empty footer logo scenario

### DIFF
--- a/packages/core/src/components/ui/Logo/Logo.tsx
+++ b/packages/core/src/components/ui/Logo/Logo.tsx
@@ -8,6 +8,11 @@ interface LogoProps {
 }
 
 function Logo({ alt, src, loading = 'lazy' }: LogoProps) {
+  if (!src) {
+    console.error('Logo image src is required.')
+    return null
+  }
+
   return (
     <div data-fs-logo>
       <Image


### PR DESCRIPTION
## What's the purpose of this pull request?

With these changes, if merchants remove the footer logo the entire footer component will not be hid anymore, it will throw a console error but the component should be displayed with no logo.