### PR TITLE
fix: publish releases with pnpm to resolve workspace and catalog protocols

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Verify publish manifests
+        run: pnpm release:verify
+
       - name: Publish (main)
         if: github.ref_name == 'main'
         run: pnpm release

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
     "stylelint:fix": "stylelint \"**/*.scss\" --fix",
     "test": "turbo run test",
     "size": "turbo run size",
-    "release": "lerna version --conventional-commits --conventional-graduate --yes && lerna publish from-git --yes",
-    "release:dev": "lerna version --conventional-commits --conventional-prerelease --preid=dev --force-publish --yes && lerna publish from-git --dist-tag=dev --yes",
-    "release:v3": "lerna version --conventional-commits --yes && lerna publish from-git --dist-tag=v3-latest --yes",
+    "release": "lerna version --conventional-commits --conventional-graduate --yes && pnpm -r publish --access public --no-git-checks",
+    "release:dev": "lerna version --conventional-commits --conventional-prerelease --preid=dev --force-publish --yes && pnpm -r publish --access public --tag dev --no-git-checks",
+    "release:v3": "lerna version --conventional-commits --yes && pnpm -r publish --access public --tag v3-latest --no-git-checks",
+    "release:verify": "node ./scripts/verify-publish-manifests.mjs",
     "clean": "turbo run clean && rm -rf node_modules",
     "prepare": "husky"
   },

--- a/scripts/verify-publish-manifests.mjs
+++ b/scripts/verify-publish-manifests.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// Verifies that the package manifests we are about to publish do not contain
+// unresolved `workspace:` or `catalog:` protocols. These protocols are pnpm
+// workspace primitives that MUST be rewritten to concrete versions before a
+// package is uploaded to the npm registry. Publishing them as-is breaks
+// installation for any consumer outside of this monorepo.
+//
+// Strategy: pack every non-private package in `packages/*` with `pnpm pack`
+// (which is the same code path `pnpm publish` uses to produce the tarball)
+// and inspect the `package/package.json` entry inside each tarball.
+//
+// Exits with status 1 if any unresolved protocol is found, so it can be wired
+// into CI as a guard before the actual publish step.
+
+import { execFileSync } from 'node:child_process'
+import {
+  createReadStream,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createGunzip } from 'node:zlib'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const PACKAGES_DIR = join(ROOT, 'packages')
+
+const FORBIDDEN_PROTOCOLS = ['workspace:', 'catalog:']
+const DEP_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+]
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function listPublicPackages() {
+  return readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(PACKAGES_DIR, entry.name))
+    .filter((dir) => {
+      const pkgJsonPath = join(dir, 'package.json')
+      try {
+        const pkg = readJson(pkgJsonPath)
+        return !pkg.private && pkg.name
+      } catch {
+        return false
+      }
+    })
+}
+
+function pack(pkgDir, destination) {
+  try {
+    execFileSync('pnpm', ['pack', '--pack-destination', destination], {
+      cwd: pkgDir,
+      stdio: 'pipe',
+      encoding: 'utf8',
+    })
+  } catch (err) {
+    const stdout = err.stdout?.toString() ?? ''
+    const stderr = err.stderr?.toString() ?? ''
+    const message = (stderr || stdout).trim()
+    throw new Error(
+      `\`pnpm pack\` failed in ${pkgDir}.\n${message}\n\n` +
+        'Hint: this script requires dependencies to be installed. ' +
+        'Run `pnpm install` first.'
+    )
+  }
+}
+
+async function readManifestFromTarball(tarballPath) {
+  // Streaming gunzip + minimal tar parser, just enough to extract
+  // `package/package.json` without pulling extra deps.
+  const gunzip = createGunzip()
+  const stream = createReadStream(tarballPath).pipe(gunzip)
+
+  const chunks = []
+  for await (const chunk of stream) chunks.push(chunk)
+  const buffer = Buffer.concat(chunks)
+
+  let offset = 0
+  while (offset + 512 <= buffer.length) {
+    const header = buffer.subarray(offset, offset + 512)
+    const name = header.subarray(0, 100).toString('utf8').replace(/\0.*$/, '')
+    if (!name) break
+
+    const sizeStr = header
+      .subarray(124, 136)
+      .toString('utf8')
+      .replace(/\0.*$/, '')
+      .trim()
+    const size = Number.parseInt(sizeStr, 8) || 0
+    const blocks = Math.ceil(size / 512)
+    const dataStart = offset + 512
+
+    if (name === 'package/package.json') {
+      return buffer.subarray(dataStart, dataStart + size).toString('utf8')
+    }
+
+    offset = dataStart + blocks * 512
+  }
+
+  throw new Error(`package/package.json not found in ${tarballPath}`)
+}
+
+function findUnresolvedProtocols(manifest) {
+  const offenders = []
+  for (const field of DEP_FIELDS) {
+    const deps = manifest[field]
+    if (!deps) continue
+    for (const [name, version] of Object.entries(deps)) {
+      if (typeof version !== 'string') continue
+      if (FORBIDDEN_PROTOCOLS.some((p) => version.startsWith(p))) {
+        offenders.push({ field, name, version })
+      }
+    }
+  }
+  return offenders
+}
+
+async function main() {
+  const packages = listPublicPackages()
+  if (packages.length === 0) {
+    console.error('No public packages found under packages/.')
+    process.exit(1)
+  }
+
+  const stagingDir = mkdtempSync(join(tmpdir(), 'faststore-verify-'))
+  console.log(`Packing ${packages.length} package(s) into ${stagingDir}\n`)
+
+  let failed = false
+
+  try {
+    for (const pkgDir of packages) {
+      const pkg = readJson(join(pkgDir, 'package.json'))
+      process.stdout.write(`• ${pkg.name}@${pkg.version} ... `)
+
+      pack(pkgDir, stagingDir)
+
+      const tarballs = readdirSync(stagingDir).filter((f) => f.endsWith('.tgz'))
+      const matching = tarballs.find((f) =>
+        f.startsWith(`${pkg.name.replace('@', '').replace('/', '-')}-`)
+      )
+      if (!matching) {
+        console.log('FAIL')
+        console.error(`  No tarball produced for ${pkg.name}`)
+        failed = true
+        continue
+      }
+
+      const manifestRaw = await readManifestFromTarball(
+        join(stagingDir, matching)
+      )
+      const manifest = JSON.parse(manifestRaw)
+      const offenders = findUnresolvedProtocols(manifest)
+
+      if (offenders.length > 0) {
+        console.log('FAIL')
+        for (const { field, name, version } of offenders) {
+          console.error(`  ${field}.${name} = "${version}"`)
+        }
+        failed = true
+      } else {
+        console.log('OK')
+      }
+    }
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true })
+  }
+
+  if (failed) {
+    console.error(
+      '\nUnresolved workspace:/catalog: protocols would be published.\n' +
+        'Make sure release scripts use `pnpm -r publish` (not `lerna publish` /\n' +
+        '`npm publish`) so the protocols are rewritten before upload.'
+    )
+    process.exit(1)
+  }
+
+  console.log('\nAll publishable manifests are clean.')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- Replaces `lerna publish from-git` with `pnpm -r publish` in the release scripts so pnpm rewrites `workspace:*` and `catalog:` specifiers to concrete versions before uploading the tarballs to npm. `lerna version` is kept for bump, tag and changelog generation.
- Adds `pnpm release:verify`, a smoke test that packs every public `packages/*` with `pnpm pack` and inspects each tarball's `package.json` for unresolved `workspace:` or `catalog:` literals. Wired into `release.yml` before any publish step.

