### PR TITLE
fix: strip packageManager from generated .faststore/package.json

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -66,8 +66,7 @@ async function storeDev(
 
   runCommandSync({
     cmd: `${packageManager} predev`,
-    errorMessage:
-      'GraphQL was not optimized and TS files were not updated. Changes in the GraphQL layer did not take effect',
+    errorMessage: `The "predev" step ("${packageManager} predev") failed inside the ".faststore" directory. See the error output below for details.`,
     throws: 'error',
     cwd: tmpDir,
   })

--- a/packages/cli/src/utils/generate.test.ts
+++ b/packages/cli/src/utils/generate.test.ts
@@ -105,4 +105,18 @@ describe('buildFaststorePackageJson', () => {
 
     expect(input).toEqual(coreManifest)
   })
+
+  it('propagates the store `volta` config when provided', () => {
+    const volta = { node: '20.19.0', yarn: '1.19.1' }
+
+    const result = buildFaststorePackageJson(coreManifest, volta)
+
+    expect(result.volta).toEqual(volta)
+  })
+
+  it('omits `volta` when no config is provided', () => {
+    const result = buildFaststorePackageJson(coreManifest)
+
+    expect(result).not.toHaveProperty('volta')
+  })
 })

--- a/packages/cli/src/utils/generate.test.ts
+++ b/packages/cli/src/utils/generate.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { buildFaststorePackageJson } from './generate'
+
+describe('buildFaststorePackageJson', () => {
+  const coreManifest = {
+    name: '@faststore/core',
+    version: '4.1.2',
+    license: 'MIT',
+    browserslist: 'supports es6-module and not dead',
+    packageManager: 'pnpm@10.28.0',
+    exports: {
+      '.': './index.ts',
+      './api': './api/index.ts',
+    },
+    scripts: {
+      test: 'vitest run',
+      'test:e2e': 'cypress open',
+      generate: 'pnpm run gen-types && pnpm run cache-graphql ',
+    },
+    dependencies: {
+      next: '^16.0.0',
+      react: '^18.2.0',
+    },
+    devDependencies: {
+      vitest: 'catalog:',
+    },
+    engines: { node: '>=20' },
+    sideEffects: false,
+  }
+
+  it('strips the `packageManager` field so Yarn / Corepack do not mangle it in stores', () => {
+    const result = buildFaststorePackageJson(coreManifest)
+
+    expect(result).not.toHaveProperty('packageManager')
+  })
+
+  it('strips the `exports` field so it does not shadow @faststore/core resolution', () => {
+    const result = buildFaststorePackageJson(coreManifest)
+
+    expect(result).not.toHaveProperty('exports')
+  })
+
+  it('renames the package to `dot-faststore`', () => {
+    const result = buildFaststorePackageJson(coreManifest)
+
+    expect(result.name).toBe('dot-faststore')
+  })
+
+  it('overrides the scripts needed by the CLI on top of any pre-existing scripts', () => {
+    const result = buildFaststorePackageJson(coreManifest)
+
+    expect(result.scripts).toEqual({
+      'test:e2e': 'cypress open',
+      test: 'vitest run',
+      generate: 'faststore generate',
+      build: 'next build --webpack',
+      serve: 'next serve',
+      dev: 'next dev --webpack',
+      'dev-only': 'next dev --webpack',
+      predev: 'na run partytown',
+      prebuild: 'na run partytown',
+    })
+  })
+
+  it('preserves dependencies, devDependencies, engines and other metadata fields', () => {
+    const result = buildFaststorePackageJson(coreManifest)
+
+    expect(result.dependencies).toEqual(coreManifest.dependencies)
+    expect(result.devDependencies).toEqual(coreManifest.devDependencies)
+    expect(result.engines).toEqual(coreManifest.engines)
+    expect(result.version).toBe(coreManifest.version)
+    expect(result.license).toBe(coreManifest.license)
+    expect(result.browserslist).toBe(coreManifest.browserslist)
+    expect(result.sideEffects).toBe(false)
+  })
+
+  it('still injects the required scripts when the source manifest has no scripts entry', () => {
+    const { scripts: _, ...withoutScripts } = coreManifest
+
+    const result = buildFaststorePackageJson(withoutScripts)
+
+    expect(result.scripts).toEqual({
+      generate: 'faststore generate',
+      build: 'next build --webpack',
+      serve: 'next serve',
+      dev: 'next dev --webpack',
+      'dev-only': 'next dev --webpack',
+      predev: 'na run partytown',
+      prebuild: 'na run partytown',
+    })
+  })
+
+  it('omits `packageManager` from the output even when it is absent from the source', () => {
+    const { packageManager: _, ...withoutPackageManager } = coreManifest
+
+    const result = buildFaststorePackageJson(withoutPackageManager)
+
+    expect(result).not.toHaveProperty('packageManager')
+  })
+
+  it('does not mutate the input manifest', () => {
+    const input = structuredClone(coreManifest)
+
+    buildFaststorePackageJson(input)
+
+    expect(input).toEqual(coreManifest)
+  })
+})

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -57,6 +57,39 @@ function createTmpFolder(basePath: string) {
 }
 
 /**
+ * Builds the `.faststore/package.json` from `@faststore/core`'s manifest.
+ * Strips `exports` and `packageManager` (the latter is pinned to pnpm and
+ * breaks Yarn/Corepack on consumer stores).
+ */
+export function buildFaststorePackageJson(
+  coreManifest: Record<string, unknown>
+): Record<string, unknown> {
+  const {
+    exports: _exports,
+    packageManager: _packageManager,
+    ...rest
+  } = coreManifest
+
+  const existingScripts =
+    (rest.scripts as Record<string, string> | undefined) ?? {}
+
+  return {
+    ...rest,
+    name: 'dot-faststore',
+    scripts: {
+      ...existingScripts,
+      generate: 'faststore generate',
+      build: 'next build --webpack',
+      serve: 'next serve',
+      dev: 'next dev --webpack',
+      'dev-only': 'next dev --webpack',
+      predev: 'na run partytown',
+      prebuild: 'na run partytown',
+    },
+  }
+}
+
+/**
  * Prevents imports from @faststore/core from randomly conflicting
  * where sometimes the package.json from the .faststore folder
  * took precedence over @faststore/core's package.json.
@@ -64,21 +97,11 @@ function createTmpFolder(basePath: string) {
 function filterAndCopyPackageJson(basePath: string) {
   const { coreDir, tmpDir } = withBasePath(basePath)
 
-  const { exports: _, ...filteredFileContent } = JSON.parse(
+  const coreManifest = JSON.parse(
     readFileSync(path.join(coreDir, 'package.json'), 'utf8')
   )
 
-  filteredFileContent.name = 'dot-faststore'
-  filteredFileContent.scripts = {
-    ...filteredFileContent.scripts,
-    generate: 'faststore generate',
-    build: 'next build --webpack',
-    serve: 'next serve',
-    dev: 'next dev --webpack',
-    'dev-only': 'next dev --webpack',
-    predev: 'na run partytown',
-    prebuild: 'na run partytown',
-  }
+  const filteredFileContent = buildFaststorePackageJson(coreManifest)
 
   writeJsonSync(path.join(tmpDir, 'package.json'), filteredFileContent, {
     spaces: 2,

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -60,9 +60,15 @@ function createTmpFolder(basePath: string) {
  * Builds the `.faststore/package.json` from `@faststore/core`'s manifest.
  * Strips `exports` and `packageManager` (the latter is pinned to pnpm and
  * breaks Yarn/Corepack on consumer stores).
+ *
+ * Propagates the store's `volta` config (when present) so Volta pins the same
+ * Node/Yarn versions inside `.faststore`. Volta stops at the nearest
+ * `package.json` and would otherwise fall back to a global Yarn Berry, which
+ * breaks on the nested manifest.
  */
 export function buildFaststorePackageJson(
-  coreManifest: Record<string, unknown>
+  coreManifest: Record<string, unknown>,
+  voltaConfig?: Record<string, unknown>
 ): Record<string, unknown> {
   const {
     exports: _exports,
@@ -76,6 +82,7 @@ export function buildFaststorePackageJson(
   return {
     ...rest,
     name: 'dot-faststore',
+    ...(voltaConfig ? { volta: voltaConfig } : {}),
     scripts: {
       ...existingScripts,
       generate: 'faststore generate',
@@ -90,18 +97,46 @@ export function buildFaststorePackageJson(
 }
 
 /**
+ * Reads the `volta` config from the store root `package.json`, if present.
+ * Returns `undefined` when the file or the field is missing so the generated
+ * manifest stays untouched for stores that do not use Volta.
+ */
+function readRootVoltaConfig(
+  rootDir: string
+): Record<string, unknown> | undefined {
+  try {
+    const rootManifestPath = path.join(rootDir, 'package.json')
+
+    if (!existsSync(rootManifestPath)) {
+      return undefined
+    }
+
+    const rootManifest = JSON.parse(readFileSync(rootManifestPath, 'utf8'))
+
+    return rootManifest?.volta
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Prevents imports from @faststore/core from randomly conflicting
  * where sometimes the package.json from the .faststore folder
  * took precedence over @faststore/core's package.json.
  */
 function filterAndCopyPackageJson(basePath: string) {
-  const { coreDir, tmpDir } = withBasePath(basePath)
+  const { coreDir, tmpDir, getRoot } = withBasePath(basePath)
 
   const coreManifest = JSON.parse(
     readFileSync(path.join(coreDir, 'package.json'), 'utf8')
   )
 
-  const filteredFileContent = buildFaststorePackageJson(coreManifest)
+  const voltaConfig = readRootVoltaConfig(getRoot())
+
+  const filteredFileContent = buildFaststorePackageJson(
+    coreManifest,
+    voltaConfig
+  )
 
   writeJsonSync(path.join(tmpDir, 'package.json'), filteredFileContent, {
     spaces: 2,

--- a/packages/cli/src/utils/runCommandSync.ts
+++ b/packages/cli/src/utils/runCommandSync.ts
@@ -8,19 +8,17 @@ type ExecSyncError = (ExecException & ChildProcess) | undefined
 const showError = ({
   message,
   cmd,
-  error,
+  output,
 }: {
   message: string
   cmd: string
-  error: ExecSyncError
+  output?: string
 }) => {
   logger.error(`${chalk.red('error')} - ${message}`)
 
-  if (cmd && error) {
-    logger.log(
-      `${chalk.magenta('DEBUG')} - $ ${JSON.stringify(cmd, null, 2)} error root ↓`
-    )
-    logger.log(error.stdout?.toString())
+  if (cmd && output) {
+    logger.log(`${chalk.magenta('DEBUG')} - $ ${JSON.stringify(cmd)} error ↓`)
+    logger.log(output)
   }
 
   process.exit(1)
@@ -29,19 +27,17 @@ const showError = ({
 const showWarning = ({
   message,
   cmd,
-  error,
+  output,
 }: {
   message: string
   cmd: string
-  error: ExecSyncError
+  output?: string
 }) => {
   logger.warn(`${chalk.yellow('warn')} - ${message}`)
 
-  if (cmd && error) {
-    logger.log(
-      `${chalk.magenta('DEBUG')} - $ ${JSON.stringify(cmd, null, 2)} warn root ↓`
-    )
-    logger.log(error.stdout?.toString())
+  if (cmd && output) {
+    logger.log(`${chalk.magenta('DEBUG')} - $ ${JSON.stringify(cmd)} warn ↓`)
+    logger.log(output)
   }
 }
 
@@ -71,12 +67,18 @@ export const runCommandSync = ({
     logger.log(`[STATUS] ${res?.toString() ?? 'Unknown'}`)
     logger.log(`[FINISHED] ${cmd}`)
   } catch (error) {
-    const sanitizedError = debug ? (error as ExecSyncError) : undefined
+    const execError = error as ExecSyncError
+    // Always surface the tool's own output (stdout+stderr are merged via 2>&1)
+    // so store devs see the real root cause instead of only the generic message.
+    const output =
+      execError?.stdout?.toString() ||
+      execError?.stderr?.toString() ||
+      undefined
 
     if (throws === 'warning') {
-      showWarning({ message: errorMessage, cmd, error: sanitizedError })
+      showWarning({ message: errorMessage, cmd, output })
     } else {
-      showError({ message: errorMessage, cmd, error: sanitizedError })
+      showError({ message: errorMessage, cmd, output })
     }
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes a class of issues where the generated `<store>/.faststore/package.json` breaks local dev on consumer stores, depending on the package manager / version manager the developer uses.

There are two distinct root causes, both stemming from how `.faststore/package.json` is generated from `@faststore/core`'s manifest:

1. **`packageManager` leak (Corepack / Yarn Berry).** `@faststore/core`'s `package.json` declares `"packageManager": "pnpm@10.28.0"`. The CLI's `filterAndCopyPackageJson` only stripped `exports`, so this field leaked into `.faststore/package.json`. Stores running Yarn against `.faststore/` (via `yarn predev`, `yarn dev-only`, `yarn build`, etc.) trip Corepack / Yarn Berry, which either refuses to run or mangles the field into invalid strings like `yarn@pnpm@10.28.0`.

2. **Missing `volta` pin (Volta resolves the wrong Yarn).** Volta determines tool versions by walking up to the **nearest** `package.json` and stops there — it does not keep climbing to inherit a parent's `volta` config (that requires an explicit `volta.extends`). Since the generated `.faststore/package.json` had no `volta` field, Volta users running anything inside `.faststore/` (the `predev` step runs with `cwd = .faststore`) fell back to their global Yarn — typically Yarn Berry (4.x) — instead of the version pinned at the store root. Yarn Berry then errors on the nested manifest:

   > Usage Error: The nearest package directory (.../.faststore) doesn't seem to be part of the project declared in ...

On top of that, this failure was hard to diagnose: the `predev` error message was a copy-paste from the GraphQL codegen step (mentioning GraphQL/TS, which is unrelated), and `runCommandSync` only surfaced the underlying tool output when `DISCOVERY_DEBUG=true`, so store devs only ever saw a generic, misleading message.

## How it works?

**Manifest generation (`packages/cli/src/utils/generate.ts`)**

- Extracts the filtering logic of `filterAndCopyPackageJson` into a pure helper `buildFaststorePackageJson(coreManifest, voltaConfig?)`.
- The helper strips `packageManager` and `exports`, renames the package to `dot-faststore`, and merges in the CLI-required scripts.
- Adds `readRootVoltaConfig(rootDir)`, which reads the `volta` field from the **store root** `package.json` (when present) and returns `undefined` otherwise, so stores that don't use Volta are unaffected.
- `filterAndCopyPackageJson` now resolves the store root via `withBasePath(...).getRoot()`, reads its `volta` config, and forwards it to the helper, which injects it into `.faststore/package.json`. This keeps Volta pinned to the same Node/Yarn the store root declares.

**Surfacing the real error (`packages/cli/src/utils/runCommandSync.ts`)**

- On failure, the tool's own output (stdout/stderr, already merged via `2>&1`) is now **always** shown — not only under `DISCOVERY_DEBUG`. This means store devs see the actual root cause (e.g. the Yarn Berry message, which itself lists the possible fixes).

**Clearer `predev` message (`packages/cli/src/commands/dev.ts`)**

- Replaces the misleading GraphQL/TS message (duplicated from `generate-graphql.ts`) with a concise one that states which step failed and where, deferring details to the now-visible underlying output:

  > The "predev" step ("<pm> predev") failed inside the ".faststore" directory. See the error output below for details.

## Tests

- `packages/cli/src/utils/generate.test.ts`: existing coverage for stripping `packageManager`/`exports`, the `dot-faststore` rename, scripts merging, metadata preservation and input immutability; plus new cases asserting the store `volta` config is propagated when provided and omitted when absent.