### PR TITLE
fix(core): version authenticator routes to v1

### DIFF
--- a/packages/core/src/sdk/account/useSetPassword.ts
+++ b/packages/core/src/sdk/account/useSetPassword.ts
@@ -57,7 +57,7 @@ export const useSetPassword = (accountName?: string) => {
         }
 
         const response = await fetch(
-          `/api/authenticator/pub/authentication/classic/setpassword?expireSessions=true&an=${an}`,
+          `/api/authenticator/v1/pub/authentication/classic/setpassword?expireSessions=true&an=${an}`,
           {
             method: 'POST',
             body: buildFormData(body),
@@ -139,7 +139,7 @@ const startLogin = async ({
     const scope = accountName ?? config.api.storeId
 
     const response = await fetch(
-      `/api/authenticator/pub/authentication/start?an=${an}`,
+      `/api/authenticator/v1/pub/authentication/start?an=${an}`,
       {
         method: 'POST',
         credentials: 'include',

--- a/packages/core/test/sdk/account/useSetPassword.test.ts
+++ b/packages/core/test/sdk/account/useSetPassword.test.ts
@@ -72,7 +72,7 @@ describe('useSetPassword', () => {
 
     const url = String(call?.[0])
     expect(url).toContain(
-      '/api/authenticator/pub/authentication/classic/setpassword'
+      '/api/authenticator/v1/pub/authentication/classic/setpassword'
     )
     expect(url).not.toContain('/api/vtexid/')
     expect(url).toContain('expireSessions=true')
@@ -94,7 +94,7 @@ describe('useSetPassword', () => {
     expect(call).toBeDefined()
 
     const url = String(call?.[0])
-    expect(url).toContain('/api/authenticator/pub/authentication/start')
+    expect(url).toContain('/api/authenticator/v1/pub/authentication/start')
     expect(url).not.toContain('/api/vtexid/')
     expect(url).toContain('an=myaccount')
 


### PR DESCRIPTION
## Summary

The Authenticator API now uses versioned routes. The unversioned paths will be deprecated soon, so this PR adds the `v1` segment after `authenticator/` for the routes used by `useSetPassword`:

- `/api/authenticator/pub/authentication/classic/setpassword` → `/api/authenticator/v1/pub/authentication/classic/setpassword`
- `/api/authenticator/pub/authentication/start` → `/api/authenticator/v1/pub/authentication/start`

## Test plan

- [x] `pnpm vitest run test/sdk/account/useSetPassword.test.ts` passes
- [ ] Validate set-password flow against a store using the versioned routes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal API path references for password setting functionality to use the latest authenticator service version. No changes to user-facing behavior or request/response structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->