### PR TITLE
Feat: added autoplay function to carousel

### DIFF
--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -87,6 +87,21 @@ export interface CarouselProps extends SwipeableProps {
     left?: ReactNode
     right?: ReactNode
   }
+
+  /*
+   * Check whether the carousel will play automatically or not.
+   */
+  autoPlay: boolean
+  autoPlayIntervalTime: number
+  /*
+   * Specify when it's paused after mouse entering carousel items list.
+   */
+  isPaused: boolean
+  setIsPaused: (paused: boolean) => void
+  /*
+   * Specify in which page carousel is at the moment.
+   */
+  setCurrentPage: (page: number) => void
 }
 
 function Carousel({
@@ -104,6 +119,11 @@ function Carousel({
   variant = 'scroll',
   itemsPerPage = 1,
   navigationIcons = undefined,
+  autoPlay,
+  autoPlayIntervalTime,
+  isPaused,
+  setIsPaused,
+  setCurrentPage,
   ...swipeableConfigOverrides
 }: PropsWithChildren<CarouselProps>) {
   if (itemsPerPage < 1) {
@@ -146,6 +166,29 @@ function Carousel({
       )
     }
   }, [carouselItemsWidth])
+
+  useEffect(() => {
+    setCurrentPage(sliderState.currentPage)
+
+    if (
+      isPaused ||
+      !autoPlay ||
+      sliderState.currentPage === childrenCount - 1
+    ) {
+      return
+    }
+
+    const autoPlayInterval = setInterval(() => {
+      slide('next', sliderDispatch)
+    }, autoPlayIntervalTime)
+
+    return () => {
+      sliderDispatch({
+        type: 'STOP_SLIDE',
+      })
+      clearInterval(autoPlayInterval)
+    }
+  }, [sliderState.currentPage, isPaused])
 
   const showNavigationArrows =
     pagesCount !== 1 &&
@@ -394,6 +437,12 @@ function Carousel({
           dir={isRTL ? 'rtl' : 'ltr'}
           onScroll={onScrollTrack}
           onTransitionEnd={onTransitionTrackEnd}
+          onMouseEnter={() => {
+            setIsPaused(true)
+          }}
+          onMouseLeave={() => {
+            setIsPaused(false)
+          }}
         >
           {slides.map((currentSlide, idx) => (
             <CarouselItem

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -175,7 +175,8 @@ function Carousel({
     if (
       isPaused ||
       !autoPlay ||
-      sliderState.currentPage === childrenCount - 1
+      !autoPlayIntervalTime ||
+      (!infiniteMode && sliderState.currentPage === childrenCount - 1)
     ) {
       return
     }
@@ -190,7 +191,16 @@ function Carousel({
       })
       clearInterval(autoPlayInterval)
     }
-  }, [sliderState.currentPage, isPaused])
+  }, [
+    sliderState.currentPage,
+    isPaused,
+    autoPlay,
+    autoPlayIntervalTime,
+    childrenCount,
+    slide,
+    sliderDispatch,
+    setCurrentPage,
+  ])
 
   const showNavigationArrows =
     pagesCount !== 1 &&

--- a/packages/components/src/molecules/Carousel/Carousel.tsx
+++ b/packages/components/src/molecules/Carousel/Carousel.tsx
@@ -91,17 +91,17 @@ export interface CarouselProps extends SwipeableProps {
   /*
    * Check whether the carousel will play automatically or not.
    */
-  autoPlay: boolean
-  autoPlayIntervalTime: number
+  autoPlay?: boolean
+  autoPlayIntervalTime?: number
   /*
    * Specify when it's paused after mouse entering carousel items list.
    */
-  isPaused: boolean
-  setIsPaused: (paused: boolean) => void
+  isPaused?: boolean
+  setIsPaused?: (paused: boolean) => void
   /*
    * Specify in which page carousel is at the moment.
    */
-  setCurrentPage: (page: number) => void
+  setCurrentPage?: (page: number) => void
 }
 
 function Carousel({
@@ -168,7 +168,9 @@ function Carousel({
   }, [carouselItemsWidth])
 
   useEffect(() => {
-    setCurrentPage(sliderState.currentPage)
+    if (setCurrentPage !== undefined) {
+      setCurrentPage(sliderState.currentPage)
+    }
 
     if (
       isPaused ||
@@ -437,12 +439,14 @@ function Carousel({
           dir={isRTL ? 'rtl' : 'ltr'}
           onScroll={onScrollTrack}
           onTransitionEnd={onTransitionTrackEnd}
-          onMouseEnter={() => {
-            setIsPaused(true)
-          }}
-          onMouseLeave={() => {
-            setIsPaused(false)
-          }}
+          {...(isPaused !== undefined && setIsPaused !== undefined ? {
+            onMouseEnter: () => {
+              setIsPaused(true)
+            },
+            onMouseLeave: () => {
+              setIsPaused(false)
+            }
+          } : {})}
         >
           {slides.map((currentSlide, idx) => (
             <CarouselItem


### PR DESCRIPTION
## What's the purpose of this pull request?

The purpose is adding the possibility to the carousel to play automatically.

## How it works?

It checks if the autoplay prop is true, then it sets an interval following the autoPlayIntervalTime prop, it'll also pause the autoplay whenever the user hover over the carousel items list.

## How to test it?

For it to be tested, you should call the carousel molecule from @faststore/ui, then add the props autoPlay and autoPlayIntervalTime, then if prefer, add states to prevent autoplay to keep going when mouse enters it's carousel list.
I also added a state function to get the current page, which is more specific for what is needed.

### Starters Deploy Preview

In Progress...
<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Carousel now supports automatic slide advancement with customizable interval timing.
  * Hovering the carousel pauses autoplay.
  * External controls can pause/resume autoplay and programmatically set the current slide.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->