### PR TITLE
fix: Avoid duplicate SKU selectors when changing locale

### DIFF
--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -7,6 +7,7 @@ import type { ComponentType } from 'react'
 
 import { gql } from '@generated'
 import type {
+  ClientProductQueryQuery,
   ServerProductQueryQuery,
   ServerProductQueryQueryVariables,
 } from '@generated/graphql'
@@ -83,6 +84,30 @@ type Props = PDPContentType & {
 // https://www.npmjs.com/package/deepmerge
 const overwriteMerge = (_: any[], sourceArray: any[]) => sourceArray
 
+/**
+ * Merges server + client PDP payloads. After `deepmerge`, we replace `skuVariants` from
+ * the client when present: localized `availableVariations` keys differ by locale, and
+ * default object merge would keep both (duplicate SKU selectors).
+ */
+const mergePdpData = (
+  server: ServerProductQueryQuery,
+  client: Partial<ClientProductQueryQuery> | Record<string, unknown> | undefined
+) => {
+  const merged = deepmerge(server, (client ?? {}) as ServerProductQueryQuery, {
+    arrayMerge: overwriteMerge,
+  })
+
+  const clientSkuVariants = (
+    client as Partial<ClientProductQueryQuery> | undefined
+  )?.product?.isVariantOf?.skuVariants
+
+  if (clientSkuVariants != null && merged.product?.isVariantOf != null) {
+    merged.product.isVariantOf.skuVariants = clientSkuVariants
+  }
+
+  return merged
+}
+
 const isClientOfferEnabled = (storeConfig as StoreConfig).experimental
   .enableClientOffer
 
@@ -156,7 +181,7 @@ function Page({
     globalSectionsProp ?? {}
   const context = {
     data: {
-      ...deepmerge(server, client, { arrayMerge: overwriteMerge }),
+      ...mergePdpData(server, client),
       isValidating,
     },
     globalSettings,


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR attempts to fix the duplicate SKU selectors when switching the locales.

|before|after|
|-|-|
|<img width="1446" height="854" alt="image" src="https://github.com/user-attachments/assets/ca45f834-2ec3-4fe5-8167-b6c1409feeac" />|<img width="1349" height="774" alt="image" src="https://github.com/user-attachments/assets/d6ee28eb-f092-4eb1-aa45-747598550a82" />|

## How it works?

`mergePdpData` uses deepmerge with overwriteMerge for arrays, then overrides `product.isVariantOf.skuVariants` with the client payload when the client sends skuVariants. That way localized keys in availableVariations are not accumulated across server and client; the client’s skuVariants wins and the UI renders a single selector block.

## How to test it?
- Run the project locally, enabling the localization feature as explained [here](https://github.com/vtex/faststore/pull/3093)
- Open the Nike Men's Air Max 1 G Spikeless Golf Shoes PDP 
- Switch the locale to pt-BR or it-IT
- It should display one sku selector according to the current locale.



https://github.com/user-attachments/assets/ea9f2acb-3d04-4869-b7b2-0cf024904791


### Starters Deploy Preview

[preview link](https://sfj-e5c612c--brandless.preview.vtex.app)
[PR](https://github.com/vtex-sites/brandless.store/pull/159)

## References

https://vtex-dev.atlassian.net/browse/SFS-3094?atlOrigin=eyJpIjoiYjZmYWFkNTJhYWU2NDA5MzgxNTcyMzBjMzgwYmNlMDMiLCJwIjoiaiJ9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product variant data handling to ensure correct merging of SKU information from multiple sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->