### PR TITLE
feat: Add product comparison sort options to hCMS

### DIFF
--- a/packages/components/src/organisms/ProductComparison/ProductComparisonSidebar.tsx
+++ b/packages/components/src/organisms/ProductComparison/ProductComparisonSidebar.tsx
@@ -5,9 +5,9 @@ import React, {
   useMemo,
   useState,
 } from 'react'
+import type { IProductComparison } from '.'
 import { useFadeEffect, useProductComparison } from '../../hooks'
 import SlideOver, { SlideOverHeader, type SlideOverProps } from '../SlideOver'
-import type { IProductComparison } from '.'
 
 import {
   Table,
@@ -20,18 +20,18 @@ import ToggleField from '../../molecules/ToggleField'
 
 import Badge from '../../atoms/Badge'
 import Button from '../../atoms/Button'
-import Select from '../../atoms/Select'
+import Icon from '../../atoms/Icon'
 import Price, { type PriceFormatter } from '../../atoms/Price'
+import Select from '../../atoms/Select'
+import Dropdown, {
+  DropdownButton,
+  DropdownItem,
+  DropdownMenu,
+} from '../../molecules/Dropdown'
 import ProductCard, {
   ProductCardContent,
   ProductCardImage,
 } from '../../molecules/ProductCard'
-import Dropdown, {
-  DropdownButton,
-  DropdownMenu,
-  DropdownItem,
-} from '../../molecules/Dropdown'
-import Icon from '../../atoms/Icon'
 
 const SPECIFICATION = 'SPECIFICATION'
 
@@ -55,25 +55,23 @@ export interface ProductComparisonSidebarProps
    */
   title: string
   /**
-   * Defines the sort label.
+   * Defines the sort-related labels.
    */
-  sortLabel: string
+  sortLabels: {
+    label?: string
+    options?: {
+      productByName?: string
+      productByPrice?: string
+    }
+  }
   /**
    * Defines the filter label.
    */
   filterLabel: string
   /**
-   * Defines the product name label.
-   */
-  productNameFilterLabel: string
-  /**
    * Defines the toggle field label.
    */
   toggleFieldLabel: string
-  /**
-   * Defines the price label.
-   */
-  priceLabel: string
   /**
    * Defines the preference label.
    */
@@ -135,12 +133,10 @@ function useProductSpecifications(
 
 function ProductComparisonSidebar({
   title,
-  sortLabel,
+  sortLabels: { label: sortLabel = '', options: sortOptionsLabels = {} } = {},
   filterLabel,
   preferencesLabel,
-  productNameFilterLabel,
   toggleFieldLabel,
-  priceLabel,
   cartButtonLabel,
   priceWithTaxLabel,
   technicalInformation,
@@ -297,7 +293,7 @@ function ProductComparisonSidebar({
                 {selectedFilter === 'productByName' && (
                   <Icon name="Checked" width={16} height={16} />
                 )}
-                <p>{productNameFilterLabel}</p>
+                <p>{sortOptionsLabels?.productByName}</p>
               </DropdownItem>
               <DropdownItem
                 dismissOnClick={false}
@@ -309,7 +305,7 @@ function ProductComparisonSidebar({
                 {selectedFilter === 'productByPrice' && (
                   <Icon name="Checked" width={16} height={16} />
                 )}
-                <p>{priceLabel}</p>
+                <p>{sortOptionsLabels?.productByPrice}</p>
               </DropdownItem>
             </div>
           </DropdownMenu>

--- a/packages/core/cms/faststore/sections.json
+++ b/packages/core/cms/faststore/sections.json
@@ -2158,15 +2158,32 @@
                       "type": "string",
                       "default": "Filters"
                     },
-                    "productNameFilterLabel": {
-                      "title": "Filter by product name text",
-                      "type": "string",
-                      "default": "Product name"
-                    },
-                    "sortLabel": {
-                      "title": "Sort filter text",
-                      "type": "string",
-                      "default": "Sort by"
+                    "sortLabels": {
+                      "title": "Sort labels",
+                      "type": "object",
+                      "properties": {
+                        "label": {
+                          "title": "Sort filter text",
+                          "type": "string",
+                          "default": "Sort by"
+                        },
+                        "options": {
+                          "title": "Sort options",
+                          "type": "object",
+                          "properties": {
+                            "productByName": {
+                              "title": "Product Name",
+                              "type": "string",
+                              "default": "Product Name"
+                            },
+                            "productByPrice": {
+                              "title": "Price",
+                              "type": "string",
+                              "default": "Price"
+                            }
+                          }
+                        }
+                      }
                     },
                     "toggleFieldLabel": {
                       "title": "Toggle filter text",
@@ -2182,11 +2199,6 @@
                       "title": "Add to cart button",
                       "type": "string",
                       "default": "Add to cart"
-                    },
-                    "priceLabel": {
-                      "title": "Price text",
-                      "type": "string",
-                      "default": "Price"
                     },
                     "priceWithTaxLabel": {
                       "title": "Price with taxes text",

--- a/packages/core/src/components/ui/ProductComparison/ProductComparisonSidebar.tsx
+++ b/packages/core/src/components/ui/ProductComparison/ProductComparisonSidebar.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useEffect } from 'react'
 import {
   type IProductComparison,
   type ProductComparisonSidebarProps as UIProductComparisonSidebarProps,
   ProductComparisonSidebar as UIProductComparisonSidebar,
   useProductComparison,
 } from '@faststore/ui'
+import React from 'react'
 
 import { gql } from '@generated/gql'
 import type { ClientManyProductsSelectedQueryQuery } from '@generated/graphql'
@@ -12,24 +12,38 @@ import type { ClientManyProductsSelectedQueryQuery } from '@generated/graphql'
 import { useBuyButton } from 'src/sdk/cart/useBuyButton'
 import { useProductsSelected } from 'src/sdk/product/useProductsSelected'
 
-const sortOptions = [
-  {
-    value: 'productByName',
-    label: 'Product Name',
-    onChange: (productComparison: IProductComparison[]) =>
-      productComparison.sort((a, b) => a.name.localeCompare(b.name)),
-  },
-  {
-    value: 'productByPrice',
-    label: 'Price',
-    onChange: (productComparison: IProductComparison[]) =>
-      productComparison.sort((a, b) => a.offers.lowPrice - b.offers.lowPrice),
-  },
-] as const
+type SortOptionsValue = 'productByName' | 'productByPrice'
 
-export type SortOptions = (typeof sortOptions)[number]
+export type SortOptions = {
+  value: SortOptionsValue
+  label: string
+  onChange: (productComparison: IProductComparison[]) => IProductComparison[]
+}
+
+function getSortOptions(
+  sortOptionsLabels: Record<SortOptionsValue, string>
+): SortOptions[] {
+  const { productByName = '', productByPrice = '' } = sortOptionsLabels
+  return [
+    {
+      value: 'productByName',
+      label: productByName,
+      onChange: (productComparison: IProductComparison[]) =>
+        productComparison.sort((a, b) => a.name.localeCompare(b.name)),
+    },
+    {
+      value: 'productByPrice',
+      label: productByPrice,
+      onChange: (productComparison: IProductComparison[]) =>
+        productComparison.sort((a, b) => a.offers.lowPrice - b.offers.lowPrice),
+    },
+  ]
+}
 
 function ProductComparisonSidebar(props: UIProductComparisonSidebarProps) {
+  const {
+    sortLabels: { options: sortOptionsLabels = {} } = {},
+  } = props
   const { productIds, products, isOpen, handleProductsComparison } =
     useProductComparison()
   const [productIdToBuy, setProductIdToBuy] = React.useState<string | null>(
@@ -159,7 +173,10 @@ function ProductComparisonSidebar(props: UIProductComparisonSidebarProps) {
     <UIProductComparisonSidebar
       handleProductToBuy={setProductIdToBuy}
       setPendingEvent={setPendingEvent}
-      sortOptions={[...sortOptions]}
+      sortOptions={getSortOptions({
+        productByName: sortOptionsLabels?.productByName,
+        productByPrice: sortOptionsLabels?.productByPrice,
+      })}
       {...props}
     />
   )

--- a/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
+++ b/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
@@ -71,13 +71,17 @@ export interface ProductGalleryProps {
       selectionWarning: string
       sidebarComponent?: {
         title: string
-        sortLabel: string
+        sortLabels?: {
+          label?: string
+          options?: {
+            productByName?: string
+            productByPrice?: string
+          }
+        }
         filterLabel: string
-        productNameFilterLabel: string
         preferencesLabel: string
         toggleFieldLabel: string
         cartButtonLabel: string
-        priceLabel: string
         priceWithTaxLabel: string
       }
       technicalInformation?: {


### PR DESCRIPTION
## What's the purpose of this pull request?

Add the product comparison sort options to hCMS so it can be editable. We need it there so it can be translated through the CMS.

⚠️ Breaking change: there is no more hardcoded labels, it necessarily has to come through CMS.
This PR will be merged in the `feat/multilanguage` feature branch, which will be available only in the next faststore major version.

## How it works?

It was hardcoded, so adding it to the hCMS schema allows it to be editable.

## How to test it?

Enable the product comparison feature in Search/PLP through hCMS and update the sort options labels:
<img width="538" height="200" alt="Screenshot 2025-11-10 at 15 02 45" src="https://github.com/user-attachments/assets/c9f38ed2-6b9b-40b8-8061-107e8d9a712b" />

You can test the Search/PLP on desktop and mobile, choosing some products to compare and opening the product comparison sidebar.

| Search | PLP |
| ---- | ---- |
| <img width="1001" height="472" alt="Screenshot 2025-11-10 at 15 10 18" src="https://github.com/user-attachments/assets/a4a61938-82cc-4cda-9f2e-2e24730ea77a" /> | <img width="996" height="467" alt="Screenshot 2025-11-10 at 15 09 11" src="https://github.com/user-attachments/assets/47937111-a2b0-41fe-b03b-1a9a51f6e0e8" /> |
|<img width="1493" height="800" alt="Screenshot 2025-11-10 at 15 17 04" src="https://github.com/user-attachments/assets/f0686066-d333-4d4e-a497-5ebb80ccdf72" /> | <img width="1497" height="799" alt="Screenshot 2025-11-10 at 15 15 57" src="https://github.com/user-attachments/assets/cb6ac62a-7fe7-4f6d-a4b8-17111a1ac86a" /> |
| <img width="316" height="682" alt="Screenshot 2025-11-10 at 15 17 20" src="https://github.com/user-attachments/assets/93ebae88-6ba4-4923-b96a-f7847f8408aa" /> | <img width="318" height="683" alt="Screenshot 2025-11-10 at 15 16 06" src="https://github.com/user-attachments/assets/14a31321-3bee-42a2-adc5-6dd33725612c" /> |

### Starters Deploy Preview

- https://brandless-cma5xay4001f6dn4xjwato8b4-3wiqbhrja.b.vtex.app/ ([PR](https://github.com/vtex-sites/brandless.store/pull/116))

## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SFS-2918)