### PR TITLE
fix(ui): replace mixed-support flex alignment values with flex-prefixed equivalents

### DIFF
--- a/packages/core/src/components/account/MyAccountDrawer/OrganizationDrawer/section.module.scss
+++ b/packages/core/src/components/account/MyAccountDrawer/OrganizationDrawer/section.module.scss
@@ -35,8 +35,8 @@
         --fs-slide-over-header-bkg: #f5f5f5;
 
         flex-direction: row;
-        align-items: start;
-        justify-content: end;
+        align-items: flex-start;
+        justify-content: flex-end;
         height: var(--fs-slide-over-header-height);
         padding: var(--fs-spacing-2);
         background-color: var(--fs-slide-over-header-bkg);

--- a/packages/ui/src/components/molecules/Toast/styles.scss
+++ b/packages/ui/src/components/molecules/Toast/styles.scss
@@ -53,7 +53,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
   width: var(--fs-toast-width);
   min-height: var(--fs-toast-min-height);
   padding: var(--fs-toast-padding);

--- a/packages/ui/src/components/organisms/LocalizationSelector/styles.scss
+++ b/packages/ui/src/components/organisms/LocalizationSelector/styles.scss
@@ -41,7 +41,7 @@
 
   [data-fs-localization-selector-actions] {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
   }
 
   [data-fs-localization-selector-error] {


### PR DESCRIPTION
## Summary

- Replace `justify-content: end` → `justify-content: flex-end` in `LocalizationSelector/styles.scss`
- Replace `align-items: start` → `align-items: flex-start` and `justify-content: end` → `justify-content: flex-end` in `OrganizationDrawer/section.module.scss`
- Replace `justify-content: start` → `justify-content: flex-start` in `Toast/styles.scss`

These changes resolve autoprefixer warnings about mixed browser support when using the bare `start`/`end` CSS keywords as flex alignment values. The `flex-start`/`flex-end` variants are universally supported in flex contexts.

## Test plan

- [ ] Verify the LocalizationSelector renders correctly (actions row alignment unchanged)
- [ ] Verify the OrganizationDrawer header renders correctly (row layout unchanged)
- [ ] Verify the Toast renders correctly (content alignment unchanged)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized flex container alignment properties across multiple UI components including account drawer headers, toast notifications, and localization selector menus to ensure consistent visual behavior and reliable layout rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->