Closes #3307.

## Why

`@faststore/{cli,core,api,ui,components}@4.0.0` were published with literal `workspace:*` and `catalog:` in their dependencies, breaking installs outside the monorepo. Confirmed against the registry:

- `@faststore/cli@4.0.0` — `@faststore/api: workspace:*`, `@faststore/core: workspace:*`, plus 9+ `catalog:` entries.
- `@faststore/core@4.0.0` — 18 `catalog:` entries (`react`, `react-dom`, `next`, `graphql`, …).
- `@faststore/api@4.0.0` — 7 `catalog:` entries + `@faststore/diagnostics: workspace:*`.
- `@faststore/ui@4.0.0`, `@faststore/components@4.0.0` — `catalog:` for shared deps.

Root cause: `lerna publish` (regardless of `npmClient: "pnpm"` in `lerna.json`, which only affects install) delegates the actual upload to `npm publish`. `npm publish` does not know about pnpm's `catalog:` protocol and only rewrites `workspace:*` when the monorepo is declared via `workspaces` in the root `package.json` (which this repo does not — it uses `pnpm-workspace.yaml`). The regression was introduced in #3302 (v4) when the catalog migration landed without updating the publish pipeline.

## Changes

### `package.json`

```diff
-"release": "lerna version --conventional-commits --conventional-graduate --yes && lerna publish from-git --yes",
-"release:dev": "lerna version --conventional-commits --conventional-prerelease --preid=dev --force-publish --yes && lerna publish from-git --dist-tag=dev --yes",
-"release:v3": "lerna version --conventional-commits --yes && lerna publish from-git --dist-tag=v3-latest --yes",
+"release": "lerna version --conventional-commits --conventional-graduate --yes && pnpm -r publish --access public --no-git-checks",
+"release:dev": "lerna version --conventional-commits --conventional-prerelease --preid=dev --force-publish --yes && pnpm -r publish --access public --tag dev --no-git-checks",
+"release:v3": "lerna version --conventional-commits --yes && pnpm -r publish --access public --tag v3-latest --no-git-checks",
+"release:verify": "node ./scripts/verify-publish-manifests.mjs",
```

`pnpm -r publish` walks `packages/*`, skips private packages, runs the same `prepack` lifecycle that the previous flow did (so `oclif readme` etc. still execute), and rewrites `workspace:*` / `catalog:` while building each tarball. `--no-git-checks` is needed because `lerna version` already created the tag commit.

### `scripts/verify-publish-manifests.mjs`

Standalone Node script (no extra deps) that:

1. Iterates every non-private `packages/*/package.json`.
2. Runs `pnpm pack` per package into a temp dir.
3. Extracts `package/package.json` from each `.tgz` and walks `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`.
4. Fails with a clear, per-package report if any value starts with `workspace:` or `catalog:`.

### `.github/workflows/release.yml`

Added a `Verify publish manifests` step (running `pnpm release:verify`) right before the per-branch publish steps, so a regression to a non-resolving publish tool is caught before anything reaches npm.

## Test plan

- [x] `pnpm lint` — clean.
- [x] `pnpm release:verify` locally — passes for all 8 public packages on this branch.
- [x] Synthetic negative test of `findUnresolvedProtocols`: detects `workspace:*` and `catalog:` (named or bare) across all four dep fields.
- [ ] CD pipeline runs `Verify publish manifests` before publish on a future release.
- [ ] Once merged, cut a `4.0.1` (or `4.1.0-dev.x`) and confirm via `npm view @faststore/cli@<new> dependencies` that no `workspace:` / `catalog:` strings appear.

