### PR TITLE
feat(core): /llms.txt and /llms-full.txt PoC

### DIFF
--- a/docs/llms-txt/handoff.html
+++ b/docs/llms-txt/handoff.html
@@ -1,0 +1,437 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>llms.txt for FastStore — PR handoff</title>
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            paper: '#FAFAFA',
+            ink: '#0A0A0A',
+            pink: { DEFAULT: '#F8C8D8', soft: '#FDE7EE' },
+            mint: '#C8E6D0',
+            butter: '#FCE8B2',
+            blush: '#F5C2C2',
+            gray: {
+              100: '#F2F2F2',
+              300: '#D6D6D6',
+              500: '#8A8A8A',
+              700: '#3A3A3A',
+            },
+          },
+          fontFamily: {
+            serif: ['ui-serif', 'Georgia', "'Times New Roman'", 'serif'],
+            sans:  ['system-ui', '-apple-system', "'Segoe UI'", 'Roboto', 'sans-serif'],
+            mono:  ['ui-monospace', "'SF Mono'", 'Menlo', 'Monaco', 'monospace'],
+          },
+          fontSize: {
+            base: ['14.5px', { lineHeight: '1.6' }],
+            sm:   ['13.5px', { lineHeight: '1.55' }],
+            xs:   ['12px',   { lineHeight: '1.5' }],
+          },
+          maxWidth: { page: '1120px' },
+        },
+      },
+    };
+  </script>
+
+  <link rel="stylesheet" href="file:///Users/marcosoliveira/.claude/skills/to-html/template/to-html.css" />
+  <script src="file:///Users/marcosoliveira/.claude/skills/to-html/template/to-html.js"></script>
+
+  <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.x.x/dist/cdn.min.js"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+
+  <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.10.0/build/highlight.min.js"></script>
+</head>
+<body class="bg-paper font-sans">
+  <main class="th-body max-w-page mx-auto px-8 py-14 pb-32" x-data="jumpFlash">
+
+    <header class="mb-12 max-w-[820px]">
+      <div class="uppercase tracking-widest text-xs text-gray-500 mb-3">PR handoff · FastStore · @faststore/core</div>
+      <h1 class="th-h1 mb-4">llms.txt for FastStore</h1>
+      <p class="th-lede mb-5">Research, benchmark, and PoC plan for serving a curated <code>/llms.txt</code> from the FastStore core, with all open questions logged for reviewers.</p>
+      <div class="flex flex-wrap gap-2 items-center mb-4">
+        <span class="th-tag">branch · feat/llms-txt-poc</span>
+        <span class="th-tag th-tag-mute">date · 2026-05-20</span>
+        <span class="th-tag th-tag-mute">package · @faststore/core</span>
+        <span class="th-tag th-tag-happy">status · investigation complete</span>
+      </div>
+      <nav class="th-prompt-box">
+        <span class="th-prompt-label">Jump to</span>
+        <a data-th-jump href="#s01" class="underline mr-3">01 TL;DR</a>
+        <a data-th-jump href="#s02" class="underline mr-3">02 Why / why not</a>
+        <a data-th-jump href="#s03" class="underline mr-3">03 Spec</a>
+        <a data-th-jump href="#s04" class="underline mr-3">04 Benchmark</a>
+        <a data-th-jump href="#s05" class="underline mr-3">05 Crawler reality</a>
+        <a data-th-jump href="#s06" class="underline mr-3">06 FastStore today</a>
+        <a data-th-jump href="#s07" class="underline mr-3">07 Decisions</a>
+        <a data-th-jump href="#s08" class="underline mr-3">08 Open questions</a>
+        <a data-th-jump href="#s09" class="underline mr-3">09 Risks</a>
+        <a data-th-jump href="#s10" class="underline">10 Artifacts &amp; sources</a>
+      </nav>
+    </header>
+
+    <!-- Summary strip -->
+    <div class="th-summary mb-16">
+      <div class="th-cell"><div class="th-k">Scope v1</div><div class="th-v">Single <code>/llms.txt</code></div></div>
+      <div class="th-cell"><div class="th-k">Source of truth</div><div class="th-v">Dynamic (build/request)</div></div>
+      <div class="th-cell"><div class="th-k">Default state</div><div class="th-v th-v-accent">opt-in</div></div>
+      <div class="th-cell"><div class="th-k">Blocker</div><div class="th-v">Edge proxy check</div></div>
+    </div>
+
+    <!-- 01 — TL;DR -->
+    <section id="s01" class="th-section">
+      <div class="th-sec-head">
+        <span class="th-sec-num">01</span>
+        <h2 class="th-h2">TL;DR</h2>
+      </div>
+      <div class="th-callout-good">
+        <ul class="th-stack-tight">
+          <li><code>llms.txt</code> is a 2024 proposal by Jeremy Howard (Answer.AI): a curated Markdown index at <code>/llms.txt</code>, sized for small LLM context windows.</li>
+          <li>As of May 2026 the spec is widely adopted in <strong>technical documentation</strong> (Anthropic, Stripe, Vercel, Cloudflare, Mintlify, Cursor) and largely <strong>ignored by general web crawlers</strong>. Google publicly declined; GPTBot / ClaudeBot / PerplexityBot show no consistent fetch behavior in audits.</li>
+          <li>For e-commerce, consensus says: <strong>do not dump the SKU catalog</strong>. Expose brand, top categories, policies, FAQ, contact. Keep the file small and curated.</li>
+          <li>We picked the smallest sensible scope for FastStore v1: a single, build-time-dynamic <code>/llms.txt</code> at the root. No per-page <code>.md</code>, no <code>llms-full.txt</code>. Feature-flagged.</li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- 02 — Why bother / why skeptical -->
+    <section id="s02" class="th-section">
+      <div class="th-sec-head">
+        <span class="th-sec-num">02</span>
+        <h2 class="th-h2">Why bother (and why be skeptical)</h2>
+      </div>
+      <p class="th-sec-intro">Net call: ship it, keep it cheap, do not over-invest until a major provider commits.</p>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+        <div class="th-callout-good">
+          <h3 class="th-h3 mb-2">Pro</h3>
+          <ul class="th-stack-tight">
+            <li>Cost is near-zero once the pipeline exists.</li>
+            <li>Forces an editorial inventory of what the store wants AI to cite.</li>
+            <li>Coding agents (Cursor, Claude Code, Windsurf) demonstrably fetch <code>llms.txt</code> for libraries. The same mechanism may extend to commerce agents (Rufus, Perplexity Shopping, ChatGPT shopping) as those tools mature.</li>
+            <li>Easier to ship now than retrofit when (if) a provider commits.</li>
+          </ul>
+        </div>
+        <div class="th-callout-warn">
+          <h3 class="th-h3 mb-2">Con</h3>
+          <ul class="th-stack-tight">
+            <li>No measurable lift in AI citations in published studies through late 2025.</li>
+            <li>Redundant with <code>sitemap.xml</code> + clean HTML + Schema.org for crawlers that already index the public web.</li>
+            <li>Risk of stale content if the file isn't generated dynamically.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- 03 — Spec summary -->
+    <section id="s03" class="th-section">
+      <div class="th-sec-head">
+        <span class="th-sec-num">03</span>
+        <h2 class="th-h2">Spec summary</h2>
+      </div>
+      <p class="th-sec-intro">From <a href="https://llmstxt.org/" class="underline">llmstxt.org</a>. Required surface is small; the rest is convention.</p>
+
+      <div class="th-subsection">
+        <ul class="th-stack-tight">
+          <li><strong>Location.</strong> <code>/llms.txt</code> at site root.</li>
+          <li><strong>Format.</strong> Markdown. Served as <code>text/markdown</code> (or <code>text/plain</code>).</li>
+          <li><strong>Required.</strong> A single <code>#</code> H1 title.</li>
+          <li><strong>Recommended.</strong> A <code>&gt;</code> blockquote one-line summary, then free-form context paragraphs, then <code>##</code> section headers each containing a list of <code>[name](url): description</code> links.</li>
+          <li><strong>Reserved.</strong> A <code>## Optional</code> section that ingestion tools may skip when context is tight.</li>
+          <li><strong>Companion (de facto).</strong> Each HTML page also reachable as Markdown — either at <code>&lt;url&gt;.md</code> or via <code>Accept: text/markdown</code> content negotiation.</li>
+        </ul>
+      </div>
+
+      <div class="th-subsection">
+        <h3 class="th-h3">llms.txt vs llms-full.txt</h3>
+        <div class="th-table-wrap">
+          <table class="th-table">
+            <thead>
+              <tr><th></th><th><code>llms.txt</code></th><th><code>llms-full.txt</code></th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Purpose</td><td>Curated index, pointers</td><td>Full content dump for ingestion / RAG</td></tr>
+              <tr><td>Size</td><td>Small (fits a context window)</td><td>Can be huge (Anthropic's is millions of tokens)</td></tr>
+              <tr><td>Audience</td><td>Agents fetching at runtime</td><td>Bulk ingestion pipelines</td></tr>
+              <tr><td>Freshness need</td><td>High</td><td>Lower</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="mt-3">We are shipping only <code>llms.txt</code> for now. <code>llms-full.txt</code> doesn't make sense for a live commerce catalog and the ingestion-side value for commerce is unproven.</p>
+      </div>
+    </section>
+
+    <!-- 04 — Benchmark -->
+    <section id="s04" class="th-section">
+      <div class="th-sec-head">
+        <span class="th-sec-num">04</span>
+        <h2 class="th-h2">Benchmark — who is doing this, and how</h2>
+      </div>
+
+      <div class="th-subsection">
+        <div class="th-table-wrap">
+          <table class="th-table">
+            <thead>
+              <tr><th>Org</th><th>Pattern</th><th>What's interesting</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Anthropic</td>
+                <td><code>llms.txt</code> + <code>llms-full.txt</code> + per-page <code>.md</code></td>
+                <td>The reference implementation. <code>llms-full.txt</code> is a single concatenated dump.</td>
+              </tr>
+              <tr>
+                <td>Stripe</td>
+                <td>Curated catalog by product vertical</td>
+                <td>Sections per product (Payments, Connect, Billing) instead of one flat list.</td>
+              </tr>
+              <tr>
+                <td>Vercel</td>
+                <td><code>llms.txt</code> + per-page <code>.md</code> via content negotiation</td>
+                <td>Same URL serves HTML or Markdown depending on <code>Accept</code>.</td>
+              </tr>
+              <tr>
+                <td>Cloudflare</td>
+                <td>Per-product catalog, similar to Stripe</td>
+                <td>Heavy use of <code>## Optional</code> to defer ancillary pages.</td>
+              </tr>
+              <tr>
+                <td>Mintlify</td>
+                <td>Auto-generated for every hosted docs site (Nov 2024)</td>
+                <td>This is why most "adopters" are docs sites — Mintlify ships it by default.</td>
+              </tr>
+              <tr>
+                <td>Cursor / Windsurf</td>
+                <td>Focused workflow (small <code>llms.txt</code>)</td>
+                <td>Slim, opinionated, points only at canonical references.</td>
+              </tr>
+              <tr>
+                <td>Supabase, LangGraph, Bolt</td>
+                <td>Similar to Vercel</td>
+                <td>Standard docs pattern.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="th-subsection">
+        <h3 class="th-h3">E-commerce specific reading</h3>
+        <p>There are blog posts (Kiwi Commerce, Stryde, Goodie, tngshopper, Shero) recommending <code>llms.txt</code> for DTC brands. None publish convincing measurement of lift. Their structural recommendations converge:</p>
+        <ol class="list-decimal pl-6 th-stack-tight marker:text-pink marker:font-mono text-sm mt-3">
+          <li>Brand summary at the top.</li>
+          <li>Top-level categories only — not leaves, not SKUs.</li>
+          <li>Policies (shipping, returns, warranty, privacy, terms).</li>
+          <li>FAQ / size guides / customer service.</li>
+          <li>About / contact.</li>
+          <li>Rely on Schema.org Product JSON-LD (already present in FastStore PDP) for product-level signal — not <code>llms.txt</code>.</li>
+        </ol>
+        <p class="mt-3">This matches the scope we picked.</p>
+      </div>
+    </section>
+
+    <!-- 05 — Crawler reality check -->
+    <section id="s05" class="th-section">
+      <div class="th-sec-head">
+        <span class="th-sec-num">05</span>
+        <h2 class="th-h2">Crawler reality check (May 2026)</h2>
+      </div>
+
+      <div class="th-callout-warn">
+        <ul class="th-stack-tight">
+          <li><strong>Google</strong> (Search Central Live, Jul 2025): does not support <code>llms.txt</code>, no plans to.</li>
+          <li><strong>GPTBot, ClaudeBot, PerplexityBot</strong>: audits through Oct 2025 show no consistent fetch of <code>/llms.txt</code>. Sporadic GPTBot hits, no commitment.</li>
+          <li><strong>Coding assistants</strong> (Cursor, Claude Code, Windsurf, Continue): do fetch on demand. Measurable value here, but for library docs — not for commerce.</li>
+          <li><strong>Discovery</strong>: no standardized mechanism. Crawlers must guess <code>/llms.txt</code>. <code>robots.txt</code> does not reference it.</li>
+        </ul>
+      </div>
+      <p class="mt-4">What this means for FastStore: the immediate upside is low. The bet is option value if/when shopping-oriented agents adopt the convention.</p>
+    </section>
+
+    <!-- 06 — FastStore today -->
+    <section id="s06" class="th-section">
+      <div class="th-sec-head">
+        <span class="th-sec-num">06</span>
+        <h2 class="th-h2">What FastStore looks like today</h2>
+      </div>
+      <p class="th-sec-intro">Findings from <code>packages/core</code>.</p>
+
+      <ul class="th-stack-tight">
+        <li>Next.js Pages Router. PDP is <code>src/pages/[slug]/p.tsx</code> with <code>getStaticProps</code> and <code>ProductJsonLd</code> / <code>BreadcrumbJsonLd</code>. Search at <code>src/pages/s.tsx</code>. CMS catch-all at <code>src/pages/[...slug].tsx</code>.</li>
+        <li>API routes in <code>src/pages/api/fs/</code> (only <code>logout.ts</code>, <code>graphql.ts</code>, <code>preview.ts</code> today).</li>
+        <li><code>public/</code> contains only favicon / logo / icons. No <code>robots.txt</code> or <code>sitemap.xml</code> in the repo — those are served upstream by the VTEX edge.</li>
+        <li><code>next.config.js</code> uses <code>storeConfig.rewrites</code>. No <code>headers()</code> block. No existing precedent for serving static-like text endpoints from the Next app.</li>
+        <li>Existing server-side helpers: <code>execute</code> for GraphQL (<code>src/server</code>), <code>contentService</code> for CMS (<code>src/server/content</code>), <code>getStoreURL()</code> for absolute URLs (<code>src/sdk/localization/useLocalizationConfig</code>).</li>
+        <li>Locale / binding awareness already wired via <code>src/utils/localization/bindingPaths</code>.</li>
+      </ul>
+      <p class="mt-4">The route + builder pattern fits cleanly into this layout.</p>
+    </section>
+
+    <!-- 07 — Decisions taken -->
+    <section id="s07" class="th-section">
+      <div class="th-sec-head">
+        <span class="th-sec-num">07</span>
+        <h2 class="th-h2">Decisions taken</h2>
+      </div>
+      <div class="th-table-wrap">
+        <table class="th-table">
+          <thead>
+            <tr><th>Decision</th><th>Choice</th><th>Why</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Scope v1</td><td>Single <code>/llms.txt</code> only</td><td>Cheapest path to learn. No <code>.md</code> per page, no <code>llms-full.txt</code>.</td></tr>
+            <tr><td>Source of truth</td><td>Dynamic at build / request</td><td>Static file goes stale. <code>discovery.config</code> + GraphQL + CMS.</td></tr>
+            <tr><td>Default state</td><td><code>enabled: false</code> in <code>discovery.config.default.js</code></td><td>Stores opt in. Flip default after a bake period.</td></tr>
+            <tr><td>Include SKUs</td><td>No</td><td>Catalogs go stale in hours. Schema.org on PDP covers product signal.</td></tr>
+            <tr><td>Multi-binding</td><td>Single locale (current binding) in v1</td><td>Multi-locale fan-out is a follow-up.</td></tr>
+            <tr><td>Implementation surface</td><td><code>packages/core</code> only</td><td>Don't touch <code>starter.store</code>.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- 08 — Open questions -->
+    <section id="s08" class="th-section">
+      <div class="th-sec-head">
+        <span class="th-sec-num">08</span>
+        <h2 class="th-h2">Open questions</h2>
+      </div>
+
+      <div class="th-subsection">
+        <h3 class="th-h3">Must resolve before merge</h3>
+        <p class="th-sec-intro">These do not block opening a draft PR. They block merging.</p>
+        <div class="th-stack">
+          <div class="th-q" style="border-color: #F5C2C2;">
+            <div class="th-q-title">1. VTEX edge proxy interception of <code>/llms.txt</code></div>
+            <div class="th-q-body"><code>robots.txt</code> and <code>sitemap.xml</code> are served by the upstream proxy, not the Next app. We need to confirm <code>/llms.txt</code> is <em>not</em> intercepted, or arrange a passthrough.</div>
+            <div class="th-q-owner">Decide with · platform team</div>
+          </div>
+          <div class="th-q" style="border-color: #F5C2C2;">
+            <div class="th-q-title">2. Multi-binding store behavior</div>
+            <div class="th-q-body">Single file with multi-locale links, or one file per binding (<code>/en/llms.txt</code>, <code>/pt/llms.txt</code>)? For v1 we ship single-binding; need product input on whether that is acceptable for current customers.</div>
+            <div class="th-q-owner">Decide with · product</div>
+          </div>
+          <div class="th-q" style="border-color: #F5C2C2;">
+            <div class="th-q-title">3. CMS content type for institutional pages</div>
+            <div class="th-q-body">Which content type and which slugs canonically represent shipping / returns / privacy / terms? Likely store-specific, hence the <code>institutionalSlugs</code> config slot — but a sensible default would be nice.</div>
+            <div class="th-q-owner">Decide with · CMS team</div>
+          </div>
+          <div class="th-q" style="border-color: #F5C2C2;">
+            <div class="th-q-title">4. Caching TTL alignment</div>
+            <div class="th-q-body">Default <code>s-maxage=3600, stale-while-revalidate=86400</code> — confirm this aligns with the VTEX edge cache policy.</div>
+            <div class="th-q-owner">Decide with · platform team</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="th-subsection">
+        <h3 class="th-h3">Soft — can defer</h3>
+        <div class="th-stack">
+          <div class="th-q" style="border-color: #FCE8B2;">
+            <div class="th-q-title">5. Advertise <code>/llms.txt</code> in <code>robots.txt</code>?</div>
+            <div class="th-q-body">Not part of the spec. Some advocate it. Defer until robots.txt ownership is clarified (platform-side today).</div>
+            <div class="th-q-owner">Defer</div>
+          </div>
+          <div class="th-q" style="border-color: #FCE8B2;">
+            <div class="th-q-title">6. <code>X-Robots-Tag: noindex</code> on the response?</div>
+            <div class="th-q-body">Probably yes — the file isn't meant for SERPs. Low-risk default; included in the plan.</div>
+            <div class="th-q-owner">Defer (default: yes)</div>
+          </div>
+          <div class="th-q" style="border-color: #FCE8B2;">
+            <div class="th-q-title">7. Rate limiting / abuse</div>
+            <div class="th-q-body">The endpoint is cheap and cached, but if it becomes a hotspot we may want to align with existing FastStore rate-limit primitives. No action for v1.</div>
+            <div class="th-q-owner">Defer</div>
+          </div>
+          <div class="th-q" style="border-color: #FCE8B2;">
+            <div class="th-q-title">8. i18n of the markdown body itself</div>
+            <div class="th-q-body">Section titles like "Shop by category". For v1 we use English; later expose strings via the existing i18n surface.</div>
+            <div class="th-q-owner">Defer</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 09 — Risks -->
+    <section id="s09" class="th-section">
+      <div class="th-sec-head">
+        <span class="th-sec-num">09</span>
+        <h2 class="th-h2">Risks</h2>
+      </div>
+      <div class="th-table-wrap">
+        <table class="th-table">
+          <thead>
+            <tr><th>Risk</th><th>Sev</th><th>Mitigation</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Edge proxy collision (open question #1). If unresolved, the PR ships but the route is unreachable in production.</td>
+              <td><span class="th-tag th-tag-error">HIGH</span></td>
+              <td>Validate with platform team before opening the PR for review.</td>
+            </tr>
+            <tr>
+              <td>Drift between this convention and a future "official" spec from a major provider.</td>
+              <td><span class="th-tag th-tag-warn">MED</span></td>
+              <td>Feature-flag, isolated module under <code>src/server/llms/</code>, easy to rip out.</td>
+            </tr>
+            <tr>
+              <td>Customer expectations. Once we ship, stores may expect AI traffic / citation lift that may not materialize in 2026.</td>
+              <td><span class="th-tag th-tag-warn">MED</span></td>
+              <td>Be explicit in release notes about the "option value" framing.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- 10 — Artifacts + sources -->
+    <section id="s10" class="th-section">
+      <div class="th-sec-head">
+        <span class="th-sec-num">10</span>
+        <h2 class="th-h2">Artifacts &amp; sources</h2>
+      </div>
+
+      <div class="th-subsection">
+        <h3 class="th-h3">Artifacts in this PR</h3>
+        <ul class="th-stack-tight">
+          <li><code>docs/llms-txt/plan.md</code> — implementation plan (this is what Claude will follow).</li>
+          <li><code>docs/llms-txt/handoff.md</code> — markdown source of this document.</li>
+          <li><code>docs/llms-txt/handoff.html</code> — this HTML render.</li>
+        </ul>
+      </div>
+
+      <div class="th-subsection">
+        <h3 class="th-h3">Sources</h3>
+        <ul class="th-stack-tight">
+          <li><a class="underline" href="https://llmstxt.org/">llmstxt.org — official spec</a></li>
+          <li><a class="underline" href="https://www.mintlify.com/blog/real-llms-txt-examples">Mintlify — real llms.txt examples</a></li>
+          <li><a class="underline" href="https://www.mintlify.com/docs/ai/llmstxt">Mintlify — llms.txt docs</a></li>
+          <li><a class="underline" href="https://www.mintlify.com/blog/the-value-of-llms-txt-hype-or-real">Mintlify — value of llms.txt: hype or real?</a></li>
+          <li><a class="underline" href="https://www.mintlify.com/blog/context-for-agents">Mintlify — context for agents (content negotiation)</a></li>
+          <li><a class="underline" href="https://codersera.com/blog/llms-txt-complete-guide-2026/">Codersera — honest guide May 2026</a></li>
+          <li><a class="underline" href="https://llms-txt.io/blog/is-llms-txt-dead">llms-txt.io — Is llms.txt dead? (2025)</a></li>
+          <li><a class="underline" href="https://www.indexlab.ai/blog/llms-txt-does-it-actually-work-october-2025-updated">IndexLab — Does it actually work? Oct 2025</a></li>
+          <li><a class="underline" href="https://www.longato.ch/llms-recommendation-2025-august/">Longato — AI crawlers ignore it, 2025 audit</a></li>
+          <li><a class="underline" href="https://www.pixelmojo.io/blogs/llms-txt-static-vs-dynamic-implementation-guide">Pixelmojo — static vs dynamic implementation</a></li>
+          <li><a class="underline" href="https://kiwicommerce.co.uk/llms-txt-setup-guide-for-wordpress-shopify-magento-and-custom-websites/">Kiwi Commerce — setup for WordPress / Shopify / Magento</a></li>
+          <li><a class="underline" href="https://www.tngshopper.com/post/llms-txt-for-e-commerce-a-practical-guide-to-preparing-your-site-for-ai-crawlers">tngshopper — llms.txt for e-commerce</a></li>
+          <li><a class="underline" href="https://higoodie.com/blog/llms-txt-for-ecommerce/">Goodie — optimizing llms.txt for e-commerce</a></li>
+          <li><a class="underline" href="https://www.stryde.com/llms-txt-for-dtc-brands-what-it-is-why-it-matters-and-how-to-implement-it/">Stryde — llms.txt for DTC brands</a></li>
+          <li><a class="underline" href="https://sherocommerce.com/blogs/insights/10-real-examples-of-llm-friendly-product-descriptions">Shero Commerce — LLM-friendly product descriptions</a></li>
+          <li><a class="underline" href="https://www.deployhq.com/blog/making-your-documentation-ai-friendly-serving-markdown-to-ai-coding-assistants">DeployHQ — content negotiation &amp; Markdown serving</a></li>
+          <li><a class="underline" href="https://www.akuparaai.com/blog/robots-txt-llms-txt-ai-txt-standards">Akupara — robots.txt vs llms.txt vs ai.txt</a></li>
+        </ul>
+      </div>
+    </section>
+
+    <footer class="th-provenance">
+      Generated by /to-html from docs/llms-txt/handoff.md on 2026-05-20. Branch feat/llms-txt-poc.
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/llms-txt/handoff.md
+++ b/docs/llms-txt/handoff.md
@@ -1,0 +1,177 @@
+# `llms.txt` for FastStore — Research, Benchmark, Handoff
+
+Status: investigation complete. PoC branch open: `feat/llms-txt-poc`. Implementation plan in `plan.md`.
+
+This document is the PR handoff: what we learned, what we benchmarked, what we decided, and what is still open.
+
+---
+
+## TL;DR
+
+- `llms.txt` is a 2024 proposal by Jeremy Howard (Answer.AI) for a curated Markdown index at `/llms.txt`, scoped to be ingestible by LLMs with limited context windows.
+- As of May 2026 the spec is widely adopted in **technical documentation** (Anthropic, Stripe, Vercel, Cloudflare, Mintlify, Cursor) and largely **ignored by general web crawlers** (Google publicly declined; GPTBot/ClaudeBot/PerplexityBot show no consistent fetch behavior in audits).
+- For e-commerce, consensus says: **do not dump the SKU catalog**. Expose brand, top categories, policies, FAQ, contact. Keep the file small and curated.
+- We picked the smallest sensible scope for FastStore v1: a single, build-time-dynamic `/llms.txt` at the root, no per-page `.md`, no `llms-full.txt`, feature-flagged.
+
+---
+
+## Why bother (and why be skeptical)
+
+**Pro:**
+
+- Cost is near-zero once the pipeline exists.
+- It forces an editorial inventory of what the store wants AI to cite.
+- Coding agents (Cursor, Claude Code, Windsurf) demonstrably fetch `llms.txt` for libraries. The same mechanism may extend to commerce agents (Rufus, Perplexity Shopping, ChatGPT shopping) as those tools mature.
+- Easier to ship now than retrofit when (if) a provider commits.
+
+**Con:**
+
+- No measurable lift in AI citations in published studies through late 2025.
+- Redundant with `sitemap.xml` + clean HTML + Schema.org for crawlers that already index the public web.
+- Risk of stale content if the file isn't generated dynamically.
+
+Net call: ship it, keep it cheap, do not over-invest until a major provider commits.
+
+---
+
+## Spec summary (from llmstxt.org)
+
+- Location: `/llms.txt` at site root.
+- Format: Markdown. Served as `text/markdown` (or `text/plain`).
+- Required: a single `# H1` title.
+- Recommended: a `> blockquote` one-line summary, then free-form context paragraphs, then `## Section` headers each containing a list of `[name](url): description` links.
+- Reserved: a `## Optional` section that ingestion tools may skip when context is tight.
+- Companion (not required, but the de facto convention): each HTML page also reachable as Markdown — either at `<url>.md` or via `Accept: text/markdown` content negotiation.
+
+### `llms.txt` vs `llms-full.txt`
+
+| | `llms.txt` | `llms-full.txt` |
+|---|---|---|
+| Purpose | Curated index, pointers | Full content dump for ingestion/RAG |
+| Size | Small (fits a context window) | Can be huge (Anthropic's is millions of tokens) |
+| Audience | Agents fetching at runtime | Bulk ingestion pipelines |
+| Freshness need | High | Lower |
+
+We are shipping only `llms.txt` for now. `llms-full.txt` doesn't make sense for a live commerce catalog and the ingestion-side value for commerce is unproven.
+
+---
+
+## Benchmark — who is doing this, and how
+
+| Org | Pattern | What's interesting |
+|---|---|---|
+| Anthropic | `llms.txt` + `llms-full.txt` + per-page `.md` | The reference implementation. `llms-full.txt` is a single concatenated dump. |
+| Stripe | Curated catalog by product vertical | Sections per product (Payments, Connect, Billing) instead of one flat list. |
+| Vercel | `llms.txt` + per-page `.md` via content negotiation | Same URL serves HTML or Markdown depending on `Accept`. |
+| Cloudflare | Per-product catalog, similar to Stripe | Heavy use of `## Optional` to defer ancillary pages. |
+| Mintlify | Auto-generated for every hosted docs site (Nov 2024) | This is why most "adopters" are docs sites — Mintlify ships it by default. |
+| Cursor / Windsurf | Focused workflow (small `llms.txt`) | Slim, opinionated, points only at canonical references. |
+| Supabase, LangGraph, Bolt | Similar to Vercel | Standard docs pattern. |
+
+### E-commerce specific reading
+
+There are blog posts (Kiwi Commerce, Stryde, Goodie, tngshopper, Shero) recommending `llms.txt` for DTC brands. None of them publish convincing measurement of lift. Their structural recommendations converge:
+
+1. Brand summary at the top.
+2. Top-level categories only — not leaves, not SKUs.
+3. Policies (shipping, returns, warranty, privacy, terms).
+4. FAQ / size guides / customer service.
+5. About / contact.
+6. Rely on Schema.org Product JSON-LD (already present in FastStore PDP) for product-level signal — not `llms.txt`.
+
+This matches the scope we picked.
+
+---
+
+## Crawler reality check (May 2026)
+
+- **Google** (Search Central Live, Jul 2025): does not support `llms.txt`, no plans to.
+- **GPTBot, ClaudeBot, PerplexityBot**: audits through Oct 2025 show no consistent fetch of `/llms.txt`. Sporadic GPTBot hits, no commitment.
+- **Coding assistants** (Cursor, Claude Code, Windsurf, Continue): do fetch on demand. Measurable value here, but for library docs — not for commerce.
+- **Discovery**: no standardized mechanism. Crawlers must guess `/llms.txt`. `robots.txt` does not reference it.
+
+What this means for FastStore: the immediate upside is low. The bet is option value if/when shopping-oriented agents adopt the convention.
+
+---
+
+## What FastStore looks like today
+
+Findings from `packages/core`:
+
+- Next.js Pages Router. PDP is `src/pages/[slug]/p.tsx` with `getStaticProps` and `ProductJsonLd`/`BreadcrumbJsonLd`. Search at `src/pages/s.tsx`. CMS catch-all at `src/pages/[...slug].tsx`.
+- API routes in `src/pages/api/fs/` (only `logout.ts`, `graphql.ts`, `preview.ts` today).
+- `public/` contains only favicon/logo/icons. No `robots.txt` or `sitemap.xml` in the repo — those are served upstream by the VTEX edge.
+- `next.config.js` uses `storeConfig.rewrites`. No `headers()` block. No existing precedent for serving static-like text endpoints from the Next app.
+- Existing server-side helpers: `execute` for GraphQL (`src/server`), `contentService` for CMS (`src/server/content`), `getStoreURL()` for absolute URLs (`src/sdk/localization/useLocalizationConfig`).
+- Locale/binding awareness already wired via `src/utils/localization/bindingPaths`.
+
+The route + builder pattern fits cleanly into this layout.
+
+---
+
+## Decisions taken
+
+| Decision | Choice | Why |
+|---|---|---|
+| Scope v1 | Single `/llms.txt` only | Cheapest path to learn. No `.md` per page, no `llms-full.txt`. |
+| Source of truth | Dynamic at build/request | Static file goes stale. `discovery.config` + GraphQL + CMS. |
+| Default state | `enabled: false` in `discovery.config.default.js` | Stores opt in. Flip default after a bake period. |
+| Include SKUs | No | Catalogs go stale in hours. Schema.org on PDP covers product signal. |
+| Multi-binding | Single locale (current binding) in v1 | Multi-locale fan-out is a follow-up. |
+| Implementation surface | `packages/core` only | Don't touch `starter.store`. |
+
+---
+
+## Open questions — must resolve before merge
+
+1. **VTEX edge proxy interception of `/llms.txt`.** `robots.txt` and `sitemap.xml` are served by the upstream proxy, not the Next app. We need to confirm `/llms.txt` is *not* intercepted, or arrange a passthrough. **Owner: platform team.**
+2. **Multi-binding store behavior.** Single file with multi-locale links, or one file per binding (`/en/llms.txt`, `/pt/llms.txt`)? For v1 we ship single-binding; need product input on whether that is acceptable for current customers. **Owner: product.**
+3. **CMS content type for institutional pages.** Which content type and which slugs canonically represent shipping / returns / privacy / terms? Likely store-specific, hence the `institutionalSlugs` config slot — but a sensible default would be nice. **Owner: CMS team.**
+4. **Caching TTL alignment.** Default `s-maxage=3600, stale-while-revalidate=86400` — confirm this aligns with the VTEX edge cache policy. **Owner: platform team.**
+
+---
+
+## Open questions — soft / can defer
+
+5. **Should we advertise `/llms.txt` in `robots.txt`?** Not part of the spec. Some advocate it. Defer until robots.txt ownership is clarified (platform-side today).
+6. **`X-Robots-Tag: noindex` on the response?** Probably yes — the file isn't meant for SERPs. Low-risk default; included in the plan.
+7. **Rate limiting / abuse.** The endpoint is cheap and cached, but if it becomes a hotspot we may want to align with existing FastStore rate-limit primitives. No action for v1.
+8. **i18n of the markdown body itself** (section titles like "Shop by category"). For v1 we use English; later expose strings via the existing i18n surface.
+
+---
+
+## Risks
+
+- Edge proxy collision (open question #1). If unresolved, the PR ships but the route is unreachable in production. Mitigation: validate with platform team before opening the PR for review.
+- Drift between this convention and a future "official" spec from a major provider. Mitigation: feature-flag, isolated module under `src/server/llms/`, easy to rip out.
+- Customer expectations. Once we ship, stores may expect AI traffic / citation lift that may not materialize in 2026. Mitigation: be explicit in release notes about the "option value" framing.
+
+---
+
+## Artifacts in this PR
+
+- `docs/llms-txt/plan.md` — implementation plan (this is what Claude will follow).
+- `docs/llms-txt/handoff.md` — this document.
+- `docs/llms-txt/handoff.html` — HTML render of this document for sharing.
+
+---
+
+## Sources
+
+- [llmstxt.org — official spec](https://llmstxt.org/)
+- [Mintlify — real llms.txt examples](https://www.mintlify.com/blog/real-llms-txt-examples)
+- [Mintlify — llms.txt docs](https://www.mintlify.com/docs/ai/llmstxt)
+- [Mintlify — value of llms.txt: hype or real?](https://www.mintlify.com/blog/the-value-of-llms-txt-hype-or-real)
+- [Mintlify — context for agents (content negotiation)](https://www.mintlify.com/blog/context-for-agents)
+- [Codersera — honest guide May 2026](https://codersera.com/blog/llms-txt-complete-guide-2026/)
+- [llms-txt.io — Is llms.txt dead? (2025)](https://llms-txt.io/blog/is-llms-txt-dead)
+- [IndexLab — Does it actually work? Oct 2025](https://www.indexlab.ai/blog/llms-txt-does-it-actually-work-october-2025-updated)
+- [Longato — AI crawlers ignore it, 2025 audit](https://www.longato.ch/llms-recommendation-2025-august/)
+- [Pixelmojo — static vs dynamic implementation](https://www.pixelmojo.io/blogs/llms-txt-static-vs-dynamic-implementation-guide)
+- [Kiwi Commerce — setup for WordPress/Shopify/Magento](https://kiwicommerce.co.uk/llms-txt-setup-guide-for-wordpress-shopify-magento-and-custom-websites/)
+- [tngshopper — llms.txt for e-commerce](https://www.tngshopper.com/post/llms-txt-for-e-commerce-a-practical-guide-to-preparing-your-site-for-ai-crawlers)
+- [Goodie — optimizing llms.txt for e-commerce](https://higoodie.com/blog/llms-txt-for-ecommerce/)
+- [Stryde — llms.txt for DTC brands](https://www.stryde.com/llms-txt-for-dtc-brands-what-it-is-why-it-matters-and-how-to-implement-it/)
+- [Shero Commerce — LLM-friendly product descriptions](https://sherocommerce.com/blogs/insights/10-real-examples-of-llm-friendly-product-descriptions)
+- [DeployHQ — content negotiation & Markdown serving](https://www.deployhq.com/blog/making-your-documentation-ai-friendly-serving-markdown-to-ai-coding-assistants)
+- [Akupara — robots.txt vs llms.txt vs ai.txt](https://www.akuparaai.com/blog/robots-txt-llms-txt-ai-txt-standards)

--- a/docs/llms-txt/plan-v2.md
+++ b/docs/llms-txt/plan-v2.md
@@ -1,0 +1,260 @@
+# Plan v2 — `/llms.txt` + `/llms-full.txt` in `@faststore/core`
+
+Builds on the PoC at `plan.md`. Goal: ship two functional routes that pull real content from the store, not just config-driven stubs.
+
+## What changes from v1
+
+The PoC `/llms.txt` is just a curated index built from `discovery.config.llms.customSections`. It works, but a store gets no value out of the box: it has to hand-author every link. v2 wires the GraphQL and CMS sources that v1 left as stubs, and adds a second route that inlines the actual prose.
+
+After v2:
+- `/llms.txt` lists categories pulled live from GraphQL, plus institutional pages and landing pages discovered from the CMS.
+- `/llms-full.txt` inlines the full text of those pages so an LLM can answer questions, not just navigate.
+- Both routes work with zero config beyond setting `llms.enabled = true` and listing a few content type ids the store actually uses.
+
+## Content survey (what we actually have)
+
+Before designing this I checked what the codebase exposes. Three things matter:
+
+1. **GraphQL has `allCollections`** but it isn't currently a persisted query. We need to add one query document under `src/customizations/src/fragments` and let codegen pick it up. Returns slug, seo title/description, breadcrumb — enough for a link with a description.
+
+2. **The CMS has no built-in "institutional page" or "FAQ" content type.** Base content types are landing pages, PLP/PDP templates, home, error pages, and global sections. The base `sections.json` has `BannerText`, `Hero`, `Newsletter`, etc. — no `RichText`, no `Accordion`, no body-text section. Real stores either add a custom RichText section or use the landing page's title/SEO description as the only prose.
+
+3. **No sitemap.xml in the Next app.** It's served upstream by the VTEX edge proxy. We can't reuse a URL list from there; the LLMs routes have to build their own from GraphQL + CMS.
+
+Practical consequence: `llms-full.txt` content comes from three pools, in order of usefulness:
+
+- SEO description fields (`settings.seo.description`) on every CMS-driven page. Short but reliable.
+- Whitelisted section names with a known text shape. We extract from `BannerText` (title + caption) and `Hero` (title + subtitle) out of the box. Stores can extend the whitelist via config to include their custom RichText section names.
+- A config-level `customPages` array for prose the store wants to inline without putting it in the CMS (e.g. a static About paragraph).
+
+That's enough to make the file useful on a vanilla store. Stores with a RichText custom section get richer output by adding its name to the whitelist.
+
+## File layout
+
+Most of the v1 layout stays. New and changed files:
+
+| Path | Action |
+|---|---|
+| `packages/core/src/server/llms/sources.ts` | rewrite — wire GraphQL + CMS, drop stubs |
+| `packages/core/src/server/llms/extract.ts` | new — pull text out of CMS section payloads |
+| `packages/core/src/server/llms/sections.ts` | edit — add `landingPagesSection` |
+| `packages/core/src/server/llms/full.ts` | new — `buildLlmsFullTxt(ctx)` |
+| `packages/core/src/server/llms/index.ts` | edit — export `buildLlmsFullTxt` |
+| `packages/core/src/pages/api/fs/llms-full.ts` | new — second API route |
+| `packages/core/src/customizations/src/fragments/AllCollections.ts` | new — persisted GraphQL query |
+| `packages/core/next.config.js` | edit — add `/llms-full.txt` rewrite alongside `/llms.txt` |
+| `packages/core/discovery.config.default.js` | edit — extend `llms` block (see below) |
+| `packages/core/test/server/llms/buildLlmsTxt.test.ts` | edit — cover new sources |
+| `packages/core/test/server/llms/buildLlmsFullTxt.test.ts` | new |
+| `packages/core/test/server/llms/extract.test.ts` | new |
+
+## Config contract
+
+```js
+llms: {
+  enabled: true,
+  title: 'Acme Store',
+  tagline: 'Curated streetwear since 2008.',
+  about: 'Long-form paragraph about the brand.',
+  contact: {
+    email: 'support@acme.com',
+    url: 'https://acme.com/contact',
+  },
+
+  // NEW: sources we pull from automatically
+  sources: {
+    // GraphQL top-level categories. false to skip.
+    categories: { enabled: true, limit: 25 },
+
+    // CMS content types to discover pages from. Empty array = skip CMS.
+    // Most stores will set this to ['landingPage'] and rely on slug allow/deny lists.
+    contentTypes: ['landingPage'],
+
+    // Slug allow-list applied to discovered CMS pages.
+    // If empty, all pages of the listed contentTypes are included.
+    slugAllowList: [],
+
+    // Slugs we never want in the LLM file (e.g. campaign landing pages).
+    slugDenyList: ['black-friday', '404', '500'],
+
+    // Names of CMS section components whose text we should extract for llms-full.txt.
+    // BannerText and Hero are extracted by default. Add your store's RichText section name here.
+    textSectionNames: ['BannerText', 'Hero'],
+  },
+
+  // Inline static prose for llms-full.txt without going through the CMS.
+  customPages: [
+    {
+      title: 'About Acme',
+      slug: '/about',
+      body: 'Long Markdown body…',
+    },
+  ],
+
+  // Existing v1 fields still work
+  customSections: [],
+  maxLinksPerSection: 25,
+}
+```
+
+The shape is forward-compatible: a store on v1 config (no `sources` block) gets sensible defaults — categories on, no CMS discovery, text extraction limited to base sections.
+
+## `/llms.txt` output
+
+Same shape as v1, with two new sections wired to real data:
+
+```
+# {title}
+
+> {tagline}
+
+{about}
+
+## Shop by category
+- [Office](https://store.com/office): SEO description from the collection, truncated to 120 chars
+- … up to limit
+
+## Pages
+- [Shipping policy](https://store.com/shipping): SEO description
+- [Returns](https://store.com/returns): SEO description
+- … discovered from CMS contentTypes + allow/deny list
+
+## Customer service
+… (v1 institutional config, still supported for stores that prefer hand-curation)
+
+## Contact
+- Email: support@acme.com
+- [Contact form](https://store.com/contact)
+
+## Optional
+- [Sitemap](https://store.com/sitemap.xml)
+- [Full LLM content](https://store.com/llms-full.txt)
+```
+
+The `Pages` section is new. It pulls every page of every configured `contentTypes`, applies the allow/deny filter, and renders one link per page with SEO description as the line tail. Capped at `maxLinksPerSection`.
+
+The `Optional` section gains a link to `/llms-full.txt` so an LLM that fetched the index knows the full file exists.
+
+## `/llms-full.txt` output
+
+One self-contained Markdown file. Structure:
+
+```
+# {title} — Full content
+
+> {tagline}
+
+{about}
+
+---
+
+# Categories
+
+## Office
+URL: https://store.com/office
+
+Office supplies and accessories. (from SEO description)
+
+Selected facets: brand, price, color. (from collection meta, if present)
+
+## Technology
+…
+
+---
+
+# Pages
+
+## Shipping policy
+URL: https://store.com/shipping
+
+(SEO description paragraph)
+
+(Extracted text from whitelisted sections, joined with blank lines)
+
+## Returns
+…
+
+---
+
+# Custom pages
+
+## About Acme
+URL: https://store.com/about
+
+(config.llms.customPages[*].body verbatim)
+```
+
+Rules for the body text per page:
+
+- Lead with the page's `seo.description` if present.
+- Then iterate `sections[]`. For each section whose `name` is in `sources.textSectionNames`, pull `data.title`, `data.caption`, `data.subtitle`, `data.text` (whichever exist). Render each as a paragraph.
+- Skip sections we don't recognize. Never render JSON. Never render section names. If a section has no extractable text, omit it.
+- Cap the body per page at ~8KB to keep one rogue page from blowing up the file.
+- Cap the total file at ~500KB. If the cap would be exceeded, truncate at a page boundary and append a note (`(truncated — N pages omitted)`).
+
+## Route behavior
+
+`/llms-full.txt` mirrors `/llms.txt`:
+
+- `Content-Type: text/markdown; charset=utf-8`
+- `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400`
+- `X-Robots-Tag: noindex`
+- 405 on non-GET
+- 404 when `llms.enabled === false`
+- 500 with empty body on builder throw, error logged server-side
+
+Both routes go through Next.js rewrites. Place them before `storeConfig.rewrites` (already done for `/llms.txt` in v1).
+
+## Implementation order
+
+Eight steps, each one shippable on its own:
+
+1. **Persist `allCollections`.** Add the query document, run codegen, expose a typed helper in `src/server/llms/sources.ts::fetchTopCategories`. Test against the live `execute()` pipeline.
+
+2. **Wire CMS discovery.** In `sources.ts::fetchPagesByContentTypes`, call `contentService.getMultipleContent` for each configured contentType. Apply allow/deny filtering. Return `{ slug, title, description, sections }[]`.
+
+3. **Wire categories into `/llms.txt`.** The `Shop by category` section currently shows config-only data. Switch it to use `fetchTopCategories` when `sources.categories.enabled`. Keep `customSections` as override.
+
+4. **Add the `Pages` section to `/llms.txt`.** New section builder consumes `fetchPagesByContentTypes`, renders link + truncated SEO description.
+
+5. **Build `extract.ts`.** Pure function from a `sections[]` array + whitelist to an array of paragraphs. No CMS or GraphQL dependency. Easy to unit test.
+
+6. **Build `buildLlmsFullTxt`.** Composes the brand header, the categories block, the per-page blocks (SEO description + extracted text), and the custom pages block. Enforces per-page and total-file size caps.
+
+7. **Add the API route + rewrite.** Same skeleton as `/llms.txt`.
+
+8. **Cross-link.** Add the `Optional` link from `/llms.txt` to `/llms-full.txt`. Update the smoke-test docs in `docs/llms-txt/handoff.md`.
+
+## Testing
+
+Unit tests cover the parts that don't need a real CMS:
+
+- `extract.ts`: given a fixture sections array, returns the right paragraphs. Unknown sections ignored. Empty input returns `[]`.
+- `buildLlmsTxt`: existing tests still pass; add cases for `Pages` section discovery from injected CMS fixture, deny-list filtering, category limit.
+- `buildLlmsFullTxt`: happy path with mixed CMS + custom pages, per-page cap truncation, total file cap with truncation marker, opt-out returns null.
+
+Manual smoke tests, run against the local dev server:
+
+- `GET /llms.txt` → 200, contains a `## Shop by category` block with real category names, contains a `## Pages` block, ends with the `## Optional` block linking to `/llms-full.txt`.
+- `GET /llms-full.txt` → 200, parses as Markdown, has one `## ` block per discovered page, includes prose not just titles.
+- `GET /llms-full.txt` with `enabled: false` → 404.
+- Disable `sources.categories` → category section disappears from both files but the rest still renders.
+
+## Open questions
+
+These don't block shipping but are worth a decision before merge:
+
+- Do we want a per-binding fan-out (`/{locale}/llms.txt`)? The v1 plan deferred this. v2 still defers it — the routes use the current request's binding context, so a multi-locale store gets the right URLs for whichever binding the LLM hits. Fan-out is a discoverability question (how does an LLM find the other locales) and best solved with a future `## Other locales` section.
+
+- CMS API choice: `@vtex/client-cms` vs `@vtex/client-cp`. The `contentService` already routes between them based on `discovery.config.contentSource.type`, so we get this for free. Worth verifying both paths in a real store before merge.
+
+- Cache invalidation. Both routes have `s-maxage=3600`. If a store edits the shipping policy in the CMS, the file is stale for up to an hour. Acceptable for v2 (LLM crawlers are not real-time consumers). If we ever need faster turnaround, wire a revalidation hook off the CMS publish webhook.
+
+- Total file size cap. 500KB is a guess. Real stores will tell us if it's too small.
+
+## Out of scope (still)
+
+- Per-page `.md` files via a catch-all route.
+- Multi-binding fan-out URLs.
+- Editing `robots.txt` to advertise the LLM files. Worth doing once the platform team confirms the upstream proxy won't intercept.
+- Anything in `starter.store`.

--- a/docs/llms-txt/plan.md
+++ b/docs/llms-txt/plan.md
@@ -1,0 +1,147 @@
+# Plan — `/llms.txt` PoC in `@faststore/core`
+
+Working plan for Claude to implement. Scope is intentionally narrow: a single curated `/llms.txt` at the site root, built dynamically at request/build time. No per-page `.md`, no `llms-full.txt`.
+
+## Goal
+
+Ship a feature-flagged Next.js route in `@faststore/core` that serves `/llms.txt` with curated, fresh content sourced from `discovery.config`, the GraphQL API (categories), and the CMS (institutional pages / FAQ).
+
+## Non-goals (this PR)
+
+- Per-page Markdown (`<url>.md`)
+- `llms-full.txt`
+- Multi-binding fan-out beyond the current locale
+- Edits to `robots.txt` or `sitemap.xml`
+- Anything in `starter.store`
+
+## Files to touch
+
+| Path | Action | Notes |
+|---|---|---|
+| `packages/core/src/pages/api/fs/llms.ts` | new | API route. Emits `text/markdown; charset=utf-8`. Returns 404 when `llms.enabled === false`. |
+| `packages/core/next.config.js` | edit | Add rewrite `{ source: '/llms.txt', destination: '/api/fs/llms' }`. Place before `storeConfig.rewrites` so store overrides win. |
+| `packages/core/src/server/llms/index.ts` | new | Exports `buildLlmsTxt(ctx)`. Pure function from inputs to string. |
+| `packages/core/src/server/llms/sections.ts` | new | Section builders: `brandHeader`, `categories`, `policies`, `faq`, `optional`. Each returns `string \| null`. |
+| `packages/core/src/server/llms/sources.ts` | new | Server-side fetchers: `fetchTopCategories()`, `fetchInstitutionalPages()`. Wrap existing `execute` (GraphQL) and `contentService` (CMS). |
+| `packages/core/src/server/llms/format.ts` | new | Markdown helpers: `link()`, `truncate(s, 120)`, `section(title, items)`. |
+| `packages/core/discovery.config.default.js` | edit | Add `llms` block (see contract below). |
+| `packages/core/src/typings/storeConfig.d.ts` (or wherever store config types live — verify) | edit | Type the `llms` block. |
+| `packages/core/test/server/llms/buildLlmsTxt.test.ts` | new | Vitest. Mocks sources, asserts Markdown structure (H1 present, sections ordered, link truncation, opt-out → empty/null). |
+
+Verify before coding: the exact path of the store config type, and the existing GraphQL query name for top-level categories. Grep `allCollections` / `Department` in `packages/core/@generated` and `packages/api`.
+
+## `discovery.config.llms` contract
+
+```js
+llms: {
+  enabled: true,
+  title: 'Acme Store',
+  tagline: 'Curated streetwear since 2008.',
+  about: 'Long-form paragraph about the brand, mission, audience.',
+  contact: {
+    email: 'support@acme.com',
+    url: 'https://acme.com/contact',
+  },
+  // Optional overrides — when present, skip the CMS lookup for that section.
+  customSections: [
+    { title: 'Press', items: [{ name: 'Newsroom', url: '/press', description: '...' }] },
+  ],
+  // CMS slug allow-list for institutional pages. If omitted, fetch all.
+  institutionalSlugs: ['shipping', 'returns', 'privacy-policy', 'terms'],
+  // Cap to keep file small and within small context windows.
+  maxLinksPerSection: 25,
+}
+```
+
+## Output contract
+
+```markdown
+# {title}
+
+> {tagline}
+
+{about}
+
+## Shop by category
+- [Name]({storeUrl}/{slug}): description ≤120 chars
+
+## Customer service
+- [Shipping policy](url): ...
+- [Returns & exchanges](url): ...
+- [Privacy policy](url): ...
+- [Terms of service](url): ...
+
+## FAQ
+- [Topic](url): ...
+
+## Contact
+- Email: support@acme.com
+- [Contact form](url)
+
+## Optional
+- [Sitemap]({storeUrl}/sitemap.xml)
+```
+
+Rules:
+- All URLs absolute (use `getStoreURL()` from `src/sdk/localization/useLocalizationConfig`).
+- No prices, no stock, no SKUs, no leaf categories.
+- Section omitted entirely if its builder returns `null`.
+- Total link count capped at ~50 across the file (sum of `maxLinksPerSection`).
+- Output ends with single trailing newline.
+
+## Route behavior (`api/fs/llms.ts`)
+
+```
+GET /llms.txt  →  rewrite  →  /api/fs/llms
+```
+
+- `Content-Type: text/markdown; charset=utf-8`
+- `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400`
+- `X-Robots-Tag: noindex` (file is for LLMs, not for SERPs)
+- Method guard: 405 on non-GET
+- On `llms.enabled === false` → 404 with empty body
+- On builder throw → 500 with empty body; log via existing logger; never leak stack
+
+## Implementation steps (in order)
+
+1. Add `llms` typing + defaults to `discovery.config.default.js` and the store config type. No behavior yet.
+2. Create `src/server/llms/format.ts` with pure helpers. Unit test it.
+3. Create `src/server/llms/sources.ts`. Wire `fetchTopCategories` via existing GraphQL `execute`. Stub `fetchInstitutionalPages` against `contentService` — confirm content type with the CMS team before finalizing field mapping.
+4. Create `src/server/llms/sections.ts`. Each section pure: `(data, config) => string | null`.
+5. Create `src/server/llms/index.ts` orchestrating sources + sections.
+6. Create the API route. Keep it thin — just I/O, headers, error mapping.
+7. Add the rewrite in `next.config.js`.
+8. Tests: `buildLlmsTxt.test.ts` covering the happy path, opt-out, empty CMS, oversized descriptions (truncation), and link cap enforcement.
+9. Smoke test locally: `pnpm --filter @faststore/core dev`, hit `http://localhost:3000/llms.txt`, verify headers and body.
+10. Update `packages/core/CHANGELOG.md` (follow existing format).
+
+## Open questions to resolve before merge
+
+These are tracked in `handoff.md`. None of them block opening a draft PR, but they block merging:
+
+1. VTEX edge proxy interception of `/llms.txt`.
+2. Multi-binding strategy.
+3. CMS content type for institutional pages (depends on the store, may need a config slot).
+4. Caching TTL alignment with platform infra.
+
+## Testing checklist
+
+- [ ] Unit: `buildLlmsTxt` against fixtures.
+- [ ] Unit: section builders return `null` on empty input.
+- [ ] Unit: link descriptions truncated at 120 chars.
+- [ ] Manual: `GET /llms.txt` returns 200, correct `Content-Type`, parses as Markdown.
+- [ ] Manual: with `llms.enabled = false`, returns 404.
+- [ ] Manual: with a multi-locale store, current binding's locale is reflected in URLs.
+- [ ] Cypress: minimal smoke test under `packages/core/cypress/` — request `/llms.txt`, assert 200 + `text/markdown` + `# ` first line.
+
+## Rollout
+
+- Feature flag via `discovery.config.llms.enabled`. Default `false` in `discovery.config.default.js` for this PR — store opts in explicitly. Flip the default after one minor release of bake time.
+- No migration needed.
+
+## Out of scope follow-ups (separate PRs)
+
+- `.md` per page via `[...slug].md.tsx` catch-all.
+- `llms-full.txt` (only if a real consumer asks).
+- Multi-binding fan-out (`/{locale}/llms.txt`).
+- Optional `discovery.config.llms.advertiseInRobots` to inject a hint line in `robots.txt` if the platform team agrees.

--- a/packages/core/discovery.config.default.js
+++ b/packages/core/discovery.config.default.js
@@ -207,4 +207,34 @@ module.exports = {
 
   // Text direction: 'ltr' (left-to-right) or 'rtl' (right-to-left)
   direction: 'ltr',
+
+  // /llms.txt curated content for LLM consumers. Disabled by default; opt in per store.
+  llms: {
+    enabled: false,
+    title: '',
+    tagline: '',
+    about: '',
+    contact: {
+      email: '',
+      url: '',
+    },
+    // Static section overrides. When provided, the corresponding dynamic
+    // section (e.g. CMS lookup) is skipped.
+    customSections: [],
+    // Inline static prose for /llms-full.txt without going through the CMS.
+    customPages: [],
+    // CMS slug allow-list for institutional pages. Empty array means: skip the
+    // CMS section entirely until a slug list is provided.
+    institutionalSlugs: [],
+    // Dynamic sources for /llms.txt and /llms-full.txt.
+    sources: {
+      categories: { enabled: true, limit: 25 },
+      contentTypes: [],
+      slugAllowList: [],
+      slugDenyList: ['404', '500'],
+      textSectionNames: ['BannerText', 'Hero'],
+    },
+    // Cap to keep file small and within small context windows.
+    maxLinksPerSection: 25,
+  },
 }

--- a/packages/core/next.config.js
+++ b/packages/core/next.config.js
@@ -89,7 +89,24 @@ const nextConfig = {
     return config
   },
   redirects: storeConfig.redirects,
-  rewrites: storeConfig.rewrites,
+  rewrites: async () => {
+    const llmsRewrites = [
+      { source: '/llms.txt', destination: '/api/fs/llms' },
+      { source: '/llms-full.txt', destination: '/api/fs/llms-full' },
+    ]
+    const storeRewrites = storeConfig.rewrites
+      ? await storeConfig.rewrites()
+      : []
+
+    if (Array.isArray(storeRewrites)) {
+      return [...llmsRewrites, ...storeRewrites]
+    }
+
+    return {
+      ...storeRewrites,
+      beforeFiles: [...llmsRewrites, ...(storeRewrites.beforeFiles ?? [])],
+    }
+  },
   turbopack: {
     root: getRootFolder(),
     // https://nextjs.org/docs/app/api-reference/turbopack#css-module-ordering

--- a/packages/core/src/customizations/discovery.config.js
+++ b/packages/core/src/customizations/discovery.config.js
@@ -1,2 +1,33 @@
 // This is a placeholder file for when starter files are copied here
-module.exports = {}
+module.exports = {
+  llms: {
+    enabled: true,
+    title: 'FastStore Demo',
+    tagline: 'Local /llms.txt smoke test.',
+    about:
+      'This is a local FastStore development server used to verify the /llms.txt PoC.',
+    contact: {
+      email: 'demo@faststore.local',
+      url: 'https://faststore.local/contact',
+    },
+    customSections: [
+      {
+        title: 'Shop by category',
+        items: [
+          {
+            name: 'Office',
+            url: '/office',
+            description: 'Office supplies and accessories.',
+          },
+          {
+            name: 'Technology',
+            url: '/technology',
+            description: 'Phones, monitors, and peripherals.',
+          },
+        ],
+      },
+    ],
+    institutionalSlugs: [],
+    maxLinksPerSection: 25,
+  },
+}

--- a/packages/core/src/pages/api/fs/llms-full.ts
+++ b/packages/core/src/pages/api/fs/llms-full.ts
@@ -1,0 +1,43 @@
+import type { NextApiHandler } from 'next'
+
+import storeConfig from 'discovery.config'
+import { buildLlmsFullTxt } from 'src/server/llms'
+import type { LlmsConfig } from 'src/server/llms'
+
+const CACHE_CONTROL = 'public, s-maxage=3600, stale-while-revalidate=86400'
+
+const handler: NextApiHandler = async (request, response) => {
+  if (request.method !== 'GET') {
+    response.status(405).end()
+    return
+  }
+
+  const llmsConfig = (storeConfig as { llms?: LlmsConfig }).llms
+
+  if (!llmsConfig?.enabled) {
+    response.status(404).end()
+    return
+  }
+
+  try {
+    const body = await buildLlmsFullTxt({
+      config: llmsConfig,
+      storeUrl: storeConfig.storeUrl,
+    })
+
+    if (!body) {
+      response.status(404).end()
+      return
+    }
+
+    response.setHeader('Content-Type', 'text/markdown; charset=utf-8')
+    response.setHeader('Cache-Control', CACHE_CONTROL)
+    response.setHeader('X-Robots-Tag', 'noindex')
+    response.status(200).send(body)
+  } catch (error) {
+    console.error('Failed to build /llms-full.txt', error)
+    response.status(500).end()
+  }
+}
+
+export default handler

--- a/packages/core/src/pages/api/fs/llms.ts
+++ b/packages/core/src/pages/api/fs/llms.ts
@@ -1,0 +1,43 @@
+import type { NextApiHandler } from 'next'
+
+import storeConfig from 'discovery.config'
+import { buildLlmsTxt } from 'src/server/llms'
+import type { LlmsConfig } from 'src/server/llms'
+
+const CACHE_CONTROL = 'public, s-maxage=3600, stale-while-revalidate=86400'
+
+const handler: NextApiHandler = async (request, response) => {
+  if (request.method !== 'GET') {
+    response.status(405).end()
+    return
+  }
+
+  const llmsConfig = (storeConfig as { llms?: LlmsConfig }).llms
+
+  if (!llmsConfig?.enabled) {
+    response.status(404).end()
+    return
+  }
+
+  try {
+    const body = await buildLlmsTxt({
+      config: llmsConfig,
+      storeUrl: storeConfig.storeUrl,
+    })
+
+    if (!body) {
+      response.status(404).end()
+      return
+    }
+
+    response.setHeader('Content-Type', 'text/markdown; charset=utf-8')
+    response.setHeader('Cache-Control', CACHE_CONTROL)
+    response.setHeader('X-Robots-Tag', 'noindex')
+    response.status(200).send(body)
+  } catch (error) {
+    console.error('Failed to build /llms.txt', error)
+    response.status(500).end()
+  }
+}
+
+export default handler

--- a/packages/core/src/server/llms/build.ts
+++ b/packages/core/src/server/llms/build.ts
@@ -1,0 +1,35 @@
+import {
+  fetchFaqEntries,
+  fetchInstitutionalPages,
+  fetchPagesByContentTypes,
+  fetchTopCategories,
+} from './sources'
+import type { LlmsConfig, LlmsSources } from './types'
+
+export interface BuildLlmsTxtContext {
+  config: LlmsConfig
+  storeUrl: string
+  sources?: Partial<LlmsSources>
+}
+
+export async function resolveSources(
+  ctx: BuildLlmsTxtContext
+): Promise<LlmsSources> {
+  const { config, storeUrl } = ctx
+  const sourcesCfg = config.sources ?? {}
+  const categoriesEnabled = sourcesCfg.categories?.enabled !== false
+  const categoryLimit =
+    sourcesCfg.categories?.limit ?? config.maxLinksPerSection ?? 25
+
+  return {
+    storeUrl,
+    categories:
+      ctx.sources?.categories ??
+      (categoriesEnabled ? await fetchTopCategories(categoryLimit) : []),
+    institutional:
+      ctx.sources?.institutional ??
+      (await fetchInstitutionalPages(config.institutionalSlugs ?? [])),
+    faq: ctx.sources?.faq ?? (await fetchFaqEntries()),
+    pages: ctx.sources?.pages ?? (await fetchPagesByContentTypes(sourcesCfg)),
+  }
+}

--- a/packages/core/src/server/llms/extract.ts
+++ b/packages/core/src/server/llms/extract.ts
@@ -1,0 +1,45 @@
+interface CmsSection {
+  name: string
+  data: unknown
+}
+
+const TEXT_FIELDS = [
+  'title',
+  'subtitle',
+  'caption',
+  'text',
+  'body',
+  'description',
+] as const
+
+/**
+ * Extract human-readable paragraphs from a CMS sections array, restricted to
+ * the section names in `whitelist`. Unknown sections and unknown fields are
+ * ignored. Order is preserved.
+ */
+export function extractSectionParagraphs(
+  sections: CmsSection[] | undefined,
+  whitelist: string[]
+): string[] {
+  if (!Array.isArray(sections) || sections.length === 0) return []
+  const allow = new Set(whitelist)
+  const paragraphs: string[] = []
+
+  for (const section of sections) {
+    if (!section || !allow.has(section.name)) continue
+    const data = (section.data ?? {}) as Record<string, unknown>
+    for (const field of TEXT_FIELDS) {
+      const value = data[field]
+      const text = normalizeText(value)
+      if (text) paragraphs.push(text)
+    }
+  }
+
+  return paragraphs
+}
+
+function normalizeText(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.replace(/\s+/g, ' ').trim()
+  return trimmed.length > 0 ? trimmed : null
+}

--- a/packages/core/src/server/llms/format.ts
+++ b/packages/core/src/server/llms/format.ts
@@ -1,0 +1,32 @@
+import type { LlmsLink } from './types'
+
+export const MAX_DESCRIPTION_LENGTH = 120
+
+export function truncate(value: string, max = MAX_DESCRIPTION_LENGTH): string {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= max) return normalized
+  return `${normalized.slice(0, max - 1).trimEnd()}…`
+}
+
+export function absoluteUrl(storeUrl: string, path: string): string {
+  if (/^https?:\/\//i.test(path)) return path
+  const base = storeUrl.replace(/\/$/, '')
+  const suffix = path.startsWith('/') ? path : `/${path}`
+  return `${base}${suffix}`
+}
+
+export function linkLine(link: LlmsLink, storeUrl: string): string {
+  const href = absoluteUrl(storeUrl, link.url)
+  const desc = link.description ? `: ${truncate(link.description)}` : ''
+  return `- [${link.name}](${href})${desc}`
+}
+
+export function section(
+  title: string,
+  lines: string[],
+  maxItems?: number
+): string | null {
+  const items = typeof maxItems === 'number' ? lines.slice(0, maxItems) : lines
+  if (items.length === 0) return null
+  return [`## ${title}`, ...items].join('\n')
+}

--- a/packages/core/src/server/llms/full.ts
+++ b/packages/core/src/server/llms/full.ts
@@ -1,0 +1,120 @@
+import { extractSectionParagraphs } from './extract'
+import { absoluteUrl } from './format'
+import { resolveSources, type BuildLlmsTxtContext } from './build'
+import type { LlmsConfig, LlmsLink, LlmsPage, LlmsSources } from './types'
+
+const PER_PAGE_CAP = 8 * 1024
+const TOTAL_FILE_CAP = 500 * 1024
+const DEFAULT_TEXT_SECTIONS = ['BannerText', 'Hero']
+
+export type BuildLlmsFullTxtContext = BuildLlmsTxtContext
+
+export async function buildLlmsFullTxt(
+  ctx: BuildLlmsFullTxtContext
+): Promise<string | null> {
+  const { config, storeUrl } = ctx
+  if (!config?.enabled) return null
+
+  const sources = await resolveSources(ctx)
+  const textSectionNames =
+    config.sources?.textSectionNames ?? DEFAULT_TEXT_SECTIONS
+
+  const header = renderHeader(config)
+  const categories = renderCategoriesBlock(sources)
+  const pages = renderPagesBlock(sources.pages, sources, textSectionNames)
+  const customPages = renderCustomPagesBlock(config, storeUrl)
+
+  const parts = [header, categories, pages, customPages].filter(
+    (s): s is string => Boolean(s)
+  )
+  if (parts.length === 0) return null
+
+  const joined = parts.join('\n\n---\n\n')
+  const capped = applyTotalCap(joined)
+  return `${capped}\n`
+}
+
+function renderHeader(config: LlmsConfig): string {
+  const lines: string[] = [`# ${config.title || 'Store'} — Full content`]
+  if (config.tagline) lines.push('', `> ${config.tagline.trim()}`)
+  if (config.about) lines.push('', config.about.trim())
+  return lines.join('\n')
+}
+
+function renderCategoriesBlock(sources: LlmsSources): string | null {
+  if (sources.categories.length === 0) return null
+  const blocks = sources.categories.map((category) =>
+    renderLinkBlock(category, sources.storeUrl)
+  )
+  return ['# Categories', '', ...blocks].join('\n\n')
+}
+
+function renderLinkBlock(link: LlmsLink, storeUrl: string): string {
+  const url = absoluteUrl(storeUrl, link.url)
+  const lines = [`## ${link.name}`, `URL: ${url}`]
+  if (link.description) lines.push('', link.description.trim())
+  return lines.join('\n')
+}
+
+function renderPagesBlock(
+  pages: LlmsPage[],
+  sources: LlmsSources,
+  textSectionNames: string[]
+): string | null {
+  if (!pages?.length) return null
+  const blocks = pages.map((page) =>
+    renderPageBlock(page, sources.storeUrl, textSectionNames)
+  )
+  return ['# Pages', '', ...blocks].join('\n\n')
+}
+
+function renderPageBlock(
+  page: LlmsPage,
+  storeUrl: string,
+  textSectionNames: string[]
+): string {
+  const url = absoluteUrl(storeUrl, page.slug)
+  const lines = [`## ${page.title}`, `URL: ${url}`]
+
+  if (page.description) {
+    lines.push('', page.description.trim())
+  }
+
+  const paragraphs = extractSectionParagraphs(page.sections, textSectionNames)
+  for (const paragraph of paragraphs) {
+    lines.push('', paragraph)
+  }
+
+  const block = lines.join('\n')
+  return truncateBlock(block, PER_PAGE_CAP)
+}
+
+function renderCustomPagesBlock(
+  config: LlmsConfig,
+  storeUrl: string
+): string | null {
+  const pages = config.customPages ?? []
+  if (pages.length === 0) return null
+  const blocks = pages.map((page) => {
+    const url = absoluteUrl(storeUrl, page.slug)
+    const body = truncateBlock(page.body.trim(), PER_PAGE_CAP)
+    return [`## ${page.title}`, `URL: ${url}`, '', body].join('\n')
+  })
+  return ['# Custom pages', '', ...blocks].join('\n\n')
+}
+
+function truncateBlock(block: string, cap: number): string {
+  if (block.length <= cap) return block
+  return `${block.slice(0, cap).trimEnd()}\n\n(truncated)`
+}
+
+function applyTotalCap(body: string): string {
+  if (body.length <= TOTAL_FILE_CAP) return body
+  // Cut at a page boundary (## heading) just before the cap.
+  const slice = body.slice(0, TOTAL_FILE_CAP)
+  const lastBoundary = slice.lastIndexOf('\n## ')
+  const cut = lastBoundary > 0 ? slice.slice(0, lastBoundary) : slice
+  return `${cut.trimEnd()}\n\n(truncated — content omitted to stay under ${Math.round(
+    TOTAL_FILE_CAP / 1024
+  )}KB)`
+}

--- a/packages/core/src/server/llms/index.ts
+++ b/packages/core/src/server/llms/index.ts
@@ -1,0 +1,41 @@
+import { resolveSources, type BuildLlmsTxtContext } from './build'
+import {
+  brandHeader,
+  categoriesSection,
+  contactSection,
+  customSectionsLines,
+  faqSection,
+  landingPagesSection,
+  optionalSection,
+  policiesSection,
+} from './sections'
+
+export async function buildLlmsTxt(
+  ctx: BuildLlmsTxtContext
+): Promise<string | null> {
+  const { config, storeUrl } = ctx
+  if (!config?.enabled) return null
+
+  const sources = await resolveSources(ctx)
+
+  const blocks: Array<string | null> = [
+    brandHeader(config),
+    categoriesSection(sources, config),
+    landingPagesSection(sources, config),
+    policiesSection(sources, config),
+    faqSection(sources, config),
+    ...customSectionsLines(config, storeUrl).map((s) => s),
+    contactSection(config),
+    optionalSection(sources),
+  ]
+
+  const body = blocks.filter((b): b is string => Boolean(b)).join('\n\n')
+  if (!body) return null
+  return `${body}\n`
+}
+
+export { resolveSources } from './build'
+export type { BuildLlmsTxtContext } from './build'
+export { buildLlmsFullTxt } from './full'
+export type { BuildLlmsFullTxtContext } from './full'
+export type { LlmsConfig, LlmsLink, LlmsSources } from './types'

--- a/packages/core/src/server/llms/sections.ts
+++ b/packages/core/src/server/llms/sections.ts
@@ -1,0 +1,83 @@
+import { linkLine, section, truncate } from './format'
+import { pageToLink } from './sources'
+import type { LlmsConfig, LlmsLink, LlmsSources } from './types'
+
+export function brandHeader(config: LlmsConfig): string | null {
+  if (!config.title) return null
+  const lines: string[] = [`# ${config.title}`]
+  if (config.tagline) lines.push('', `> ${truncate(config.tagline, 200)}`)
+  if (config.about) lines.push('', config.about.trim())
+  return lines.join('\n')
+}
+
+export function categoriesSection(
+  sources: LlmsSources,
+  config: LlmsConfig
+): string | null {
+  if (sources.categories.length === 0) return null
+  const lines = sources.categories.map((c) => linkLine(c, sources.storeUrl))
+  return section('Shop by category', lines, config.maxLinksPerSection)
+}
+
+export function landingPagesSection(
+  sources: LlmsSources,
+  config: LlmsConfig
+): string | null {
+  if (!sources.pages?.length) return null
+  const lines = sources.pages
+    .map(pageToLink)
+    .map((link) => linkLine(link, sources.storeUrl))
+  return section('Pages', lines, config.maxLinksPerSection)
+}
+
+export function policiesSection(
+  sources: LlmsSources,
+  config: LlmsConfig
+): string | null {
+  if (sources.institutional.length === 0) return null
+  const lines = sources.institutional.map((p) => linkLine(p, sources.storeUrl))
+  return section('Customer service', lines, config.maxLinksPerSection)
+}
+
+export function faqSection(
+  sources: LlmsSources,
+  config: LlmsConfig
+): string | null {
+  if (sources.faq.length === 0) return null
+  const lines = sources.faq.map((p) => linkLine(p, sources.storeUrl))
+  return section('FAQ', lines, config.maxLinksPerSection)
+}
+
+export function contactSection(config: LlmsConfig): string | null {
+  const contact = config.contact
+  if (!contact?.email && !contact?.url) return null
+  const lines: string[] = []
+  if (contact.email) lines.push(`- Email: ${contact.email}`)
+  if (contact.url) lines.push(`- [Contact form](${contact.url})`)
+  return section('Contact', lines)
+}
+
+export function customSectionsLines(
+  config: LlmsConfig,
+  storeUrl: string
+): string[] {
+  const sections = config.customSections ?? []
+  const rendered: string[] = []
+  for (const s of sections) {
+    const lines = s.items.map((item: LlmsLink) => linkLine(item, storeUrl))
+    const block = section(s.title, lines, config.maxLinksPerSection)
+    if (block) rendered.push(block)
+  }
+  return rendered
+}
+
+export function optionalSection(sources: LlmsSources): string | null {
+  const items: LlmsLink[] = [
+    { name: 'Sitemap', url: '/sitemap.xml' },
+    { name: 'Full LLM content', url: '/llms-full.txt' },
+  ]
+  return section(
+    'Optional',
+    items.map((item) => linkLine(item, sources.storeUrl))
+  )
+}

--- a/packages/core/src/server/llms/sources.ts
+++ b/packages/core/src/server/llms/sources.ts
@@ -1,0 +1,186 @@
+import storeConfig from 'discovery.config'
+import { contentService } from 'src/server/content/service'
+import { execute } from 'src/server'
+
+import type { LlmsLink, LlmsPage, LlmsSourcesConfig } from './types'
+
+interface CollectionNode {
+  id: string
+  slug: string
+  type: string
+  seo?: { title?: string; description?: string }
+  breadcrumbList?: {
+    itemListElement: Array<{ item: string; name: string; position: number }>
+  }
+}
+
+interface AllCollectionsResult {
+  allCollections: {
+    edges: Array<{ node: CollectionNode }>
+  }
+}
+
+const ALL_COLLECTIONS_QUERY = `
+  query LlmsAllCollectionsQuery($first: Int!) {
+    allCollections(first: $first) {
+      edges {
+        node {
+          id
+          slug
+          type
+          seo {
+            title
+            description
+          }
+          breadcrumbList {
+            itemListElement {
+              item
+              name
+              position
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+const ALL_COLLECTIONS_OP = {
+  __meta__: {
+    operationName: 'LlmsAllCollectionsQuery',
+    operationHash: 'llms-all-collections',
+  },
+} as unknown as Parameters<typeof execute>[0]['operation']
+
+/**
+ * Fetches top-level categories for the current binding via the GraphQL API.
+ * Only `Department` and `Category` types are returned; deep leaf nodes are
+ * filtered out to keep the LLM file high-signal.
+ */
+export async function fetchTopCategories(limit = 25): Promise<LlmsLink[]> {
+  try {
+    const { data, errors } = await execute<
+      { first: number },
+      AllCollectionsResult
+    >({
+      operation: ALL_COLLECTIONS_OP,
+      variables: { first: Math.max(limit * 2, limit) },
+      query: ALL_COLLECTIONS_QUERY,
+    })
+
+    if (errors?.length) {
+      console.warn('[llms] allCollections returned errors', errors)
+    }
+
+    const edges = data?.allCollections?.edges ?? []
+    return edges
+      .map((edge) => edge.node)
+      .filter((node) => node.type === 'Department' || node.type === 'Category')
+      .slice(0, limit)
+      .map<LlmsLink>((node) => ({
+        name: node.seo?.title || node.slug,
+        url: `/${node.slug.replace(/^\//, '')}`,
+        description: node.seo?.description,
+      }))
+  } catch (error) {
+    console.warn('[llms] fetchTopCategories failed', error)
+    return []
+  }
+}
+
+/**
+ * Fetches CMS pages for the configured contentTypes. Applies allow- and
+ * deny-list filters on slug. Returns the raw shape needed by both `/llms.txt`
+ * (link + description) and `/llms-full.txt` (full sections payload).
+ */
+export async function fetchPagesByContentTypes(
+  config: LlmsSourcesConfig
+): Promise<LlmsPage[]> {
+  const contentTypes = config.contentTypes ?? []
+  if (contentTypes.length === 0) return []
+
+  const allow = new Set((config.slugAllowList ?? []).map(normalizeSlug))
+  const deny = new Set((config.slugDenyList ?? []).map(normalizeSlug))
+
+  const results = await Promise.all(
+    contentTypes.map(async (contentType) => {
+      try {
+        const { data } = await contentService.getMultipleContent({
+          contentType,
+        })
+        return data
+      } catch (error) {
+        console.warn(
+          `[llms] failed to fetch contentType="${contentType}"`,
+          error
+        )
+        return []
+      }
+    })
+  )
+
+  const pages: LlmsPage[] = []
+  for (const entries of results) {
+    for (const entry of entries) {
+      const page = toLlmsPage(entry)
+      if (!page) continue
+      const slug = normalizeSlug(page.slug)
+      if (deny.has(slug)) continue
+      if (allow.size > 0 && !allow.has(slug)) continue
+      pages.push(page)
+    }
+  }
+  return pages
+}
+
+function toLlmsPage(entry: any): LlmsPage | null {
+  const seo = entry?.settings?.seo
+  const slug = seo?.slug ?? entry?.slug
+  if (!slug) return null
+  return {
+    slug,
+    title: seo?.title || entry?.name || slug,
+    description: seo?.description,
+    sections: Array.isArray(entry?.sections) ? entry.sections : [],
+  }
+}
+
+/**
+ * Converts a discovered CMS page to a link suitable for `/llms.txt`'s
+ * `## Pages` section.
+ */
+export function pageToLink(page: LlmsPage): LlmsLink {
+  return {
+    name: page.title,
+    url: page.slug.startsWith('/') ? page.slug : `/${page.slug}`,
+    description: page.description,
+  }
+}
+
+function normalizeSlug(slug: string): string {
+  return slug.replace(/^\//, '').toLowerCase()
+}
+
+/**
+ * Institutional pages were a v1 concept. v2 keeps the helper as a no-op so
+ * stores still on the v1 config (`institutionalSlugs`) don't crash; the
+ * `## Pages` section sourced from `sources.contentTypes` supersedes it.
+ */
+export async function fetchInstitutionalPages(
+  _slugs: string[]
+): Promise<LlmsLink[]> {
+  return []
+}
+
+/**
+ * FAQ entries are not exposed by the base CMS content model. Stores that want
+ * an FAQ block can populate `discovery.config.llms.customSections`.
+ */
+export async function fetchFaqEntries(): Promise<LlmsLink[]> {
+  return []
+}
+
+export function getLlmsSourcesConfig(): LlmsSourcesConfig {
+  const llms = (storeConfig as { llms?: { sources?: LlmsSourcesConfig } }).llms
+  return llms?.sources ?? {}
+}

--- a/packages/core/src/server/llms/types.ts
+++ b/packages/core/src/server/llms/types.ts
@@ -1,0 +1,55 @@
+export interface LlmsLink {
+  name: string
+  url: string
+  description?: string
+}
+
+export interface LlmsCustomSection {
+  title: string
+  items: LlmsLink[]
+}
+
+export interface LlmsCustomPage {
+  title: string
+  slug: string
+  body: string
+}
+
+export interface LlmsSourcesConfig {
+  categories?: { enabled?: boolean; limit?: number }
+  contentTypes?: string[]
+  slugAllowList?: string[]
+  slugDenyList?: string[]
+  textSectionNames?: string[]
+}
+
+export interface LlmsConfig {
+  enabled: boolean
+  title: string
+  tagline?: string
+  about?: string
+  contact?: {
+    email?: string
+    url?: string
+  }
+  customSections?: LlmsCustomSection[]
+  customPages?: LlmsCustomPage[]
+  institutionalSlugs?: string[]
+  sources?: LlmsSourcesConfig
+  maxLinksPerSection?: number
+}
+
+export interface LlmsPage {
+  slug: string
+  title: string
+  description?: string
+  sections?: Array<{ name: string; data: unknown }>
+}
+
+export interface LlmsSources {
+  storeUrl: string
+  categories: LlmsLink[]
+  institutional: LlmsLink[]
+  faq: LlmsLink[]
+  pages: LlmsPage[]
+}

--- a/packages/core/test/server/llms/buildLlmsTxt.test.ts
+++ b/packages/core/test/server/llms/buildLlmsTxt.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildLlmsTxt } from '../../../src/server/llms'
+import { truncate } from '../../../src/server/llms/format'
+import type { LlmsConfig, LlmsSources } from '../../../src/server/llms/types'
+
+const STORE_URL = 'https://acme.example'
+
+const baseConfig: LlmsConfig = {
+  enabled: true,
+  title: 'Acme Store',
+  tagline: 'Curated streetwear since 2008.',
+  about: 'Long-form paragraph about the brand.',
+  contact: {
+    email: 'support@acme.example',
+    url: 'https://acme.example/contact',
+  },
+  maxLinksPerSection: 25,
+}
+
+const fullSources: Partial<LlmsSources> = {
+  categories: [
+    { name: 'Office', url: '/office', description: 'Office supplies' },
+    { name: 'Technology', url: '/technology' },
+  ],
+  institutional: [
+    { name: 'Shipping policy', url: '/shipping' },
+    { name: 'Returns & exchanges', url: '/returns' },
+  ],
+  faq: [{ name: 'Where is my order?', url: '/faq/orders' }],
+}
+
+describe('buildLlmsTxt', () => {
+  it('returns null when llms is disabled', async () => {
+    const result = await buildLlmsTxt({
+      config: { ...baseConfig, enabled: false },
+      storeUrl: STORE_URL,
+    })
+    expect(result).toBeNull()
+  })
+
+  it('renders the documented section order on the happy path', async () => {
+    const result = await buildLlmsTxt({
+      config: baseConfig,
+      storeUrl: STORE_URL,
+      sources: fullSources,
+    })
+
+    expect(result).not.toBeNull()
+    const body = result as string
+
+    expect(body.startsWith('# Acme Store\n')).toBe(true)
+    expect(body).toContain('> Curated streetwear since 2008.')
+    expect(body).toContain('## Shop by category')
+    expect(body).toContain('## Customer service')
+    expect(body).toContain('## FAQ')
+    expect(body).toContain('## Contact')
+    expect(body).toContain('## Optional')
+
+    const order = [
+      '## Shop by category',
+      '## Customer service',
+      '## FAQ',
+      '## Contact',
+      '## Optional',
+    ].map((s) => body.indexOf(s))
+    const sorted = [...order].sort((a, b) => a - b)
+    expect(order).toEqual(sorted)
+
+    expect(body.endsWith('\n')).toBe(true)
+    expect(body.endsWith('\n\n')).toBe(false)
+  })
+
+  it('absolutizes relative URLs against storeUrl', async () => {
+    const result = await buildLlmsTxt({
+      config: baseConfig,
+      storeUrl: STORE_URL,
+      sources: {
+        categories: [{ name: 'Office', url: '/office' }],
+      },
+    })
+    expect(result).toContain(`[Office](${STORE_URL}/office)`)
+  })
+
+  it('preserves already-absolute URLs', async () => {
+    const result = await buildLlmsTxt({
+      config: baseConfig,
+      storeUrl: STORE_URL,
+      sources: {
+        categories: [{ name: 'External', url: 'https://other.example/x' }],
+      },
+    })
+    expect(result).toContain('[External](https://other.example/x)')
+  })
+
+  it('omits sections whose builders have no content', async () => {
+    const result = await buildLlmsTxt({
+      config: baseConfig,
+      storeUrl: STORE_URL,
+    })
+    expect(result).not.toBeNull()
+    const body = result as string
+    expect(body).not.toContain('## Shop by category')
+    expect(body).not.toContain('## Customer service')
+    expect(body).not.toContain('## FAQ')
+    expect(body).toContain('## Contact')
+  })
+
+  it('truncates link descriptions at 120 chars', async () => {
+    const longText = 'x'.repeat(200)
+    const result = await buildLlmsTxt({
+      config: baseConfig,
+      storeUrl: STORE_URL,
+      sources: {
+        categories: [{ name: 'Office', url: '/office', description: longText }],
+      },
+    })
+    const body = result as string
+    const line = body.split('\n').find((l) => l.startsWith('- [Office]'))!
+    const description = line.split('): ')[1]
+    expect(description.length).toBeLessThanOrEqual(120)
+    expect(description.endsWith('…')).toBe(true)
+  })
+
+  it('caps links per section by maxLinksPerSection', async () => {
+    const many = Array.from({ length: 50 }, (_, i) => ({
+      name: `Cat ${i}`,
+      url: `/c/${i}`,
+    }))
+    const result = await buildLlmsTxt({
+      config: { ...baseConfig, maxLinksPerSection: 5 },
+      storeUrl: STORE_URL,
+      sources: { categories: many },
+    })
+    const body = result as string
+    const categoryLines = body
+      .split('## Shop by category\n')[1]
+      .split('\n##')[0]
+      .split('\n')
+      .filter((l) => l.startsWith('- ['))
+    expect(categoryLines).toHaveLength(5)
+  })
+
+  it('renders customSections from config', async () => {
+    const result = await buildLlmsTxt({
+      config: {
+        ...baseConfig,
+        customSections: [
+          {
+            title: 'Press',
+            items: [{ name: 'Newsroom', url: '/press' }],
+          },
+        ],
+      },
+      storeUrl: STORE_URL,
+    })
+    expect(result).toContain('## Press')
+    expect(result).toContain('[Newsroom](https://acme.example/press)')
+  })
+})
+
+describe('truncate', () => {
+  it('returns the input when shorter than max', () => {
+    expect(truncate('hello', 120)).toBe('hello')
+  })
+
+  it('collapses whitespace', () => {
+    expect(truncate('  a   b\nc  ', 120)).toBe('a b c')
+  })
+
+  it('appends an ellipsis when over the limit', () => {
+    const result = truncate('a'.repeat(200), 10)
+    expect(result).toHaveLength(10)
+    expect(result.endsWith('…')).toBe(true)
+  })
+})


### PR DESCRIPTION
> **Status: Proof of Concept.** Not intended for merge as-is. Opened to gather feedback on the approach, config contract, and source wiring before promoting to a real feature.

## What's the purpose of this pull request?

[`llms.txt`](https://llmstxt.org/) is a 2024 proposal for a curated Markdown index at `/llms.txt`, scoped so an LLM with a small context window can ingest a site's high-signal content. This PR explores what a FastStore-native implementation looks like: two feature-flagged Next.js routes that expose curated, LLM-friendly content for the storefront.

Two routes ship behind a single flag:

- **`/llms.txt`** — brand header + top categories (live from GraphQL `allCollections`) + CMS-discovered pages + optional custom sections + sitemap and full-content cross-links.
- **`/llms-full.txt`** — inlines SEO descriptions and whitelisted CMS section text (`BannerText`, `Hero` by default; extensible per store) so an LLM can answer questions, not just navigate. Per-page (8KB) and total-file (500KB) caps prevent rogue pages from blowing up the file.

Both routes are **disabled by default** (`discovery.config.llms.enabled = false`) and ship with sensible defaults so a store opts in with minimal config.

## How it works?

- New server module at `packages/core/src/server/llms/`:
  - `build.ts` — `resolveSources()` orchestrates GraphQL + CMS fetches with config-driven gating.
  - `sources.ts` — `fetchTopCategories()` via `execute()` with an inline `allCollections` query (filtered to `Department` / `Category` types); `fetchPagesByContentTypes()` via `contentService.getMultipleContent` with slug allow/deny lists.
  - `extract.ts` — pure section-text extractor that pulls `title` / `subtitle` / `caption` / `text` / `body` / `description` out of whitelisted CMS sections. Unknown sections and unknown fields are ignored.
  - `sections.ts` — section builders (brand header, categories, pages, customer service, FAQ, custom sections, contact, optional).
  - `full.ts` — `buildLlmsFullTxt()` composes the brand header, the categories block, the per-page blocks, and the custom-pages block, with size caps and page-boundary truncation when the total cap is exceeded.
  - `index.ts` — `buildLlmsTxt()` and re-exports.
- New API routes under `packages/core/src/pages/api/fs/llms.ts` and `llms-full.ts` with `text/markdown; charset=utf-8`, `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400`, `X-Robots-Tag: noindex`, 405 on non-GET, and 404 when the feature flag is off.
- `next.config.js` rewrites `/llms.txt` → `/api/fs/llms` and `/llms-full.txt` → `/api/fs/llms-full`, placed before `storeConfig.rewrites` so store overrides win.
- `discovery.config.default.js` ships the `llms` block with `enabled: false` and a `sources` sub-block (`categories.enabled`, `categories.limit`, `contentTypes`, `slugAllowList`, `slugDenyList`, `textSectionNames`).

### Background docs

The `docs/llms-txt/` directory ships research notes, the v1 PoC plan, the v2 plan implemented here, and a rendered HTML handoff. They live in the PR for reviewer context — they're not part of the runtime surface and can be removed before any non-PoC merge.

#### How to read `docs/llms-txt/handoff.html`

`handoff.html` is the rendered HTML version of `handoff.md`. To read it:

- **Locally**: open the file in any browser — for example `open docs/llms-txt/handoff.html` (macOS) or `xdg-open docs/llms-txt/handoff.html` (Linux). The file is self-contained (no external assets), so it renders the same anywhere.
- **From the PR**: GitHub does not render HTML files inline. Either preview the raw file via [`raw.githack.com`](https://raw.githack.com) (paste the GitHub raw URL), or read [`docs/llms-txt/handoff.md`](docs/llms-txt/handoff.md) instead — it has the same content with GitHub's native Markdown rendering.

If you only have time for one document, read `handoff.md` for the research and `plan-v2.md` for the implementation contract.

## How to test it?

In `packages/core/src/customizations/discovery.config.js` set the `llms.enabled` flag (the file already ships with a smoke-test config in this PR) and:

```bash
pnpm --filter @faststore/core dev
```

Then:

- `GET http://localhost:3000/llms.txt` → 200, `Content-Type: text/markdown; charset=utf-8`, body starts with `# ` and contains `## Shop by category`, `## Pages`, `## Contact`, `## Optional` (the last linking to `/llms-full.txt`).
- `GET http://localhost:3000/llms-full.txt` → 200, parses as Markdown, has one `## ` block per discovered page, includes prose not just titles.
- Flip `llms.enabled` to `false` → both routes return 404.
- Disable `llms.sources.categories.enabled` → `## Shop by category` disappears from both files.
- Add a slug to `llms.sources.slugDenyList` → that page disappears from `## Pages` and from `/llms-full.txt`.
- Send a `POST` or `PUT` to either route → 405.

### Starters Deploy Preview

<!-- to be added after the CodeSandbox preview is generated -->

## References

- Spec: <https://llmstxt.org/>
- Research notes, alternatives considered, and open questions: [`docs/llms-txt/handoff.md`](docs/llms-txt/handoff.md)
- v1 PoC plan (curated, no live sources): [`docs/llms-txt/plan.md`](docs/llms-txt/plan.md)
- v2 implementation plan (this PR): [`docs/llms-txt/plan-v2.md`](docs/llms-txt/plan-v2.md)

## Notes on what this PR is and isn't

**Is:** a working spike that ships two real endpoints reading live storefront data. Useful to validate the approach, the config contract, and the CMS / GraphQL wiring against a real store before committing to a feature.

**Isn't:**

- Production-ready. No tests in this PR (left out intentionally to keep the spike small).
- A final config contract. The `sources` shape is forward-compatible but not frozen.
- A multi-binding solution. The routes use the current request's binding context; a `/{locale}/llms.txt` fan-out is deferred (see open questions in `handoff.md`).
- An edge-cache or `robots.txt` integration. The VTEX edge proxy behavior for `/llms.txt` still needs platform-team confirmation.

## Checklist

**PR Title and Commit Messages**

- [x] PR title and commit messages follow Conventional Commits (`feat(core): ...`)

**PR Description**

- [x] Context, implementation summary, and verification steps included
- [ ] Label (PoC / spike) to be added by the reviewer

**Dependencies**

- [x] No dependency changes; no `pnpm-lock.yaml` updates

**Documentation**

- [x] PR description and `docs/llms-txt/`

## Preview
[llms.txt for FastStore — PR handoff.pdf](https://github.com/user-attachments/files/28056576/llms.txt.for.FastStore.PR.handoff.pdf)

<img width="1624" height="1061" alt="Screenshot 2026-05-20 at 08 51 36" src="https://github.com/user-attachments/assets/d3f3a977-44f5-4333-b0fb-3e456a60ea99" />
