### PR TITLE
fix: region slider section render 3.x

### DIFF
--- a/packages/core/src/components/cms/RenderSections.tsx
+++ b/packages/core/src/components/cms/RenderSections.tsx
@@ -23,7 +23,37 @@ interface Props {
   isInteractive?: boolean
 }
 
-const SECTIONS_OUT_OF_VIEWPORT = ['CartSidebar', 'RegionModal', 'RegionSlider']
+const REGION_SLIDER_SECTION_NAME = 'RegionSlider'
+
+const SECTIONS_OUT_OF_VIEWPORT = [
+  'CartSidebar',
+  'RegionModal',
+  REGION_SLIDER_SECTION_NAME,
+]
+
+/**
+ * Ensure a RegionSlider section exists in the iteration. After PR #2961 the
+ * section was removed from `sections.json`, so CP-based stores (whose CP
+ * schemas were generated in PR #3071) and fresh hCMS stores no longer have it
+ * in their CMS content. The runtime still expects the section to flow through
+ * `RenderSections` so that `LazyLoadingSection` can gate the lazy import on
+ * `regionSlider.isOpen`. Inject the entry only if it is not already present in
+ * `sections` or `globalSections` to avoid double-rendering for legacy hCMS
+ * stores that have it persisted in their CMS.
+ */
+function withRegionSliderSection(
+  sections: Section[] | undefined,
+  globalSections: Section[] | undefined
+): Section[] {
+  const base = sections ?? []
+  const isPresent =
+    base.some(({ name }) => name === REGION_SLIDER_SECTION_NAME) ||
+    globalSections?.some(({ name }) => name === REGION_SLIDER_SECTION_NAME)
+
+  if (isPresent) return base
+
+  return [...base, { name: REGION_SLIDER_SECTION_NAME, data: {} }]
+}
 
 const Toast = dynamic(
   () => import(/* webpackChunkName: "Toast" */ '../common/Toast'),
@@ -148,6 +178,11 @@ function RenderSections({
     globalSections ?? sections
   )
 
+  const augmentedSections = useMemo(
+    () => withRegionSliderSection(sections, globalSections),
+    [sections, globalSections]
+  )
+
   const { isInteractive } = useTTI()
   const router = useRouter()
 
@@ -170,9 +205,9 @@ function RenderSections({
           isInteractive={isInteractive}
         />
       )}
-      {sections && sections.length > 0 && (
+      {augmentedSections.length > 0 && (
         <RenderSectionsBase
-          sections={sections}
+          sections={augmentedSections}
           components={components}
           isInteractive={isInteractive}
         />


### PR DESCRIPTION
Same fix made [here](https://github.com/vtex/faststore/pull/3318), but for the v3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Region Slider section is now automatically included in the CMS rendering system, ensuring it's always available for use even when not explicitly configured. Duplicate entries are prevented to maintain clean section management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3321)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->