### PR TITLE
feat: make ScrollToTopButton text editable via hCMS

### DIFF
--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -2546,5 +2546,31 @@
         }
       }
     }
+  },
+  {
+    "name": "ScrollToTopButton",
+    "requiredScopes": ["plp", "search"],
+    "schema": {
+      "title": "Scroll to Top Button",
+      "description": "A button to scroll the page back to the top",
+      "type": "object",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "title": "Button Text",
+          "description": "Text displayed on the button",
+          "type": "string",
+          "default": "Scroll to top"
+        },
+        "iconPosition": {
+          "title": "Icon Position",
+          "description": "Position of the icon relative to the text",
+          "type": "string",
+          "enumNames": ["Left", "Right"],
+          "enum": ["left", "right"],
+          "default": "left"
+        }
+      }
+    }
   }
 ]

--- a/packages/core/src/components/cms/plp/Components.ts
+++ b/packages/core/src/components/cms/plp/Components.ts
@@ -41,6 +41,14 @@ const ProductTiles = dynamic(
     ),
   { ssr: false }
 )
+const ScrollToTopButton = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "ScrollToTopButton" */
+      'src/components/sections/ScrollToTopButton'
+    ),
+  { ssr: false }
+)
 
 /**
  * Sections: Components imported from each store's custom components and '../components/sections' only.
@@ -55,6 +63,7 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
   [getComponentKey(Newsletter, 'Newsletter')]: Newsletter,
   [getComponentKey(ProductShelf, 'ProductShelf')]: ProductShelf,
   [getComponentKey(ProductTiles, 'ProductTiles')]: ProductTiles,
+  [getComponentKey(ScrollToTopButton, 'ScrollToTopButton')]: ScrollToTopButton,
   ...PLUGINS_COMPONENTS,
   ...CUSTOM_COMPONENTS,
 }

--- a/packages/core/src/components/sections/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/packages/core/src/components/sections/ScrollToTopButton/ScrollToTopButton.tsx
@@ -7,9 +7,8 @@ import styles from './section.module.scss'
 interface ScrollToTopButtonProps {
   /**
    * Button copy.
-   * @default 'Scroll to top'
    */
-  text?: string
+  text: string
   /**
    * Button's icon.
    * @default <Icon name="CaretUp" width={16} height={16} weight="bold" />
@@ -23,7 +22,7 @@ interface ScrollToTopButtonProps {
 }
 
 function ScrollToTopButton({
-  text = 'Scroll to top',
+  text,
   icon = <Icon name="CaretUp" width={16} height={16} weight="bold" />,
   iconPosition = 'left',
 }: ScrollToTopButtonProps) {
@@ -40,5 +39,7 @@ function ScrollToTopButton({
     </Section>
   )
 }
+
+ScrollToTopButton.$componentKey = 'ScrollToTopButton'
 
 export default ScrollToTopButton

--- a/packages/core/src/components/templates/ProductListingPage/ProductListing.tsx
+++ b/packages/core/src/components/templates/ProductListingPage/ProductListing.tsx
@@ -26,14 +26,6 @@ import { useProductGalleryQuery } from 'src/sdk/product/useProductGalleryQuery'
 import { useApplySearchState } from 'src/sdk/search/state'
 import { isContentPlatformSource } from 'src/server/content/utils'
 
-const ScrollToTopButton = dynamic(
-  () =>
-    import(
-      /* webpackChunkName: "ScrollToTopButton" */
-      'src/components/sections/ScrollToTopButton'
-    )
-)
-
 export type ProductListingPageProps = {
   data: ServerCollectionPageQueryQuery & ServerManyProductsQueryQuery
   serverManyProductsVariables: ServerManyProductsQueryQueryVariables
@@ -110,11 +102,7 @@ export default function ProductListing({
             sections={sections}
             globalSections={globalSections}
             components={COMPONENTS}
-          >
-            <LazyLoadingSection sectionName="ScrollToTopButton">
-              <ScrollToTopButton />
-            </LazyLoadingSection>
-          </RenderSections>
+          />
         </UseGalleryPageContext.Provider>
       </PageProvider>
     </>


### PR DESCRIPTION
## What's the purpose of this pull request?

Make `ScrollToTopButton` text editable through hCMS by converting it from a hardcoded component to a CMS-managed section.

**⚠️ Breaking Change**: The `ScrollToTopButton` has been removed from the PLP template and must now be manually added via hCMS to PLPs.

Print PLP without ScrollToTopButton hardcoded and no setup in hCMS
<img width="1800" height="1014" alt="image" src="https://github.com/user-attachments/assets/b547a62a-a2d1-4097-abb1-4b86a6e63f01" />

## How it works?

Removed hardcoded `ScrollToTopButton` from `ProductListing`. It is now rendered dynamically via hCMS with configurable text and icon position.

CMS
<img width="680" height="281" alt="Captura de Tela 2025-11-06 às 15 26 49" src="https://github.com/user-attachments/assets/9b64fe77-d207-4013-b5bf-a5a5305029da" />

<img width="1298" height="374" alt="Captura de Tela 2025-11-06 às 15 27 11" src="https://github.com/user-attachments/assets/20e74ee9-061a-4450-94e7-176b0c0e0425" />
<img width="1344" height="511" alt="Captura de Tela 2025-11-06 às 16 20 41" src="https://github.com/user-attachments/assets/1fc2ccdc-805d-4ee6-8aea-84616aefc159" />



## How to test it?

In a Search page or PLP, observe the Scroll to Top Button. It should have the text and icon position configured through the Headless CMS.


## References

[Jira task](https://vtex-dev.atlassian.net/jira/software/c/projects/SFS/boards/1051?selectedIssue=SFS-2916)