### PR TITLE
chore: bump version to 4.1.1-dev.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.1.0-dev.10",
+  "version": "4.1.1-dev.0",
   "npmClient": "pnpm",
   "command": {
     "publish": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faststore/api",
-  "version": "4.1.0-dev.10",
+  "version": "4.1.1-dev.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "typings": "dist/src/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faststore/cli",
-  "version": "4.1.0-dev.10",
+  "version": "4.1.1-dev.0",
   "description": "FastStore CLI",
   "author": "Emerson Laurentino @emersonlaurentino",
   "type": "module",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faststore/components",
-  "version": "4.1.0-dev.10",
+  "version": "4.1.1-dev.0",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.mjs",
   "typings": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faststore/core",
-  "version": "4.1.0-dev.10",
+  "version": "4.1.1-dev.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/diagnostics/package.json
+++ b/packages/diagnostics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faststore/diagnostics",
-  "version": "4.1.0-dev.10",
+  "version": "4.1.1-dev.0",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faststore/lighthouse",
-  "version": "4.1.0-dev.10",
+  "version": "4.1.1-dev.0",
   "author": "Emerson Laurentino",
   "license": "MIT",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faststore/sdk",
-  "version": "4.1.0-dev.10",
+  "version": "4.1.1-dev.0",
   "description": "Hooks for creating your next component library",
   "license": "MIT",
   "repository": {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faststore/storybook",
-  "version": "4.1.0-dev.10",
+  "version": "4.1.1-dev.0",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faststore/ui",
-  "version": "4.1.0-dev.10",
+  "version": "4.1.1-dev.0",
   "description": "A lightweight, framework agnostic component library for React",
   "author": "emersonlaurentino",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Advances the `dev` prerelease cycle from `4.1.0-dev.10` to `4.1.1-dev.0` so the next CD publish targets the `4.1.1` patch line instead of incrementing to `4.1.0-dev.11`.
- Updates `lerna.json` and every `packages/*/package.json` (`api`, `cli`, `components`, `core`, `diagnostics`, `lighthouse`, `sdk`, `storybook`, `ui`) to the new version in lockstep with Lerna fixed mode.
- Internal cross-package references stay on `workspace:*` / `workspace:^`; pnpm substitutes the real version at publish time, so no other edits are needed.

## Why bypass `lerna version`?

The conventional `release:dev` flow (`lerna version --conventional-prerelease`) would only bump the prerelease counter (`4.1.0-dev.10` → `4.1.0-dev.11`). To jump the patch segment to `4.1.1` while staying in the `dev` prerelease cycle, we set the version explicitly.

## Test plan

- [ ] Confirm the diff only touches `lerna.json` and `packages/*/package.json` version fields.
- [ ] After merge, watch the `release.yml` run on `dev` and confirm the next publish is in the `4.1.1-dev.*` line.
- [ ] Verify on npm: `npm view @faststore/core dist-tags --json` reports `dev: 4.1.1-dev.*` for all 8 published packages.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions across all FastStore packages from 4.1.0-dev.10 to 4.1.1-dev.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->