### PR TITLE
fix: validateSession error when isSessionReady is sent - SFS-2944

### DIFF
--- a/packages/core/src/components/region/RegionModal/RegionModal.tsx
+++ b/packages/core/src/components/region/RegionModal/RegionModal.tsx
@@ -64,7 +64,7 @@ function RegionModal(regionModalProps: RegionModalProps) {
   } = cmsData?.regionalization ?? {}
 
   const inputRef = useRef<HTMLInputElement>(null)
-  const { isValidating, ...session } = useSession()
+  const { isValidating, isSessionReady, ...session } = useSession()
   const { modal: displayModal, closeModal } = useUI()
 
   const [input, setInput] = useState<string>('')

--- a/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
+++ b/packages/core/src/components/region/RegionPopover/RegionPopover.tsx
@@ -77,7 +77,7 @@ function RegionPopover(regionPopoverProps: RegionPopoverProps) {
   } = cmsData?.regionalization ?? {}
 
   const inputRef = useRef<HTMLInputElement>(null)
-  const { isValidating, ...session } = useSession()
+  const { isValidating, isSessionReady, ...session } = useSession()
   const { popover: displayPopover, closePopover } = useUI()
   const { onPostalCodeChange } = useDeliveryPromise()
   const { city, postalCode } = sessionStore.read()

--- a/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
+++ b/packages/core/src/components/region/RegionSlider/RegionSlider.tsx
@@ -45,7 +45,7 @@ function RegionSlider() {
     regionSlider: { type: regionSliderType, isOpen },
     closeRegionSlider,
   } = useUI()
-  const { isValidating, ...session } = useSession()
+  const { isValidating, isSessionReady, ...session } = useSession()
   const { state: searchState, setState: setSearchState } = useSearch()
   const {
     loading: loadingRegion,


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix a bug that occurs when regionalized and `isSessionReady` is sent in the' validateSession' and' validateCart' mutations.

## How does it work?

It removes the `isSessionReady` from the session sent to the `setRegion` method.

<img width="1909" height="916" alt="Screenshot 2025-11-11 at 16 22 55" src="https://github.com/user-attachments/assets/468cc987-a2ee-432f-b306-399bfd32e891" />
