### PR TITLE
fix: createNextJSPages throwing preventing copy of store discovery-co…

### DIFF
--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -236,25 +236,25 @@ function copyUserStarterToCustomizations(basePath: string) {
       copySync(userSrcDir, tmpCustomizationsSrcDir, { dereference: true })
       createNextJsPages(basePath)
     }
-
-    if (existsSync(userStoreConfigFile)) {
-      copySync(userStoreConfigFile, tmpStoreConfigFile, { dereference: true })
-    } else if (existsSync(userLegacyStoreConfigFile)) {
-      copySync(userLegacyStoreConfigFile, tmpStoreConfigFile, {
-        dereference: true,
-      })
-    } else {
-      logger.info(
-        `${chalk.blue(
-          'info'
-        )} - No store config file was found in the root directory`
-      )
-    }
-
-    logger.log(`${chalk.green('success')} - Starter files copied`)
   } catch (err) {
     logger.error(`${chalk.red('error')} - ${err}`)
   }
+
+  if (existsSync(userStoreConfigFile)) {
+    copySync(userStoreConfigFile, tmpStoreConfigFile, { dereference: true })
+  } else if (existsSync(userLegacyStoreConfigFile)) {
+    copySync(userLegacyStoreConfigFile, tmpStoreConfigFile, {
+      dereference: true,
+    })
+  } else {
+    logger.info(
+      `${chalk.blue(
+        'info'
+      )} - No store config file was found in the root directory`
+    )
+  }
+
+  logger.log(`${chalk.green('success')} - Starter files copied`)
 }
 
 async function createCmsWebhookUrlsJsonFile(basePath: string) {


### PR DESCRIPTION
When running cli the step of creating the .faststore folder was not copying the discovery.config of the store because the `createNextJsPages` trhow an error of use trying to create new nextjs pages/apis  that is not allowed. 

The behaviour of not allowing is not changed, only kept the flow of script as it was before fixing the config copy that was being steped in this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling and diagnostics in the initialization process to ensure more accurate error reporting when setup encounters issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->