### PR TITLE
fix: error shipping without neighborhood

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/types/Address.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/types/Address.ts
@@ -4,14 +4,14 @@ export interface AddressInput {
 }
 
 export interface Address {
-  postalCode: string
-  city: string
-  state: string
-  country: string
-  street: string
-  number: string
-  neighborhood: string
-  complement: string
-  reference: string
-  geoCoordinates: [number, number] // [longitude, latitude]
+  postalCode: string | null
+  city: string | null
+  state: string | null
+  country: string | null
+  street: string | null
+  number: string | null
+  neighborhood: string | null
+  complement: string | null
+  reference: string | null
+  geoCoordinates: [number, number] | null // [longitude, latitude]
 }

--- a/packages/api/src/platforms/vtex/resolvers/validateSession.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateSession.ts
@@ -20,8 +20,14 @@ async function getPreciseLocationData(
       country,
     })
 
-    const [longitude, latitude] = address.geoCoordinates
-    return { city: address.city, geoCoordinates: { latitude, longitude } }
+    const geoCoordinates = address.geoCoordinates
+      ? {
+          latitude: address.geoCoordinates[1],
+          longitude: address.geoCoordinates[0],
+        }
+      : null
+
+    return { city: address.city, geoCoordinates }
   } catch (err) {
     console.error(
       `Error while getting geo coordinates for the current postal code (${postalCode}) and country (${country}).\n`


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix this error:

```
GraphQLError [Object]: Cannot return null for non-nullable field Address.neighborhood.
    at shippingQueryshippingResolverHandler (eval at compileQuery 
```

thread:
https://vtex.slack.com/archives/C06EC3LCZA8/p1767707762424329