### PR TITLE
feat(core): SSR ProductGallery and fix CLS on screen-size detection (VTE-9)

### DIFF
--- a/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
+++ b/packages/core/src/components/ui/ProductGallery/ProductGallery.tsx
@@ -1,6 +1,6 @@
 import { NextSeo } from 'next-seo'
 import dynamic from 'next/dynamic'
-import { Suspense, lazy, useState, type MouseEvent } from 'react'
+import { Suspense, useState, type MouseEvent } from 'react'
 
 import { useSearch } from '@faststore/sdk'
 import { useUI } from '@faststore/ui'
@@ -24,8 +24,7 @@ import useScreenResize from 'src/sdk/ui/useScreenResize'
 
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import styles from '../../sections/ProductGallery/section.module.scss'
-
-const ProductGalleryPage = lazy(() => import('./ProductGalleryPage'))
+import ProductGalleryPage from './ProductGalleryPage'
 const FilterSkeleton = dynamic(
   () =>
     import(

--- a/packages/core/src/sdk/ui/useScreenResize.ts
+++ b/packages/core/src/sdk/ui/useScreenResize.ts
@@ -1,4 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useLayoutEffect, useState } from 'react'
+
+// useLayoutEffect fires synchronously before the browser paints, eliminating
+// the layout shift caused by useEffect firing after the first paint.
+// Falls back to useEffect on the server (SSR) where window is not available.
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
 // We are using the Moto G Power device measurement as a reference (mobile), as used by PageSpeed Insights.
 const MAX_MOBILE_WIDTH = 420
@@ -10,7 +16,7 @@ function useScreenResize() {
   const [isTablet, setIsTablet] = useState(undefined)
   const [isDesktop, setIsDesktop] = useState(undefined)
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const handleResize = () => {
       setIsMobile(window.innerWidth <= MAX_MOBILE_WIDTH)
       setIsTablet(


### PR DESCRIPTION
## Summary

Two related changes that reduce layout shift on PLP first paint.

- **ProductGallery**: replace `React.lazy(() => import('./ProductGalleryPage'))` with a static import of `ProductGalleryPage`. The lazy chunk was loaded on the client after hydration, so the gallery first rendered the Suspense fallback and then swapped in the real content, producing a measurable CLS. Inlining the gallery into the parent bundle removes the swap.
- **useScreenResize**: switch from `useEffect` to an isomorphic `useLayoutEffect` (`useLayoutEffect` in the browser, `useEffect` during SSR). The previous `useEffect` ran after the first paint, so mobile-only branches first rendered with `isMobile=undefined` and then shifted once the effect updated the state. `useLayoutEffect` runs synchronously before paint, eliminating the shift.

This is the second slice of #3345.

## Notes for reviewers

- SonarQube flagged `useIsomorphicLayoutEffect` definition with a `negated condition` warning and a `Prefer globalThis.window over window` warning. Both are intentional — the negated form is the canonical pattern from the React docs, and `window` (not `globalThis.window`) is the convention used throughout the rest of the file. Happy to revisit if reviewers prefer otherwise.

## Test plan

- [ ] PLP first paint CWV: CLS does not regress (Lighthouse mobile).
- [ ] PLP renders the full gallery on first paint (no Suspense fallback flash).
- [ ] `useScreenResize` consumers continue to receive correct `isMobile`/`isTablet`/`isDesktop` after window resize.
- [ ] `pnpm test --filter=@faststore/core` passes.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved component loading and rendering architecture for better performance
  * Enhanced server-side rendering compatibility for layout operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->