### PR TITLE
fix: Update search results description formatting 

### DIFF
--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -16,7 +16,7 @@ module.exports = {
     },
     search: {
       titleTemplate: '%s | Search results',
-      descriptionTemplate: '%s: Search results description',
+      descriptionTemplate: '%s Search results description',
       noIndex: true,
       noFollow: true,
       bodyH1: 'Showing results for:',

--- a/packages/core/src/pages/s.tsx
+++ b/packages/core/src/pages/s.tsx
@@ -57,8 +57,10 @@ function generateSEOData(storeConfig: StoreConfig, searchTerm?: string) {
   const title = searchTerm ?? seo.title ?? 'Search Results'
   const titleTemplate = searchSeo?.titleTemplate ?? seo.titleTemplate
   const description = searchSeo?.descriptionTemplate
-    ? searchSeo.descriptionTemplate.replace(/%s/g, () => searchTerm)
-    : seo.description
+    ? searchSeo.descriptionTemplate
+        .replace(/%s/g, () => searchTerm ?? '')
+        ?.trim()
+    : seo.description?.trim()
 
   // default behavior without SSR
   if (!isSSREnabled) {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to fix the source code to show `undefined` `searchTerm`.
<img width="916" height="811" alt="Screenshot 2025-11-20 at 19 01 42" src="https://github.com/user-attachments/assets/b07e44a4-9e37-45e3-9712-6ab19b1af758" />


## How it works?

1. The source code can't access the searchTerm from the build time; thus, this page uses the default
<img width="1899" height="656" alt="Screenshot 2025-11-20 at 18 42 43" src="https://github.com/user-attachments/assets/697d1b4a-e5cb-4325-a5a1-3ba5d429b7b3" />

2. The final code (runtime code after hydration, you can see the element tab in the devtools), can access the dynamic search term and uses it.
<img width="1570" height="1049" alt="Screenshot 2025-11-20 at 18 42 05" src="https://github.com/user-attachments/assets/04e0a613-950f-4416-9200-dcc239326b41" />

## How to test it?

You can run `pnpm build && pnpm serve` and view the source code (right-click> Source Code). Additionally, you can view the final code using the Element tab in the DevTools.
