### PR TITLE
fix(core): propagate upstream error status instead of always 500

### DIFF
--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -201,7 +201,7 @@ const handler: NextApiHandler = async (request, response) => {
       { headers: request.headers }
     )
 
-    const hasErrors = Array.isArray(errors)
+    const hasErrors = Array.isArray(errors) && errors.length > 0
 
     if (hasErrors) {
       // After error masking, entries are GraphQLError instances whose

--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -18,6 +18,21 @@ const DEFAULT_MAX_AGE = 5 * 60 // 5 minutes
 const DEFAULT_STALE_WHILE_REVALIDATE = 60 * 60 // 1 hour
 const ALLOWED_HOST_SUFFIXES = ['localhost', '.vtex.app', '.localhost']
 
+/**
+ * Recovers a FastStoreError from an execution error, whether it is the error
+ * itself or wrapped as the `originalError` of a masked GraphQLError.
+ */
+const recoverFastStoreError = (graphqlError: unknown) => {
+  if (isFastStoreError(graphqlError)) {
+    return graphqlError
+  }
+
+  const originalError = (graphqlError as { originalError?: unknown })
+    ?.originalError
+
+  return isFastStoreError(originalError) ? originalError : undefined
+}
+
 // Example: "Set-Cookie: key=value; Domain=example.com; Path=/"
 const MATCH_DOMAIN_REGEXP = /(?:^|;\s*)(?:domain=)([^;]+)/i
 
@@ -189,10 +204,50 @@ const handler: NextApiHandler = async (request, response) => {
     const hasErrors = Array.isArray(errors)
 
     if (hasErrors) {
-      const error = errors.find(isFastStoreError)
-      console.error('Graphql execution returned with error: ', error)
+      // After error masking, entries are GraphQLError instances whose
+      // `name` is "GraphQLError" — the original FastStoreError (carrying the
+      // upstream status) is nested in `originalError`. Recover it so the BFF
+      // propagates the real status instead of collapsing everything to 500.
+      const fastStoreError = errors.map(recoverFastStoreError).find(Boolean)
 
-      response.status(error?.extensions.status ?? 500).end()
+      console.error(
+        'Graphql execution returned with error: ',
+        errors.map((graphqlError) => {
+          const fsError = recoverFastStoreError(graphqlError)
+
+          return {
+            message: (graphqlError as { message?: string })?.message,
+            status: fsError?.extensions.status,
+            type: fsError?.extensions.type,
+          }
+        })
+      )
+
+      const status = fastStoreError?.extensions.status ?? 500
+
+      // No recoverable FastStoreError: keep the masked, body-less 500.
+      if (!fastStoreError) {
+        response.status(status).end()
+        return
+      }
+
+      // Only FastStoreError-derived details are exposed. `type`/`status` are a
+      // closed enum (safe everywhere); the free-text `message` may echo raw
+      // upstream text, so it is restricted to non-production responses. The
+      // full message is still available server-side via the log above.
+      const responseError = {
+        extensions: {
+          type: fastStoreError.extensions.type,
+          status: fastStoreError.extensions.status,
+        },
+        ...(process.env.NODE_ENV !== 'production'
+          ? { message: fastStoreError.message }
+          : {}),
+      }
+
+      response.status(status)
+      response.setHeader('content-type', 'application/json')
+      response.send(JSON.stringify({ errors: [responseError] }))
       return
     }
 

--- a/packages/core/test/pages/api/graphql.test.ts
+++ b/packages/core/test/pages/api/graphql.test.ts
@@ -1,0 +1,167 @@
+import {
+  BadRequestError,
+  FastStoreError,
+  ForbiddenError,
+  NotFoundError,
+  UnauthorizedError,
+} from '@faststore/api'
+import { GraphQLError } from 'graphql'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import handler from '../../../src/pages/api/graphql'
+import { execute } from '../../../src/server'
+
+vi.mock('../../../src/server', () => ({
+  execute: vi.fn(),
+}))
+
+const mockedExecute = vi.mocked(execute)
+
+const createResponse = () => {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    setHeader: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis(),
+  }
+
+  return res as unknown as NextApiResponse & typeof res
+}
+
+const createRequest = (operationName = 'ClientShippingSimulationQuery') =>
+  ({
+    method: 'GET',
+    headers: { host: 'localhost:3000' },
+    query: {
+      operationName,
+      operationHash: 'hash',
+      variables: '{}',
+    },
+  }) as unknown as NextApiRequest
+
+const mockExecuteWithErrors = (errors: unknown[]) => {
+  mockedExecute.mockResolvedValue({
+    data: null,
+    errors,
+    extensions: { cookies: new Map(), cacheControl: undefined },
+  } as never)
+}
+
+// Reproduces what `useMaskedErrors` produces: a GraphQLError whose
+// `originalError` is the FastStoreError thrown by a resolver/`fetchAPI`.
+const maskedError = (original: FastStoreError) =>
+  new GraphQLError(original.message, { originalError: original })
+
+describe('/api/graphql error status propagation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('propagates the upstream 400 from a wrapped BadRequestError instead of 500', async () => {
+    mockExecuteWithErrors([
+      maskedError(new BadRequestError('O campo CEP (88) é inválido')),
+    ])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.end).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['UnauthorizedError', () => new UnauthorizedError('nope'), 401],
+    ['ForbiddenError', () => new ForbiddenError('nope'), 403],
+    ['NotFoundError', () => new NotFoundError('nope'), 404],
+  ])('propagates %s status', async (_name, makeError, expectedStatus) => {
+    mockExecuteWithErrors([maskedError(makeError())])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(expectedStatus)
+  })
+
+  it('propagates an unmapped upstream status (UnknownError 429)', async () => {
+    mockExecuteWithErrors([
+      maskedError(
+        new FastStoreError({ status: 429, type: 'UnknownError' }, 'slow down')
+      ),
+    ])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(429)
+  })
+
+  it('recovers status when the error itself is a FastStoreError (not wrapped)', async () => {
+    mockExecuteWithErrors([new BadRequestError('bad input')])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+  })
+
+  it('falls back to a body-less 500 for non-FastStore errors', async () => {
+    mockExecuteWithErrors([new GraphQLError('Sorry, something went wrong.')])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.end).toHaveBeenCalled()
+    expect(res.send).not.toHaveBeenCalled()
+  })
+
+  it('exposes type, status and message in the body outside production', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    mockExecuteWithErrors([maskedError(new BadRequestError('invalid CEP'))])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    const body = JSON.parse(
+      (res.send as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    )
+    expect(body.errors[0]).toEqual({
+      extensions: { type: 'BadRequestError', status: 400 },
+      message: 'invalid CEP',
+    })
+  })
+
+  it('omits the free-text message from the body in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    mockExecuteWithErrors([maskedError(new BadRequestError('invalid CEP'))])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    const body = JSON.parse(
+      (res.send as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    )
+    expect(body.errors[0]).toEqual({
+      extensions: { type: 'BadRequestError', status: 400 },
+    })
+    expect(body.errors[0].message).toBeUndefined()
+  })
+
+  it('uses the first recoverable FastStoreError when several errors exist', async () => {
+    mockExecuteWithErrors([
+      new GraphQLError('plain error'),
+      maskedError(new NotFoundError('missing')),
+      maskedError(new BadRequestError('bad')),
+    ])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(404)
+  })
+})


