### PR TITLE
fix: image loader error at vtex assets

### DIFF
--- a/packages/core/src/components/ui/Image/loader.ts
+++ b/packages/core/src/components/ui/Image/loader.ts
@@ -5,20 +5,20 @@ function handleVtexUrls(src: string, width: number, quality = 8) {
     quality > 10 ? Math.ceil(Math.min(quality, 100) / 10) : quality
 
   // Handle VTEX IDs pattern: /ids/{number}/{filename}.{extension}?{queryParams} (Product Images)
-  const regex = /(\/ids\/\d+)\/([^/?]+)(\.[^/?]+)(\?.+)?$/
+  const regex = /(\/ids\/[\d-]+)\/([^/?]+)(\.[^/?]+)(\?.+)?$/
   if (regex.test(src)) {
     return src.replace(
       regex,
       (_match, idPart, filename, _extension, queryString = '') => {
         const qs = new URLSearchParams(queryString)
         qs.set('quality', customQuality.toString())
-        return `${idPart}-${width}-auto/${filename}.webp?${qs.toString()}`
+        return `${idPart.split('-').at(0)}-${width}-auto/${filename}.webp?${qs.toString()}`
       }
     )
   }
 
   // Handle VTEX file manager URLs (CMS Images)
-  if (src.includes('vtexassets') && src.includes('/assets')) {
+  if (src.includes('vtexassets')) {
     const url = new URL(src)
     url.searchParams.set('width', width.toString())
     url.searchParams.set('aspect', 'true')


### PR DESCRIPTION
Image asset from vtex was parsing wrong cause Regex didnt realise it could include - in the ids

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication to forward tokens via account-scoped cookies instead of separate headers
  * Fixed refresh token behavior for local development environments
  * Improved image loader handling for VTEX URLs with hyphenated numeric IDs
  * Enhanced search infinite scroll reset logic

* **New Features**
  * CMS now accepts all available components in page sections, expanding layout flexibility

* **Style**
  * Improved ProductGrid padding and spacing across breakpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->