### PR TITLE
feat: Enable fraction digit formatting for SEO's `product:price:amount` meta tag

### DIFF
--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -13,7 +13,7 @@ module.exports = {
     pdp: {
       titleTemplate: '%s | FastStore PDP',
       descriptionTemplate: '%s products on FastStore Product Detail Page',
-      minPriceFractionDigits: undefined,
+      minPriceAmountFractionDigits: undefined,
     },
     search: {
       titleTemplate: '%s | Search results',

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -110,11 +110,11 @@ function Page({
 
   if (
     product.offers.lowPrice != undefined &&
-    pdpSeo?.minPriceFractionDigits &&
-    typeof pdpSeo.minPriceFractionDigits === 'number'
+    pdpSeo?.minPriceAmountFractionDigits &&
+    typeof pdpSeo.minPriceAmountFractionDigits === 'number'
   ) {
     productPriceAmountMetatag = product.offers.lowPrice
-      .toFixed(pdpSeo.minPriceFractionDigits)
+      .toFixed(pdpSeo.minPriceAmountFractionDigits)
       .toString()
   }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

With these changes, merchants will be able to choose the the minimum price fraction digits to be used on SEO's product price meta tag, preventing mismatch values between displayed product price and SEO's `product:price:amount`.

## How to test it?

Check if the displayed price for any product matches with the SEO's `product:price:amount` meta tag.

### Starters Deploy Preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product price meta tags (used by search engines and social previews) now support configurable decimal precision, producing consistently formatted price values for improved SEO and display.
  * When no precision is set, prices fall back to previous default formatting to preserve existing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->