### PR TITLE
chore: enable localization in breadcrumb localization

### DIFF
--- a/packages/core/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/packages/core/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -2,6 +2,7 @@ import type { BreadcrumbProps as UIBreadcrumbProps } from '@faststore/ui'
 import { Breadcrumb as UIBreadcrumb } from '@faststore/ui'
 import { memo } from 'react'
 
+import storeConfig from 'discovery.config'
 import Link from 'src/components/ui/Link'
 import { useOverrideComponents } from 'src/sdk/overrides/OverrideContext'
 export interface BreadcrumbProps extends UIBreadcrumbProps {
@@ -31,11 +32,17 @@ const Breadcrumb = ({ icon, alt, ...otherProps }: BreadcrumbProps) => {
           />
         </Link>
       }
-      renderLink={({ itemProps: { item: link, name } }) => (
-        <Link data-fs-breadcrumb-link href={link} prefetch={false}>
-          {name}
-        </Link>
-      )}
+      renderLink={({ itemProps: { item: link, name } }) =>
+        // workaround to display the name without a link since localized slug is not available yet
+        // TODO: when slug localized available remove this workaround
+        storeConfig.localization?.enabled ? (
+          <span data-fs-breadcrumb-link>{name}</span>
+        ) : (
+          <Link data-fs-breadcrumb-link href={link} prefetch={false}>
+            {name}
+          </Link>
+        )
+      }
       {...Breadcrumb.props}
       {...otherProps}
     />

--- a/packages/core/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/packages/core/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -34,7 +34,7 @@ const Breadcrumb = ({ icon, alt, ...otherProps }: BreadcrumbProps) => {
       }
       renderLink={({ itemProps: { item: link, name } }) =>
         // workaround to display the name without a link since localized slug is not available yet
-        // TODO: when slug localized available remove this workaround
+        // TODO: when localized slugs are available remove this workaround
         storeConfig.localization?.enabled ? (
           <span data-fs-breadcrumb-link>{name}</span>
         ) : (

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -327,8 +327,6 @@ export const getStaticProps: GetStaticProps<
   ] = await Promise.all([
     execute<ServerProductQueryQueryVariables, ServerProductQueryQuery>({
       variables: {
-        // Workaround until i18n slugs are fixed with Intelligent Search and Catalog.
-        // With we add locale ({ key: 'locale', value: locale }), breadcrumbList returns translated slugs that lead to 404s.
         locator: [
           { key: 'slug', value: slug },
           { key: 'channel', value: getChannelForLocale(locale) },

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -7,7 +7,6 @@ import type { ComponentType } from 'react'
 
 import { gql } from '@generated'
 import type {
-  ClientProductQueryQuery,
   ServerProductQueryQuery,
   ServerProductQueryQueryVariables,
 } from '@generated/graphql'
@@ -84,30 +83,6 @@ type Props = PDPContentType & {
 // https://www.npmjs.com/package/deepmerge
 const overwriteMerge = (_: any[], sourceArray: any[]) => sourceArray
 
-/**
- * Merges server + client PDP payloads. After `deepmerge`, we replace `skuVariants` from
- * the client when present: localized `availableVariations` keys differ by locale, and
- * default object merge would keep both (duplicate SKU selectors).
- */
-const mergePdpData = (
-  server: ServerProductQueryQuery,
-  client: Partial<ClientProductQueryQuery> | Record<string, unknown> | undefined
-) => {
-  const merged = deepmerge(server, (client ?? {}) as ServerProductQueryQuery, {
-    arrayMerge: overwriteMerge,
-  })
-
-  const clientSkuVariants = (
-    client as Partial<ClientProductQueryQuery> | undefined
-  )?.product?.isVariantOf?.skuVariants
-
-  if (clientSkuVariants != null && merged.product?.isVariantOf != null) {
-    merged.product.isVariantOf.skuVariants = clientSkuVariants
-  }
-
-  return merged
-}
-
 const isClientOfferEnabled = (storeConfig as StoreConfig).experimental
   .enableClientOffer
 
@@ -181,7 +156,7 @@ function Page({
     globalSectionsProp ?? {}
   const context = {
     data: {
-      ...mergePdpData(server, client),
+      ...deepmerge(server, client, { arrayMerge: overwriteMerge }),
       isValidating,
     },
     globalSettings,
@@ -357,6 +332,7 @@ export const getStaticProps: GetStaticProps<
         locator: [
           { key: 'slug', value: slug },
           { key: 'channel', value: getChannelForLocale(locale) },
+          { key: 'locale', value: locale },
         ],
       },
       operation: query,

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -202,7 +202,12 @@ function Page({
         ]}
         titleTemplate={titleTemplate}
       />
-      <BreadcrumbJsonLd itemListElements={itemListElements} />
+
+      {/* TODO: when localized slugs are available remove this workaround */}
+      {!storeConfig.localization?.enabled && (
+        <BreadcrumbJsonLd itemListElements={itemListElements} />
+      )}
+
       <ProductJsonLd
         id={`${meta.canonical}${settings?.seo?.id ?? ''}`}
         mainEntityOfPage={`${meta.canonical}${


### PR DESCRIPTION
## What's the purpose of this pull request?

- Enables localization for breadcrumb
- When localization is enabled, breadcrumb items render as plain text (non-clickable) instead of links, since slug translations are not yet available and the links would otherwise be broken.

## How to test it?

- You should be able to see the breadcrumb text translated according to the current locale.

### Starters Deploy Preview

https://github.com/vtex-sites/brandless.store/pull/164

## References

[task](https://vtex-dev.atlassian.net/browse/SFS-3146)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumb items now render correctly based on localization settings, ensuring consistent behavior across different configurations.

* **Refactor**
  * Simplified product data merging logic for improved performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->