### PR TITLE
fix: forward auth token only via account-scoped cookie

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -20,6 +20,7 @@ import type { Channel } from '../../utils/channel'
 import {
   getAuthCookie,
   getStoreCookie,
+  getUpdatedCookie,
   getWithAutCookie,
   getWithCookie,
 } from '../../utils/cookies'
@@ -738,8 +739,9 @@ export const VtexCommerce = (
     vtexid: {
       validate: (): Promise<VtexIdResponse> => {
         const headers: HeadersInit = withAutCookie(forwardedHost, account)
-        // Token is read from the incoming request's account-scoped auth cookie.
-        const token = getAuthCookie(ctx.headers?.cookie ?? '', account)
+        // Read from the merged cookie set so the body token stays in sync with
+        // the `cookie` header (both pull from request + storage updates).
+        const token = getAuthCookie(getUpdatedCookie(ctx) ?? '', account)
 
         return fetchAPI(
           `${base}/api/vtexid/credential/validate`,

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -18,6 +18,7 @@ import type { Context, Options } from '../../index'
 import { getWithAppKeyAndToken } from '../../utils/auth'
 import type { Channel } from '../../utils/channel'
 import {
+  getAuthCookie,
   getStoreCookie,
   getWithAutCookie,
   getWithCookie,
@@ -737,14 +738,14 @@ export const VtexCommerce = (
     vtexid: {
       validate: (): Promise<VtexIdResponse> => {
         const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        // Token is read from the incoming request's account-scoped auth cookie.
+        const token = getAuthCookie(ctx.headers?.cookie ?? '', account)
 
         return fetchAPI(
           `${base}/api/vtexid/credential/validate`,
           {
             headers,
-            body: JSON.stringify({
-              token: headers['VtexIdclientAutCookie'],
-            }),
+            body: JSON.stringify({ token }),
             method: 'POST',
           },
           { storeCookies }

--- a/packages/api/src/platforms/vtex/utils/cookies.ts
+++ b/packages/api/src/platforms/vtex/utils/cookies.ts
@@ -142,22 +142,21 @@ export const getAuthCookie = (cookies: string, account: string) => {
   return authCookie || ''
 }
 
+/**
+ * Headers for authenticated VtexID requests. The auth token is carried by
+ * the forwarded `cookie` header — not duplicated as a separate header.
+ */
 export const getWithAutCookie = (ctx: ContextForCookies) => {
   const withCookie = getWithCookie(ctx)
 
-  return function withAutCookie(forwardedHost: string, account: string) {
-    const headers: HeadersInit = withCookie({
+  return function withAutCookie(
+    forwardedHost: string,
+    _account?: string
+  ): HeadersInit {
+    return withCookie({
       'content-type': 'application/json',
       'X-FORWARDED-HOST': forwardedHost,
     })
-
-    const VtexIdclientAutCookie = getAuthCookie(
-      ctx?.headers?.cookie ?? '',
-      account
-    )
-    headers['VtexIdclientAutCookie'] = VtexIdclientAutCookie
-
-    return headers
   }
 }
 

--- a/packages/api/test/integration/vtex.cookies.test.ts
+++ b/packages/api/test/integration/vtex.cookies.test.ts
@@ -299,3 +299,45 @@ describe('Cookie normalization (duplicate handling)', () => {
     expect(result).toEqual('newToken')
   })
 })
+
+describe('Auth token resolution from merged cookie set', () => {
+  const ACCOUNT = 'mystore'
+
+  it('Should pick the storage-updated auth token over the original request cookie', () => {
+    // Mirrors how `vtexid.validate` resolves the body token: the cookie header
+    // already merges request + storage updates, so the body must follow the same
+    // source to stay consistent with the outgoing `cookie` header.
+    const originalToken = 'jwt-original'
+    const refreshedToken = 'jwt-refreshed'
+
+    const ctx = {
+      headers: {
+        cookie: `vtex_session=foo; VtexIdclientAutCookie_${ACCOUNT}=${originalToken}`,
+      },
+      storage: {
+        cookies: new Map<string, { value: string }>([
+          [`VtexIdclientAutCookie_${ACCOUNT}`, { value: refreshedToken }],
+        ]),
+      },
+    }
+
+    const token = getAuthCookie(getUpdatedCookie(ctx) ?? '', ACCOUNT)
+
+    expect(token).toEqual(refreshedToken)
+  })
+
+  it('Should fall back to the original request cookie when storage has no updates', () => {
+    const originalToken = 'jwt-original'
+
+    const ctx = {
+      headers: {
+        cookie: `VtexIdclientAutCookie_${ACCOUNT}=${originalToken}`,
+      },
+      storage: { cookies: new Map() },
+    }
+
+    const token = getAuthCookie(getUpdatedCookie(ctx) ?? '', ACCOUNT)
+
+    expect(token).toEqual(originalToken)
+  })
+})

--- a/packages/api/test/integration/vtex.cookies.test.ts
+++ b/packages/api/test/integration/vtex.cookies.test.ts
@@ -4,6 +4,7 @@ import {
   getAuthCookie,
   getStoreCookie,
   getUpdatedCookie,
+  getWithAutCookie,
   getWithCookie,
   updatesContextStorageCookies,
   updatesCookieValueByKey,
@@ -95,6 +96,69 @@ describe('getWithCookie', () => {
     const newHeaders = withCookie(headers)
 
     expect(newHeaders).toEqual({ ...headers, cookie: ctx.headers.cookie })
+  })
+})
+
+describe('getWithAutCookie', () => {
+  const FORWARDED_HOST = 'mystore.fast.store'
+  const ACCOUNT = 'mystore'
+  const TOKEN = 'jwt-store-audience-value'
+
+  it('Should forward the suffixed auth cookie via the `cookie` header', () => {
+    const cookie = `vtex_session=foo; VtexIdclientAutCookie_${ACCOUNT}=${TOKEN}`
+    const ctx = {
+      headers: { cookie },
+      storage: { cookies: new Map() },
+    }
+
+    const withAutCookie = getWithAutCookie(ctx)
+    const headers = withAutCookie(FORWARDED_HOST, ACCOUNT) as Record<
+      string,
+      string
+    >
+
+    expect(headers).toEqual({
+      'content-type': 'application/json',
+      'X-FORWARDED-HOST': FORWARDED_HOST,
+      cookie,
+    })
+  })
+
+  it('Should NOT set the unscoped `VtexIdclientAutCookie` header', () => {
+    // Regression: the auth token is forwarded only via the account-scoped cookie.
+    const cookie = `VtexIdclientAutCookie_${ACCOUNT}=${TOKEN}`
+    const ctx = {
+      headers: { cookie },
+      storage: { cookies: new Map() },
+    }
+
+    const withAutCookie = getWithAutCookie(ctx)
+    const headers = withAutCookie(FORWARDED_HOST, ACCOUNT) as Record<
+      string,
+      string
+    >
+
+    expect(headers).not.toHaveProperty('VtexIdclientAutCookie')
+  })
+
+  it('Should still build base headers when no auth cookie is present', () => {
+    const ctx = {
+      headers: { cookie: 'vtex_segment=foo' },
+      storage: { cookies: new Map() },
+    }
+
+    const withAutCookie = getWithAutCookie(ctx)
+    const headers = withAutCookie(FORWARDED_HOST, ACCOUNT) as Record<
+      string,
+      string
+    >
+
+    expect(headers).toEqual({
+      'content-type': 'application/json',
+      'X-FORWARDED-HOST': FORWARDED_HOST,
+      cookie: 'vtex_segment=foo',
+    })
+    expect(headers).not.toHaveProperty('VtexIdclientAutCookie')
   })
 })
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Logged-in shoppers were unable to access the FastStore My Account area: any navigation to `/pvt/account/*` resulted in an immediate redirect to `/pvt/account/403?from=...`, where the page entered an infinite refresh-token loop.

The root cause was on the API side. Every `@auth`-protected GraphQL query relies on `vtexid.validate`, and the request that backs that call was forwarding the auth token in two ways at once: once through the standard account-scoped cookie and again under a duplicated, top-level header. The duplicated header was being rejected by the platform with `401`, even though the user's session was perfectly valid.

## How it works?

This PR removes the duplication. The auth token is now forwarded exclusively through the account-scoped cookie (`VtexIdclientAutCookie_{account}`) — exactly like every other authenticated path in the codebase already does (see `getAuthCookie`, `getJWTAutCookie`, `getIsRepresentative`).

## How to test it?

Pre-conditions: a logged-in shopper on a store that has FastStore My Account enabled (`experimental.enableFaststoreMyAccount = true`).

- Navigate to `/pvt/account/profile` — should render the profile page directly, without redirecting to `/pvt/account/403`.
- Run the package tests:

  ```bash
  pnpm --filter @faststore/api test
  ```

### Starters Deploy Preview
Before

https://github.com/user-attachments/assets/06b3e027-9e1f-4962-aa39-cf3915713f85


<!-- TODO: add deploy preview URL once available -->

## References
- [task](https://vtex-dev.atlassian.net/jira/software/projects/SO/boards/870?selectedIssue=SO-618&sprintStarted=true)
- related slack threads https://vtex.slack.com/archives/C06EC3LCZA8/p1777895253411839 https://vtex.slack.com/archives/C0164SHMAV9/p1777899569156569
- Affected package: `@faststore/api`
- Affected pages: everything under `packages/core/src/pages/pvt/account/*`
- Auth path: `@auth` directive (`packages/api/src/directives/auth.ts`) → `validateUserAuthentication` → `vtexid.validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable VTEX authentication: prefer updated account-scoped auth token when available and stop setting the unscoped auth header.
  * Simplified outgoing headers: only forward necessary headers and preserve base headers when no auth cookie is present.

* **Tests**
  * Added integration tests covering cookie merging, auth token resolution, and forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->