### PR TITLE
fix: Prevent Partytown cross-origin errors in iframe environments

### DIFF
--- a/packages/core/src/components/ThirdPartyScripts/ThirdPartyScripts.tsx
+++ b/packages/core/src/components/ThirdPartyScripts/ThirdPartyScripts.tsx
@@ -37,7 +37,7 @@ function ThirdPartyScripts() {
       {includeGTM && <GoogleTagManager containerId={gtmContainerId} />}
       {includeVTEX && <VTEX />}
       <OverrideComponents.ThirdPartyScripts />
-      {/* Only render Partytown when not in an iframe to prevent cross-origin errors */}
+      {/* Only render Partytown when not in an iframe to prevent cross-origin errors. */}
       {typeof window !== 'undefined' && window.self === window.top && (
         <Partytown key="partytown" />
       )}


### PR DESCRIPTION
 ## What's the problem this PR addresses?

  When FastStore is loaded inside an iframe (such as VTEX
  Preview), Partytown throws a SecurityError: Failed to read a 
  named property 'dispatchEvent' from 'Window' due to
  cross-origin restrictions. This prevents the preview from
  working correctly.

  ## Changes Made:

  - Modified ThirdPartyScripts.tsx to dynamically import
  Partytown only on client-side