### PR TITLE
feat: Add svg extension to public folder copy's allow list

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -14,11 +14,11 @@ import path from 'path'
 
 import ora from 'ora'
 
-import { withBasePath } from './directory'
+import { createNextJsPages } from './createNextjsPages'
 import { installDependencies } from './dependencies'
+import { withBasePath } from './directory'
 import { logger } from './logger'
 import { installPlugins } from './plugins'
-import { createNextJsPages } from './createNextjsPages'
 
 interface GenerateOptions {
   setup?: boolean
@@ -120,7 +120,7 @@ function copyCoreFiles(basePath: string) {
 function copyPublicFiles(basePath: string) {
   const { userDir, tmpDir } = withBasePath(basePath)
 
-  const allowList = ['json', 'txt', 'xml', 'ico', 'public']
+  const allowList = ['json', 'txt', 'xml', 'ico', 'public', 'svg']
   try {
     if (existsSync(`${userDir}/public`)) {
       copySync(`${userDir}/public`, `${tmpDir}/public`, {


### PR DESCRIPTION
## What's the purpose of this pull request?

Allow svg files in public folder, avoid it getting deleted/overwritten when generating .faststore

## How it works?

Add it to the allow list.

## How to test it?

Create a svg file or modify an existing svg file, it should be copied correctly to the `/.faststore/public` when running the build command. You can use this PR to test: https://github.com/vtex-sites/faststoreqa.store/pull/887, I've added a new svg file and changed an existing one, before it was being deleted/overwritten.
<img width="287" height="420" alt="Screenshot 2025-11-20 at 09 57 19" src="https://github.com/user-attachments/assets/7b01d806-bdf9-4c3b-a385-32ea11ab2518" />

Nothing else should change.

### Starters Deploy Preview

- https://storeframework-cm652ufll028lmgv665a6xv0g-h0max2o2h.b.vtex.app/

## References
- [Jira task](https://vtex-dev.atlassian.net/browse/SO-559)