### PR TITLE
fix: PLP "Load more products" overwriting list instead of appending

### DIFF
--- a/packages/sdk/src/search/Provider.tsx
+++ b/packages/sdk/src/search/Provider.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from 'react'
-import React, { createContext, useEffect } from 'react'
+import React, { createContext, useEffect, useMemo } from 'react'
 
 import type { State as SearchState } from '../types'
 import {
@@ -43,9 +43,33 @@ export const Provider = ({
 
   useEffect(() => {
     globalSearchStateValue.setState(rest)
-    shouldResetInfiniteScroll &&
-      globalSearchStateValue.resetInfiniteScroll(rest.page ?? 0)
   }, [rest.term, rest.sort, rest.selectedFacets, rest.page])
+
+  // Stable, content-based key for the search "content" (term/sort/facets).
+  // `parseSearchState` produces a new `selectedFacets` array on every URL parse
+  // even when the content hasn't changed, so we cannot rely on referential
+  // equality to gate the infinite scroll reset.
+  const searchContentKey = useMemo(
+    () =>
+      JSON.stringify({
+        term: rest.term ?? null,
+        sort: rest.sort ?? null,
+        selectedFacets: rest.selectedFacets ?? [],
+      }),
+    [rest.term, rest.sort, rest.selectedFacets]
+  )
+
+  useEffect(() => {
+    if (shouldResetInfiniteScroll) {
+      globalSearchStateValue.resetInfiniteScroll(rest.page ?? 0)
+    }
+    // `rest.page` is intentionally excluded from deps: the reset must happen
+    // only when the search content (term/sort/facets) changes, not when the
+    // URL `?page=` changes alone (e.g., when the Sentinel reflects the page
+    // currently in viewport). The value read here is the latest at the moment
+    // the effect runs, which matches the intent.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchContentKey, shouldResetInfiniteScroll])
 
   return <>{children}</>
 }

--- a/packages/ui/src/components/organisms/ProductGrid/styles.scss
+++ b/packages/ui/src/components/organisms/ProductGrid/styles.scss
@@ -23,19 +23,17 @@
   grid-gap: var(--fs-product-grid-gap-mobile);
 
   @include utilities.media(">=tablet") {
-    $pagination-start-index: 2;
-
     grid-template-columns: repeat(var(--fs-product-grid-columns-desktop), 1fr);
     grid-gap: var(--fs-product-grid-gap-tablet);
-
-    &:nth-of-type(n + #{$pagination-start-index}) {
-      margin-top: var(--fs-product-grid-gap-desktop);
-    }
+    padding-bottom: var(--fs-product-grid-gap-tablet);
   }
 
-  @include utilities.media("<notebook") { padding-bottom: var(--fs-grid-gap-2); }
+  @include utilities.media("<notebook") {
+    padding-bottom: var(--fs-product-grid-gap-mobile);
+  }
 
   @include utilities.media(">=notebook") {
     grid-gap: var(--fs-product-grid-gap-desktop);
+    padding-bottom: var(--fs-product-grid-gap-desktop);
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

On a PLP, clicking "Load more products" was supposed to append the next 12 products below the existing 12. Instead, the new page **replaced** the current list, so the user kept seeing only 12 items.

Root cause: the `Provider` in `@faststore/sdk` was resetting the infinite-scroll `pages` array on **every** URL change reaching `<SearchProvider>`. Two converging conditions made it fire on a Sentinel-triggered URL update:

1. `parseSearchState` always returns a new `selectedFacets` array reference, even when the content is identical.
2. The `Sentinel` reflects the page in viewport into the URL via `router.replace('?page=N')`. That update bubbles back to the `Provider` via `asPath`, and the effect's referential deps fire, calling `resetInfiniteScroll(N)`, which collapses `pages` to `[N]`.

## How it works?

The `useEffect` in `packages/sdk/src/search/Provider.tsx` was split into two with different responsibilities:

- `setState(rest)` keeps running on any change to `term`, `sort`, `selectedFacets`, or `page` — preserving the search-context sync introduced in #3015.
- `resetInfiniteScroll` now runs only when the **content** of the search (`term` / `sort` / `selectedFacets`) changes, gated by a stable, content-based key built via `JSON.stringify`. Page-only URL updates no longer trigger a reset.

`rest.page` is intentionally excluded from the reset effect's deps. React closures still capture the latest value at the moment the effect runs, so when content actually changes (e.g., the user toggles a filter, which atomically also sets `page: 0`), the reset uses the correct page. An `eslint-disable` with a code comment documents the intent.

## How to test it?

Pre-conditions: any PLP with more than 12 products and "Load more products" enabled.

- Open a PLP, confirm the first 12 products render.
- Click **Load more products** , the next 12 products must be **appended** below the original 12 (24 in total). Repeat the click — 36, 48, and so on.
- Toggle a filter while having multiple pages stacked, the gallery must reset to the first page of the new filtered results.
- Change the **Sort** while having multiple pages stacked, same expected reset.
- Reload the page on a deep-link such as `/<plp>?page=2`, the gallery should open directly on page 2 (deep-link still works).
- Use the browser **Back / Forward** buttons after stacking pages, navigation works as usual.

### Starters Deploy Preview
[URL Preview with fix](https://sfj-4f851a9--storeframework.preview.vtex.app/office?category-1=office&fuzzy=0&operator=and&facets=category-1%2Cfuzzy%2Coperator&sort=score_desc&page=1)
<!-- TODO: add deploy preview URL once available -->

## References

- Jira ticket: [SFS-3162](https://vtex-dev.atlassian.net/browse/SFS-3162)
- #3015 (`fix: search update`) — introduced the dependency-array on the `Provider` effect that, combined with the `Sentinel`, caused the regression.


[SFS-3162]: https://vtex-dev.atlassian.net/browse/SFS-3162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable infinite-scroll reset so results reload consistently when search term, sort order, or filters change.
* **Style**
  * Improved product grid responsive spacing and bottom padding across mobile, tablet, notebook, and desktop breakpoints for more consistent layout and pagination spacing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3305)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->