### PR TITLE
chore: improve session validation logic by conditionally checking localization flag

### DIFF
--- a/packages/core/src/sdk/session/index.ts
+++ b/packages/core/src/sdk/session/index.ts
@@ -140,20 +140,22 @@ export const validateSession = async (session: Session) => {
     session = refreshed
   }
 
-  const settings = getSettings()
-  const newChanel = JSON.stringify({
-    ...(JSON.parse(session.channel ?? '{}') ?? {}),
-    salesChannel: settings.salesChannel,
-  })
+  if (storeConfig.localization?.enabled) {
+    const settings = getSettings()
+    const newChanel = JSON.stringify({
+      ...(JSON.parse(session.channel ?? '{}') ?? {}),
+      salesChannel: settings.salesChannel,
+    })
 
-  if (
-    newChanel !== session.channel ||
-    settings.locale !== session.locale ||
-    deepEqual(settings.currency, session.currency) === false
-  ) {
-    session.locale = settings.locale
-    session.currency = settings.currency
-    session.channel = newChanel
+    if (
+      newChanel !== session.channel ||
+      settings.locale !== session.locale ||
+      deepEqual(settings.currency, session.currency) === false
+    ) {
+      session.locale = settings.locale
+      session.currency = settings.currency
+      session.channel = newChanel
+    }
   }
 
   // If deliveryPromise is enabled and there is no postalCode in the session


### PR DESCRIPTION
## What's the purpose of this pull request?

This pull request introduces a conditional check for localization settings in the `validateSession` function to ensure that localization-related session updates only occur when localization is enabled. This helps prevent unnecessary or incorrect modifications to session data when localization is not in use.

Session validation improvements:

* Added a check for `storeConfig.localization?.enabled` before updating session currency and channel based on localization settings in `validateSession` in `session/index.ts`. [[1]](diffhunk://#diff-290ea657fb800da722fad84e0fc08d57ce2ad6614f0751450af0c10f7a813ddeR143) [[2]](diffhunk://#diff-290ea657fb800da722fad84e0fc08d57ce2ad6614f0751450af0c10f7a813ddeR159)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced session validation performance by optimizing localization enrichment logic to execute conditionally based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->