### PR TITLE
fix: landing page plp and sort fallback

### DIFF
--- a/packages/core/src/components/common/PreviewTag/section.module.scss
+++ b/packages/core/src/components/common/PreviewTag/section.module.scss
@@ -40,8 +40,6 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 16px;
-            height: 16px;
             background: var(--fs-color-danger-bkg);
             border-radius: 50%;
             transition: var(--fs-transition-property) var(--fs-transition-timing) var(--fs-transition-function);

--- a/packages/core/src/components/search/Sort/Sort.tsx
+++ b/packages/core/src/components/search/Sort/Sort.tsx
@@ -1,37 +1,39 @@
 import { useSearch } from '@faststore/sdk'
 import { SelectField } from '@faststore/ui'
 
-const SORT_OPTIONS_KEYS = [
-  'price_desc',
-  'price_asc',
-  'orders_desc',
-  'name_asc',
-  'name_desc',
-  'release_desc',
-  'discount_desc',
-  'score_desc',
-] as const
+const DEFAULT_OPTIONS = {
+  price_desc: 'Price, descending',
+  price_asc: 'Price, ascending',
+  orders_desc: 'Top sales',
+  name_asc: 'Name, A-Z',
+  name_desc: 'Name, Z-A',
+  release_desc: 'Release date',
+  discount_desc: 'Discount',
+  score_desc: 'Relevance',
+} as const
+
+const SORT_OPTIONS_KEYS = Object.keys(DEFAULT_OPTIONS) as Array<
+  keyof typeof DEFAULT_OPTIONS
+>
 
 type SortOptionKeys = (typeof SORT_OPTIONS_KEYS)[number]
 
 export interface SortProps {
-  label: string
-  options: Record<SortOptionKeys, string>
+  label?: string
+  options?: Partial<Record<SortOptionKeys, string>>
 }
 
-const validSortKeys = [...SORT_OPTIONS_KEYS] as Array<SortOptionKeys>
-
-function Sort({ label, options }: SortProps) {
+function Sort({ label = 'Sort by', options = DEFAULT_OPTIONS }: SortProps) {
   const { state, setState } = useSearch()
 
-  const optionsMap = validSortKeys.reduce(
+  const optionsMap = SORT_OPTIONS_KEYS.reduce(
     (acc, key) => {
       if (Object.hasOwn(options, key)) {
-        acc[key] = options[key]
+        acc[key] = options[key] ?? DEFAULT_OPTIONS[key]
       }
       return acc
     },
-    {} as SortProps['options']
+    {} as Record<SortOptionKeys, string>
   )
 
   const keys = Object.keys(optionsMap) as Array<SortOptionKeys>

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -19,8 +19,8 @@ import type { PageContentType } from 'src/server/cms'
 import { getComponentKey } from 'src/utils/cms'
 
 import storeConfig from 'discovery.config'
-import { contentService } from 'src/server/content/service'
 import { getStoreURL } from 'src/sdk/localization/useLocalizationConfig'
+import { contentService } from 'src/server/content/service'
 import type { ContentRequestContext } from 'src/server/content/types'
 
 /* A list of components that can be used in the CMS. */
@@ -147,7 +147,7 @@ export const getLandingPageBySlug = async (
         filters:
           contentContext.previewData?.contentType === 'landingPage'
             ? undefined
-            : { filters: { 'settings.seo.slug': `/${slug}` } },
+            : { 'settings.seo.slug': `/${slug}` },
       })
     return landingPageData
   } catch (error) {

--- a/packages/core/src/components/templates/LandingPage/LandingPage.tsx
+++ b/packages/core/src/components/templates/LandingPage/LandingPage.tsx
@@ -121,7 +121,7 @@ export const getLandingPageBySlug = async (
     if (storeConfig.cms.data) {
       const cmsData = JSON.parse(storeConfig.cms.data)
       const pageBySlug = cmsData['landingPage'].find((page: any) => {
-        return slug === page.settings?.seo?.slug
+        return `/${slug}` === page.settings?.seo?.slug
       })
 
       if (pageBySlug) {
@@ -147,7 +147,7 @@ export const getLandingPageBySlug = async (
         filters:
           contentContext.previewData?.contentType === 'landingPage'
             ? undefined
-            : { 'settings.seo.slug': `/${slug}` },
+            : { filters: { 'settings.seo.slug': `/${slug}` } },
       })
     return landingPageData
   } catch (error) {

--- a/packages/core/src/server/cms/index.ts
+++ b/packages/core/src/server/cms/index.ts
@@ -1,4 +1,4 @@
-import type { ContentData, ContentTypeOptions, Locator } from '@vtex/client-cms'
+import type { ContentData, Locator } from '@vtex/client-cms'
 import ClientCMS from '@vtex/client-cms'
 
 import MultipleContentError from 'src/sdk/error/MultipleContentError'
@@ -10,7 +10,7 @@ export type Options =
   | Locator
   | {
       contentType: string
-      filters?: Partial<ContentTypeOptions>
+      filters?: Record<string, string>
     }
 
 type ProductGallerySettings = {
@@ -94,7 +94,7 @@ export const getCMSPage = async (
   const perPage = 10
   const response = await cmsClient.getCMSPagesByContentType(
     options.contentType,
-    { ...options.filters, page: page, perPage }
+    { filters: options.filters, page: page, perPage }
   )
 
   pages.push(...response.data)
@@ -109,7 +109,7 @@ export const getCMSPage = async (
     const restOfPages = await Promise.all(
       pagesToFetch.map((i) =>
         cmsClient.getCMSPagesByContentType(options.contentType, {
-          ...options.filters,
+          filters: options.filters,
           page: i,
           perPage,
         })

--- a/packages/core/src/server/content/types.ts
+++ b/packages/core/src/server/content/types.ts
@@ -21,7 +21,7 @@ export interface ContentParams extends ContentRequestContext {
   documentId?: string
   versionId?: string
   releaseId?: string
-  filters?: Record<string, unknown>
+  filters?: Record<string, string>
   locale?: string
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?
 
This pull request introduces improvements to the sorting component and fixes to landing page retrieval logic. The main changes include providing default sort options, making the sort label and options optional, and correcting how landing pages are matched and queried by slug.

Enhancements to sorting functionality:

* Added a `DEFAULT_OPTIONS` object for sort options, making the `label` and `options` props of the `Sort` component optional and providing sensible defaults if they are not specified. (`packages/core/src/components/search/Sort/Sort.tsx`)
* Ensured that the sort options fallback to defaults if a custom label or options are not provided, improving component usability and robustness. (`packages/core/src/components/search/Sort/Sort.tsx`)

Bug fixes for landing page slug matching:

* Fixed the landing page lookup to correctly compare slugs by prepending a `/` to the input slug, ensuring accurate page retrieval. (`packages/core/src/components/templates/LandingPage/LandingPage.tsx`)
* Corrected the filter structure in the landing page query to nest the slug filter inside a `filters` object, aligning with expected API requirements. (`packages/core/src/components/templates/LandingPage/LandingPage.tsx`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed landing page slug matching to ensure correct URL path resolution and page loading.

* **Refactor**
  * Improved Sort control flexibility with sensible defaults and support for partial customization of sort options.

* **Chores**
  * Standardized CMS content filtering and fetch behavior for more reliable content loading.
  * Tightened content API typings for consistent filter handling.

* **Style**
  * Centered preview icon layout and removed fixed sizing for improved visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->