### PR TITLE
chore: adds postal code as key value

### DIFF
--- a/packages/core/src/sdk/graphql/request.ts
+++ b/packages/core/src/sdk/graphql/request.ts
@@ -29,7 +29,7 @@ export const request = async <Query = unknown, Variables = unknown>(
   variables: Variables,
   options?: RequestOptions
 ) => {
-  // Get cache busting value based person?.id from session
+  // Get cache busting value based on auth state and postal code
   const value = getClientCacheBustingValue()
 
   const { data, errors } = await baseRequest<Variables, Query>('/api/graphql', {

--- a/packages/core/src/sdk/graphql/useQuery.ts
+++ b/packages/core/src/sdk/graphql/useQuery.ts
@@ -2,6 +2,7 @@ import type { SWRConfiguration } from 'swr'
 import useSWR from 'swr'
 
 import { getClientCacheBustingValue } from 'src/utils/cookieCacheBusting'
+import { sessionStore } from 'src/sdk/session'
 
 import type { Operation, RequestOptions } from './request'
 import { request } from './request'
@@ -15,16 +16,23 @@ export const getKey = <Variables>(
 ) => `${operationName}::${JSON.stringify(variables)}`
 
 /**
- * Returns a suffix for the cache key based on auth state (logged-in vs anonymous).
- * This ensures SWR keeps separate cache entries for logged-in and logged-out users,
- * avoiding stale product data (e.g. prices, availability) when switching session state.
+ * Returns a suffix for the cache key based on auth state and region.
+ * This ensures SWR keeps separate cache entries for:
+ * - logged-in vs anonymous users (via person.id)
+ * - different postal codes / regions (via postalCode)
+ * Avoiding stale product data (e.g. prices, availability, delivery facets) when
+ * switching session state or region.
  */
 const getSessionCacheKeySuffix = (): string => {
   if (typeof window === 'undefined') {
     return ''
   }
-  const value = getClientCacheBustingValue()
-  return value ?? ''
+  const authValue = getClientCacheBustingValue()
+  const postalCode =
+    sessionStore.read()?.postalCode ??
+    sessionStore.readInitial()?.postalCode ??
+    ''
+  return `${authValue ?? ''}::${postalCode}`
 }
 
 export const DEFAULT_OPTIONS = {

--- a/packages/core/src/sdk/graphql/useQuery.ts
+++ b/packages/core/src/sdk/graphql/useQuery.ts
@@ -7,7 +7,7 @@ import type { Operation, RequestOptions } from './request'
 import { request } from './request'
 
 export type QueryOptions = SWRConfiguration &
-  RequestOptions & { doNotRun?: boolean }
+  RequestOptions & { doNotRun?: boolean; keySuffix?: string }
 
 export const getKey = <Variables>(
   operationName: string,
@@ -46,7 +46,8 @@ export const useQuery = <Data, Variables = Record<string, unknown>>(
       if (options?.doNotRun) return null
       const baseKey = getKey(operation['__meta__']['operationName'], variables)
       const sessionSuffix = getSessionCacheKeySuffix()
-      return `${baseKey}::${sessionSuffix}`
+      const extra = options?.keySuffix ? `::${options.keySuffix}` : ''
+      return `${baseKey}::${sessionSuffix}${extra}`
     },
     {
       fetcher: () => {

--- a/packages/core/src/sdk/graphql/useQuery.ts
+++ b/packages/core/src/sdk/graphql/useQuery.ts
@@ -2,13 +2,12 @@ import type { SWRConfiguration } from 'swr'
 import useSWR from 'swr'
 
 import { getClientCacheBustingValue } from 'src/utils/cookieCacheBusting'
-import { sessionStore } from 'src/sdk/session'
 
 import type { Operation, RequestOptions } from './request'
 import { request } from './request'
 
 export type QueryOptions = SWRConfiguration &
-  RequestOptions & { doNotRun?: boolean; keySuffix?: string }
+  RequestOptions & { doNotRun?: boolean }
 
 export const getKey = <Variables>(
   operationName: string,
@@ -16,23 +15,16 @@ export const getKey = <Variables>(
 ) => `${operationName}::${JSON.stringify(variables)}`
 
 /**
- * Returns a suffix for the cache key based on auth state and region.
- * This ensures SWR keeps separate cache entries for:
- * - logged-in vs anonymous users (via person.id)
- * - different postal codes / regions (via postalCode)
- * Avoiding stale product data (e.g. prices, availability, delivery facets) when
- * switching session state or region.
+ * Returns a suffix for the cache key based on auth state (logged-in vs anonymous).
+ * This ensures SWR keeps separate cache entries for logged-in and logged-out users,
+ * avoiding stale product data (e.g. prices, availability) when switching session state.
  */
 const getSessionCacheKeySuffix = (): string => {
   if (typeof window === 'undefined') {
     return ''
   }
-  const authValue = getClientCacheBustingValue()
-  const postalCode =
-    sessionStore.read()?.postalCode ??
-    sessionStore.readInitial()?.postalCode ??
-    ''
-  return `${authValue ?? ''}::${postalCode}`
+  const value = getClientCacheBustingValue()
+  return value ?? ''
 }
 
 export const DEFAULT_OPTIONS = {
@@ -54,8 +46,7 @@ export const useQuery = <Data, Variables = Record<string, unknown>>(
       if (options?.doNotRun) return null
       const baseKey = getKey(operation['__meta__']['operationName'], variables)
       const sessionSuffix = getSessionCacheKeySuffix()
-      const extra = options?.keySuffix ? `::${options.keySuffix}` : ''
-      return `${baseKey}::${sessionSuffix}${extra}`
+      return `${baseKey}::${sessionSuffix}`
     },
     {
       fetcher: () => {

--- a/packages/core/src/sdk/product/usePageProductsQuery.ts
+++ b/packages/core/src/sdk/product/usePageProductsQuery.ts
@@ -1,3 +1,4 @@
+import storeConfig from 'discovery.config'
 import { useSearch } from '@faststore/sdk'
 import { gql } from '@generated'
 import type {
@@ -81,8 +82,23 @@ export const useCreateUseGalleryPage = (
   params?: UseCreateUseGalleryPageProps
 ) => {
   const initialPages = params?.initialPages?.search ? [params.initialPages] : []
+
+  // Seed the cache with the same region-aware key shape that useGalleryPage uses,
+  // so hasSameVariables correctly matches on first mount and avoids an unnecessary
+  // re-fetch of the SSR-loaded page.
+  const isDeliveryPromiseEnabled = storeConfig.deliveryPromise?.enabled ?? false
+  const { postalCode } = useSession()
   const initialVariables = params?.serverManyProductsVariables
-    ? [getKey(params.serverManyProductsVariables)]
+    ? [
+        getKey(
+          isDeliveryPromiseEnabled
+            ? {
+                ...params.serverManyProductsVariables,
+                _postalCode: postalCode ?? '',
+              }
+            : params.serverManyProductsVariables
+        ),
+      ]
     : []
 
   const [pages, setPages] =
@@ -98,7 +114,7 @@ export const useCreateUseGalleryPage = (
       itemsPerPage,
     } = useSearch()
 
-    const { postalCode } = useSession()
+    const { postalCode, isValidating: isSessionValidating } = useSession()
 
     const localizedVariables = useLocalizedVariables({
       first: itemsPerPage,
@@ -110,8 +126,12 @@ export const useCreateUseGalleryPage = (
 
     // Include postalCode in the cache key so pages are invalidated on region change.
     // _postalCode is not sent to the API — it only affects the local cache comparison.
+    // Only applied when deliveryPromise is enabled to avoid unnecessary cache fragmentation.
     const localizedVariablesWithRegion = useMemo(
-      () => ({ ...localizedVariables, _postalCode: postalCode ?? '' }),
+      () =>
+        isDeliveryPromiseEnabled
+          ? { ...localizedVariables, _postalCode: postalCode ?? '' }
+          : localizedVariables,
       [localizedVariables, postalCode]
     )
 
@@ -133,7 +153,8 @@ export const useCreateUseGalleryPage = (
     >(query, localizedVariables, {
       fallbackData: null,
       suspense: true,
-      doNotRun: !shouldFetch,
+      doNotRun:
+        !shouldFetch || (isDeliveryPromiseEnabled && isSessionValidating),
     })
 
     const shouldUpdatePages = data !== null

--- a/packages/core/src/sdk/product/usePageProductsQuery.ts
+++ b/packages/core/src/sdk/product/usePageProductsQuery.ts
@@ -15,6 +15,7 @@ import {
   useState,
 } from 'react'
 import { useQuery } from 'src/sdk/graphql/useQuery'
+import { useSession } from 'src/sdk/session'
 import { generatedBuildTime } from '../../../next-seo.config'
 import { useLocalizedVariables } from './useLocalizedVariables'
 import { useShouldFetchFirstPage } from './useShouldFetchFirstPage'
@@ -97,6 +98,8 @@ export const useCreateUseGalleryPage = (
       itemsPerPage,
     } = useSearch()
 
+    const { postalCode } = useSession()
+
     const localizedVariables = useLocalizedVariables({
       first: itemsPerPage,
       after: (itemsPerPage * page).toString(),
@@ -105,9 +108,16 @@ export const useCreateUseGalleryPage = (
       selectedFacets,
     })
 
+    // Include postalCode in the cache key so pages are invalidated on region change.
+    // _postalCode is not sent to the API — it only affects the local cache comparison.
+    const localizedVariablesWithRegion = useMemo(
+      () => ({ ...localizedVariables, _postalCode: postalCode ?? '' }),
+      [localizedVariables, postalCode]
+    )
+
     const hasSameVariables = deepEquals(
       pagesCache.current[page],
-      getKey(localizedVariables)
+      getKey(localizedVariablesWithRegion)
     )
 
     const shouldFetchFirstPage = useShouldFetchFirstPage({
@@ -129,7 +139,7 @@ export const useCreateUseGalleryPage = (
     const shouldUpdatePages = data !== null
 
     if (shouldUpdatePages) {
-      pagesCache.current[page] = getKey(localizedVariables)
+      pagesCache.current[page] = getKey(localizedVariablesWithRegion)
 
       // Update refs
       const newPages = [...pagesRef.current]

--- a/packages/core/src/sdk/product/useProductGalleryQuery.ts
+++ b/packages/core/src/sdk/product/useProductGalleryQuery.ts
@@ -1,3 +1,4 @@
+import storeConfig from 'discovery.config'
 import { gql } from '@generated'
 import { useQuery } from 'src/sdk/graphql/useQuery'
 import { useSession } from 'src/sdk/session'
@@ -138,7 +139,7 @@ export const useProductGalleryQuery = ({
   selectedFacets,
   itemsPerPage,
 }: ProductGalleryQueryOptions) => {
-  const { locale } = useSession()
+  const { locale, isValidating: isSessionValidating } = useSession()
   const { state, setState } = useSearch()
   const localizedVariables = useLocalizedVariables({
     first: itemsPerPage,
@@ -148,7 +149,10 @@ export const useProductGalleryQuery = ({
     selectedFacets,
   })
 
+  const isDeliveryPromiseEnabled = storeConfig.deliveryPromise?.enabled ?? false
+
   const queryResult = useQuery<Query, Variables>(query, localizedVariables, {
+    doNotRun: isDeliveryPromiseEnabled && isSessionValidating,
     onSuccess: (data: Query) => {
       const updatedFuzzyFacetValue = data.search.metadata?.fuzzy
       const updatedOperatorFacetValue = data.search.metadata?.logicalOperator
@@ -196,6 +200,7 @@ export const useProductGalleryQuery = ({
   const operatorFacetValue = findFacetValue(selectedFacets, 'operator')
   const shouldRefetchQuery =
     !queryResult.error && (!fuzzyFacetValue || !operatorFacetValue)
+
   if (shouldRefetchQuery) {
     // The first result is not relevant, return null data to avoid rendering the page while the query is being re-fetched
     return { ...queryResult, isValidating: true, data: null }

--- a/packages/core/src/sdk/product/useProductGalleryQuery.ts
+++ b/packages/core/src/sdk/product/useProductGalleryQuery.ts
@@ -138,7 +138,7 @@ export const useProductGalleryQuery = ({
   selectedFacets,
   itemsPerPage,
 }: ProductGalleryQueryOptions) => {
-  const { locale } = useSession()
+  const { locale, postalCode } = useSession()
   const { state, setState } = useSearch()
   const localizedVariables = useLocalizedVariables({
     first: itemsPerPage,
@@ -149,6 +149,7 @@ export const useProductGalleryQuery = ({
   })
 
   const queryResult = useQuery<Query, Variables>(query, localizedVariables, {
+    keySuffix: postalCode ?? undefined,
     onSuccess: (data: Query) => {
       const updatedFuzzyFacetValue = data.search.metadata?.fuzzy
       const updatedOperatorFacetValue = data.search.metadata?.logicalOperator

--- a/packages/core/src/sdk/product/useProductGalleryQuery.ts
+++ b/packages/core/src/sdk/product/useProductGalleryQuery.ts
@@ -138,7 +138,7 @@ export const useProductGalleryQuery = ({
   selectedFacets,
   itemsPerPage,
 }: ProductGalleryQueryOptions) => {
-  const { locale, postalCode } = useSession()
+  const { locale } = useSession()
   const { state, setState } = useSearch()
   const localizedVariables = useLocalizedVariables({
     first: itemsPerPage,
@@ -149,7 +149,6 @@ export const useProductGalleryQuery = ({
   })
 
   const queryResult = useQuery<Query, Variables>(query, localizedVariables, {
-    keySuffix: postalCode ?? undefined,
     onSuccess: (data: Query) => {
       const updatedFuzzyFacetValue = data.search.metadata?.fuzzy
       const updatedOperatorFacetValue = data.search.metadata?.logicalOperator

--- a/packages/core/src/utils/cookieCacheBusting.ts
+++ b/packages/core/src/utils/cookieCacheBusting.ts
@@ -1,6 +1,8 @@
+import storeConfig from 'discovery.config'
 import { sessionStore } from 'src/sdk/session'
 
 export const STORAGE_KEY_PERSON_ID = 'faststore_person_id'
+export const STORAGE_KEY_POSTAL_CODE = 'faststore_postal_code'
 export const STORAGE_KEY_CACHE_BUST_LAST_VALUE =
   'faststore_cache_bust_last_value'
 
@@ -17,8 +19,19 @@ const getPersonId = (): string | null => {
 }
 
 /**
- * Gets the stored person id from sessionStorage (client-side only)
+ * Gets postalCode from session when deliveryPromise is enabled.
+ * Reads session store directly since vtex_segment is httpOnly and inaccessible via JavaScript.
+ * Returns null for stores that don't use delivery promise — postal code has no effect
+ * on their facets, so there is no need to fragment the CDN cache by region.
  */
+const getPostalCode = (): string | null => {
+  if (typeof window === 'undefined' || !storeConfig.deliveryPromise?.enabled) {
+    return null
+  }
+  const session = sessionStore.read() ?? sessionStore.readInitial()
+  return session?.postalCode ?? null
+}
+
 const getStoredPersonId = (): string | null => {
   if (typeof sessionStorage === 'undefined') {
     return null
@@ -26,6 +39,21 @@ const getStoredPersonId = (): string | null => {
 
   try {
     return sessionStorage.getItem(STORAGE_KEY_PERSON_ID)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Gets the postal code from sessionStorage (client-side only)
+ */
+const getStoredPostalCode = (): string | null => {
+  if (typeof sessionStorage === 'undefined') {
+    return null
+  }
+
+  try {
+    return sessionStorage.getItem(STORAGE_KEY_POSTAL_CODE)
   } catch {
     return null
   }
@@ -50,9 +78,22 @@ const storePersonId = (value: string | null): void => {
   }
 }
 
-/**
- * Gets the last cache busting value from sessionStorage (client-side only)
- */
+const storePostalCode = (value: string | null): void => {
+  if (typeof sessionStorage === 'undefined') {
+    return
+  }
+
+  try {
+    if (value === null) {
+      sessionStorage.removeItem(STORAGE_KEY_POSTAL_CODE)
+    } else {
+      sessionStorage.setItem(STORAGE_KEY_POSTAL_CODE, value)
+    }
+  } catch {
+    // Ignore storage errors
+  }
+}
+
 const getLastValue = (): string | null => {
   if (typeof sessionStorage === 'undefined') {
     return null
@@ -66,7 +107,7 @@ const getLastValue = (): string | null => {
 }
 
 /**
- * Stores the last cache busting value in sessionStorage (client-side only)
+ * Stores the last value in sessionStorage (client-side only)
  */
 const storeLastValue = (value: string): void => {
   if (typeof sessionStorage === 'undefined') {
@@ -81,7 +122,7 @@ const storeLastValue = (value: string): void => {
 }
 
 /**
- * Clears all cache busting related data from sessionStorage (client-side only)
+ * Clears the cache busting related data from sessionStorage (client-side only)
  */
 const clearCacheBustingStorage = (): void => {
   if (typeof sessionStorage === 'undefined') {
@@ -90,46 +131,65 @@ const clearCacheBustingStorage = (): void => {
 
   try {
     sessionStorage.removeItem(STORAGE_KEY_PERSON_ID)
+    sessionStorage.removeItem(STORAGE_KEY_POSTAL_CODE)
     sessionStorage.removeItem(STORAGE_KEY_CACHE_BUST_LAST_VALUE)
   } catch {
     // Ignore storage errors
   }
 }
 
+const buildValue = (
+  personId: string | null,
+  postalCode: string | null
+): string => {
+  const timestamp = Date.now().toString()
+  return [timestamp, personId, postalCode].filter(Boolean).join('::')
+}
+
 /**
- * Gets cache busting value for client-side based on auth state changes.
- * Uses person?.id from session (via useSession/ValidateSession) since auth cookies
- * are now httpOnly and cannot be accessed via JavaScript.
+ * Gets cache busting value for client-side GET requests based on session state.
+ *
+ * Covers two axes that make GraphQL responses user/region-specific:
+ * - Auth state (person.id): logged-in users see personalised prices and availability.
+ * - Postal code: delivery-promise facets (shipping, delivery-options) differ per region.
+ *
+ * The value is appended as the `v` query param so the CDN treats each
+ * combination as a distinct cache entry. Returns null when neither axis is set,
+ * meaning the public CDN cache is shared across all anonymous visitors with no
+ * location — which is the correct behaviour for stores without delivery promise.
  */
 export const getClientCacheBustingValue = (): string | null => {
   const currentPersonId = getPersonId()
+  const currentPostalCode = getPostalCode()
 
-  // Guard clause: if user is not logged in (no person?.id), clear storage and don't proceed with cache busting logic
-  if (currentPersonId === null) {
+  // No session-specific data: clear storage and allow shared public CDN caching (don't proceed with cache busting logic)
+  if (!currentPersonId && !currentPostalCode) {
     clearCacheBustingStorage()
     return null
   }
 
   const storedPersonId = getStoredPersonId()
+  const storedPostalCode = getStoredPostalCode()
 
-  // If person changed (login/logout or different user), update stored value and return new value
-  if (currentPersonId !== storedPersonId) {
+  // Either axis changed: persist new state and generate a fresh cache-busting value
+  if (
+    currentPersonId !== storedPersonId ||
+    currentPostalCode !== storedPostalCode
+  ) {
     storePersonId(currentPersonId)
-    const timestamp = Date.now().toString()
-    const value = `${timestamp}::${currentPersonId}`
+    storePostalCode(currentPostalCode)
+    const value = buildValue(currentPersonId, currentPostalCode)
     storeLastValue(value)
     return value
   }
 
-  // Person hasn't changed, return last value or create one if it doesn't exist
+  // Nothing changed: reuse existing value (or create one if storage was cleared)
   const lastValue = getLastValue()
   if (lastValue) {
     return lastValue
   }
 
-  // Fallback: if no last value, create one
-  const timestamp = Date.now().toString()
-  const value = `${timestamp}::${currentPersonId}`
+  const value = buildValue(currentPersonId, currentPostalCode)
   storeLastValue(value)
   return value
 }

--- a/packages/core/test/utils/cookieCacheBusting.test.ts
+++ b/packages/core/test/utils/cookieCacheBusting.test.ts
@@ -12,19 +12,33 @@ jest.mock('src/sdk/session', () => ({
   },
 }))
 
+jest.mock('discovery.config', () => ({
+  deliveryPromise: { enabled: true },
+}))
+
 import {
   getClientCacheBustingValue,
   STORAGE_KEY_PERSON_ID,
+  STORAGE_KEY_POSTAL_CODE,
   STORAGE_KEY_CACHE_BUST_LAST_VALUE,
 } from '../../src/utils/cookieCacheBusting'
 
-const setSessionPerson = (personId: string) => {
-  const session = { person: { id: personId } }
+const setSession = ({
+  personId = null,
+  postalCode = null,
+}: {
+  personId?: string | null
+  postalCode?: string | null
+}) => {
+  const session = {
+    person: personId ? { id: personId } : null,
+    postalCode,
+  }
   mockRead.mockReturnValue(session)
   mockReadInitial.mockReturnValue(session)
 }
 
-const clearSessionPerson = () => {
+const clearSession = () => {
   mockRead.mockReturnValue(null)
   mockReadInitial.mockReturnValue(null)
 }
@@ -33,96 +47,174 @@ describe('cookieCacheBusting', () => {
   beforeEach(() => {
     jest.restoreAllMocks()
     sessionStorage.clear()
-    clearSessionPerson()
+    clearSession()
   })
 
-  it('should clear storage and return null when user is not logged in (no person?.id)', () => {
-    const removeItemSpy = jest.spyOn(Storage.prototype, 'removeItem')
+  describe('returns null (shared public CDN cache)', () => {
+    it('should clear storage and return null when neither person nor postalCode is set', () => {
+      const removeItemSpy = jest.spyOn(Storage.prototype, 'removeItem')
 
-    const result = getClientCacheBustingValue()
+      const result = getClientCacheBustingValue()
 
-    expect(result).toBeNull()
-    expect(removeItemSpy).toHaveBeenCalledWith(STORAGE_KEY_PERSON_ID)
-    expect(removeItemSpy).toHaveBeenCalledWith(
-      STORAGE_KEY_CACHE_BUST_LAST_VALUE
-    )
+      expect(result).toBeNull()
+      expect(removeItemSpy).toHaveBeenCalledWith(STORAGE_KEY_PERSON_ID)
+      expect(removeItemSpy).toHaveBeenCalledWith(STORAGE_KEY_POSTAL_CODE)
+      expect(removeItemSpy).toHaveBeenCalledWith(
+        STORAGE_KEY_CACHE_BUST_LAST_VALUE
+      )
+    })
   })
 
-  it('should return a new timestamp and persist values when auth state changed (login)', () => {
-    setSessionPerson('user-id-1')
+  describe('auth state (person.id)', () => {
+    it('should return a new timestamp value and persist when person logs in', () => {
+      setSession({ personId: 'user-id-1' })
 
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1700000000000)
-    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem')
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1700000000000)
+      const setItemSpy = jest.spyOn(Storage.prototype, 'setItem')
 
-    const result = getClientCacheBustingValue()
+      const result = getClientCacheBustingValue()
 
-    expect(result).toBe('1700000000000::user-id-1')
-    expect(nowSpy).toHaveBeenCalled()
-    expect(setItemSpy).toHaveBeenCalledWith(STORAGE_KEY_PERSON_ID, 'user-id-1')
-    expect(setItemSpy).toHaveBeenCalledWith(
-      STORAGE_KEY_CACHE_BUST_LAST_VALUE,
-      '1700000000000::user-id-1'
-    )
+      expect(result).toBe('1700000000000::user-id-1')
+      expect(nowSpy).toHaveBeenCalled()
+      expect(setItemSpy).toHaveBeenCalledWith(
+        STORAGE_KEY_PERSON_ID,
+        'user-id-1'
+      )
+      expect(setItemSpy).toHaveBeenCalledWith(
+        STORAGE_KEY_CACHE_BUST_LAST_VALUE,
+        '1700000000000::user-id-1'
+      )
+    })
+
+    it('should return last cached value when auth state is the same', () => {
+      setSession({ personId: 'user-id-1' })
+      sessionStorage.setItem(STORAGE_KEY_PERSON_ID, 'user-id-1')
+      sessionStorage.setItem(
+        STORAGE_KEY_CACHE_BUST_LAST_VALUE,
+        '1700000000000::user-id-1'
+      )
+
+      const nowSpy = jest.spyOn(Date, 'now')
+      const setItemSpy = jest.spyOn(Storage.prototype, 'setItem')
+
+      const result = getClientCacheBustingValue()
+
+      expect(result).toBe('1700000000000::user-id-1')
+      expect(nowSpy).not.toHaveBeenCalled()
+      expect(setItemSpy).not.toHaveBeenCalled()
+    })
+
+    it('should create and persist a new value when auth state is the same but last value is missing', () => {
+      setSession({ personId: 'user-id-1' })
+      sessionStorage.setItem(STORAGE_KEY_PERSON_ID, 'user-id-1')
+
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1700000000123)
+      const setItemSpy = jest.spyOn(Storage.prototype, 'setItem')
+
+      const result = getClientCacheBustingValue()
+
+      expect(result).toBe('1700000000123::user-id-1')
+      expect(nowSpy).toHaveBeenCalled()
+      expect(setItemSpy).toHaveBeenCalledWith(
+        STORAGE_KEY_CACHE_BUST_LAST_VALUE,
+        '1700000000123::user-id-1'
+      )
+      expect(setItemSpy).not.toHaveBeenCalledWith(
+        STORAGE_KEY_PERSON_ID,
+        'user-id-1'
+      )
+    })
+
+    it('should detect user change and return a new timestamp', () => {
+      setSession({ personId: 'user-id-2' })
+      sessionStorage.setItem(STORAGE_KEY_PERSON_ID, 'user-id-1')
+      sessionStorage.setItem(
+        STORAGE_KEY_CACHE_BUST_LAST_VALUE,
+        '1700000000000::user-id-1'
+      )
+
+      jest.spyOn(Date, 'now').mockReturnValue(1700000000456)
+
+      const result = getClientCacheBustingValue()
+
+      expect(result).toBe('1700000000456::user-id-2')
+      expect(sessionStorage.getItem(STORAGE_KEY_PERSON_ID)).toBe('user-id-2')
+      expect(sessionStorage.getItem(STORAGE_KEY_CACHE_BUST_LAST_VALUE)).toBe(
+        '1700000000456::user-id-2'
+      )
+    })
   })
 
-  it('should return last cached value when auth state is the same and last value exists', () => {
-    setSessionPerson('user-id-1')
-    sessionStorage.setItem(STORAGE_KEY_PERSON_ID, 'user-id-1')
-    sessionStorage.setItem(
-      STORAGE_KEY_CACHE_BUST_LAST_VALUE,
-      '1700000000000::user-id-1'
-    )
+  describe('postalCode (delivery promise / regional facets)', () => {
+    it('should return a value for anonymous users who have a postalCode set', () => {
+      setSession({ postalCode: '24230220' })
 
-    const nowSpy = jest.spyOn(Date, 'now')
-    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem')
+      jest.spyOn(Date, 'now').mockReturnValue(1700000001000)
 
-    const result = getClientCacheBustingValue()
+      const result = getClientCacheBustingValue()
 
-    expect(result).toBe('1700000000000::user-id-1')
-    expect(nowSpy).not.toHaveBeenCalled()
-    expect(setItemSpy).not.toHaveBeenCalled()
-  })
+      expect(result).toBe('1700000001000::24230220')
+    })
 
-  it('should create and persist a new last value when auth state is the same but last value is missing', () => {
-    setSessionPerson('user-id-1')
-    sessionStorage.setItem(STORAGE_KEY_PERSON_ID, 'user-id-1')
+    it('should return last cached value when postalCode is the same', () => {
+      setSession({ postalCode: '24230220' })
+      sessionStorage.setItem(STORAGE_KEY_POSTAL_CODE, '24230220')
+      sessionStorage.setItem(
+        STORAGE_KEY_CACHE_BUST_LAST_VALUE,
+        '1700000001000::24230220'
+      )
 
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1700000000123)
-    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem')
+      const nowSpy = jest.spyOn(Date, 'now')
 
-    const result = getClientCacheBustingValue()
+      const result = getClientCacheBustingValue()
 
-    expect(result).toBe('1700000000123::user-id-1')
-    expect(nowSpy).toHaveBeenCalled()
-    expect(setItemSpy).toHaveBeenCalledWith(
-      STORAGE_KEY_CACHE_BUST_LAST_VALUE,
-      '1700000000123::user-id-1'
-    )
-    expect(setItemSpy).not.toHaveBeenCalledWith(
-      STORAGE_KEY_PERSON_ID,
-      'user-id-1'
-    )
-  })
+      expect(result).toBe('1700000001000::24230220')
+      expect(nowSpy).not.toHaveBeenCalled()
+    })
 
-  it('should detect user change and return new timestamp', () => {
-    setSessionPerson('user-id-1')
-    sessionStorage.setItem(STORAGE_KEY_PERSON_ID, 'user-id-1')
-    sessionStorage.setItem(
-      STORAGE_KEY_CACHE_BUST_LAST_VALUE,
-      '1700000000000::user-id-1'
-    )
+    it('should return a new value when postalCode changes', () => {
+      setSession({ postalCode: '24230220' })
+      sessionStorage.setItem(STORAGE_KEY_POSTAL_CODE, '50030260')
+      sessionStorage.setItem(
+        STORAGE_KEY_CACHE_BUST_LAST_VALUE,
+        '1700000001000::50030260'
+      )
 
-    // Simulate user switch (e.g. re-login with different account)
-    setSessionPerson('user-id-2')
+      jest.spyOn(Date, 'now').mockReturnValue(1700000002000)
 
-    jest.spyOn(Date, 'now').mockReturnValue(1700000000456)
+      const result = getClientCacheBustingValue()
 
-    const result = getClientCacheBustingValue()
+      expect(result).toBe('1700000002000::24230220')
+      expect(sessionStorage.getItem(STORAGE_KEY_POSTAL_CODE)).toBe('24230220')
+      expect(sessionStorage.getItem(STORAGE_KEY_CACHE_BUST_LAST_VALUE)).toBe(
+        '1700000002000::24230220'
+      )
+    })
 
-    expect(result).toBe('1700000000456::user-id-2')
-    expect(sessionStorage.getItem(STORAGE_KEY_PERSON_ID)).toBe('user-id-2')
-    expect(sessionStorage.getItem(STORAGE_KEY_CACHE_BUST_LAST_VALUE)).toBe(
-      '1700000000456::user-id-2'
-    )
+    it('should combine personId and postalCode for logged-in users', () => {
+      setSession({ personId: 'user-id-1', postalCode: '24230220' })
+
+      jest.spyOn(Date, 'now').mockReturnValue(1700000003000)
+
+      const result = getClientCacheBustingValue()
+
+      expect(result).toBe('1700000003000::user-id-1::24230220')
+    })
+
+    it('should generate a new value when postalCode changes for a logged-in user', () => {
+      setSession({ personId: 'user-id-1', postalCode: '24230220' })
+      sessionStorage.setItem(STORAGE_KEY_PERSON_ID, 'user-id-1')
+      sessionStorage.setItem(STORAGE_KEY_POSTAL_CODE, '50030260')
+      sessionStorage.setItem(
+        STORAGE_KEY_CACHE_BUST_LAST_VALUE,
+        '1700000003000::user-id-1::50030260'
+      )
+
+      jest.spyOn(Date, 'now').mockReturnValue(1700000004000)
+
+      const result = getClientCacheBustingValue()
+
+      expect(result).toBe('1700000004000::user-id-1::24230220')
+    })
   })
 })


### PR DESCRIPTION
## What's the purpose of this pull request?

On the PLP, when a user changes their postal code to one where certain delivery methods (e.g. "Shipping", "Dynamic Estimate") are unavailable, the delivery facets (Delivery Methods, Delivery Options) are not updated — the stale filters from the previous postal code remain visible.

## How it works?

- cookieCacheBusting.ts — extend getClientCacheBustingValue() to track postalCode alongside person.id. The resulting v query param (e.g. v=timestamp::userId::24230220) is already appended to every GET request URL, so this single change busts both the CDN cache and the SWR client-side cache when the postal code changes.

- useProductGalleryQuery.ts / usePageProductsQuery.ts — add doNotRun: isDeliveryPromiseEnabled && isSessionValidating to gate the gallery and product queries while validateSession is in flight. 

- usePageProductsQuery.ts — include _postalCode in the pagesCache comparison key (localizedVariablesWithRegion). This is needed so the hasSameVariables guard — which decides whether SWR is allowed to run at all — correctly detects a postal code change and sets shouldFetch = true. Without it, the local cache guard would permanently block the query for an unchanged set of search params. The SSR pagesCache seed is updated to match this shape so the first hydration render doesn't trigger an unnecessary re-fetch.

## How to test it?

Run locally or check this [preview](https://vendemo-cm9sir9v900u7z6llkl62l70j-mdd18ev50.b.vtex.app)
In discovery.config file:
- use `vendemo` account to test
```
  api: {
    storeId: 'vendemo',
   ..}
```
- enable deliveryPromise:
```
deliveryPromise: {
    enabled: true,
    mandatory: false,
  },
```

You should be the filters being updated after changing the postal code.

https://github.com/user-attachments/assets/bf0814e4-d863-421e-9d15-f0f8de6d87be


### Starters Deploy Preview

<!--- Add a link to a deploy preview from `starter.store` with this branch being used. --->

<!--- Tip: You can get an installable version of this branch from the CodeSandbox generated when this PR is created. --->

## References

https://vtex.slack.com/archives/C0164SHMAV9/p1776083445684739


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Product queries now incorporate postal code and region information for more location-specific results and optimized data caching.
  * Enhanced session handling and request optimization for delivery-related features.
  * Cache management now simultaneously monitors authentication state and location changes for improved accuracy.

* **Tests**
  * Extended test coverage for location-aware caching across authenticated and anonymous user scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->