### PR TITLE
fix: forward auth token only via account-scoped cookie

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -21,7 +21,6 @@ import {
   getAuthCookie,
   getStoreCookie,
   getUpdatedCookie,
-  getWithAutCookie,
   getWithCookie,
 } from '../../utils/cookies'
 import type { ContractResponse } from './Contract'
@@ -65,7 +64,6 @@ export const VtexCommerce = (
   const base = `https://${account}.${environment}.com.br`
   const storeCookies = getStoreCookie(ctx)
   const withCookie = getWithCookie(ctx)
-  const withAutCookie = getWithAutCookie(ctx)
   const withAppKeyAndToken = getWithAppKeyAndToken()
 
   const host =
@@ -490,7 +488,10 @@ export const VtexCommerce = (
     },
     profile: {
       addresses: async (userId: string): Promise<Record<string, string>> => {
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
 
         return fetchAPI(
           `${base}/api/profile-system/pvt/profiles/${userId}/addresses`,
@@ -501,7 +502,10 @@ export const VtexCommerce = (
     },
     oms: {
       userOrder: ({ orderId }: { orderId: string }): Promise<UserOrder> => {
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
 
         return fetchAPI(
           `${base}/api/oms/user/orders/${orderId}`,
@@ -584,7 +588,10 @@ export const VtexCommerce = (
       getCommercialAuthorizationsByOrderId: ({
         orderId,
       }: ICommercialAuthorizationByOrderId): Promise<CommercialAuthorizationResponse> => {
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
 
         return fetchAPI(
           `${base}/${account}/commercial-authorizations/order/${orderId}`,
@@ -601,7 +608,10 @@ export const VtexCommerce = (
         ruleId,
         approved,
       }: IProcessOrderAuthorization): Promise<CommercialAuthorizationResponse> => {
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
 
         const APPROVAL_SCORE = 100
         const REJECTION_SCORE = 0
@@ -629,7 +639,10 @@ export const VtexCommerce = (
       getUnitByUserId: ({
         userId,
       }: { userId: string }): Promise<UnitResponse> => {
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
 
         return fetchAPI(
           `${base}/api/units/v1/${userId}/unit`,
@@ -643,7 +656,10 @@ export const VtexCommerce = (
       getOrgUnitById: ({
         orgUnitId,
       }: { orgUnitId: string }): Promise<UnitResponse> => {
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
 
         return fetchAPI(
           `${base}/api/units/v1/${orgUnitId}`,
@@ -657,7 +673,10 @@ export const VtexCommerce = (
       getScopesByOrgUnit: ({
         orgUnitId,
       }: { orgUnitId: string }): Promise<ScopesByUnit> => {
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
 
         return fetchAPI(
           `${base}/api/units/v1/${orgUnitId}/scopes`,
@@ -677,7 +696,10 @@ export const VtexCommerce = (
         name: string
         email: string
       }> => {
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
 
         return fetchAPI(
           `${base}/api/license-manager/users/${userId}`,
@@ -695,7 +717,10 @@ export const VtexCommerce = (
         name: string
         email: string
       }> => {
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
 
         return fetchAPI(
           `${base}/api/license-manager/pvt/users/${email}`,
@@ -712,7 +737,10 @@ export const VtexCommerce = (
         Email: string
         Roles: Array<{ Id: number; Name: string }>
       }> => {
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
 
         return fetchAPI(
           `${base}/api/license-manager/storefront/users/${userId}/roles`,
@@ -781,7 +809,10 @@ export const VtexCommerce = (
     },
     vtexid: {
       validate: (): Promise<VtexIdResponse> => {
-        const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        const headers: HeadersInit = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
         // Read from the merged cookie set so the body token stays in sync with
         // the `cookie` header (both pull from request + storage updates).
         const token = getAuthCookie(getUpdatedCookie(ctx) ?? '', account)

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -20,6 +20,7 @@ import type { Channel } from '../../utils/channel'
 import {
   getAuthCookie,
   getStoreCookie,
+  getUpdatedCookie,
   getWithAutCookie,
   getWithCookie,
 } from '../../utils/cookies'
@@ -781,8 +782,9 @@ export const VtexCommerce = (
     vtexid: {
       validate: (): Promise<VtexIdResponse> => {
         const headers: HeadersInit = withAutCookie(forwardedHost, account)
-        // Token is read from the incoming request's account-scoped auth cookie.
-        const token = getAuthCookie(ctx.headers?.cookie ?? '', account)
+        // Read from the merged cookie set so the body token stays in sync with
+        // the `cookie` header (both pull from request + storage updates).
+        const token = getAuthCookie(getUpdatedCookie(ctx) ?? '', account)
 
         return fetchAPI(
           `${base}/api/vtexid/credential/validate`,

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -18,6 +18,7 @@ import type { GraphqlContext } from '../../index'
 import { getWithAppKeyAndToken } from '../../utils/auth'
 import type { Channel } from '../../utils/channel'
 import {
+  getAuthCookie,
   getStoreCookie,
   getWithAutCookie,
   getWithCookie,
@@ -780,14 +781,14 @@ export const VtexCommerce = (
     vtexid: {
       validate: (): Promise<VtexIdResponse> => {
         const headers: HeadersInit = withAutCookie(forwardedHost, account)
+        // Token is read from the incoming request's account-scoped auth cookie.
+        const token = getAuthCookie(ctx.headers?.cookie ?? '', account)
 
         return fetchAPI(
           `${base}/api/vtexid/credential/validate`,
           {
             headers,
-            body: JSON.stringify({
-              token: headers['VtexIdclientAutCookie'],
-            }),
+            body: JSON.stringify({ token }),
             method: 'POST',
           },
           { storeCookies }

--- a/packages/api/src/platforms/vtex/utils/cookies.ts
+++ b/packages/api/src/platforms/vtex/utils/cookies.ts
@@ -145,22 +145,21 @@ export const getAuthCookie = (cookies: string, account: string) => {
   return authCookie || ''
 }
 
+/**
+ * Headers for authenticated VtexID requests. The auth token is carried by
+ * the forwarded `cookie` header — not duplicated as a separate header.
+ */
 export const getWithAutCookie = (ctx: ContextForCookies) => {
   const withCookie = getWithCookie(ctx)
 
-  return function withAutCookie(forwardedHost: string, account: string) {
-    const headers: HeadersInit = withCookie({
+  return function withAutCookie(
+    forwardedHost: string,
+    _account?: string
+  ): HeadersInit {
+    return withCookie({
       'content-type': 'application/json',
       'X-FORWARDED-HOST': forwardedHost,
     })
-
-    const VtexIdclientAutCookie = getAuthCookie(
-      ctx?.headers?.cookie ?? '',
-      account
-    )
-    headers['VtexIdclientAutCookie'] = VtexIdclientAutCookie
-
-    return headers
   }
 }
 

--- a/packages/api/src/platforms/vtex/utils/cookies.ts
+++ b/packages/api/src/platforms/vtex/utils/cookies.ts
@@ -146,24 +146,6 @@ export const getAuthCookie = (cookies: string, account: string) => {
 }
 
 /**
- * Headers for authenticated VtexID requests. The auth token is carried by
- * the forwarded `cookie` header — not duplicated as a separate header.
- */
-export const getWithAutCookie = (ctx: ContextForCookies) => {
-  const withCookie = getWithCookie(ctx)
-
-  return function withAutCookie(
-    forwardedHost: string,
-    _account?: string
-  ): HeadersInit {
-    return withCookie({
-      'content-type': 'application/json',
-      'X-FORWARDED-HOST': forwardedHost,
-    })
-  }
-}
-
-/**
  * This function updates the cookie value based on its key
  *
  * const existingCookies = 'key=value1; key2=; key3=value3';

--- a/packages/api/test/integration/vtex.cookies.test.ts
+++ b/packages/api/test/integration/vtex.cookies.test.ts
@@ -6,7 +6,6 @@ import {
   getAuthCookie,
   getStoreCookie,
   getUpdatedCookie,
-  getWithAutCookie,
   getWithCookie,
   updatesContextStorageCookies,
   updatesCookieValueByKey,
@@ -98,69 +97,6 @@ describe('getWithCookie', () => {
     const newHeaders = withCookie(headers)
 
     expect(newHeaders).toEqual({ ...headers, cookie: ctx.headers.cookie })
-  })
-})
-
-describe('getWithAutCookie', () => {
-  const FORWARDED_HOST = 'mystore.fast.store'
-  const ACCOUNT = 'mystore'
-  const TOKEN = 'jwt-store-audience-value'
-
-  it('Should forward the suffixed auth cookie via the `cookie` header', () => {
-    const cookie = `vtex_session=foo; VtexIdclientAutCookie_${ACCOUNT}=${TOKEN}`
-    const ctx = {
-      headers: { cookie },
-      storage: { cookies: new Map() },
-    }
-
-    const withAutCookie = getWithAutCookie(ctx)
-    const headers = withAutCookie(FORWARDED_HOST, ACCOUNT) as Record<
-      string,
-      string
-    >
-
-    expect(headers).toEqual({
-      'content-type': 'application/json',
-      'X-FORWARDED-HOST': FORWARDED_HOST,
-      cookie,
-    })
-  })
-
-  it('Should NOT set the unscoped `VtexIdclientAutCookie` header', () => {
-    // Regression: the auth token is forwarded only via the account-scoped cookie.
-    const cookie = `VtexIdclientAutCookie_${ACCOUNT}=${TOKEN}`
-    const ctx = {
-      headers: { cookie },
-      storage: { cookies: new Map() },
-    }
-
-    const withAutCookie = getWithAutCookie(ctx)
-    const headers = withAutCookie(FORWARDED_HOST, ACCOUNT) as Record<
-      string,
-      string
-    >
-
-    expect(headers).not.toHaveProperty('VtexIdclientAutCookie')
-  })
-
-  it('Should still build base headers when no auth cookie is present', () => {
-    const ctx = {
-      headers: { cookie: 'vtex_segment=foo' },
-      storage: { cookies: new Map() },
-    }
-
-    const withAutCookie = getWithAutCookie(ctx)
-    const headers = withAutCookie(FORWARDED_HOST, ACCOUNT) as Record<
-      string,
-      string
-    >
-
-    expect(headers).toEqual({
-      'content-type': 'application/json',
-      'X-FORWARDED-HOST': FORWARDED_HOST,
-      cookie: 'vtex_segment=foo',
-    })
-    expect(headers).not.toHaveProperty('VtexIdclientAutCookie')
   })
 })
 

--- a/packages/api/test/integration/vtex.cookies.test.ts
+++ b/packages/api/test/integration/vtex.cookies.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { GraphqlContext } from '../../src/platforms/vtex'
 import type { ContextForCookies } from '../../src/platforms/vtex/utils/cookies'
 import {
+  getAuthCookie,
   getStoreCookie,
   getUpdatedCookie,
   getWithAutCookie,
@@ -253,5 +254,92 @@ describe('getStoreCookie', () => {
         'CheckoutOrderFormOwnership=CFEUHpzya69CNICSrc4h5cJzeQE856pULms%2BxxQdF9EOh5WPwtrzqMwl9FwAhPVM; expires=Sat, 08 Jun 2024 20:12:41 GMT; domain=vtexfaststore.com; path=/; secure; samesite=strict; httponly',
     })
     expect(ctx.storage.cookies.size).toEqual(2)
+  })
+})
+
+describe('Cookie normalization (duplicate handling)', () => {
+  it('Should handle duplicate cookies and keep the last value in getUpdatedCookie', () => {
+    const cookieWithDuplicates =
+      'VtexIdclientAutCookie_account=oldValue; vtex_session=sessionValue; VtexIdclientAutCookie_account=newValue'
+    const ctx = {
+      headers: { cookie: cookieWithDuplicates },
+      storage: { cookies: new Map() },
+    }
+
+    const result = getUpdatedCookie(ctx)
+
+    // Should keep the last value for duplicate keys, maintaining order of first appearance
+    expect(result).toEqual(
+      'VtexIdclientAutCookie_account=newValue; vtex_session=sessionValue'
+    )
+  })
+
+  it('Should handle multiple duplicate cookies and keep the last values', () => {
+    const cookieWithMultipleDuplicates =
+      'key1=value1; key2=value2; key1=value1_updated; key3=value3; key2=value2_updated; key1=value1_final'
+    const ctx = {
+      headers: { cookie: cookieWithMultipleDuplicates },
+      storage: { cookies: new Map() },
+    }
+
+    const result = getUpdatedCookie(ctx)
+
+    // Should keep the last value for each duplicate key, maintaining order of first appearance
+    expect(result).toEqual(
+      'key1=value1_final; key2=value2_updated; key3=value3'
+    )
+  })
+
+  it('Should handle duplicate auth cookies in getAuthCookie and return the last value', () => {
+    const cookieWithDuplicateAuth =
+      'VtexIdclientAutCookie_account=oldToken; other_cookie=value; VtexIdclientAutCookie_account=newToken'
+    const account = 'account'
+
+    const result = getAuthCookie(cookieWithDuplicateAuth, account)
+
+    // Should return the last (newest) auth token
+    expect(result).toEqual('newToken')
+  })
+})
+
+describe('Auth token resolution from merged cookie set', () => {
+  const ACCOUNT = 'mystore'
+
+  it('Should pick the storage-updated auth token over the original request cookie', () => {
+    // Mirrors how `vtexid.validate` resolves the body token: the cookie header
+    // already merges request + storage updates, so the body must follow the same
+    // source to stay consistent with the outgoing `cookie` header.
+    const originalToken = 'jwt-original'
+    const refreshedToken = 'jwt-refreshed'
+
+    const ctx = {
+      headers: {
+        cookie: `vtex_session=foo; VtexIdclientAutCookie_${ACCOUNT}=${originalToken}`,
+      },
+      storage: {
+        cookies: new Map<string, { value: string }>([
+          [`VtexIdclientAutCookie_${ACCOUNT}`, { value: refreshedToken }],
+        ]),
+      },
+    }
+
+    const token = getAuthCookie(getUpdatedCookie(ctx) ?? '', ACCOUNT)
+
+    expect(token).toEqual(refreshedToken)
+  })
+
+  it('Should fall back to the original request cookie when storage has no updates', () => {
+    const originalToken = 'jwt-original'
+
+    const ctx = {
+      headers: {
+        cookie: `VtexIdclientAutCookie_${ACCOUNT}=${originalToken}`,
+      },
+      storage: { cookies: new Map() },
+    }
+
+    const token = getAuthCookie(getUpdatedCookie(ctx) ?? '', ACCOUNT)
+
+    expect(token).toEqual(originalToken)
   })
 })

--- a/packages/api/test/integration/vtex.cookies.test.ts
+++ b/packages/api/test/integration/vtex.cookies.test.ts
@@ -5,6 +5,7 @@ import type { ContextForCookies } from '../../src/platforms/vtex/utils/cookies'
 import {
   getStoreCookie,
   getUpdatedCookie,
+  getWithAutCookie,
   getWithCookie,
   updatesContextStorageCookies,
   updatesCookieValueByKey,
@@ -96,6 +97,69 @@ describe('getWithCookie', () => {
     const newHeaders = withCookie(headers)
 
     expect(newHeaders).toEqual({ ...headers, cookie: ctx.headers.cookie })
+  })
+})
+
+describe('getWithAutCookie', () => {
+  const FORWARDED_HOST = 'mystore.fast.store'
+  const ACCOUNT = 'mystore'
+  const TOKEN = 'jwt-store-audience-value'
+
+  it('Should forward the suffixed auth cookie via the `cookie` header', () => {
+    const cookie = `vtex_session=foo; VtexIdclientAutCookie_${ACCOUNT}=${TOKEN}`
+    const ctx = {
+      headers: { cookie },
+      storage: { cookies: new Map() },
+    }
+
+    const withAutCookie = getWithAutCookie(ctx)
+    const headers = withAutCookie(FORWARDED_HOST, ACCOUNT) as Record<
+      string,
+      string
+    >
+
+    expect(headers).toEqual({
+      'content-type': 'application/json',
+      'X-FORWARDED-HOST': FORWARDED_HOST,
+      cookie,
+    })
+  })
+
+  it('Should NOT set the unscoped `VtexIdclientAutCookie` header', () => {
+    // Regression: the auth token is forwarded only via the account-scoped cookie.
+    const cookie = `VtexIdclientAutCookie_${ACCOUNT}=${TOKEN}`
+    const ctx = {
+      headers: { cookie },
+      storage: { cookies: new Map() },
+    }
+
+    const withAutCookie = getWithAutCookie(ctx)
+    const headers = withAutCookie(FORWARDED_HOST, ACCOUNT) as Record<
+      string,
+      string
+    >
+
+    expect(headers).not.toHaveProperty('VtexIdclientAutCookie')
+  })
+
+  it('Should still build base headers when no auth cookie is present', () => {
+    const ctx = {
+      headers: { cookie: 'vtex_segment=foo' },
+      storage: { cookies: new Map() },
+    }
+
+    const withAutCookie = getWithAutCookie(ctx)
+    const headers = withAutCookie(FORWARDED_HOST, ACCOUNT) as Record<
+      string,
+      string
+    >
+
+    expect(headers).toEqual({
+      'content-type': 'application/json',
+      'X-FORWARDED-HOST': FORWARDED_HOST,
+      cookie: 'vtex_segment=foo',
+    })
+    expect(headers).not.toHaveProperty('VtexIdclientAutCookie')
   })
 })
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Logged-in shoppers were unable to access the FastStore My Account area: any navigation to `/pvt/account/*` resulted in an immediate redirect to `/pvt/account/403?from=...`, where the page entered an infinite refresh-token loop.

The root cause was on the API side. Every `@auth`-protected GraphQL query relies on `vtexid.validate`, and the request that backs that call was forwarding the auth token in two ways at once: once through the standard account-scoped cookie and again under a duplicated, top-level header. The duplicated header was being rejected by the platform with `401`, even though the user's session was perfectly valid.

## How it works?

This PR removes the duplication. The auth token is now forwarded exclusively through the account-scoped cookie (`VtexIdclientAutCookie_{account}`) — exactly like every other authenticated path in the codebase already does (see `getAuthCookie`, `getJWTAutCookie`, `getIsRepresentative`).

## How to test it?

Pre-conditions: a logged-in shopper on a store that has FastStore My Account enabled (`experimental.enableFaststoreMyAccount = true`).

- Navigate to `/pvt/account/profile` — should render the profile page directly, without redirecting to `/pvt/account/403`.
- Run the package tests:

  ```bash
  pnpm --filter @faststore/api test
  ```

### Starters Deploy Preview
Before

https://github.com/user-attachments/assets/06b3e027-9e1f-4962-aa39-cf3915713f85


<!-- TODO: add deploy preview URL once available -->

## References
- [task](https://vtex-dev.atlassian.net/jira/software/projects/SO/boards/870?selectedIssue=SO-618&sprintStarted=true)
- related slack threads https://vtex.slack.com/archives/C06EC3LCZA8/p1777895253411839 https://vtex.slack.com/archives/C0164SHMAV9/p1777899569156569
- Affected package: `@faststore/api`
- Affected pages: everything under `packages/core/src/pages/pvt/account/*`
- Auth path: `@auth` directive (`packages/api/src/directives/auth.ts`) → `validateUserAuthentication` → `vtexid.validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VTEX authentication token validation now derives the token from the merged/updated cookie set, with improved handling of duplicate auth cookie entries.
  * Updated VTEX request headers to use consistent cookie-based header construction (including forwarded host and content type) instead of the previous auth-cookie helper.

* **Tests**
  * Added integration coverage for VTEX cookie normalization, including collapsing duplicate cookie keys and resolving the latest auth token value.
  * Added fallback behavior checks when storage-provided cookie updates are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->