### PR TITLE
fix: prevents duplicates of unavailable SKUs overriding available SKUs in getSkuLoader

### DIFF
--- a/packages/api/src/platforms/vtex/loaders/sku.ts
+++ b/packages/api/src/platforms/vtex/loaders/sku.ts
@@ -26,7 +26,9 @@ export const getSkuLoader = ({ flags }: Options, clients: Clients) => {
     const skuBySkuId = products.reduce(
       (acc, product) => {
         for (const sku of product.items) {
-          acc[sku.itemId] = enhanceSku(sku, product)
+          if (skuIds.includes(sku.itemId)) {
+            acc[sku.itemId] = enhanceSku(sku, product)
+          }
         }
 
         return acc


### PR DESCRIPTION
## What's the purpose of this pull request?

Fixes a bug in getSkuLoader that returns duplicates of inactive/unavailable Related SKUs in the array if there are any, and overrides the available ones.

## How it works?

Checks if the SKU ID is available before calling `enhanceSku` to prevent the active/available Related SKUs to be overwritten and returned in the array.
