### PR TITLE
fix: use starter.store 3.x branch in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           done
 
       - name: Clone starter
-        run: git clone https://github.com/vtex-sites/starter.store.git starter
+        run: git clone --branch 3.x --depth 1 https://github.com/vtex-sites/starter.store.git starter
 
       - name: Install specific Yarn version
         run: npm install -g yarn@1.22.19 # https://github.com/yarnpkg/yarn/issues/9015


### PR DESCRIPTION
## What's the purpose of this pull request?

The FastStore CI job on the `3.x` branch has been failing on the **Build starter** step since the `starter.store` repository was migrated to FastStore v4.

Our CI workflow clones `vtex-sites/starter.store` to run a real build against the starter. Since the clone has no branch ref, it picks up `main` — which is now on v4. As a result the v3 tarballs are never materialized, and `yarn build` fails. This blocks every PR targeting `3.x`.

To unblock CI on `3.x` we need to clone a v3-compatible starter. A dedicated `3.x` branch was created on `vtex-sites/starter.store`. This PR points the CI clone step to that branch.

## How to test it?

- Open this PR and confirm that the **FastStore** CI job (specifically the **Build starter** step) now passes against `3.x`.
- Re-run CI on a blocked PR targeting `3.x` (e.g. #3321) after this is merged + rebased on top — the same step should turn green there too.

## References

- `starter.store` v4 migration commit that broke CI on `3.x`: [vtex-sites/starter.store@d709f5b](https://github.com/vtex-sites/starter.store/commit/d709f5bb2af606628d3696a68c6c7737f1484b55)
- New frozen v3 branch tip: [vtex-sites/starter.store@8f8aa00 (branch `3.x`)](https://github.com/vtex-sites/starter.store/tree/3.x)
- PR currently blocked by the CI failure: #3321