### PR TITLE
fix(core): fix locale validation for disabled localization and pvt routes

### DIFF
--- a/packages/core/src/utils/localization/validateLocaleForHostname.ts
+++ b/packages/core/src/utils/localization/validateLocaleForHostname.ts
@@ -1,4 +1,4 @@
-import storeConfig from 'discovery.config.default.js'
+import storeConfig from 'discovery.config'
 import type { LocalesSettings } from '../../typings/locales'
 import { getRequestHostname } from '../getRequestHostname'
 
@@ -51,6 +51,13 @@ export function validateLocaleForHostname(
   hostname: string,
   locale: string
 ): boolean {
+  const localesSettings = getLocalesSettings()
+
+  // Skip validation when localization is disabled (consistent with bindingPaths.ts)
+  if (!localesSettings?.enabled) {
+    return true
+  }
+
   const normalizedHostname = getRequestHostname(hostname)
 
   if (!normalizedHostname) {

--- a/packages/core/src/utils/localization/validateLocaleForHostname.ts
+++ b/packages/core/src/utils/localization/validateLocaleForHostname.ts
@@ -51,10 +51,8 @@ export function validateLocaleForHostname(
   hostname: string,
   locale: string
 ): boolean {
-  const localesSettings = getLocalesSettings()
-
   // Skip validation when localization is disabled (consistent with bindingPaths.ts)
-  if (!localesSettings?.enabled) {
+  if (!storeConfig.localization?.enabled) {
     return true
   }
 

--- a/packages/core/src/utils/localization/withLocaleValidation.ts
+++ b/packages/core/src/utils/localization/withLocaleValidation.ts
@@ -23,6 +23,12 @@ export function withLocaleValidationSSR<P extends Record<string, any>>(
       return getServerSidePropsFn(context)
     }
 
+    // Skip locale validation for private/authenticated routes
+    const pathname = req.url?.split('?')[0] ?? ''
+    if (pathname.startsWith('/pvt/')) {
+      return getServerSidePropsFn(context)
+    }
+
     const isValid = validateLocaleForHostname(hostname, locale)
 
     if (!isValid) {


### PR DESCRIPTION
## Problem

`validateLocaleForHostname` has three bugs that cause 404 on all SSR pages when upgrading to FastStore v4:

### 1. Wrong config import
The function imports from `discovery.config.default.js` (FastStore default config only) instead of `discovery.config` (merged default + store config). All other utils in the same codebase use `discovery.config`.

This means any locale bindings defined in the store's `discovery.config.js` are completely ignored during validation.

### 2. `localization.enabled` flag not respected
When `localization.enabled: false`, the function still runs full hostname/binding validation and returns `notFound: true` for any non-localhost host. 

All other functions in `bindingPaths.ts` correctly check `!storeConfig.localization?.enabled` and return early — `validateLocaleForHostname` was the only one missing this check.

### 3. `/pvt/` routes incorrectly validated
`withLocaleValidationSSR` is applied to all SSR pages including B2B portal pages under `/pvt/`. These are private authenticated routes that have no relationship to storefront locale routing and should never be blocked by locale validation.

## Fix

1. **Import fix**: `discovery.config.default.js` → `discovery.config`
2. **enabled check**: Skip validation when `localization.enabled` is `false`, consistent with `bindingPaths.ts`
3. **pvt bypass**: Skip locale validation for routes starting with `/pvt/`

## Impact

Stores upgrading to v4 with `localization.enabled: false` (the default) were getting 404 on all SSR pages (`/pvt/account`, `/pvt/organization-account/...`, etc.) in any non-localhost environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Locale validation now correctly short-circuits when localization is disabled, preventing unnecessary validation and avoiding false negatives.
  * Locale validation is skipped for private/authenticated routes, ensuring those requests proceed without hostname-based locale checks and improving request handling for protected paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->