### PR TITLE
fix(core): allow localized /pvt routes with path-based locale bindings

### DIFF
--- a/packages/core/src/pages/pvt/account/403.tsx
+++ b/packages/core/src/pages/pvt/account/403.tsx
@@ -20,6 +20,7 @@ import { OverriddenDefaultEmptyState as EmptyState } from 'src/components/sectio
 import CUSTOM_COMPONENTS from 'src/customizations/src/components'
 import PLUGINS_COMPONENTS from 'src/plugins'
 import { useRefreshToken } from 'src/sdk/account/useRefreshToken'
+import { useLink } from 'src/sdk/ui/useLink'
 import PageProvider from 'src/sdk/overrides/PageProvider'
 import { execute } from 'src/server'
 import { injectGlobalSections } from 'src/server/cms/global'
@@ -50,6 +51,7 @@ function Page({
   needsRefreshToken,
   fromPage,
 }: Props) {
+  const { resolveLink } = useLink()
   const { sections: globalSections, settings: globalSettings } =
     globalSectionsProp ?? { sections: [], settings: {} }
 
@@ -75,7 +77,7 @@ function Page({
             subtitle="You don't have permission to access this page."
             showLoader={false}
           >
-            <LinkButton variant="secondary" href="/pvt/account">
+            <LinkButton variant="secondary" href={resolveLink('/pvt/account')}>
               Back to Account
             </LinkButton>
           </EmptyState>

--- a/packages/core/src/proxy.ts
+++ b/packages/core/src/proxy.ts
@@ -4,6 +4,7 @@ import { getRequestHostname } from 'src/utils/getRequestHostname'
 import {
   getCustomPathsFromBindings,
   getSubdomainBindings,
+  hostnameHasPathBasedLocaleBindings,
   isValidLocale,
 } from 'src/utils/localization/bindingPaths'
 
@@ -55,11 +56,13 @@ const validLocales = new Set(
  *
  * @param request - The request to rewrite.
  * @param locale - The locale to rewrite to.
+ * @param hostname - Client-facing hostname from the Host header.
  * @returns The rewritten response or null if the request is not a subdomain request.
  */
 function rewriteSubdomainRequest(
   request: NextRequest,
-  locale: string
+  locale: string,
+  hostname: string
 ): NextResponse | null {
   const { pathname, search } = request.nextUrl
 
@@ -69,6 +72,10 @@ function rewriteSubdomainRequest(
     const [, currentLocale] = dataMatch
 
     if (currentLocale !== locale && validLocales.has(currentLocale)) {
+      if (hostnameHasPathBasedLocaleBindings(hostname)) {
+        return null
+      }
+
       const url = request.nextUrl.clone()
       url.pathname = pathname.replace(`/${currentLocale}/`, `/${locale}/`)
       url.search = search
@@ -82,6 +89,10 @@ function rewriteSubdomainRequest(
   const firstSegment = pathname.split('/')[1] ?? ''
 
   if (!validLocales.has(firstSegment)) {
+    if (hostnameHasPathBasedLocaleBindings(hostname)) {
+      return null
+    }
+
     const rest = pathname.replace(/^\/+/, '')
     const normalizedPath = rest ? `/${locale}/${rest}` : `/${locale}`
 
@@ -115,7 +126,11 @@ function localizationRewrite(request: NextRequest): NextResponse {
   const subdomainMatch = subdomainBindings.find((b) => b.hostname === hostname)
 
   if (subdomainMatch && isValidLocale(subdomainMatch.locale)) {
-    const result = rewriteSubdomainRequest(request, subdomainMatch.locale)
+    const result = rewriteSubdomainRequest(
+      request,
+      subdomainMatch.locale,
+      hostname
+    )
 
     if (result) {
       return result

--- a/packages/core/src/utils/localization/bindingPaths.ts
+++ b/packages/core/src/utils/localization/bindingPaths.ts
@@ -151,6 +151,47 @@ export function getSubdomainBindings(): SubdomainBinding[] {
 }
 
 /**
+ * True when the hostname serves at least one locale via a non-root URL path
+ * (including locale-code paths like `/pt-BR`, not only custom paths like `/europe/it`).
+ */
+export function hostnameHasPathBasedLocaleBindings(hostname: string): boolean {
+  if (!storeConfig.localization?.enabled) {
+    return false
+  }
+
+  const locales = (storeConfig.localization.locales ||
+    {}) as LocalesSettings['locales']
+
+  for (const localeConfig of Object.values(locales)) {
+    if (!localeConfig?.bindings?.length) {
+      continue
+    }
+
+    for (const binding of localeConfig.bindings) {
+      if (!binding.url) {
+        continue
+      }
+
+      try {
+        const urlObj = new URL(binding.url)
+        if (urlObj.hostname !== hostname) {
+          continue
+        }
+
+        const pathname = urlObj.pathname.replace(/\/$/, '') || '/'
+        if (pathname !== '/') {
+          return true
+        }
+      } catch {
+        continue
+      }
+    }
+  }
+
+  return false
+}
+
+/**
  * Extracts custom path prefix from current pathname
  * @param pathname - Current pathname (e.g., '/europe/it/apparel')
  * @returns Custom path prefix if found, null otherwise

--- a/packages/core/src/utils/localization/getLocalizedRedirect.ts
+++ b/packages/core/src/utils/localization/getLocalizedRedirect.ts
@@ -3,6 +3,18 @@ import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
 
 type LocaleContext = Pick<GetServerSidePropsContext, 'locale' | 'defaultLocale'>
 
+/**
+ * Next.js supports `redirect.locale` for i18n GSSP redirects at runtime.
+ * The public `Redirect` type omits this field.
+ */
+type RedirectWithI18nLocale = {
+  destination: string
+  permanent?: boolean
+  statusCode?: 301 | 302 | 303 | 307 | 308
+  basePath?: false
+  locale?: string | false
+}
+
 function isInternalPath(destination: string): boolean {
   return destination.startsWith('/') && !destination.startsWith('//')
 }
@@ -20,7 +32,8 @@ export function localizeRedirectResult<P extends Record<string, unknown>>(
     return result
   }
 
-  const { destination, locale: redirectLocale } = result.redirect
+  const redirect = result.redirect as RedirectWithI18nLocale
+  const { destination, locale: redirectLocale } = redirect
 
   if (
     !isInternalPath(destination) ||
@@ -39,8 +52,8 @@ export function localizeRedirectResult<P extends Record<string, unknown>>(
 
   return {
     redirect: {
-      ...result.redirect,
+      ...redirect,
       locale: context.locale,
     },
-  }
+  } as GetServerSidePropsResult<P>
 }

--- a/packages/core/src/utils/localization/getLocalizedRedirect.ts
+++ b/packages/core/src/utils/localization/getLocalizedRedirect.ts
@@ -1,0 +1,46 @@
+import storeConfig from 'discovery.config'
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
+
+type LocaleContext = Pick<GetServerSidePropsContext, 'locale' | 'defaultLocale'>
+
+function isInternalPath(destination: string): boolean {
+  return destination.startsWith('/') && !destination.startsWith('//')
+}
+
+/**
+ * Adds `redirect.locale` for internal redirects when the active locale differs
+ * from defaultLocale. Next.js i18n uses this to preserve the locale prefix
+ * (e.g. /pt-BR/pvt/...) — do not prefix the destination path manually.
+ */
+export function localizeRedirectResult<P extends Record<string, unknown>>(
+  context: LocaleContext,
+  result: GetServerSidePropsResult<P>
+): GetServerSidePropsResult<P> {
+  if (!('redirect' in result) || !result.redirect) {
+    return result
+  }
+
+  const { destination, locale: redirectLocale } = result.redirect
+
+  if (
+    !isInternalPath(destination) ||
+    redirectLocale !== undefined ||
+    !context.locale
+  ) {
+    return result
+  }
+
+  const defaultLocale =
+    context.defaultLocale ?? storeConfig.localization?.defaultLocale
+
+  if (!defaultLocale || context.locale === defaultLocale) {
+    return result
+  }
+
+  return {
+    redirect: {
+      ...result.redirect,
+      locale: context.locale,
+    },
+  }
+}

--- a/packages/core/src/utils/localization/withLocaleValidation.ts
+++ b/packages/core/src/utils/localization/withLocaleValidation.ts
@@ -1,4 +1,5 @@
 import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
+import { localizeRedirectResult } from './getLocalizedRedirect'
 import { validateLocaleForHostname } from './validateLocaleForHostname'
 
 type ServerPropsHandler<P> = (
@@ -19,14 +20,20 @@ export function withLocaleValidationSSR<P extends Record<string, any>>(
     const hostname = req.headers.host || ''
 
     if (!locale) {
-      // If there's no locale in context, execute original function
-      return getServerSidePropsFn(context)
+      return localizeRedirectResult(
+        context,
+        await getServerSidePropsFn(context)
+      )
     }
 
-    // Skip locale validation for private/authenticated routes
-    const pathname = req.url?.split('?')[0] ?? ''
+    // Skip locale validation for private/authenticated routes.
+    // resolvedUrl is locale-stripped by Next.js; req.url may still include the prefix.
+    const pathname = context.resolvedUrl?.split('?')[0] ?? ''
     if (pathname.startsWith('/pvt/')) {
-      return getServerSidePropsFn(context)
+      return localizeRedirectResult(
+        context,
+        await getServerSidePropsFn(context)
+      )
     }
 
     const isValid = validateLocaleForHostname(hostname, locale)
@@ -37,6 +44,6 @@ export function withLocaleValidationSSR<P extends Record<string, any>>(
       }
     }
 
-    return getServerSidePropsFn(context)
+    return localizeRedirectResult(context, await getServerSidePropsFn(context))
   }
 }

--- a/packages/core/test/utils/localization/getLocalizedRedirect.test.ts
+++ b/packages/core/test/utils/localization/getLocalizedRedirect.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { localizeRedirectResult } from '../../../src/utils/localization/getLocalizedRedirect'
+
+describe('localizeRedirectResult', () => {
+  it('returns props unchanged', () => {
+    expect(
+      localizeRedirectResult(
+        { locale: 'pt-BR', defaultLocale: 'en-US' },
+        { props: { foo: 'bar' } }
+      )
+    ).toEqual({ props: { foo: 'bar' } })
+  })
+
+  it('does not set locale for default locale redirects', () => {
+    expect(
+      localizeRedirectResult(
+        { locale: 'en-US', defaultLocale: 'en-US' },
+        {
+          redirect: {
+            destination: '/pvt/account/403?from=%2Fpvt%2Faccount%2Fprofile',
+            permanent: false,
+          },
+        }
+      )
+    ).toEqual({
+      redirect: {
+        destination: '/pvt/account/403?from=%2Fpvt%2Faccount%2Fprofile',
+        permanent: false,
+      },
+    })
+  })
+
+  it('sets locale on internal redirects for non-default locale', () => {
+    expect(
+      localizeRedirectResult(
+        { locale: 'pt-BR', defaultLocale: 'en-US' },
+        {
+          redirect: {
+            destination: '/pvt/account/403?from=%2Fpvt%2Faccount%2Fprofile',
+            permanent: false,
+          },
+        }
+      )
+    ).toEqual({
+      redirect: {
+        destination: '/pvt/account/403?from=%2Fpvt%2Faccount%2Fprofile',
+        permanent: false,
+        locale: 'pt-BR',
+      },
+    })
+  })
+
+  it('does not modify external redirects', () => {
+    const external = {
+      redirect: {
+        destination: 'https://account.example.com/login',
+        permanent: false,
+      },
+    }
+
+    expect(
+      localizeRedirectResult(
+        { locale: 'pt-BR', defaultLocale: 'en-US' },
+        external
+      )
+    ).toEqual(external)
+  })
+
+  it('does not override an existing redirect locale', () => {
+    expect(
+      localizeRedirectResult(
+        { locale: 'pt-BR', defaultLocale: 'en-US' },
+        {
+          redirect: {
+            destination: '/pvt/account/profile',
+            permanent: false,
+            locale: false,
+          },
+        }
+      )
+    ).toEqual({
+      redirect: {
+        destination: '/pvt/account/profile',
+        permanent: false,
+        locale: false,
+      },
+    })
+  })
+})

--- a/packages/core/test/utils/localization/withLocaleValidation.test.ts
+++ b/packages/core/test/utils/localization/withLocaleValidation.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GetServerSidePropsContext } from 'next'
+import { withLocaleValidationSSR } from '../../../src/utils/localization/withLocaleValidation'
+
+vi.mock('../../../discovery.config.js', () => ({
+  default: {
+    localization: {
+      enabled: true,
+      defaultLocale: 'en-US',
+      locales: {
+        'pt-BR': {
+          bindings: [{ url: 'https://b2bfaststore.vtexfaststore.com/pt-BR' }],
+        },
+        'en-US': {
+          bindings: [{ url: 'https://b2bfaststore.vtexfaststore.com/' }],
+        },
+      },
+    },
+  },
+}))
+
+function buildContext({
+  locale,
+  reqUrl,
+  resolvedUrl,
+  host,
+}: {
+  locale: string
+  reqUrl: string
+  resolvedUrl: string
+  host: string
+}): GetServerSidePropsContext {
+  return {
+    locale,
+    resolvedUrl,
+    req: {
+      url: reqUrl,
+      headers: { host },
+    },
+  } as GetServerSidePropsContext
+}
+
+describe('withLocaleValidationSSR — /pvt/ routes with locale prefix', () => {
+  it('skips validation for /pvt/ when resolvedUrl has no locale prefix', async () => {
+    const innerFn = vi.fn().mockResolvedValue({ props: {} })
+    const wrapped = withLocaleValidationSSR(innerFn)
+
+    await wrapped(
+      buildContext({
+        locale: 'en-US',
+        reqUrl: '/pvt/account/profile',
+        resolvedUrl: '/pvt/account/profile',
+        host: 'wrong-internal-host.vtex.com',
+      })
+    )
+
+    expect(innerFn).toHaveBeenCalledOnce()
+  })
+
+  it('skips validation for pt-BR /pvt/ even when req.url includes locale prefix', async () => {
+    const innerFn = vi.fn().mockResolvedValue({ props: {} })
+    const wrapped = withLocaleValidationSSR(innerFn)
+
+    await wrapped(
+      buildContext({
+        locale: 'pt-BR',
+        reqUrl: '/pt-BR/pvt/account/profile',
+        resolvedUrl: '/pvt/account/profile',
+        host: 'wrong-internal-host.vtex.com',
+      })
+    )
+
+    expect(innerFn).toHaveBeenCalledOnce()
+  })
+
+  it('returns notFound for non-/pvt/ routes with invalid hostname', async () => {
+    const innerFn = vi.fn().mockResolvedValue({ props: {} })
+    const wrapped = withLocaleValidationSSR(innerFn)
+
+    const result = await wrapped(
+      buildContext({
+        locale: 'pt-BR',
+        reqUrl: '/pt-BR/office',
+        resolvedUrl: '/office',
+        host: 'wrong-internal-host.vtex.com',
+      })
+    )
+
+    expect(result).toEqual({ notFound: true })
+    expect(innerFn).not.toHaveBeenCalled()
+  })
+
+  it('adds redirect.locale for /pvt/ internal redirects on non-default locale', async () => {
+    const innerFn = vi.fn().mockResolvedValue({
+      redirect: {
+        destination: '/pvt/account/403?from=%2Fpvt%2Faccount%2Fprofile',
+        permanent: false,
+      },
+    })
+    const wrapped = withLocaleValidationSSR(innerFn)
+
+    const result = await wrapped(
+      buildContext({
+        locale: 'pt-BR',
+        defaultLocale: 'en-US',
+        reqUrl: '/pt-BR/pvt/account/profile',
+        resolvedUrl: '/pvt/account/profile',
+        host: 'b2bfaststore.vtexfaststore.com',
+      } as GetServerSidePropsContext)
+    )
+
+    expect(result).toEqual({
+      redirect: {
+        destination: '/pvt/account/403?from=%2Fpvt%2Faccount%2Fprofile',
+        permanent: false,
+        locale: 'pt-BR',
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fix locale validation for `/pvt/*` routes by checking `context.resolvedUrl` (locale-stripped) instead of `req.url`, which could still include the path prefix and incorrectly trigger `notFound` for non-default locales.
- Prevent the proxy from prepending the subdomain default locale when the hostname also serves path-based locale bindings (e.g. `/pt-BR` on the same domain), which caused double-prefixed paths like `/pt-BR/en-US/pvt/account/403` and 404s.
- Preserve locale on SSR redirects centrally in `withLocaleValidationSSR` via `redirect.locale`, so My Account pages do not need per-page redirect changes.
- Use `useLink` on the My Account 403 page so client-side navigation keeps the active locale prefix.

## Test plan

- [x] `pnpm vitest run test/utils/localization/ test/proxy.test.ts` (84 tests passing)
- [ ] Visit `/pt-BR/pvt/account/` on a store with path-based locale bindings — should show 403 (not 404)
- [ ] Visit `/en-US/pvt/account/` — should behave the same as before
- [ ] Check Network tab: no `x-middleware-rewrite` with double locale prefix (`/pt-BR/en-US/...`)
- [ ] Verify My Account redirect chain (profile → 403) keeps `/pt-BR` in the URL
- [ ] Click "Back to Account" on the 403 page and confirm it navigates to the localized account URL


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "Back to Account" link on 403 unauthorized page to correctly resolve navigation destination
  * Improved locale preference preservation during internal redirects
  * Enhanced detection of locale binding configurations for subdomain-based setups

* **Tests**
  * Added comprehensive test coverage for locale-aware redirect handling and validation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->