### PR TITLE
fix: Add slug field to landing page schema - CROC-185

### DIFF
--- a/packages/core/cms/faststore/pages/cms_content_type__landingpage.jsonc
+++ b/packages/core/cms/faststore/pages/cms_content_type__landingpage.jsonc
@@ -5,6 +5,12 @@
     "type": "object",
     "title": "Landing Page",
     "properties": {
+      "slug": {
+        "widget": {
+          "ui:widget": "slug"
+        },
+        "type": "string"
+      },
       "seo": {
         "title": "SEO",
         "description": "Search Engine Optimization options",


### PR DESCRIPTION
## What's the purpose of this pull request?

We noticed the slug field (for preview and page creation) is not present in the newest CMS schema for FS.

## How it works?

<img width="939" height="173" alt="image" src="https://github.com/user-attachments/assets/ade6bc02-78bb-4021-9483-9b78b4bde2c7" />

## How to test it?

https://usb2bstore.myvtex.com/admin/content-platform/branches/main/form/faststore/landingPage/entries/b9a51bfe-3ce4-4f61-8e82-2542466a9728

Editing the slug and preview the page, it should work

## References

[PR adding the schemas](https://github.com/vtex/faststore/pull/3071)


