### PR TITLE
docs: document allowed PR scopes in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,9 @@ Each package within the FastStore monorepo MUST maintain clear boundaries and a 
 
 ### VII. Conventional Commits & Semantic Versioning
 
-- Commit format: `<type>: <description>` (e.g. `feat(sdk): add cart persistence`).
+- Commit format: `<type>(<scope>): <description>` (e.g. `feat(sdk): add cart persistence`).
 - Allowed types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci`, `test`.
+- Allowed scopes: `core`, `ui`, `api`, `components`, `sdk`, `lighthouse`, `diagnostics`, `deps`, `deps-dev`. PRs using any other scope will fail the "Lint PR" CI check enforced by `.github/workflows/pr.yml`.
 - Breaking changes MUST include `BREAKING CHANGE:` in commit body or `!` after type.
 - Lerna automatically versions packages based on Conventional Commits.
 - All packages follow `MAJOR.MINOR.PATCH` semantic versioning.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,9 @@ Each package within the FastStore monorepo MUST maintain clear boundaries and a 
 
 ### VII. Conventional Commits & Semantic Versioning
 
-- Commit format: `<type>(<scope>): <description>` (e.g. `feat(sdk): add cart persistence`).
+- Commit format: `<type>[(<scope>)]: <description>` — scope is optional (e.g. `feat(sdk): add cart persistence` or `docs: update AGENTS.md`).
 - Allowed types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci`, `test`.
-- Allowed scopes: `core`, `ui`, `api`, `components`, `sdk`, `lighthouse`, `diagnostics`, `deps`, `deps-dev`. PRs using any other scope will fail the "Lint PR" CI check enforced by `.github/workflows/pr.yml`.
+- Allowed scopes (when used): `core`, `ui`, `api`, `components`, `sdk`, `lighthouse`, `diagnostics`, `deps`, `deps-dev`. PRs using any other scope will fail the "Lint PR" CI check enforced by `.github/workflows/pr.yml`. Omit the scope for cross-cutting changes (e.g. root `AGENTS.md`, repo-wide config).
 - Breaking changes MUST include `BREAKING CHANGE:` in commit body or `!` after type.
 - Lerna automatically versions packages based on Conventional Commits.
 - All packages follow `MAJOR.MINOR.PATCH` semantic versioning.


### PR DESCRIPTION
## Summary

- Adds the explicit list of allowed commit scopes (`core`, `ui`, `api`, `components`, `sdk`, `lighthouse`, `diagnostics`, `deps`, `deps-dev`) to section VII of `AGENTS.md`
- References `.github/workflows/pr.yml` as the enforcement point so agents know where the rule lives
- Prevents agents from opening PRs with invalid scopes (e.g. `i18n`) that fail the "Lint PR" CI check

## Test plan

- [ ] Verify the "Lint PR" CI check passes for this PR title

Made with [Cursor](https://cursor.com)