### PR TITLE
fix: paginate listEntries with scroll

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
     "@parcel/watcher": "^2.4.0",
     "@types/react": "^18.2.42",
     "@vtex/client-cms": "^0.2.16",
-    "@vtex/client-cp": "0.3.5",
+    "@vtex/client-cp": "0.6.0",
     "@vtex/prettier-config": "1.0.0",
     "autoprefixer": "^10.4.0",
     "cookie": "^0.7.0",

--- a/packages/core/src/server/content/service.ts
+++ b/packages/core/src/server/content/service.ts
@@ -46,8 +46,29 @@ export class ContentService {
 
     if (isContentPlatformSource()) {
       const serviceParams = this.convertOptionsToParams(options)
-      const { entries } = await this.clientCP.listEntries(serviceParams)
-      return this.fillEntriesWithData(entries, serviceParams, options.isPreview)
+      // TODO: This should be temporary until the cp data-plane have a search engine.
+      const MAX_PAGES = 25
+      const allEntries: ContentEntry[] = []
+      let scroll: string | undefined
+      let pages = 0
+
+      do {
+        const result = await this.clientCP.listEntries(serviceParams, scroll)
+        allEntries.push(...result.entries)
+        const next = result.scroll ?? undefined
+        if (next && next === scroll) break
+        scroll = next
+      } while (scroll && ++pages < MAX_PAGES)
+
+      if (pages >= MAX_PAGES) {
+        console.warn('listEntries pagination hit MAX_PAGES cap', serviceParams)
+      }
+
+      return this.fillEntriesWithData(
+        allEntries,
+        serviceParams,
+        options.isPreview
+      )
     }
     return getCMSPage(options.cmsOptions)
   }
@@ -60,6 +81,11 @@ export class ContentService {
     const options = this.createContentOptions(plpParams)
 
     if (isContentPlatformSource()) {
+      const directMatch = await this.getSingleContent<PLPContentType>(plpParams)
+      if (directMatch) {
+        return directMatch
+      }
+
       const pages = (await this.getMultipleContent(plpParams)).data
       if (!pages?.length) throw new MissingContentError(options.cmsOptions)
       return findBestPLPTemplate(
@@ -79,6 +105,11 @@ export class ContentService {
     const options = this.createContentOptions(pdpParams)
 
     if (isContentPlatformSource()) {
+      const directMatch = await this.getSingleContent<PDPContentType>(pdpParams)
+      if (directMatch) {
+        return directMatch
+      }
+
       const pages = (await this.getMultipleContent(pdpParams)).data
       if (!pages.length) throw new MissingContentError(options.cmsOptions)
       return findBestPDPTemplate(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,8 +375,8 @@ importers:
         specifier: ^0.2.16
         version: 0.2.16(encoding@0.1.13)
       "@vtex/client-cp":
-        specifier: 0.3.5
-        version: 0.3.5
+        specifier: 0.6.0
+        version: 0.6.0
       "@vtex/prettier-config":
         specifier: 1.0.0
         version: 1.0.0(prettier@2.8.3)
@@ -6161,10 +6161,10 @@ packages:
         integrity: sha512-mK5OiaaGHItVuispyy8yXLILnMx4aOJj7HkamOmAL12+KbnkiKKpO1vJEb3hRB16lK1rHtl7Q5H3aTFsMqrf0w==,
       }
 
-  "@vtex/client-cp@0.3.5":
+  "@vtex/client-cp@0.6.0":
     resolution:
       {
-        integrity: sha512-uzvpYz1LHiPxBc0FmVVG0azfGWiYJhIJf2JgcNSsi3V5oxR/dwM6tbh+JigSNQpp6bNn9GglLvMpYboxORMsnQ==,
+        integrity: sha512-+ijNI8uOIB84oOSZFiEmEcjXe23sK9lwTyvyoB72y1gS7Xfqgwn93F9gzrbYjxerPNZTb8ZSlsGBLWxCx1ONBw==,
       }
     engines: { node: ">=16" }
 
@@ -23583,7 +23583,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  "@vtex/client-cp@0.3.5":
+  "@vtex/client-cp@0.6.0":
     dependencies:
       axios: 1.9.0
     transitivePeerDependencies:


### PR DESCRIPTION
## What's the purpose of this pull request?

`ContentService.getPage` was returning only the first page of entries from Content Platform because `listEntries` wasn't following the `scroll` token. Pages backed by CP silently missed content beyond the first batch.

## How it works?

In `packages/core/src/server/content/service.ts`, the single `listEntries` call is replaced by a loop that accumulates entries while a `scroll` token is returned, then passes the full list to `fillEntriesWithData`.

## How to test it?

- On a store using the CP data source, create enough entries for a given content type to exceed a single page.
- Request that page and verify all entries are returned (not just the first batch).
- Confirm non-CP (hCMS) path is unaffected.

### Starters Deploy Preview

N/A

## References

Cherry-pick of 2e43804b7c3ee336eee5a19f1a11d3185c01102d from `dev` into `3.x`.

## Type of Change

- [ ] 🍕 New feature
- [x] 🐛 Bug fix
- [ ] 🔥 Breaking change
- [ ] 🤖 Build/CI
- [ ] 📝 Documentation
- [ ] ♻️ Refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core client dependency to latest version for enhanced compatibility

* **Refactor**
  * Optimized content retrieval logic with improved pagination support and streamlined single-item lookup to enhance performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->