### PR TITLE
fix: validate cart loop shipping simulation / logged

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/validateCart.ts
+++ b/packages/api/src/platforms/vtex/resolvers/validateCart.ts
@@ -188,8 +188,26 @@ const orderFormToCart = async (
   }
 }
 
-const getOrderFormEtag = ({ items }: OrderForm, sessionJwt: SessionJwt) =>
-  md5(JSON.stringify({ sessionId: sessionJwt?.id ?? '', items }))
+const getOrderFormEtag = ({ items }: OrderForm, sessionJwt: SessionJwt) => {
+  // Only include critical item properties in etag to avoid false positives
+  // when prices or availability change due to regionalization
+
+  // Include:
+  // - id (SKU): to detect item additions/removals
+  // - quantity: to detect quantity changes
+  // - seller: to detect seller changes
+  // - attachments: to detect customizations/personalizations changes
+  const criticalItems = items.map((item) => ({
+    id: item.id,
+    quantity: item.quantity,
+    seller: item.seller,
+    attachments: item.attachments, // customizations
+  }))
+
+  return md5(
+    JSON.stringify({ sessionId: sessionJwt?.id ?? '', items: criticalItems })
+  )
+}
 
 const setOrderFormEtag = async (
   form: OrderForm,


### PR DESCRIPTION
## What's the purpose of this pull request?

Infinite loop occurred when validating cart when:
- User was logged in (sessionId present)
- postalCode was set (regionalization active)
- Adding items in cart
- cartEtag changing all the time

You can try simulate the problem [here](https://lunellifs.vtex.app/calca-reta-de-cintura-media-com-bolsos-em-lyocell-1-9037e-2432/p)

## How it works?

- Change `getOrderFormEtag` to filter only fields that indicate real cart changes.
- ShippingData verification before early return null: Previously, we returned `null` immediately when changes.length === 0, ignoring potential need to update shippingData, now we ensures shippingData is updated when necessary (If no changes in the items, but shippingData need to be updated, we update only the shippingData, avoiding inconsistent states.

Scenarios that I've tested:
1. The default one (user logged in + postalCode set)
2. Changing postalCode

https://github.com/user-attachments/assets/24531442-f780-4c96-8438-d35638fc7dcc

3. Adding a item that is unavailable (more than one)

https://github.com/user-attachments/assets/d7de3f82-c650-4f7b-96df-b0b842eae6fa


### Starters Deploy Preview

preview [link](https://storeframework-cm652ufll028lmgv665a6xv0g-cupdt2xwr.b.vtex.app/calcas?category-1=calcas&fuzzy=0&operator=and&facets=category-1%2Cfuzzy%2Coperator&sort=score_desc&page=0)

1. Simulates login (using `lunellifs` acc)
2. Adds a postalCode
3. Adds any item to the cart, try to add more than one.
The items should be updating according in the card. 

## References

