### PR TITLE
fix: image loader error at vtex assets

### DIFF
--- a/packages/core/src/components/ui/Image/loader.ts
+++ b/packages/core/src/components/ui/Image/loader.ts
@@ -5,14 +5,14 @@ function handleVtexUrls(src: string, width: number, quality = 8) {
     quality > 10 ? Math.ceil(Math.min(quality, 100) / 10) : quality
 
   // Handle VTEX IDs pattern: /ids/{number}/{filename}.{extension}?{queryParams} (Product Images)
-  const regex = /(\/ids\/\d+)\/([^/?]+)(\.[^/?]+)(\?.+)?$/
+  const regex = /(\/ids\/[\d-]+)\/([^/?]+)(\.[^/?]+)(\?.+)?$/
   if (regex.test(src)) {
     return src.replace(
       regex,
       (_match, idPart, filename, _extension, queryString = '') => {
         const qs = new URLSearchParams(queryString)
         qs.set('quality', customQuality.toString())
-        return `${idPart}-${width}-auto/${filename}.webp?${qs.toString()}`
+        return `${idPart.split('-').at(0)}-${width}-auto/${filename}.webp?${qs.toString()}`
       }
     )
   }


### PR DESCRIPTION
Image loader error at vtex url parse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image URL handling to correctly process identifiers containing dashes, ensuring proper image loading and quality optimization across all supported image sources. The enhancement enables more reliable parsing of URLs with dash-separated identifiers and increases overall platform compatibility with a wider variety of image source formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtex/faststore/pull/3360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->