### PR TITLE
fix(sdk): refetch first PLP page from page-load time, not build time

### DIFF
--- a/packages/core/src/sdk/product/usePageProductsQuery.ts
+++ b/packages/core/src/sdk/product/usePageProductsQuery.ts
@@ -17,7 +17,6 @@ import {
 } from 'react'
 import { useQuery } from 'src/sdk/graphql/useQuery'
 import { useSession } from 'src/sdk/session'
-import { generatedBuildTime } from '../../../next-seo.config'
 import { useLocalizedVariables } from './useLocalizedVariables'
 import { useShouldFetchFirstPage } from './useShouldFetchFirstPage'
 
@@ -142,7 +141,6 @@ export const useCreateUseGalleryPage = (
 
     const shouldFetchFirstPage = useShouldFetchFirstPage({
       page,
-      generatedBuildTime,
     })
 
     const shouldFetch = !hasSameVariables || shouldFetchFirstPage

--- a/packages/core/src/sdk/product/useShouldFetchFirstPage.ts
+++ b/packages/core/src/sdk/product/useShouldFetchFirstPage.ts
@@ -11,45 +11,44 @@ function hasTimeElapsed({
 
 interface UseShouldFetchFirstPageParams {
   page: number
-  generatedBuildTime: number
 }
 
 /**
  * This hook determines if the first page (page 0) should be fetched.
  * This is because the first page is initially fetched from the server side and injected into the cache for performance and SEO reasons.
  * So this hook checks if the first page should be fetched again on the client side
- * after 5 minutes since the build time (last fetch from the server side) or the last fetch time from the client side.
+ * after 5 minutes since the user loaded the page (not the build time), or the last fetch time from the client side.
  *
  * @param page The page number
- * @param generatedBuildTime The time the page was generated
  * @returns boolean
  *
  **/
 export function useShouldFetchFirstPage({
   page,
-  generatedBuildTime,
 }: UseShouldFetchFirstPageParams): boolean {
-  if (page !== 0) return false
-
+  // useRef must be called before any early return to comply with Rules of Hooks.
+  const pageLoadTime = useRef(Date.now())
   const lastFetchTime = useRef<number | undefined>()
 
-  const passedFiveMinutesAfterBuild = hasTimeElapsed({
-    timestamp: generatedBuildTime,
+  if (page !== 0) return false
+
+  const passedFiveMinutesSincePageLoad = hasTimeElapsed({
+    timestamp: pageLoadTime.current,
     period: FIVE_MINUTES,
   })
 
-  const isFirstClientSideFetchFromFirstPage =
-    lastFetchTime.current === undefined
+  const currentLastFetchTime = lastFetchTime.current
+  const isFirstClientSideFetchFromFirstPage = currentLastFetchTime === undefined
 
   const passedFiveMinutesSinceLastFetch =
-    !isFirstClientSideFetchFromFirstPage &&
+    currentLastFetchTime !== undefined &&
     hasTimeElapsed({
-      timestamp: lastFetchTime.current!,
+      timestamp: currentLastFetchTime,
       period: FIVE_MINUTES,
     })
 
   if (
-    passedFiveMinutesAfterBuild &&
+    passedFiveMinutesSincePageLoad &&
     (isFirstClientSideFetchFromFirstPage || passedFiveMinutesSinceLastFetch)
   ) {
     lastFetchTime.current = Date.now()


### PR DESCRIPTION
## Summary

`useShouldFetchFirstPage` previously used `generatedBuildTime` as the reference for the 5-minute refetch window. For static PLP pages served hours or days after the build, the build-time check is always `true` on the first client-side render, so the hook would refetch on every initial navigation — defeating the cache injected by SSR.

This PR switches to a per-mount `pageLoadTime` ref (set on first render via `useRef(Date.now())`) and only refetches once 5 minutes have elapsed since the user actually opened the page. This matches the documented intent ("don't refetch immediately after SSR injects the cache") and removes the dependency on the build timestamp from `usePageProductsQuery`.

Also reorders the hook body so `useRef` is called before the `page !== 0` early return, complying with the Rules of Hooks.

This is the third slice of #3345.

## Behavior changes

- First PLP visit no longer triggers a redundant client-side fetch right after SSR.
- Subsequent refetch logic (after 5min) is unchanged in spirit, but anchored to the user's session rather than the build.
- Public API of `useShouldFetchFirstPage` changes: the `generatedBuildTime` parameter is removed. Only internal call site (`usePageProductsQuery`) is updated; the hook is not part of the documented SDK surface.

## Test plan

- [ ] On a fresh PLP load, the network panel shows only the SSR-injected query, no immediate client refetch.
- [ ] After waiting 5 minutes and triggering a refetch (filter/sort change), the first-page fetch happens.
- [ ] `pnpm test --filter=@faststore/core` passes (existing tests for `useShouldFetchFirstPage` may need updates — flag if so).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated product data refresh logic to use client-side page load timing instead of server-side build time for determining when to refetch the first page, while maintaining the 5-minute refresh window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->