### PR TITLE
chore: revert accidental 4.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [4.2.1](https://github.com/vtex/faststore/compare/v4.2.0...v4.2.1) (2026-06-01)
-
-### Bug Fixes
-
-- fix vtex message ([e9b2105](https://github.com/vtex/faststore/commit/e9b21055dba0ba24658eda1511056ef29d6b0274))
-
 # [4.2.0](https://github.com/vtex/faststore/compare/v4.1.2...v4.2.0) (2026-06-01)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.2.1",
+  "version": "4.2.0",
   "npmClient": "pnpm",
   "command": {
     "publish": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:coverage": "turbo run test:coverage",
     "ci:dkcicd": "pnpm build && pnpm lint && pnpm size && pnpm test:coverage && mkdir -p coverage && pnpm dlx lcov-result-merger 'packages/*/coverage/lcov.info' coverage/lcov.info --prepend-source-files",
     "size": "turbo run size",
-    "release": "lerna version --conventional-commits --conventional-graduate --force-publish --yes",
+    "release": "lerna version --conventional-commits --conventional-graduate --yes && pnpm -r publish --access public --no-git-checks",
     "release:dev": "lerna version --conventional-commits --conventional-prerelease --preid=dev --force-publish --yes && pnpm -r publish --access public --tag dev --no-git-checks",
     "release:v3": "lerna version --conventional-commits --yes && pnpm -r publish --access public --tag v3-latest --no-git-checks",
     "release:verify": "node ./scripts/verify-publish-manifests.mjs",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [4.2.1](https://github.com/vtex/faststore/compare/v4.2.0...v4.2.1) (2026-06-01)
-
-### Bug Fixes
-
-- fix vtex message ([e9b2105](https://github.com/vtex/faststore/commit/e9b21055dba0ba24658eda1511056ef29d6b0274))
-
 # [4.2.0](https://github.com/vtex/faststore/compare/v4.1.2...v4.2.0) (2026-06-01)
 
 ### Features

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faststore/cli",
-  "version": "4.2.1",
+  "version": "4.2.0",
   "description": "FastStore CLI",
   "author": "Emerson Laurentino @emersonlaurentino",
   "type": "module",

--- a/packages/cli/src/commands/generate-i18n.ts
+++ b/packages/cli/src/commands/generate-i18n.ts
@@ -93,7 +93,7 @@ export default class GenerateI18n extends Command {
       VTEX_ACCOUNT && FS_DISCOVERY_APP_KEY && FS_DISCOVERY_APP_TOKEN
 
     if (!hasCredentials) {
-      logger.error(`${chalk.red('[Error]')} - Missing credentials.\n
+      logger.error(`${chalk.red('[Error]')} - Missing VTEX credentials.\n
       ${chalk.cyan('Required Action:')}\n
       Check your FastStore WebOps Settings page - to work in production, it should contain the following variables: ${chalk.cyan('VTEX_ACCOUNT')}, ${chalk.cyan('FS_DISCOVERY_APP_KEY')}, ${chalk.cyan('FS_DISCOVERY_APP_TOKEN')}.\n
       If running locally, please check your ${chalk.bold('vtex.env')} file, it should also contain those variables.


### PR DESCRIPTION
## What's the purpose of this pull request?

Reverts an accidental `4.2.1` release

This PR restores `main` to the last legitimate release state (`4.2.0`).

> No npm publish happened: the local script had the `pnpm -r publish` step removed, so `4.2.1` only exists as git history (now being reverted). The `v4.2.1` tag was already deleted.

## How it works?

Reverts the three commits that landed on `main`, newest → oldest:

- `516e784` — `[no ci] Release: 4.2.1` (version bump + CHANGELOGs)
- `e9b2105` — `fix: fix vtex message` (test-only log string change in `generate-i18n.ts`)
- `6a13c8c` — `chore: lern force-publish release` (test edit to the `release` script in `package.json`)

After the revert, `package.json`/`lerna.json`/`CHANGELOG.md` are back at `4.2.0`, the `release` script has its `pnpm publish` step restored, and `generate-i18n.ts` keeps the original message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Version reverted from 4.2.1 to 4.2.0.

* **Bug Fixes**
  * Enhanced error messaging for missing credentials to provide clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->