### PR TITLE
chore: add new workflow to generate packages url preview

### DIFF
--- a/.github/workflows/packages-preview.yml
+++ b/.github/workflows/packages-preview.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Build
         run: pnpm build
-      - run: pnpm dlx pkg-pr-new publish --no-compact --packageManager=yarn --commentWithSha
+      - run: pnpm dlx pkg-pr-new publish './packages/*' --no-compact --packageManager=yarn --commentWithSha

--- a/.github/workflows/packages-preview.yml
+++ b/.github/workflows/packages-preview.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Build
         run: pnpm build
-      - run: pnpm dlx pkg-pr-new publish './packages/*'
+      - run: pnpm dlx pkg-pr-new publish --no-compact --packageManager=yarn --commentWithSha

--- a/.github/workflows/packages-preview.yml
+++ b/.github/workflows/packages-preview.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Build
         run: pnpm build
-      - run: pnpm dlx pkg-pr-new publish './packages/*'`
+      - run: pnpm dlx pkg-pr-new publish './packages/*'

--- a/.github/workflows/packages-preview.yml
+++ b/.github/workflows/packages-preview.yml
@@ -1,0 +1,38 @@
+name: Packages Preview
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  build:
+    name: FastStore
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.5
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Build
+        run: pnpm build
+      - run: pnpm dlx pkg-pr-new publish './packages/*'`


### PR DESCRIPTION
## What's the purpose of this pull request?

Migrate FastStore package preview pipeline away from CodeSandbox CI, which is being discontinued.

CodeSandbox CI will be shut down on April 15, 2026, which directly impacts our current PR preview flow. Without a replacement, we lose the ability to generate installable preview builds for testing changes in real stores.

This PR introduces pkg.pr.new as a replacement, ensuring continuity of the preview pipeline with a more reliable and simpler approach.

## How it works?

This PR adds a new CI workflow that generates installable package previews using pkg.pr.new for every PR.

Instead of relying on CodeSandbox, we now:
- Generate a preview package URL directly from the PR
- Allow installation via yarn/npm using a URL
- Support commit-based versions for more granular validation

Task: https://vtex-dev.atlassian.net/jira/software/c/projects/SFS/boards/1051?selectedIssue=SFS-3102
