### PR TITLE
fix: region slider section render

### DIFF
--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -23,12 +23,42 @@ interface Props {
   isInteractive?: boolean
 }
 
-const SECTIONS_OUT_OF_VIEWPORT = ['CartSidebar', 'RegionModal', 'RegionSlider']
+const REGION_SLIDER_SECTION_NAME = 'RegionSlider'
+
+const SECTIONS_OUT_OF_VIEWPORT = [
+  'CartSidebar',
+  'RegionModal',
+  REGION_SLIDER_SECTION_NAME,
+]
 
 /** Filter CMS metadata props so they are not passed to section components (and thus to the DOM). */
 function getSectionProps(data: Record<string, unknown>) {
   const { $componentKey: _key, $componentTitle: _title, ...sectionProps } = data
   return sectionProps
+}
+
+/**
+ * Ensure a RegionSlider section exists in the iteration. After PR #2961 the
+ * section was removed from `sections.json`, so CP-based stores (whose CP
+ * schemas were generated in PR #3071) and fresh hCMS stores no longer have it
+ * in their CMS content. The runtime still expects the section to flow through
+ * `RenderSections` so that `LazyLoadingSection` can gate the lazy import on
+ * `regionSlider.isOpen`. Inject the entry only if it is not already present in
+ * `sections` or `globalSections` to avoid double-rendering for legacy hCMS
+ * stores that have it persisted in their CMS.
+ */
+function withRegionSliderSection(
+  sections: Section[] | undefined,
+  globalSections: Section[] | undefined
+): Section[] {
+  const base = sections ?? []
+  const isPresent =
+    base.some(({ name }) => name === REGION_SLIDER_SECTION_NAME) ||
+    globalSections?.some(({ name }) => name === REGION_SLIDER_SECTION_NAME)
+
+  if (isPresent) return base
+
+  return [...base, { name: REGION_SLIDER_SECTION_NAME, data: {} }]
 }
 
 const Toast = dynamic(
@@ -156,6 +186,11 @@ function RenderSections({
     globalSections ?? sections
   )
 
+  const augmentedSections = useMemo(
+    () => withRegionSliderSection(sections, globalSections),
+    [sections, globalSections]
+  )
+
   const { isInteractive } = useTTI()
   const router = useRouter()
 
@@ -178,9 +213,9 @@ function RenderSections({
           isInteractive={isInteractive}
         />
       )}
-      {sections && sections.length > 0 && (
+      {augmentedSections.length > 0 && (
         <RenderSectionsBase
-          sections={sections}
+          sections={augmentedSections}
           components={components}
           isInteractive={isInteractive}
         />


### PR DESCRIPTION
## What's the purpose of this pull request?

The `RegionSlider` overlay no longer opens on stores that use **Content Platform** as their content source, even when *"Should enable global filter by pickup point"* is enabled in the CMS. The trigger button on `RegionBar` correctly dispatches `openRegionSlider(...)` and `useUI().regionSlider.isOpen` transitions to `true`, but no overlay appears in the DOM and no warning is logged.

The defect is the cumulative consequence of three correct-in-isolation changes that compose poorly:

1. **#2887 — Global filter by pickup point**: introduced `RegionSlider` as a global CMS section. The runtime in `RenderSections.tsx` started iterating the CMS-supplied `sections[]` array and mounting `RegionSlider` whenever a section with `name: "RegionSlider"` was present. Demo stores (`vendemo`, `storeframework`, `faststoreqa`) had the section saved into their hCMS content during this window.
2. **#2961 — fix: Remove `RegionSlider` section**: stripped the configurable props and then deleted the entire `{ name: "RegionSlider" }` block from `sections.json`, because the section had no editable per-page configuration. Stores that already had the section persisted in hCMS kept working (hCMS doesn't revalidate persisted content against the current schema), but the schema no longer offers it for new authoring.
3. **#3071 — chore: add content platform cms schemas**: generated the CP schemas from `sections.json` via `vtex content split-components`. Since `sections.json` had already been cleaned of `RegionSlider` 5 months earlier, the generator produced CP schemas without it. Every CP storefront created or migrated after this point — directly or transitively via `starter.store` — inherits this gap. The CP service strictly validates content entries against the uploaded schema, so no CP store can save the section.

**Impact matrix:**


| Content source                                                                            | Before this fix                          | After this fix         |
| ----------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------- |
| Content Platform, any state                                                               | Broken (trigger click is a silent no-op) | Works                  |
| hCMS, section persisted in pre-#2961 content (`vendemo`, `storeframework`, `faststoreqa`) | Works                                    | Works (no duplication) |
| hCMS, fresh store or content created after #2961                                          | Broken                                   | Works                  |


## How it works?

A small pure helper `withRegionSliderSection` is added inside `packages/core/src/components/cms/RenderSections.tsx`. It inspects the CMS-supplied `sections` and `globalSections` arrays and:

- Returns `sections` unchanged when **either** array already contains a `{ name: "RegionSlider" }` entry. This is the legacy hCMS path — the existing iteration mounts the component as it always has.
- Appends `{ name: "RegionSlider", data: {} }` to `sections` otherwise. This is the CP path and the fresh-hCMS path — the runtime guarantees the section without depending on the CMS schema.

The result is memoized as `augmentedSections` in `RenderSections` and replaces the original `sections` reference in the second `RenderSectionsBase` invocation. The injected entry then flows through the existing pipeline:

- `RenderSectionsBase` resolves the component via `components[name]`, so `CUSTOM_COMPONENTS.RegionSlider` and `PLUGINS_COMPONENTS.RegionSlider` overrides are honored unchanged.
- `LazyLoadingSection` keeps its existing `sectionName === 'RegionSlider' && regionSlider.isOpen && regionSlider.type !== 'none'` branch in `shouldLoad`. The chunk is therefore only downloaded when the shopper actually opens the slider (or after TTI, matching the bundle behavior of `CartSidebar` and `RegionModal`).
- `RegionSlider`'s internal `if (!isOpen) return null` self-gate remains the sole source of truth for visibility — no DOM is rendered when the overlay is closed.


## How to test it?

Set up a Content Platform-based storefront (you can use the one from the thread in the refs) and verify:

- Enable Delivery Promise:
  - In `discovery.config.js`, set `deliveryPromise: { enabled: true }`.
  - In the CMS global settings, enable *"Should enable global filter by pickup point"* (sets `filterByPickupPoint.enabled = true`).
- Open any page (home, PLP, PDP, search) and set a postal code.
- Click the **Filter by Store** button on the `RegionBar`.
  - Expected: the `RegionSlider` overlay opens with the configured title and pickup-point list.
- Close the overlay via the close button, `ESC`, or backdrop click.
  - Expected: the overlay closes, `regionSlider.isOpen` returns to `false`.

### Starters Deploy Preview



## References

- [Jira task](https://vtex-dev.atlassian.net/browse/SO-623)
- [Slack thread](https://vtex.slack.com/archives/C051B6LL91U/p1778608689625729)
- Original feature PR: [#2887 — Global filter by pickup point](https://github.com/vtex/faststore/pull/2887)
- Schema cleanup PR: [#2961 — fix: Remove `RegionSlider` section](https://github.com/vtex/faststore/pull/2961)
- CP schemas introduction PR: [#3071 — chore: add content platform cms schemas](https://github.com/vtex/faststore/pull/3071)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The region slider CMS section is now guaranteed to be consistently available across all CMS layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3318)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->