### PR TITLE
perf(plp): prioritize first product image as LCP (VTE-14)

### DIFF
--- a/packages/core/src/components/product/ProductCard/ProductCard.tsx
+++ b/packages/core/src/components/product/ProductCard/ProductCard.tsx
@@ -166,6 +166,7 @@ function ProductCard({
             width={imgProps?.width ?? 360}
             height={Math.round((Number(imgProps?.height) || 360) / aspectRatio)}
             loading={imgProps?.loading}
+            fetchPriority={imgProps?.fetchPriority}
           />
         </UIProductCardImage>
         <UIProductCardContent

--- a/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/packages/core/src/components/product/ProductGrid/ProductGrid.tsx
@@ -120,6 +120,7 @@ function ProductGrid({
                       height: 150,
                       sizes: '30vw',
                       loading: 'eager',
+                      fetchPriority: idx === 0 ? 'high' : undefined,
                     }}
                     {...ProductCard.props}
                     bordered={bordered ?? ProductCard.props.bordered}
@@ -188,7 +189,9 @@ function ProductGrid({
                       width: 150,
                       height: 150,
                       sizes: '30vw',
-                      loading: idx === 0 ? 'eager' : 'lazy',
+                      loading: idx < 4 ? 'eager' : 'lazy',
+                      fetchPriority:
+                        idx === 0 && page === firstPage ? 'high' : undefined,
                     }}
                     {...ProductCard.props}
                     bordered={bordered ?? ProductCard.props.bordered}

--- a/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
+++ b/packages/core/src/components/templates/ProductListingPage/ProductListingPage.tsx
@@ -5,6 +5,7 @@ import {
   SearchProvider,
 } from '@faststore/sdk'
 import { BreadcrumbJsonLd, NextSeo } from 'next-seo'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
 
@@ -19,6 +20,7 @@ import { useApplySearchState } from 'src/sdk/search/state'
 import type { PLPContentType } from 'src/server/cms/plp'
 
 import storeConfig from '../../../../discovery.config'
+import { faststoreLoader } from 'src/components/ui/Image/loader'
 import ProductListing from './ProductListing'
 import { getStoreURL } from 'src/sdk/localization/useLocalizationConfig'
 
@@ -119,6 +121,26 @@ export default function ProductListingPage({
     )
   }
 
+  // Preload the first product image so the browser fetches it at parse time,
+  // before JS hydration. PSI consistently identifies the first product grid
+  // item as the LCP element even when a Hero section is present — the hero
+  // renders at a smaller visual area than the first product card on mobile.
+  //
+  // Width reasoning: next.config.js imageSizes=[34,68,154,320], deviceSizes=[360,412,...].
+  // Product cards use sizes="30vw". At Lighthouse mobile (412px viewport, DPR≈2):
+  //   30vw × 412 × 2 = 247px → browser picks 320 (first step ≥ 247 in the srcset).
+  // Using 320 here makes the preload URL exactly match the <img> srcset selection,
+  // so the browser can reuse the preloaded response instead of fetching a second URL.
+  const rawLcpImageUrl: string | undefined =
+    server?.search?.products?.edges?.[0]?.node?.image?.[0]?.url
+  const lcpImageUrl = rawLcpImageUrl
+    ? faststoreLoader({
+        src: rawLcpImageUrl,
+        width: 320,
+        quality: 75,
+      })
+    : undefined
+
   return (
     <SearchProvider
       onChange={applySearchState}
@@ -126,6 +148,16 @@ export default function ProductListingPage({
       shouldResetInfiniteScroll={!storeConfig.experimental?.scrollRestoration}
       {...searchParams}
     >
+      {lcpImageUrl && (
+        <Head>
+          <link
+            rel="preload"
+            as="image"
+            href={lcpImageUrl}
+            fetchPriority="high"
+          />
+        </Head>
+      )}
       {/* SEO */}
       <NextSeo
         title={title}


### PR DESCRIPTION
## Summary

Improves PLP LCP by making the browser fetch and prioritize the first product card image earlier.

- **ProductListingPage**: render `<link rel="preload" as="image" fetchPriority="high">` in `<Head>` for the first product image. The preload URL is generated by `faststoreLoader` with `width=320` so it exactly matches the `<img>` srcset selection at Lighthouse mobile (412px viewport, DPR≈2, `sizes="30vw"` → 247px → next srcset step = 320). This avoids a double fetch.
- **ProductGrid**: set `fetchPriority: 'high'` on the first card image, and switch eager loading from `idx === 0` to `idx < 4` so the first visible row is not blocked by lazy loading.
- **ProductCard**: forward `fetchPriority` from `imgProps` to the underlying `Image` component.

This is the first slice of #3345.

## Context

PageSpeed Insights identifies the first product card image as the LCP element on PLP even when a Hero section is present — the hero renders at a smaller visual area than the first product card on mobile.

## Test plan

- [ ] Lighthouse mobile PLP run shows LCP element = first product image and the preload reused (no `request not used` warning in DevTools).
- [ ] PLP renders correctly when `server.search.products.edges[0]` is missing (no preload link rendered).
- [ ] Other PLPs and PDP unaffected.
- [ ] `pnpm test --filter=@faststore/core` passes.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized image loading on product listing pages with intelligent priority handling to improve page load speed.
  * First product images are now prioritized for faster initial rendering on all devices.
  * Product cards now support configurable image loading priority settings for enhanced performance control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->