### PR TITLE
fix(ui): use dvh for SlideOver height on mobile - SFS-3108

### DIFF
--- a/packages/ui/src/components/organisms/SlideOver/styles.scss
+++ b/packages/ui/src/components/organisms/SlideOver/styles.scss
@@ -32,6 +32,7 @@
 
   &:not([data-fs-slide-over-direction="bottomSide"]) {
     height: 100vh;
+    height: 100dvh;
   }
 
   &[data-fs-slide-over-size="full"] {


### PR DESCRIPTION
## What's the purpose of this pull request?

Fixes [SFS-3108](https://vtex-dev.atlassian.net/browse/SFS-3108) — the Locale Switcher (and other content rendered near the bottom of the `SlideOver`) was being cropped on a few mobile scenarios, notably on Chrome for mobile.

The root cause is the use of `height: 100vh` on the `SlideOver` container. On mobile, the `100vh` viewport unit does not account for the dynamic browser chrome (URL bar, navigation bar), so the SlideOver ends up taller than the actual visible viewport. As a result, items at the very bottom (such as the Locale Switcher) fall outside the screen and become invisible/unreachable.

## How it works?

In `packages/ui/src/components/organisms/SlideOver/styles.scss`, for the non-`bottomSide` directions, we now declare `height: 100dvh` right after the existing `height: 100vh`:

- `100vh` is kept as a fallback for browsers that do not support `dvh`.
- `100dvh` (dynamic viewport height) accounts for the visible viewport including dynamic browser chrome on mobile.

This is a CSS-only fix, no JS changes, no behavior change for desktop. The `bottomSide` direction is intentionally left untouched since it does not rely on full-viewport height.

## How to test it?

- Open a starter store on a mobile device (or DevTools mobile emulation with Chrome's mobile UI).
- Open any component that uses `SlideOver` (e.g. cart, filters, region modal, account menu).
- Confirm the Locale Switcher / bottom-most content is visible and not cropped by the browser bottom chrome.
- Confirm the desktop behavior is unchanged.

### Starters Deploy Preview

<!-- to be added after the CodeSandbox preview is generated -->

## References

- Jira: [SFS-3108](https://vtex-dev.atlassian.net/browse/SFS-3108)
- MDN — [dvh viewport unit](https://developer.mozilla.org/en-US/docs/Web/CSS/length#relative_length_units_based_on_viewport)

## Checklist

**PR Title and Commit Messages**

- [x] PR title and commit messages follow Conventional Commits (`fix(ui): ...`)

**PR Description**

- [x] Added context, root cause and verification steps

**Dependencies**

- [x] No dependency changes

**Documentation**

- [x] PR description

Made with [Cursor](https://cursor.com)

[SFS-3108]: https://vtex-dev.atlassian.net/browse/SFS-3108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFS-3108]: https://vtex-dev.atlassian.net/browse/SFS-3108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated SlideOver component height calculation to use dynamic viewport height for improved responsive behavior on non-bottom side variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->