### PR TITLE
fix: Base CMS schema (V4)

### DIFF
--- a/packages/core/cms/faststore/base.jsonc
+++ b/packages/core/cms/faststore/base.jsonc
@@ -12,17 +12,8 @@
     // Every component schema must extend this base schema.
     "base-component": {
       "type": "object",
-      "required": ["$componentKey", "$componentTitle"],
-      "properties": {
-        "$componentKey": {
-          "type": "string",
-          "description": "Unique identifier for the component"
-        },
-        "$componentTitle": {
-          "type": "string",
-          "description": "Display title for the component"
-        }
-      }
+      "required": [],
+      "properties": {}
     },
     "base-page-template": {
       "type": "object",

--- a/packages/core/cms/faststore/schema.json
+++ b/packages/core/cms/faststore/schema.json
@@ -4305,17 +4305,8 @@
   "$defs": {
     "base-component": {
       "type": "object",
-      "required": ["$componentKey", "$componentTitle"],
-      "properties": {
-        "$componentKey": {
-          "type": "string",
-          "description": "Unique identifier for the component"
-        },
-        "$componentTitle": {
-          "type": "string",
-          "description": "Display title for the component"
-        }
-      }
+      "required": [],
+      "properties": {}
     },
     "base-page-template": {
       "type": "object",


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix the base CMS schema for FS V4 (`vtex.faststore4`) to ensure that components will be created **without** the `$componentKey` and `$componentTitle` keys as properties.

## How to test it?

The latest FS schema on Schema Registry (`vtex.faststore4@1.2.0`) should not have `$componentKey` and `$componentTitle` keys as components' properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Relaxed component schema requirements to support more flexible configurations. Components no longer require specific identifier fields, enabling broader customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->