### PR TITLE
fix(api): use account-scoped cookie in orderEntry headers

### DIFF
--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -838,7 +838,10 @@ export const VtexCommerce = (
         fileName: string
         mimeType: string
       }): Promise<{ objectKey: string }> => {
-        const autHeaders = withAutCookie(forwardedHost, account)
+        const autHeaders = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
         const boundary = `----FastStoreUploadBoundary${Date.now()}`
         const CRLF = '\r\n'
 
@@ -896,7 +899,10 @@ export const VtexCommerce = (
         orderFormId: string
         sessionToken?: string
       }): Promise<{ operationId: string }> => {
-        const autHeaders = withAutCookie(forwardedHost, account)
+        const autHeaders = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
         const body = JSON.stringify({
           objectKey,
           orderFormId,
@@ -932,7 +938,10 @@ export const VtexCommerce = (
           reason: string
         }>
       }> => {
-        const autHeaders = withAutCookie(forwardedHost, account)
+        const autHeaders = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
 
         return fetchAPI(
           `${base}/api/order-entry/operation/${operationId}?an=${account}`,
@@ -945,7 +954,10 @@ export const VtexCommerce = (
       },
 
       createOrderForm: (): Promise<{ orderFormId: string }> => {
-        const autHeaders = withAutCookie(forwardedHost, account)
+        const autHeaders = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm?sc=${ctx.storage.channel.salesChannel}`,
           {
@@ -966,7 +978,10 @@ export const VtexCommerce = (
       }: {
         orderFormId: string
       }): Promise<{ items: import('./types/OrderForm').OrderFormItem[] }> => {
-        const autHeaders = withAutCookie(forwardedHost, account)
+        const autHeaders = withCookie({
+          'content-type': 'application/json',
+          'X-FORWARDED-HOST': forwardedHost,
+        })
         return fetchAPI(
           `${base}/api/checkout/pub/orderForm/${orderFormId}`,
           {

--- a/packages/api/src/platforms/vtex/clients/commerce/index.ts
+++ b/packages/api/src/platforms/vtex/clients/commerce/index.ts
@@ -914,10 +914,7 @@ export const VtexCommerce = (
           `${base}/api/order-entry/operation?an=${account}`,
           {
             method: 'POST',
-            headers: {
-              ...autHeaders,
-              'Content-Type': 'application/json',
-            },
+            headers: autHeaders,
             body,
           },
           {}
@@ -962,11 +959,7 @@ export const VtexCommerce = (
           `${base}/api/checkout/pub/orderForm?sc=${ctx.storage.channel.salesChannel}`,
           {
             method: 'POST',
-            headers: {
-              ...autHeaders,
-              'Content-Type': 'application/json',
-              'X-FORWARDED-HOST': forwardedHost,
-            },
+            headers: autHeaders,
             body: '{}',
           },
           {}
@@ -986,11 +979,7 @@ export const VtexCommerce = (
           `${base}/api/checkout/pub/orderForm/${orderFormId}`,
           {
             method: 'GET',
-            headers: {
-              ...autHeaders,
-              'Content-Type': 'application/json',
-              'X-FORWARDED-HOST': forwardedHost,
-            },
+            headers: autHeaders,
           },
           {}
         )


### PR DESCRIPTION
## What's the purpose of this pull request?

fix(api): use account-scoped cookie in orderEntry headers

The orderEntry methods (file upload via OES, #3334) still referenced the
withAutCookie helper that #3381 removed, since that PR was not rebased on
the latest dev and did not see the newly merged orderEntry block. This
left an undefined withAutCookie reference, breaking the build and tests
on dev.

Replace the 5 withAutCookie(forwardedHost, account) calls with the
withCookie({ 'content-type', 'X-FORWARDED-HOST' }) pattern adopted by
#3381 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication/header handling for order entry endpoints to ensure requests consistently include the correct `Content-Type` and forwarded host information.
  * Ensures file upload continues to use `multipart/form-data` with the proper boundary while retaining the updated base header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->