### PR TITLE
fix: externalizing node:crypto module

### DIFF
--- a/packages/api/vite.config.mts
+++ b/packages/api/vite.config.mts
@@ -16,6 +16,8 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        'node:crypto',
+        'crypto',
         ...Object.keys({
           ...(dependencies ?? {}),
           ...(peerDependencies ?? {}),


### PR DESCRIPTION
Externalizing crypto module from vite to correct import it