### PR TITLE
chore: add release:v3 script and update workflow for 3.x branch - SFS-3144

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
         run: pnpm release:v3
 
       - name: Publish to Chromatic
+        if: github.ref_name != '3.x'
         uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - dev
+      - 3.x
 
 permissions:
   id-token: write # Required for OIDC
@@ -70,6 +71,10 @@ jobs:
       - name: Publish (dev)
         if: github.ref_name == 'dev'
         run: pnpm release:dev
+
+      - name: Publish (3.x)
+        if: github.ref_name == '3.x'
+        run: pnpm release:v3
 
       - name: Publish to Chromatic
         uses: chromaui/action@latest

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "size": "turbo run size",
     "release": "lerna version --conventional-commits --conventional-graduate --yes && lerna publish from-git --yes",
     "release:dev": "lerna version --conventional-commits --conventional-prerelease --preid=dev --yes && lerna publish from-git --dist-tag=dev --yes",
+    "release:v3": "lerna version --conventional-commits --yes && lerna publish from-git --dist-tag=v3-latest --yes",
     "clean": "turbo run clean && rm -rf node_modules",
     "prepare": "husky"
   },


### PR DESCRIPTION
- Added a new script "release:v3" in package.json for versioning and publishing with a dist-tag of v3-latest.
- Updated GitHub Actions workflow to include a new job for publishing on the 3.x branch.

## What's the purpose of this pull request?

### `release.yml`

- **Linha 9** — `3.x` adicionado ao trigger de branches
- **Linhas 75-77** — Step `Publish (3.x)` com condição `if: github.ref_name == '3.x'` apontando para `pnpm release:v3`

### `package.json`

- **Linha 22** — Script `release:v3` com `lerna version --conventional-commits --yes && lerna publish from-git --dist-tag=v3-latest --yes`
- Sem `--conventional-graduate` (correto, pois no `3.x` não haverá prereleases para graduar)
- Sem `--conventional-prerelease` (correto, pois serão releases estáveis da v3)
- Com `--dist-tag=v3-latest` (correto, para não sobrescrever a tag `latest` que será da v4)

Os hotfixes da v3 publicados a partir do branch `3.x` serão instaláveis via `npm install @faststore/core@v3-latest` e não vão interferir com a tag `latest` da v4.


Nota importante: não usem pnpm release (o mesmo da main) no branch 3.x, porque esse comando usa --conventional-graduate que é para graduar prereleases. No 3.x, hotfixes serão commits normais (fix:, feat:) e o lerna version --conventional-commits (sem graduate) é o adequado — ele vai gerar 3.99.1, 3.99.2, etc., baseado nos commits.