### PR TITLE
fix: Enhance session validation logic to skip token refresh in local …

### DIFF
--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -161,7 +161,12 @@ const handler: NextApiHandler = async (request, response) => {
     // value is used to cache bust the request if there is a VtexIdclientAutCookie
     const { operation, variables, query, v: value } = parseRequest(request)
 
+    const isLocal =
+      request.headers.host?.startsWith('localhost') ||
+      request.headers.host?.startsWith('127.0.0.1')
+
     if (
+      !isLocal &&
       operation.__meta__.operationName === 'ValidateSession' &&
       discoveryConfig.experimental?.refreshToken
     ) {

--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -161,9 +161,8 @@ const handler: NextApiHandler = async (request, response) => {
     // value is used to cache bust the request if there is a VtexIdclientAutCookie
     const { operation, variables, query, v: value } = parseRequest(request)
 
-    const isLocal =
-      request.headers.host?.startsWith('localhost') ||
-      request.headers.host?.startsWith('127.0.0.1')
+    const hostname = request.headers.host?.split(':')[0]
+    const isLocal = hostname === 'localhost' || hostname === '127.0.0.1'
 
     if (
       !isLocal &&

--- a/packages/core/src/sdk/session/index.ts
+++ b/packages/core/src/sdk/session/index.ts
@@ -19,6 +19,11 @@ import { createValidationStore, useStore } from '../useStore'
 import { getPostalCode } from '../userLocation/index'
 import { RELOAD_AFTER_LOGOUT_KEY, SESSION_READY_KEY } from './storageKeys'
 
+const isLocalEnvironment = (): boolean =>
+  typeof window !== 'undefined' &&
+  (window.location.hostname === 'localhost' ||
+    window.location.hostname === '127.0.0.1')
+
 const isReloadAfterLogoutPending = (): boolean => {
   try {
     return (
@@ -120,7 +125,9 @@ export const validateSession = async (session: Session) => {
   // If the refreshToken is enabled and the refreshAfter is expired, refresh the token.
   // On success, continue to the validation flow with the refreshed session.
   // On failure (logoutAndClearSession already triggered), bail out.
+  // Skipped in local environments where the refresh token infrastructure is unavailable.
   if (
+    !isLocalEnvironment() &&
     storeConfig.experimental?.refreshToken &&
     isRefreshAfterExpired(session)
   ) {
@@ -173,7 +180,9 @@ export const validateSession = async (session: Session) => {
     return data.validateSession
   } catch (error) {
     const shouldRefreshToken =
-      error?.status === 401 && storeConfig.experimental?.refreshToken
+      !isLocalEnvironment() &&
+      error?.status === 401 &&
+      storeConfig.experimental?.refreshToken
 
     if (shouldRefreshToken) {
       const refreshed = await handleRefreshToken(session)


### PR DESCRIPTION
…environments

- Introduced a check to bypass token refresh logic when running in local environments (localhost or 127.0.0.1).
- Updated GraphQL API handler and session validation functions to ensure consistent behavior across environments.
- This change prevents unnecessary refresh attempts during local development, improving the developer experience.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session validation now detects local development environments (localhost/127.0.0.1) and adapts behavior to simplify local authentication handling and improve developer workflow.

* **Bug Fixes**
  * Refined token refresh logic to skip refresh enforcement when running locally, preventing unnecessary 401-driven refresh flows during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->