### PR TITLE
fix: localization selector stale and reset selection for unsaved changes

### DIFF
--- a/packages/core/src/components/ui/LocalizationButton/LocalizationButton.tsx
+++ b/packages/core/src/components/ui/LocalizationButton/LocalizationButton.tsx
@@ -49,6 +49,7 @@ const LocalizationButton = ({
     setLocaleCode,
     setCurrencyCode,
     save,
+    reset,
     isSaveEnabled,
     error,
   } = useBindingSelector()
@@ -97,7 +98,10 @@ const LocalizationButton = ({
       {isSelectorOpen && (
         <LocalizationSelector
           isOpen={isSelectorOpen}
-          onClose={() => setIsSelectorOpen(false)}
+          onClose={() => {
+            setIsSelectorOpen(false)
+            reset()
+          }}
           triggerRef={buttonRef}
           languages={languages}
           currencies={currencies}

--- a/packages/core/src/sdk/localization/useBindingSelector.ts
+++ b/packages/core/src/sdk/localization/useBindingSelector.ts
@@ -56,6 +56,8 @@ export interface UseBindingSelectorReturn {
   setCurrencyCode: (code: string) => void
   /** Action to save selections and redirect */
   save: () => void
+  /** Discards unsaved changes and resets selections to current session values */
+  reset: () => void
 }
 
 /**
@@ -81,7 +83,7 @@ export function useBindingSelector(): UseBindingSelectorReturn {
 
   // Sync selections when session resolves after initial render (e.g. stale session
   // from a previous locale when navigating between locale-prefixed paths).
-  // Skipped once the user has made an in-progress selection.
+  // Skipped once the user has made an in-progress selection; call reset() on close to re-enable.
   useEffect(() => {
     if (!hasUserEditedSelection.current) {
       setLocaleCode(currentLocale ?? null)
@@ -188,6 +190,14 @@ export function useBindingSelector(): UseBindingSelectorReturn {
 
   const isSaveEnabled = Boolean(localeCode && currencyCode && !error)
 
+  // Discards unsaved changes and re-enables session syncing
+  const reset = useCallback(() => {
+    hasUserEditedSelection.current = false
+    setLocaleCode(currentLocale ?? null)
+    setCurrencyCode(currentCurrency?.code ?? null)
+    setError(null)
+  }, [currentLocale, currentCurrency?.code])
+
   return {
     languages,
     currencies,
@@ -198,5 +208,6 @@ export function useBindingSelector(): UseBindingSelectorReturn {
     setLocaleCode: handleSetLocaleCode,
     setCurrencyCode: handleSetCurrencyCode,
     save,
+    reset,
   }
 }

--- a/packages/core/src/sdk/localization/useBindingSelector.ts
+++ b/packages/core/src/sdk/localization/useBindingSelector.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import storeConfig from '../../../discovery.config'
 import { buildRedirectUrl } from '../../utils/localization/bindingPaths'
@@ -77,14 +77,21 @@ export function useBindingSelector(): UseBindingSelectorReturn {
   )
   const [error, setError] = useState<BindingSelectorError | null>(null)
 
+  const hasUserEditedSelection = useRef(false)
+
   // Sync selections when session resolves after initial render (e.g. stale session
-  // from a previous locale when navigating between locale-prefixed paths)
+  // from a previous locale when navigating between locale-prefixed paths).
+  // Skipped once the user has made an in-progress selection.
   useEffect(() => {
-    setLocaleCode(currentLocale ?? null)
+    if (!hasUserEditedSelection.current) {
+      setLocaleCode(currentLocale ?? null)
+    }
   }, [currentLocale])
 
   useEffect(() => {
-    setCurrencyCode(currentCurrency?.code ?? null)
+    if (!hasUserEditedSelection.current) {
+      setCurrencyCode(currentCurrency?.code ?? null)
+    }
   }, [currentCurrency?.code])
 
   // Build language options with disambiguation - returns Record<localeCode, languageName>
@@ -108,6 +115,7 @@ export function useBindingSelector(): UseBindingSelectorReturn {
   // Handle locale code change
   const handleSetLocaleCode = useCallback(
     (code: string) => {
+      hasUserEditedSelection.current = true
       setLocaleCode(code)
       setError(null)
 
@@ -136,6 +144,7 @@ export function useBindingSelector(): UseBindingSelectorReturn {
 
   // Handle currency code change
   const handleSetCurrencyCode = useCallback((code: string) => {
+    hasUserEditedSelection.current = true
     setCurrencyCode(code)
     setError(null)
   }, [])

--- a/packages/core/src/sdk/localization/useBindingSelector.ts
+++ b/packages/core/src/sdk/localization/useBindingSelector.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import storeConfig from '../../../discovery.config'
 import { buildRedirectUrl } from '../../utils/localization/bindingPaths'
@@ -76,6 +76,16 @@ export function useBindingSelector(): UseBindingSelectorReturn {
     () => currentCurrency?.code ?? null
   )
   const [error, setError] = useState<BindingSelectorError | null>(null)
+
+  // Sync selections when session resolves after initial render (e.g. stale session
+  // from a previous locale when navigating between locale-prefixed paths)
+  useEffect(() => {
+    setLocaleCode(currentLocale ?? null)
+  }, [currentLocale])
+
+  useEffect(() => {
+    setCurrencyCode(currentCurrency?.code ?? null)
+  }, [currentCurrency?.code])
 
   // Build language options with disambiguation - returns Record<localeCode, languageName>
   const languages = useMemo(


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale and currency syncing so session changes update the UI after initial load, while still respecting user edits.

* **New Features**
  * Closing the localization selector now restores session-backed locale and currency (a reset of selection state), ensuring consistent settings when the selector is dismissed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### What to test
**Localization Selector Language display** 

- access for example a locale path /it-IT, changes to English (en-US) and save it.
- try to access via url /it-IT. the selector language field should be "italiano".


https://github.com/user-attachments/assets/a6a4ec51-dd22-46cd-b1b8-885420b0236d


**Reset selection for unsaved changes**
- open the localization selector and select another language
- click outside the selector without saving the changes
- the language field should reset to the current language


https://github.com/user-attachments/assets/bba2750d-04c7-4589-ba7e-4a2536b5fbe1


Reference:
[Jira task](https://vtex-dev.atlassian.net/browse/SFS-3161?atlOrigin=eyJpIjoiODRlNjY5NjhiODc0NDBjMTk4MDY3MTgyYjZlOWY5YzYiLCJwIjoiaiJ9)