### PR TITLE
feat: Add invalid quantity toast message to hCMS

### DIFF
--- a/packages/components/src/organisms/SKUMatrix/SKUMatrixSidebar.tsx
+++ b/packages/components/src/organisms/SKUMatrix/SKUMatrixSidebar.tsx
@@ -68,9 +68,9 @@ export interface SKUMatrixSidebarProps
     height?: number
   }>
   /**
-   * Properties related to the 'invalid quantity' toast.
+   * Labels related to the 'invalid quantity' toast.
    */
-  invalidQuantityToast?: {
+  invalidQuantityToastLabels?: {
     title?: string
     message?: string
   }
@@ -87,7 +87,7 @@ function SKUMatrixSidebar({
   ImageComponent = ImageComponentFallback,
   buyProps: { onClick: buyButtonOnClick, ...buyProps },
   overlayProps,
-  invalidQuantityToast,
+  invalidQuantityToastLabels,
   ...otherProps
 }: SKUMatrixSidebarProps) {
   const {
@@ -270,9 +270,9 @@ function SKUMatrixSidebar({
                           quantity: number
                         ) => {
                           pushToast({
-                            title: invalidQuantityToast?.title,
+                            title: invalidQuantityToastLabels?.title,
                             message:
-                              invalidQuantityToast?.message
+                              invalidQuantityToastLabels?.message
                                 ?.replace('%{min}', min.toString())
                                 ?.replace('%{max}', maxValue.toString())
                                 ?.replace('%{quantity}', quantity.toString()) ||

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -305,7 +305,7 @@
                     }
                   }
                 },
-                "invalidQuantityToast": {
+                "invalidQuantityToastLabels": {
                   "title": "Invalid quantity toast",
                   "description": "This toast will be displayed when the quantity is out of the range of the min and max values.",
                   "type": "object",
@@ -1710,7 +1710,7 @@
               "type": "boolean",
               "default": false
             },
-            "invalidQuantityToast": {
+            "invalidQuantityToastLabels": {
               "title": "Invalid quantity toast",
               "description": "This toast will be displayed when the quantity is out of the range of the min and max values.",
               "type": "object",

--- a/packages/core/src/components/search/SearchProductItem/SearchProductItem.tsx
+++ b/packages/core/src/components/search/SearchProductItem/SearchProductItem.tsx
@@ -155,9 +155,9 @@ function SearchProductItem({
         }}
         onValidateBlur={(min, max, quantity) =>
           pushToast({
-            title: quickOrderSettings?.invalidQuantityToast?.title,
+            title: quickOrderSettings?.invalidQuantityToastLabels?.title,
             message:
-              quickOrderSettings?.invalidQuantityToast?.message
+              quickOrderSettings?.invalidQuantityToastLabels?.message
                 ?.replace('%{min}', min.toString())
                 ?.replace('%{max}', max.toString())
                 ?.replace('%{quantity}', quantity.toString()) || '',
@@ -190,8 +190,8 @@ function SearchProductItem({
                     status={(status: string | null) =>
                       onChangeCustomSearchDropdownVisible(status === 'visible')
                     }
-                    invalidQuantityToast={
-                      quickOrderSettings?.invalidQuantityToast
+                    invalidQuantityToastLabels={
+                      quickOrderSettings?.invalidQuantityToastLabels
                     }
                   />
                 </UISKUMatrix>

--- a/packages/core/src/components/sections/Navbar/Navbar.tsx
+++ b/packages/core/src/components/sections/Navbar/Navbar.tsx
@@ -25,7 +25,7 @@ export interface NavbarProps {
     sort: string
     quickOrderSettings?: {
       quickOrder: boolean
-      invalidQuantityToast?: {
+      invalidQuantityToastLabels?: {
         title?: string
         message?: string
       }

--- a/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/packages/core/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -61,7 +61,7 @@ export interface ProductDetailsProps {
   }
   quantitySelector: {
     useUnitMultiplier?: boolean
-    invalidQuantityToast?: {
+    invalidQuantityToastLabels?: {
       title?: string
       message?: string
     }
@@ -262,7 +262,9 @@ function ProductDetails({
                   product={product}
                   isValidating={isValidating}
                   taxesConfiguration={taxesConfiguration}
-                  invalidQuantityToast={quantitySelector?.invalidQuantityToast}
+                  invalidQuantityToastLabels={
+                    quantitySelector?.invalidQuantityToastLabels
+                  }
                 />
 
                 {skuMatrix?.shouldDisplaySKUMatrix &&
@@ -281,8 +283,8 @@ function ProductDetails({
                           formatter={useFormattedPrice}
                           columns={skuMatrix.columns}
                           overlayProps={{ className: styles.section }}
-                          invalidQuantityToast={
-                            quantitySelector?.invalidQuantityToast
+                          invalidQuantityToastLabels={
+                            quantitySelector?.invalidQuantityToastLabels
                           }
                         />
                       </SKUMatrix.Component>

--- a/packages/core/src/components/ui/ProductDetails/ProductDetailsSettings.tsx
+++ b/packages/core/src/components/ui/ProductDetails/ProductDetailsSettings.tsx
@@ -28,7 +28,7 @@ interface ProductDetailsSettingsProps {
     usePriceWithTaxes?: boolean
     taxesLabel?: string
   }
-  invalidQuantityToast?: {
+  invalidQuantityToastLabels?: {
     title?: string
     message?: string
   }
@@ -44,7 +44,7 @@ function ProductDetailsSettings({
   notAvailableButtonTitle,
   useUnitMultiplier = false,
   taxesConfiguration,
-  invalidQuantityToast,
+  invalidQuantityToastLabels,
 }: ProductDetailsSettingsProps) {
   const {
     BuyButton,
@@ -148,9 +148,9 @@ function ProductDetailsSettings({
               quantity: number
             ) => {
               pushToast({
-                title: invalidQuantityToast?.title,
+                title: invalidQuantityToastLabels?.title,
                 message:
-                  invalidQuantityToast?.message
+                  invalidQuantityToastLabels?.message
                     ?.replace('%{min}', min.toString())
                     ?.replace('%{max}', maxValue.toString())
                     ?.replace('%{quantity}', quantity.toString()) || '',


### PR DESCRIPTION
## What's the purpose of this pull request?

Add the invalid quantity toast to hCMS so it can be editable. We need it there so it can be translated through the CMS.

⚠️ Breaking change: there is no more a hardcoded message, it necessarily has to come through CMS.
This PR will be merged in the `feat/multilanguage` feature branch, which will be available only in the next faststore major version.

## How it works?

It was hardcoded, so adding it to the hCMS schema allows it to be editable.
There are 3 places where it's being used: `SKUMatrixSidebar`, `SearchProductItem` and `ProductDetailsSettings`, those are related to 2 sections: `Navbar` and `ProductDetails`. So I've updated the schema of both sections.

## How to test it?

In the `brandless` account I've configured through hCMS those messages and I've enabled the quick order feature so we could test the change in the Navbar (this feature allows adding products directly to the cart through search terms).
<img width="250" alt="Screenshot 2025-11-06 at 14 01 25" src="https://github.com/user-attachments/assets/a890c6d9-5fc7-4b45-b0c9-c0c47afe1f0e" />

| Navbar | PDP |
| ---- | ---- |
| <img width="1333" height="376" alt="Screenshot 2025-11-06 at 13 57 31" src="https://github.com/user-attachments/assets/0c07957a-8075-446f-9921-c112eaabb585" /> | <img width="1333" height="457" alt="Screenshot 2025-11-06 at 13 57 11" src="https://github.com/user-attachments/assets/750f7214-313d-4f46-a02c-a0d71b17d39c" /> |
| <img width="1509" height="577" alt="Screenshot 2025-11-06 at 14 17 37" src="https://github.com/user-attachments/assets/f93be95e-a0a0-4119-9632-5dbd0e74a215" /> | <img width="1508" height="501" alt="Screenshot 2025-11-06 at 13 58 35" src="https://github.com/user-attachments/assets/af49ef79-c80f-491f-8ef9-78a32f30c436" /> |
| The following SKU Matrix Sidebar is displayed after clicking in "select multiple" in the search suggestions: <img width="1505" height="585" alt="Screenshot 2025-11-06 at 15 20 38" src="https://github.com/user-attachments/assets/66afaae0-6615-4801-b296-5d5e68ab7cf1" /> |  |




### Starters Deploy Preview

- https://brandless-cma5xay4001f6dn4xjwato8b4-95qmbq4tq.b.vtex.app/ ([PR](https://github.com/vtex-sites/brandless.store/pull/114))

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SFS-2917)