### PR TITLE
chore: uses images.remotePatterns instead of deprecated domains

### DIFF
--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -23,7 +23,13 @@ console.log(`
 const nextConfig = {
   /* config options here */
   images: {
-    domains: [`${storeConfig.api.storeId}.vtexassets.com`],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: `${storeConfig.api.storeId}.vtexassets.com`,
+        pathname: '/**',
+      },
+    ],
     deviceSizes: [360, 412, 540, 768, 1280, 1440],
     imageSizes: [34, 68, 154, 320],
     loader: 'custom',


### PR DESCRIPTION
## What's the purpose of this pull request?

In Next.js Version 14, domains configuration has been deprecated in favour of remotePatterns. 

## How it works?

Migrate from images.domains to images.remotePatterns in `next.config.js` file

## How to test it?

Locally and in the preview deployment, remote images behave the same as before the images.remotePatterns change (load correctly, no regressions).

### Starters Deploy Preview

https://sfj-cfc4309--brandless.preview.vtex.app/
[PR](https://github.com/vtex-sites/brandless.store/pull/160)

## References

https://nextjs.org/docs/messages/next-image-unconfigured-host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image configuration settings for enhanced compatibility and security with image serving infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->