### PR TITLE
feat: core run scripts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,8 +19,7 @@
     "gen-types": "node ../cli/bin/run generate-types .",
     "cache-graphql": "node ../cli/bin/run cache-graphql --config=./discovery.config.default.js --queries=./@generated/persisted-documents.json",
     "generate": "pnpm run gen-types && pnpm run cache-graphql ",
-    "dev": "pnpm run generate && next dev",
-    "build": "pnpm run generate && next build"
+    "dev": "pnpm run generate && next dev"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Added run scripts to run core package. 

- dev script
build script cant be commited as CI would fail cause it needs the cli do be build before, and the cli only runs after the core as it is a direct dep. 
So turbo doesn't allow circular dependency on scripts