### PR TITLE
fix: close filter on apply button click in FilterSlider component

### DIFF
--- a/packages/core/src/components/search/Filter/FilterSlider.tsx
+++ b/packages/core/src/components/search/Filter/FilterSlider.tsx
@@ -97,7 +97,7 @@ function FilterSlider({
   applyButtonLabel,
 }: FilterSliderProps & ReturnType<typeof useFilter>) {
   const { resetInfiniteScroll, setState, state } = useSearch()
-  const { openRegionSlider } = useUI()
+  const { closeFilter, openRegionSlider } = useUI()
 
   const cmsData = getGlobalSettings()
   const { deliveryPromise: deliveryPromiseSettings } = cmsData ?? {}
@@ -147,6 +147,8 @@ function FilterSlider({
                 : selected,
               page: 0,
             })
+
+            closeFilter()
           },
           children: applyButtonLabel ?? 'Apply',
         }}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to fix the behaviour that reopens the `FilterSlider` in the mobile PLP/Search page after applying some filter.

| Before | After |
|--------|--------|
| ![Jan-26-2026 11-57-37](https://github.com/user-attachments/assets/b6c3c550-7f6a-4b17-8594-e03329e7f440)|![Jan-26-2026 11-56-38](https://github.com/user-attachments/assets/0c1e342a-d48f-47a1-81a0-f18ad42c54e8)  | 

## How to test it?

Apply a filter using the mobile in some PLP/Search page and double check that the `FilterSlider` is not opening anymore.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filter panel now automatically closes after applying changes, improving the user experience and reducing unnecessary clicks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->