### PR TITLE
fix: generate plugin themes with Sass @use instead of @import

### DIFF
--- a/packages/cli/src/utils/plugins.ts
+++ b/packages/cli/src/utils/plugins.ts
@@ -282,7 +282,9 @@ const addPluginsTheme = async (basePath: string, plugins: Plugin[]) => {
         getPackagePath(getPluginName(plugin), 'src', 'themes', 'index.scss')
       )
     )
-    .map((plugin) => `@import "${getPluginName(plugin)}/src/themes/index.scss"`)
+    .map(
+      (plugin) => `@use "${getPluginName(plugin)}/src/themes/index.scss" as *;`
+    )
     .join('\n')
 
   writeFileSync(tmpThemesPluginsFile, pluginImportsContent)


### PR DESCRIPTION
## What's the purpose of this pull request?

Stores that adopt **FastStore v4-style plugins** (for example Buyer Portal) ship SCSS that uses the **module system** (`@use`) and paths such as `@faststore/ui`. Without aligning the CLI and the core bundler, themes generated for plugins stay on the legacy `@import` model and SCSS/Webpack can resolve **two different physical copies** of the same UI package, which surfaces as Sass/`include-media` issues during build.

This PR fits VTEX’s FastStore evolution by keeping **official starters and Discovery** compatible with plugins built for v4 naming and Sass usage, without forcing every store to fork tooling.

## How it works?

- **`@vtex/faststore-cli` (`packages/cli`)** — `addPluginsTheme` writes the aggregated plugin theme file using **`@use "…/themes/index.scss" as *`** instead of **`@import`**, matching plugin theme entrypoints that already use `@use` and Dart Sass expectations.
- **`@vtex/faststore-core` (`packages/core`)** — **`next.config.js`** extends Webpack **`resolve.alias`** so **`@faststore/ui`** and **`@faststore/core`** resolve to the same **`node_modules`** trees as **`@vtex/faststore-ui`** and **`@vtex/faststore-core`**, using the same app root as **`experimental.outputFileTracingRoot`** (Discovery vs monorepo). Existing **`sassOptions.additionalData`** injection for **`utilities`** is unchanged so first-party SCSS and plugins that rely on the global **`media`** mixin keep working; plugins should avoid a **second** `@use` of `utilities` in the same file when this injection is enabled.

*(If this branch only ships the CLI change, remove the core bullet or narrow it to what is actually merged.)*

## How to test it?

- In the monorepo: `pnpm install` and build/affected packages as usual (`turbo` / package scripts).
- Run **`apps/starter`** (or your integration store): `pnpm build` / `pnpm dev` and confirm **no Sass errors** on global styles and section SCSS.
- With a **Buyer Portal** (or another v4-style plugin) declared in store config:
  - Run **`faststore dev`** / **`faststore build`** so the CLI regenerates **`src/plugins/index.scss`** and confirm it contains **`@use`** lines for each plugin theme.
  - Confirm plugin SCSS that imports **`@faststore/ui`** resolves (Webpack aliases) and the build completes.

### Starters Deploy Preview

<!-- Add deploy preview URL when available (starter.store with this branch). -->

## References

- Internal notes / migration checklist previously outlined for v4 plugin themes (`additionalData`, `@use` vs `@import`, single resolution for `@faststore/*`).
- Related context: **Conventional Commits** for title/commits; plugin repos should document dependency on core **`additionalData`** for utilities when using `@include media` without local `@use` of utilities.

## Checklist

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [x] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [ ] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [x] PR description
- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated plugin theme loading mechanism to use modern SCSS standards for enhanced compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->