### PR TITLE
chore: CI remove canary-v2 branch pin from starter clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           done
 
       - name: Clone starter
-        run: git clone -b canary-v2 https://github.com/vtex-sites/starter.store.git starter
+        run: git clone https://github.com/vtex-sites/starter.store.git starter
 
       - name: Install specific Yarn version
         run: npm install -g yarn@1.22.19 # https://github.com/yarnpkg/yarn/issues/9015


### PR DESCRIPTION
## What's the purpose of this pull request?

Stop pinning the CI starter clone to canary-v2. That branch is already on main, so the workflow can clone starter.store from the default branch.