### PR DESCRIPTION
## Summary

The GraphQL BFF (`/api/graphql` handler in `@faststore/core`) collapsed **every** error into HTTP `500`, even when the upstream VTEX error was a client error (`400/401/403/404/...`). Example: an invalid `postalCode` in the shipping simulation makes VTEX Checkout return `400`, but the storefront received `500`.

**Root cause:** after `useMaskedErrors`, the `errors` array holds `GraphQLError` instances (`name === 'GraphQLError'`). The handler used `errors.find(isFastStoreError)`, which checks `name === 'FastStoreError'` and therefore never matched — the real `FastStoreError` (carrying `extensions.status`) is nested in `originalError`. So the status always fell back to `500`.

## Changes

- Added `recoverFastStoreError` to unwrap the `FastStoreError` whether it is the error itself or nested in `originalError` of a masked `GraphQLError`.
- The handler now responds with the recovered `extensions.status` (still `?? 500` as the safe default).
- For a recovered `FastStoreError`, the JSON body exposes `extensions.type` and `extensions.status` always; the free-text `message` is included **only when `NODE_ENV !== 'production'`** (and always logged server-side).
- Non-`FastStoreError`s keep the masked, body-less `500` (error masking unchanged).
- Added unit tests covering `400/401/403/404`, an unmapped `429`, unwrapped `FastStoreError`, non-FastStore→`500`, multi-error selection, and prod vs non-prod body gating.

