### PR TITLE
fix: Prevent IDB writes before store hydration completes - SFS-3121

### DIFF
--- a/packages/sdk/src/store/persisted.ts
+++ b/packages/sdk/src/store/persisted.ts
@@ -41,25 +41,38 @@ const debounce = <T extends (...args: any[]) => any>(
 export const persisted =
   <T>(key: string) =>
   (store: Store<T>) => {
+    let hydrated = false
+
     const handler = async () => {
       const payload = await getIDB<T>(key)
 
       if (typeof document !== 'undefined') {
         store.set(payload ?? store.readInitial())
       }
+
+      hydrated = true
     }
 
-    const debouncedHandler = debounce(handler, 100) // 100ms debounce
+    // Read immediately on init — no debounce — so the store is hydrated
+    // before any other subscriber (e.g. session → cart revalidation) can
+    // trigger a write that would overwrite the persisted data.
+    handler()
 
-    debouncedHandler()
+    const debouncedHandler = debounce(handler, 100)
+
     globalThis.addEventListener?.('focus', () => debouncedHandler())
     globalThis.document?.addEventListener(
       'visibilitychange',
       () => document.visibilityState === 'visible' && debouncedHandler()
     )
 
+    // Block IDB writes until the initial read completes.  This prevents a
+    // race where an early store.set (from session sync, etc.) overwrites
+    // saved data before it has been read back.
     store.subscribe((value) => {
-      setIDB(key, value)
+      if (hydrated) {
+        setIDB(key, value)
+      }
     })
 
     return store

--- a/packages/sdk/src/store/persisted.ts
+++ b/packages/sdk/src/store/persisted.ts
@@ -43,7 +43,7 @@ export const persisted =
   (store: Store<T>) => {
     let hydrated = false
 
-    const handler = async () => {
+    const hydrateFromIDB = async () => {
       const payload = await getIDB<T>(key)
 
       if (typeof document !== 'undefined') {
@@ -53,22 +53,26 @@ export const persisted =
       hydrated = true
     }
 
-    // Read immediately on init — no debounce — so the store is hydrated
-    // before any other subscriber (e.g. session → cart revalidation) can
-    // trigger a write that would overwrite the persisted data.
-    handler()
+    hydrateFromIDB()
 
-    const debouncedHandler = debounce(handler, 100)
+    // Cross-tab sync: when the user returns to this tab, unconditionally
+    // pull the latest value from IDB (another tab may have written it).
+    const syncFromIDB = async () => {
+      const payload = await getIDB<T>(key)
 
-    globalThis.addEventListener?.('focus', () => debouncedHandler())
+      if (typeof document !== 'undefined' && payload !== undefined) {
+        store.set(payload)
+      }
+    }
+
+    const debouncedSync = debounce(syncFromIDB, 100)
+
+    globalThis.addEventListener?.('focus', () => debouncedSync())
     globalThis.document?.addEventListener(
       'visibilitychange',
-      () => document.visibilityState === 'visible' && debouncedHandler()
+      () => document.visibilityState === 'visible' && debouncedSync()
     )
 
-    // Block IDB writes until the initial read completes.  This prevents a
-    // race where an early store.set (from session sync, etc.) overwrites
-    // saved data before it has been read back.
     store.subscribe((value) => {
       if (hydrated) {
         setIDB(key, value)


### PR DESCRIPTION
## What's the purpose of this pull request?

fix: Prevent IDB writes before store hydration completes

## How it works?

- Introduced a hydration flag to ensure that IDB writes are blocked until the initial read from IndexedDB is complete. This prevents potential data overwrites from early store updates.
- Modified the store initialization to read from IDB immediately without debounce, ensuring the store is hydrated before any other operations can occur.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data persistence to prevent stored information from being overwritten during app initialization, ensuring data integrity and reliability on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->