### PR TITLE
fix: bypass refresh-token flow on localhost in 403 page and useRefreshToken hook

### DIFF
--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -10,6 +10,7 @@ import type { NextApiHandler, NextApiRequest } from 'next'
 import discoveryConfig from 'discovery.config'
 import { getJWTAutCookie } from 'src/utils/getCookie'
 import { getRequestHostname } from 'src/utils/getRequestHostname'
+import { isLocalHost } from 'src/utils/isLocalHost'
 import { shouldForceRefreshTokenForValidateSession } from 'src/utils/validateSessionRefreshToken'
 import { execute } from '../../server'
 
@@ -142,8 +143,7 @@ const handler: NextApiHandler = async (request, response) => {
     // value is used to cache bust the request if there is a VtexIdclientAutCookie
     const { operation, variables, query, v: value } = parseRequest(request)
 
-    const hostname = request.headers.host?.split(':')[0]
-    const isLocal = hostname === 'localhost' || hostname === '127.0.0.1'
+    const isLocal = isLocalHost(getRequestHostname(request.headers.host))
 
     if (
       !isLocal &&

--- a/packages/core/src/pages/pvt/account/403.tsx
+++ b/packages/core/src/pages/pvt/account/403.tsx
@@ -23,6 +23,8 @@ import { useRefreshToken } from 'src/sdk/account/useRefreshToken'
 import PageProvider from 'src/sdk/overrides/PageProvider'
 import { execute } from 'src/server'
 import { injectGlobalSections } from 'src/server/cms/global'
+import { getRequestHostname } from 'src/utils/getRequestHostname'
+import { isLocalHost } from 'src/utils/isLocalHost'
 import { withLocaleValidationSSR } from 'src/utils/localization/withLocaleValidation'
 import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
 
@@ -137,10 +139,18 @@ const getServerSidePropsBase: GetServerSideProps<
     const fromPage =
       typeof context.query.from === 'string' ? context.query.from : ''
 
+    // The refresh-token round-trip is unreachable from localhost (cross-origin
+    // POST that drops the `vid_rt` cookie), and forcing it would clear the
+    // manually injected `VtexIdclientAutCookie_<account>`. Render the static
+    // 403 view instead so developers can keep testing logged-in scenarios
+    // regardless of the `experimental.refreshToken` flag.
+    const isLocal = isLocalHost(getRequestHostname(context.req.headers.host))
+
     return {
       props: {
         globalSections: globalSectionsResult,
         needsRefreshToken:
+          !isLocal &&
           (statusCode === 401 || statusCode === 403) &&
           storeConfig.experimental?.refreshToken,
         fromPage,

--- a/packages/core/src/sdk/account/useRefreshToken.ts
+++ b/packages/core/src/sdk/account/useRefreshToken.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { isLocalHostBrowser } from 'src/utils/isLocalHost'
 import { logoutAndClearSession, sessionStore } from '../session'
 import { isRefreshTokenSuccessful, refreshTokenRequest } from './refreshToken'
 
@@ -11,6 +12,17 @@ export const useRefreshToken = (
   useEffect(() => {
     const handleRefreshTokenAndUpdateSession = async () => {
       if (!needsRefreshToken) return
+
+      // The refresh-token endpoint lives on the production origin and relies on
+      // the `vid_rt` cookie scoped to that origin. From localhost the request is
+      // cross-origin, so the cookie is not sent and the refresh always fails —
+      // which would also wipe the manually injected `VtexIdclientAutCookie_<account>`
+      // via `logoutAndClearSession`. Bail out and fall back to the static 403
+      // view so developers can keep testing logged-in flows.
+      if (isLocalHostBrowser()) {
+        setShouldShow403(true)
+        return
+      }
 
       const currentSession = sessionStore.read() ?? sessionStore.readInitial()
 

--- a/packages/core/src/sdk/session/index.ts
+++ b/packages/core/src/sdk/session/index.ts
@@ -8,6 +8,7 @@ import type {
   ValidateSessionMutationVariables,
 } from '@generated/graphql'
 import deepEqual from 'fast-deep-equal'
+import { isLocalHostBrowser } from 'src/utils/isLocalHost'
 import { filterChannel } from 'src/utils/utilities'
 import storeConfig from '../../../discovery.config'
 import {
@@ -20,11 +21,6 @@ import { getSettings } from '../localization/useLocalizationConfig'
 import { createValidationStore, useStore } from '../useStore'
 import { getPostalCode } from '../userLocation/index'
 import { RELOAD_AFTER_LOGOUT_KEY, SESSION_READY_KEY } from './storageKeys'
-
-const isLocalEnvironment = (): boolean =>
-  typeof window !== 'undefined' &&
-  (window.location.hostname === 'localhost' ||
-    window.location.hostname === '127.0.0.1')
 
 const isReloadAfterLogoutPending = (): boolean => {
   try {
@@ -129,7 +125,7 @@ export const validateSession = async (session: Session) => {
   // On failure (logoutAndClearSession already triggered), bail out.
   // Skipped in local environments where the refresh token infrastructure is unavailable.
   if (
-    !isLocalEnvironment() &&
+    !isLocalHostBrowser() &&
     storeConfig.experimental?.refreshToken &&
     isRefreshAfterExpired(session)
   ) {
@@ -200,7 +196,7 @@ export const validateSession = async (session: Session) => {
     return data.validateSession
   } catch (error) {
     const shouldRefreshToken =
-      !isLocalEnvironment() &&
+      !isLocalHostBrowser() &&
       error?.status === 401 &&
       storeConfig.experimental?.refreshToken
 

--- a/packages/core/src/utils/isLocalHost.ts
+++ b/packages/core/src/utils/isLocalHost.ts
@@ -1,0 +1,33 @@
+/**
+ * Hostnames that represent a local development environment.
+ *
+ * These are the only hosts where the FastStore app skips the refresh-token
+ * flow so developers can drive the app with a manually injected
+ * `VtexIdclientAutCookie_<account>` cookie regardless of feature flags.
+ */
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1'])
+
+/**
+ * Returns `true` when the given hostname corresponds to a local development
+ * environment (`localhost` / `127.0.0.1`).
+ *
+ * Refresh-token and other production-only flows MUST be bypassed on these
+ * hostnames so that developers can test logged-in scenarios with manually
+ * injected cookies, independent of any experimental flag.
+ *
+ * The input MUST be a bare hostname (no port). Use {@link getRequestHostname}
+ * on server-side request headers before calling this helper.
+ */
+export function isLocalHost(hostname: string | null | undefined): boolean {
+  if (!hostname) return false
+  return LOCAL_HOSTNAMES.has(hostname.toLowerCase())
+}
+
+/**
+ * Browser-side wrapper that reads `window.location.hostname`. Returns `false`
+ * when `window` is not available (SSR/Node).
+ */
+export function isLocalHostBrowser(): boolean {
+  if (typeof window === 'undefined') return false
+  return isLocalHost(window.location.hostname)
+}

--- a/packages/core/test/utils/isLocalHost.browser.test.ts
+++ b/packages/core/test/utils/isLocalHost.browser.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { isLocalHostBrowser } from '../../src/utils/isLocalHost'
+
+const originalLocation = window.location
+
+function stubHostname(hostname: string) {
+  // jsdom forbids assigning to `window.location` directly, so we redefine the
+  // descriptor with a minimal stub that exposes the hostname we want to test.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...originalLocation, hostname },
+  })
+}
+
+describe('isLocalHostBrowser', () => {
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('returns true when window.location.hostname is "localhost"', () => {
+    stubHostname('localhost')
+    expect(isLocalHostBrowser()).toBe(true)
+  })
+
+  it('returns true when window.location.hostname is "127.0.0.1"', () => {
+    stubHostname('127.0.0.1')
+    expect(isLocalHostBrowser()).toBe(true)
+  })
+
+  it('returns false for a production hostname', () => {
+    stubHostname('brandless.fast.store')
+    expect(isLocalHostBrowser()).toBe(false)
+  })
+})

--- a/packages/core/test/utils/isLocalHost.test.ts
+++ b/packages/core/test/utils/isLocalHost.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { isLocalHost } from '../../src/utils/isLocalHost'
+
+describe('isLocalHost', () => {
+  it('returns true for "localhost"', () => {
+    expect(isLocalHost('localhost')).toBe(true)
+  })
+
+  it('returns true for "127.0.0.1"', () => {
+    expect(isLocalHost('127.0.0.1')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isLocalHost('LOCALHOST')).toBe(true)
+    expect(isLocalHost('Localhost')).toBe(true)
+  })
+
+  it('returns false for a production hostname', () => {
+    expect(isLocalHost('brandless.fast.store')).toBe(false)
+  })
+
+  it('returns false for IPv6 loopback (not in the bypass list)', () => {
+    // We intentionally bypass only the two canonical local hosts. IPv6
+    // loopback (`::1`) and other loopback variants are out of scope.
+    expect(isLocalHost('::1')).toBe(false)
+  })
+
+  it('returns false for inputs that still carry a port', () => {
+    // Callers MUST normalize the hostname via getRequestHostname first.
+    expect(isLocalHost('localhost:3000')).toBe(false)
+  })
+
+  it('returns false for null/undefined/empty input', () => {
+    expect(isLocalHost(null)).toBe(false)
+    expect(isLocalHost(undefined)).toBe(false)
+    expect(isLocalHost('')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

When `experimental.refreshToken` is enabled in `discovery.config`, developers could not test logged-in flows on localhost by manually injecting the `VtexIdclientAutCookie_<account>` cookie. Any SSR query in `/pvt/account/*` that returned 401/403 redirected to `/pvt/account/403`, which then fired the `useRefreshToken` hook. That hook POSTs cross-origin to `${storeUrl}/api/vtexid/refreshtoken/webstore` — and from `localhost` the `vid_rt` cookie is not sent, so the request always fails and `logoutAndClearSession` wipes the manually injected auth cookie.

## Why

The expected behavior — and what was already partially implemented for `ValidateSession` in #3285 — is that on localhost the refresh-token flow should be a no-op so developers can drive logged-in flows with an injected `VtexIdclientAutCookie_<account>` cookie, **regardless of the `experimental.refreshToken` flag**. The bypass was missing in two paths:

- `useRefreshToken` (client hook called from `/pvt/account/403.tsx`)
- The `needsRefreshToken` decision in `/pvt/account/403.tsx` `getServerSideProps`

## How

- Adds a shared `isLocalHost` util (`packages/core/src/utils/isLocalHost.ts`) exposing:
  - `isLocalHost(hostname)`: pure helper, `true` for `localhost`/`127.0.0.1` (case-insensitive). Expects a normalized hostname (no port) — pairs with the existing `getRequestHostname` helper.
  - `isLocalHostBrowser()`: client-side wrapper that reads `window.location.hostname`.
- Refactors existing inline copies to use the shared util (no behavior change):
  - `src/sdk/session/index.ts` — drops the local `isLocalEnvironment` helper.
  - `src/pages/api/graphql.ts` — replaces the ad-hoc `host?.split(':')[0]` with `isLocalHost(getRequestHostname(...))`, picking up case/whitespace/port normalization for free.
- Closes the remaining gaps (real bug fix):
  - `src/sdk/account/useRefreshToken.ts` — bails out and shows the static 403 view on localhost instead of attempting the cross-origin refresh that would wipe the injected cookie.
  - `src/pages/pvt/account/403.tsx` — `getServerSideProps` now also requires `!isLocal` to set `needsRefreshToken: true`, providing defense in depth from SSR.

## Tests

- `test/utils/isLocalHost.test.ts` (node, 7 cases): `localhost`, `127.0.0.1`, case-insensitive, production hostnames, IPv6 loopback (out of scope), input still carrying a port (contract: caller must normalize), `null`/`undefined`/`''`.
- `test/utils/isLocalHost.browser.test.ts` (browser, 3 cases): stubs `window.location.hostname` to validate `isLocalHostBrowser` for `localhost`, `127.0.0.1` and a production hostname.
- Existing tests in `test/utils/validateSessionRefreshToken.test.ts` and `test/utils/getRequestHostname.test.ts` continue to pass.

```
 ✓ |node| test/utils/validateSessionRefreshToken.test.ts (6 tests)
 ✓ |node| test/utils/isLocalHost.test.ts (7 tests)
 ✓ |node| test/utils/getRequestHostname.test.ts (12 tests)
 ✓ |browser| test/utils/isLocalHost.browser.test.ts (3 tests)
```

## Test plan

- [ ] In a store with `experimental.refreshToken: true`, run `pnpm dev` and open `localhost:3000` with a valid `VtexIdclientAutCookie_<account>` cookie injected via DevTools.
- [ ] Navigate to `/pvt/account/profile`: page should load with the user data (cookie is honored, no redirect to `/403`).
- [ ] Manually expire/tamper with the cookie to force a 401 on the SSR profile query: the user lands on `/pvt/account/403` (static view) and the injected cookie remains in the browser (no `logoutAndClearSession` round-trip).
- [ ] Repeat with `experimental.refreshToken: false`: behavior on localhost must be identical (the flag is now a no-op on localhost).
- [ ] On a non-local hostname (e.g. CodeSandbox preview): the existing refresh-token flow must still trigger as before.

## Related

- Builds on #3285 (which bypassed refresh-token logic for `ValidateSession` in the SDK and `/api/graphql`) by extending the bypass to the only two remaining paths.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced a dedicated utility for detecting local development environments, consolidating localhost identification logic and improving consistency in how authentication is handled during local development across the application.

* **Tests**
  * Added comprehensive test coverage for localhost detection functionality in both server-side and browser-side contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3325)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->