### PR TITLE
feat: Add Sort by selector labels to hCMS

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -1858,6 +1858,74 @@
             }
           }
         },
+        "sortBySelector": {
+          "title": "Sort by selector",
+          "type": "object",
+          "required": ["label", "options"],
+          "properties": {
+            "label": {
+              "title": "Label",
+              "type": "string",
+              "default": "Sort by"
+            },
+            "options": {
+              "title": "Options labels",
+              "type": "object",
+              "required": [
+                "price_desc",
+                "price_asc",
+                "orders_desc",
+                "name_asc",
+                "name_desc",
+                "release_desc",
+                "discount_desc",
+                "score_desc"
+              ],
+              "properties": {
+                "price_desc": {
+                  "title": "Price - Descending",
+                  "type": "string",
+                  "default": "Price, descending"
+                },
+                "price_asc": {
+                  "title": "Price - Ascending",
+                  "type": "string",
+                  "default": "Price, ascending"
+                },
+                "orders_desc": {
+                  "title": "Orders - Descending",
+                  "type": "string",
+                  "default": "Top sales"
+                },
+                "name_asc": {
+                  "title": "Name - Ascending",
+                  "type": "string",
+                  "default": "Name, A-Z"
+                },
+                "name_desc": {
+                  "title": "Name - Descending",
+                  "type": "string",
+                  "default": "Name, Z-A"
+                },
+                "release_desc": {
+                  "title": "Release - Descending",
+                  "type": "string",
+                  "default": "Release date"
+                },
+                "discount_desc": {
+                  "title": "Discount - Descending",
+                  "type": "string",
+                  "default": "Discount"
+                },
+                "score_desc": {
+                  "title": "Score - Descending",
+                  "type": "string",
+                  "default": "Relevance"
+                }
+              }
+            }
+          }
+        },
         "filter": {
           "title": "Filter",
           "type": "object",

--- a/packages/core/src/components/search/Sort/Sort.tsx
+++ b/packages/core/src/components/search/Sort/Sort.tsx
@@ -1,44 +1,40 @@
 import { useSearch } from '@faststore/sdk'
 import { SelectField } from '@faststore/ui'
 
-const OptionsMap = {
-  price_desc: 'Price, descending',
-  price_asc: 'Price, ascending',
-  orders_desc: 'Top sales',
-  name_asc: 'Name, A-Z',
-  name_desc: 'Name, Z-A',
-  release_desc: 'Release date',
-  discount_desc: 'Discount',
-  score_desc: 'Relevance',
-}
+const SORT_OPTIONS_KEYS = [
+  'price_desc',
+  'price_asc',
+  'orders_desc',
+  'name_asc',
+  'name_desc',
+  'release_desc',
+  'discount_desc',
+  'score_desc',
+] as const
 
-const keys = Object.keys(OptionsMap) as Array<keyof typeof OptionsMap>
+type SortOptionKeys = (typeof SORT_OPTIONS_KEYS)[number]
+
 export interface SortProps {
-  label?: string
-  options?: {
-    price_desc?: string
-    price_asc?: string
-    orders_desc?: string
-    name_asc?: string
-    name_desc?: string
-    release_desc?: string
-    discount_desc?: string
-    score_desc?: string
-  }
+  label: string
+  options: Record<SortOptionKeys, string>
 }
 
-type SortOptionKeys = keyof SortProps['options']
+const validSortKeys = [...SORT_OPTIONS_KEYS] as Array<SortOptionKeys>
 
-function Sort({ label = 'Sort by', options = OptionsMap }: SortProps) {
+function Sort({ label, options }: SortProps) {
   const { state, setState } = useSearch()
 
-  const optionsMap = Object.keys(options).reduce(
-    (acc, currentKey: SortOptionKeys) => {
-      acc[currentKey] = options[currentKey] ?? OptionsMap[currentKey]
+  const optionsMap = validSortKeys.reduce(
+    (acc, key) => {
+      if (Object.hasOwn(options, key)) {
+        acc[key] = options[key]
+      }
       return acc
     },
-    {} as Record<SortOptionKeys, string>
+    {} as SortProps['options']
   )
+
+  const keys = Object.keys(optionsMap) as Array<SortOptionKeys>
 
   return (
     <SelectField


### PR DESCRIPTION
## What's the purpose of this pull request?

Add the Sort by selector labels to hCMS so it can be editable. We need it there so it can be translated through the CMS.

⚠️ Breaking change: there is no more sort options hardcoded, the values necessarily have to come through CMS.
This PR will be merged in the `feat/multilanguage` feature branch, which will be available only in the next faststore major version.

## How it works?

It was hardcoded, so adding it to the hCMS schema allows it to be editable.

## How to test it?

In a Search page or PLP, observe the Sort by selector, it should have the values configured through the hCMS.

| PLP | Search |
| ---- | ---- |
| <img width="1031" height="922" alt="Screenshot 2025-11-05 at 09 57 37" src="https://github.com/user-attachments/assets/40379935-78f7-402c-9020-662bdc824bbe" /> | <img width="1024" height="915" alt="Screenshot 2025-11-05 at 09 57 55" src="https://github.com/user-attachments/assets/bde4a107-b6dd-414e-a592-bb29ffae1788" /> |
| <img width="1502" height="505" alt="Screenshot 2025-11-05 at 14 25 01" src="https://github.com/user-attachments/assets/f4c6fcbf-b4a1-4f8d-98ec-b49f7dfde6d5" /> | <img width="1502" height="438" alt="Screenshot 2025-11-05 at 14 25 18" src="https://github.com/user-attachments/assets/8f0f10aa-b38c-479e-9a09-3d58f9b582d8" /> |


If the field is not being displayed in the hCMS, remember to cms sync and publish the page.

### Starters Deploy Preview

- https://brandless-cma5xay4001f6dn4xjwato8b4-4tvja66oo.b.vtex.app/ ([PR](https://github.com/vtex-sites/brandless.store/pull/113))

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SFS-2915)