### PR TITLE
fix: copy .env file to build directory

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -53,6 +53,9 @@ export default class Build extends Command {
 
     await generate({ setup: true, basePath })
 
+    // Copy .env file to temporary directory to make NEXT_PUBLIC_* variables available during build
+    copyDotenv(basePath, tmpDir)
+
     const packageManager = getPreferredPackageManager()
 
     const buildResult = spawnSync(`${packageManager} run build`, {
@@ -174,5 +177,14 @@ async function checkDeps(basePath: string): Promise<Array<string>> {
     )
 
     return []
+  }
+}
+
+export function copyDotenv(basePath: string, tmpPath: string) {
+  const dotenvFile = `${basePath}/.env`
+  const destinationFile = `${tmpPath}/.env`
+
+  if (existsSync(dotenvFile)) {
+    copySync(dotenvFile, destinationFile)
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

The migration from Vercel to Homebrew of an account that uses `NEXT_PUBLIC_*` env vars failed as the builds in homebrew weren't inlining these env vars as expected.

## How it works?

This PR adds a step during build to copy the `.env` from the source to the temporary `.faststore` directory, so that Nextjs can properly read the `NEXT_PUBLIC_*` env vars during build.

## How to test it?

* Add a `NEXT_PUBLIC` env var in the store code: `console.log('NEXT_PUBLIC_TEST_VALUE', process.env.NEXT_PUBLIC_TEST_VALUE)`
* Create a .env file in the store with `NEXT_PUBLIC_TEST_VALUE=test`
* Run `yarn build`
  * Without this change, searching the built code for the variable, you can see the value was not inlined <img width="673" height="255" alt="image" src="https://github.com/user-attachments/assets/dcc8be56-de83-4302-947f-023413fcd13a" />

  * With this change, you can see the value was inlined as expected <img width="480" height="231" alt="image" src="https://github.com/user-attachments/assets/976e318c-6d74-4cd1-80d5-d890111f2fb0" />

### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

Migration preventive incident (#inc-4855): https://vtex.enterprise.slack.com/archives/C0AB4N24R7A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable handling during builds: public NEXT_PUBLIC_* variables are now ensured to be present in the build temporary directory when a .env file exists, improving consistency of public env values during generate/build steps.
  * Reduces intermittent missing-public-variable issues across local and CI builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->