### PR TITLE
feat: paginate listEntries with scroll

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
     "@lhci/cli": "^0.15.1",
     "@types/react": "catalog:",
     "@vtex/client-cms": "^0.2.16",
-    "@vtex/client-cp": "0.5.1",
+    "@vtex/client-cp": "0.6.0",
     "@vtex/prettier-config": "1.0.0",
     "autoprefixer": "^10.4.0",
     "cookie": "catalog:",

--- a/packages/core/src/server/content/service.ts
+++ b/packages/core/src/server/content/service.ts
@@ -81,10 +81,10 @@ export class ContentService {
     const options = this.createContentOptions(plpParams)
 
     if (isContentPlatformSource()) {
-      // const directMatch = await this.getSingleContent<PLPContentType>(plpParams)
-      // if (directMatch) {
-      //   return directMatch
-      // }
+      const directMatch = await this.getSingleContent<PLPContentType>(plpParams)
+      if (directMatch) {
+        return directMatch
+      }
 
       const pages = (await this.getMultipleContent(plpParams)).data
       if (!pages?.length) throw new MissingContentError(options.cmsOptions)

--- a/packages/core/src/server/content/service.ts
+++ b/packages/core/src/server/content/service.ts
@@ -46,7 +46,8 @@ export class ContentService {
 
     if (isContentPlatformSource()) {
       const serviceParams = this.convertOptionsToParams(options)
-      const MAX_PAGES = 100
+      // TODO: This should be temporary until the cp data-plane have a search engine.
+      const MAX_PAGES = 25
       const allEntries: ContentEntry[] = []
       let scroll: string | undefined
       let pages = 0
@@ -80,10 +81,10 @@ export class ContentService {
     const options = this.createContentOptions(plpParams)
 
     if (isContentPlatformSource()) {
-      const directMatch = await this.getSingleContent<PLPContentType>(plpParams)
-      if (directMatch) {
-        return directMatch
-      }
+      // const directMatch = await this.getSingleContent<PLPContentType>(plpParams)
+      // if (directMatch) {
+      //   return directMatch
+      // }
 
       const pages = (await this.getMultipleContent(plpParams)).data
       if (!pages?.length) throw new MissingContentError(options.cmsOptions)

--- a/packages/core/src/server/content/service.ts
+++ b/packages/core/src/server/content/service.ts
@@ -46,14 +46,22 @@ export class ContentService {
 
     if (isContentPlatformSource()) {
       const serviceParams = this.convertOptionsToParams(options)
+      const MAX_PAGES = 100
       const allEntries: ContentEntry[] = []
       let scroll: string | undefined
+      let pages = 0
 
       do {
         const result = await this.clientCP.listEntries(serviceParams, scroll)
         allEntries.push(...result.entries)
-        scroll = result.scroll ?? undefined
-      } while (scroll)
+        const next = result.scroll ?? undefined
+        if (next && next === scroll) break
+        scroll = next
+      } while (scroll && ++pages < MAX_PAGES)
+
+      if (pages >= MAX_PAGES) {
+        console.warn('listEntries pagination hit MAX_PAGES cap', serviceParams)
+      }
 
       return this.fillEntriesWithData(
         allEntries,
@@ -72,6 +80,11 @@ export class ContentService {
     const options = this.createContentOptions(plpParams)
 
     if (isContentPlatformSource()) {
+      const directMatch = await this.getSingleContent<PLPContentType>(plpParams)
+      if (directMatch) {
+        return directMatch
+      }
+
       const pages = (await this.getMultipleContent(plpParams)).data
       if (!pages?.length) throw new MissingContentError(options.cmsOptions)
       return findBestPLPTemplate(
@@ -91,6 +104,11 @@ export class ContentService {
     const options = this.createContentOptions(pdpParams)
 
     if (isContentPlatformSource()) {
+      const directMatch = await this.getSingleContent<PDPContentType>(pdpParams)
+      if (directMatch) {
+        return directMatch
+      }
+
       const pages = (await this.getMultipleContent(pdpParams)).data
       if (!pages.length) throw new MissingContentError(options.cmsOptions)
       return findBestPDPTemplate(

--- a/packages/core/src/server/content/service.ts
+++ b/packages/core/src/server/content/service.ts
@@ -46,8 +46,20 @@ export class ContentService {
 
     if (isContentPlatformSource()) {
       const serviceParams = this.convertOptionsToParams(options)
-      const { entries } = await this.clientCP.listEntries(serviceParams)
-      return this.fillEntriesWithData(entries, serviceParams, options.isPreview)
+      const allEntries: ContentEntry[] = []
+      let scroll: string | undefined
+
+      do {
+        const result = await this.clientCP.listEntries(serviceParams, scroll)
+        allEntries.push(...result.entries)
+        scroll = result.scroll ?? undefined
+      } while (scroll)
+
+      return this.fillEntriesWithData(
+        allEntries,
+        serviceParams,
+        options.isPreview
+      )
     }
     return getCMSPage(options.cmsOptions)
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,8 +499,8 @@ importers:
         specifier: ^0.2.16
         version: 0.2.16(encoding@0.1.13)
       "@vtex/client-cp":
-        specifier: 0.5.1
-        version: 0.5.1
+        specifier: 0.6.0
+        version: 0.6.0
       "@vtex/prettier-config":
         specifier: 1.0.0
         version: 1.0.0(prettier@2.8.8)
@@ -7326,10 +7326,10 @@ packages:
         integrity: sha512-mK5OiaaGHItVuispyy8yXLILnMx4aOJj7HkamOmAL12+KbnkiKKpO1vJEb3hRB16lK1rHtl7Q5H3aTFsMqrf0w==,
       }
 
-  "@vtex/client-cp@0.5.1":
+  "@vtex/client-cp@0.6.0":
     resolution:
       {
-        integrity: sha512-z5ooUZvOl7okcfIgXxviI4Y2TNpotbZBHhseL+AhMsyG+UxijcfqyiNDcQncWKbNmPQY6/kZgjuAh/ENaN+2CA==,
+        integrity: sha512-+ijNI8uOIB84oOSZFiEmEcjXe23sK9lwTyvyoB72y1gS7Xfqgwn93F9gzrbYjxerPNZTb8ZSlsGBLWxCx1ONBw==,
       }
     engines: { node: ">=16" }
 
@@ -24432,7 +24432,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  "@vtex/client-cp@0.5.1":
+  "@vtex/client-cp@0.6.0":
     dependencies:
       axios: 1.13.5
     transitivePeerDependencies:


### PR DESCRIPTION
## What's the purpose of this pull request?

`ContentService.getPage` was returning only the first page of entries from Content Platform because `listEntries` wasn't following the `scroll` token. Result: pages backed by CP silently missed content beyond the first batch.

## How it works?

In `packages/core/src/server/content/service.ts`, the single `listEntries` call is replaced by a loop that accumulates entries while a `scroll` token is returned, then passes the full list to `fillEntriesWithData`.

## How to test it?

- On a store using the CP data source, create enough entries for a given content type to exceed a single page.
- Request that page and verify all entries are returned (not just the first batch).
- Confirm non-CP (hCMS) path is unaffected.

### Starters Deploy Preview

N/A

## References

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Content retrieval now fully paginates via scrolling, accumulating entries across pages and avoiding truncated results (stops safely with a max-page cap and logs a warning if reached).

* **Enhancements**
  * Product listing (PLP) and product detail (PDP) now attempt a direct single-item fetch first and return immediately on direct matches, improving accuracy and performance.

* **Notes**
  * No changes to public APIs or exported entities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->