## Security note

Per root `AGENTS.md` (Security & Data Handling), this touches error-surface behavior. Only `FastStoreError`-derived details are exposed; all other errors remain masked. The free-text upstream `message` is restricted to non-production responses; production responses expose only the `type`/`status` enum.

## Known limitations / follow-ups (not in this PR)

- The storefront SDK (`src/sdk/graphql/request.ts` → `ParseInvalidRequest`) short-circuits on any non-2xx **before reading the body**, building its error from `response.status`/`statusText`. So the new JSON body benefits external/direct consumers and server logs, not the storefront UI. The storefront still benefits from the now-correct **status**. Surfacing the message in the UI would require updating `ParseInvalidRequest`.
- Error responses (both error branches) set no `cache-control`; with a broader range of statuses now emitted (e.g. `404`), consider adding `no-store`.
- The `catch`-block error path (`parseRequest`/refresh-token) is still untested and returns a body-less response (shape differs from the `try` branch).

## Test plan

- [x] `pnpm vitest run test/pages/api/graphql.test.ts --project node` (10/10 pass)
- [x] Full `@faststore/core` node suite green (217/217)
- [x] Manually verified: invalid `postalCode` shipping simulation now returns `400` (was `500`); genuine upstream `500` (intelligent search) stays `500`
- [ ] Reviewer: confirm the intended status behavior change (consumers branching on `500` will now see accurate codes)

Made with [Cursor](https://cursor.com)

|before - generic error 500|
|-|
|<img width="1729" height="700" alt="image" src="https://github.com/user-attachments/assets/fefad20e-a2f9-4bc5-9bcb-f28c76d10bd6" />|

|after - bad request|
|-|
|<img width="1862" height="303" alt="image" src="https://github.com/user-attachments/assets/c726dec0-1fdc-483b-b6ea-3f3cc858669a" />|

server-side log:
> Graphql execution returned with error:  [
>   {
>     message: '{"error":{"code":"ORD006","message":"The postal code (555) field in the shipping attachment is invalid","exception":null},"operationId":"f2c92a0b-d1f8-4cb6-8a4e-cb721fe60039","fields":{}}',
>     status: 400,
>     type: 'BadRequestError'
>   }
> ]
> 

[Jira Task](https://vtex-dev.atlassian.net/browse/SFS-2997?atlOrigin=eyJpIjoiNjY1YmViMzMyM2Y5NDI3M2I0MDEwZDhhZmE3NGZjZDEiLCJwIjoiaiJ9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL API now unwraps and propagates known error types so responses use appropriate HTTP status codes (400, 401, 403, 404, etc.) and preserve upstream status when available.
  * Responses include a structured error payload with type and status; message is omitted in production.

* **Tests**
  * Added tests covering status propagation, masked/unmasked errors, multi-error handling, and production vs. development response bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->