### PR TITLE
fix: align password-protection vocabulary in v3 (unlock, not login)

### DIFF
--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -1,6 +1,6 @@
 /*
  * Middleware is always active. It runs:
- * 1. Password protection (AuthenticationService) — when applicable (default/custom domains per env).
+ * 1. Password protection (PasswordProtectionService) — when applicable (default/custom domains per env).
  * 2. Redirects — only when ENABLE_REDIRECTS_MIDDLEWARE is set at runtime.
  */
 
@@ -8,7 +8,7 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import storeConfig from 'discovery.config'
 
-import { AuthenticationService } from './server/authentication-service'
+import { PasswordProtectionService } from './server/password-protection-service'
 
 type Redirect = {
   from: string
@@ -31,19 +31,20 @@ const redirectsClient = new DynamoRedirectsClient()
 export async function middleware(request: NextRequest) {
   const path = request.nextUrl.pathname
 
-  let authResult: Awaited<
-    ReturnType<AuthenticationService['authenticateRequest']>
+  let storeProtectionResult: Awaited<
+    ReturnType<PasswordProtectionService['checkStoreProtection']>
   >
 
   try {
-    const authService = new AuthenticationService()
-    authResult = await authService.authenticateRequest(request)
+    const protectionService = new PasswordProtectionService()
+    storeProtectionResult =
+      await protectionService.checkStoreProtection(request)
   } catch {
     return NextResponse.error()
   }
 
-  if (authResult.response.status !== 200) {
-    return authResult.response
+  if (storeProtectionResult.response.status !== 200) {
+    return storeProtectionResult.response
   }
 
   if (process.env.ENABLE_REDIRECTS_MIDDLEWARE === 'true') {
@@ -54,7 +55,7 @@ export async function middleware(request: NextRequest) {
       const redirectStatusCode = redirect.type === 'permanent' ? 301 : 302
       const response = NextResponse.redirect(redirectUrl, redirectStatusCode)
 
-      for (const cookie of authResult.response.cookies.getAll()) {
+      for (const cookie of storeProtectionResult.response.cookies.getAll()) {
         response.cookies.set(cookie)
       }
 
@@ -67,7 +68,7 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  return authResult.response
+  return storeProtectionResult.response
 }
 
 export const config = {
@@ -75,13 +76,13 @@ export const config = {
     /*
      * Match all paths including `/`
      * Exclude:
-     * - api (e.g. api/fs/auth/login)
+     * - api (e.g. api/fs/password-protection/unlock)
      * - _next/static, _next/image
      * - favicon.ico
-     * - fs-auth-login (login page)
+     * - password-protection (unlock page)
      * - ~partytown (partytown scripts)
      */
     '/',
-    '/((?!api|_next/static|_next/image|favicon.ico|fs-auth-login|~partytown).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|password-protection|~partytown).*)',
   ],
 }

--- a/packages/core/src/pages/api/fs/password-protection/unlock.ts
+++ b/packages/core/src/pages/api/fs/password-protection/unlock.ts
@@ -2,7 +2,7 @@ import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
 
 import storeConfig from 'discovery.config'
 
-import type { LoginResponse } from '../../../../utils/loginResponse'
+import type { UnlockResponse } from '../../../../utils/unlockResponse'
 import {
   sessionUrl,
   passwordProtectionTimeouts,
@@ -10,7 +10,7 @@ import {
 import {
   COOKIE_NAME,
   TOKEN_TTL_SECONDS,
-} from 'src/server/authentication-service'
+} from 'src/server/password-protection-service'
 
 interface WebOpsSessionPayload {
   valid: boolean
@@ -36,9 +36,9 @@ const isWebOpsSessionPayload = (
   )
 }
 
-const handler: NextApiHandler<LoginResponse> = async (
+const handler: NextApiHandler<UnlockResponse> = async (
   request: NextApiRequest,
-  response: NextApiResponse<LoginResponse>
+  response: NextApiResponse<UnlockResponse>
 ) => {
   if (request.method !== 'POST') {
     response.status(405).end()

--- a/packages/core/src/pages/password-protection/index.tsx
+++ b/packages/core/src/pages/password-protection/index.tsx
@@ -3,8 +3,8 @@ import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { type FormEvent, useState } from 'react'
 
-import { isLoginResponse } from '../../utils/loginResponse'
-import styles from './fs-auth-login.module.scss'
+import { isUnlockResponse } from '../../utils/unlockResponse'
+import styles from './password-protection.module.scss'
 
 export default function PasswordProtectionLogin() {
   const router = useRouter()
@@ -21,7 +21,10 @@ export default function PasswordProtectionLogin() {
     setError('')
 
     try {
-      const url = new URL('/api/fs/auth/login', globalThis.location.origin)
+      const url = new URL(
+        '/api/fs/password-protection/unlock',
+        globalThis.location.origin
+      )
       url.searchParams.set('returnTo', returnTo)
 
       const response = await fetch(url.toString(), {
@@ -32,7 +35,7 @@ export default function PasswordProtectionLogin() {
 
       const data: unknown = await response.json()
 
-      if (!isLoginResponse(data)) {
+      if (!isUnlockResponse(data)) {
         setError('Service temporarily unavailable')
         return
       }
@@ -50,7 +53,7 @@ export default function PasswordProtectionLogin() {
   }
 
   return (
-    <div className={styles.fsAuthLogin}>
+    <div className={styles.fsPasswordProtection}>
       <Head>
         <meta name="robots" content="noindex,nofollow" />
       </Head>
@@ -63,7 +66,7 @@ export default function PasswordProtectionLogin() {
 
         <form className={styles.form} onSubmit={handleSubmit}>
           <InputField
-            id="fs-auth-password"
+            id="password-protection-input"
             label="Password"
             type="password"
             value={password}
@@ -81,7 +84,7 @@ export default function PasswordProtectionLogin() {
             disabled={loading}
             loading={loading}
           >
-            Login
+            Unlock
           </Button>
         </form>
       </div>

--- a/packages/core/src/pages/password-protection/password-protection.module.scss
+++ b/packages/core/src/pages/password-protection/password-protection.module.scss
@@ -1,5 +1,5 @@
 @layer components {
-  .fsAuthLogin {
+  .fsPasswordProtection {
     @import "@faststore/ui/src/components/atoms/Button/styles.scss";
     @import "@faststore/ui/src/components/atoms/Input/styles.scss";
     @import "@faststore/ui/src/components/atoms/Loader/styles.scss";

--- a/packages/core/src/server/password-protection-service.ts
+++ b/packages/core/src/server/password-protection-service.ts
@@ -12,7 +12,7 @@ import {
   passwordProtectionTimeouts,
 } from './password-protection/webops-api'
 
-export const COOKIE_NAME = '__fs_auth_token'
+export const COOKIE_NAME = '__fs_password_protection'
 export const TOKEN_TTL_SECONDS = 10 * 60
 /** How long to reuse the RSA public key fetched from WebOps */
 const PUBLIC_KEY_CACHE_MS = 60 * 60 * 1000
@@ -25,7 +25,7 @@ interface TokenPayload {
   exp?: number
 }
 
-interface AuthResult {
+interface StoreProtectionResult {
   response: NextResponse
 }
 
@@ -73,7 +73,7 @@ export function resetPasswordProtectionPublicKeyCacheForTests(): void {
   publicKeyCache = null
 }
 
-export class AuthenticationService {
+export class PasswordProtectionService {
   private readonly storeId: string
 
   constructor() {
@@ -85,7 +85,9 @@ export class AuthenticationService {
     return host.split(':')[0].toLowerCase()
   }
 
-  async authenticateRequest(request: NextRequest): Promise<AuthResult> {
+  async checkStoreProtection(
+    request: NextRequest
+  ): Promise<StoreProtectionResult> {
     if (!this.shouldCheckProtection(request)) {
       return { response: NextResponse.next() }
     }
@@ -104,7 +106,7 @@ export class AuthenticationService {
       }
     }
 
-    return await this.handleNoAuth(request)
+    return await this.handleProtectionCheck(request)
   }
 
   private shouldCheckProtection(request: NextRequest): boolean {
@@ -182,7 +184,7 @@ export class AuthenticationService {
     request: NextRequest,
     expiredToken: string,
     payload: TokenPayload
-  ): Promise<AuthResult> {
+  ): Promise<StoreProtectionResult> {
     try {
       const res = await fetch(renewUrl(), {
         method: 'POST',
@@ -199,7 +201,7 @@ export class AuthenticationService {
 
         if (data.valid && data.token) {
           const response = NextResponse.next()
-          this.setAuthCookie(response, data.token)
+          this.setProtectionCookie(response, data.token)
 
           return { response }
         }
@@ -212,17 +214,19 @@ export class AuthenticationService {
       return { response: NextResponse.next() }
     }
 
-    return { response: this.redirectToLogin(request) }
+    return { response: this.redirectToUnlockPage(request) }
   }
 
-  private async handleNoAuth(request: NextRequest): Promise<AuthResult> {
+  private async handleProtectionCheck(
+    request: NextRequest
+  ): Promise<StoreProtectionResult> {
     try {
       const res = await fetch(protectionStatusUrl(), {
         signal: AbortSignal.timeout(passwordProtectionTimeouts.defaultMs),
       })
 
       if (!res.ok) {
-        return { response: this.redirectToLogin(request) }
+        return { response: this.redirectToUnlockPage(request) }
       }
 
       const status = await res.json()
@@ -231,7 +235,7 @@ export class AuthenticationService {
         const response = NextResponse.next()
 
         if (status.token) {
-          this.setAuthCookie(response, status.token)
+          this.setProtectionCookie(response, status.token)
         }
 
         return { response }
@@ -241,13 +245,13 @@ export class AuthenticationService {
         return { response: NextResponse.next() }
       }
 
-      return { response: this.redirectToLogin(request) }
+      return { response: this.redirectToUnlockPage(request) }
     } catch {
-      return { response: this.redirectToLogin(request) }
+      return { response: this.redirectToUnlockPage(request) }
     }
   }
 
-  private setAuthCookie(response: NextResponse, token: string): void {
+  private setProtectionCookie(response: NextResponse, token: string): void {
     response.cookies.set(COOKIE_NAME, token, {
       httpOnly: true,
       secure: true,
@@ -257,8 +261,8 @@ export class AuthenticationService {
     })
   }
 
-  private redirectToLogin(request: NextRequest): NextResponse {
-    const loginUrl = new URL('/fs-auth-login', request.url)
+  private redirectToUnlockPage(request: NextRequest): NextResponse {
+    const loginUrl = new URL('/password-protection', request.url)
     const returnTo = `${request.nextUrl.pathname}${request.nextUrl.search}`
     loginUrl.searchParams.set('returnTo', returnTo)
 

--- a/packages/core/src/server/password-protection-service.ts
+++ b/packages/core/src/server/password-protection-service.ts
@@ -262,11 +262,11 @@ export class PasswordProtectionService {
   }
 
   private redirectToUnlockPage(request: NextRequest): NextResponse {
-    const loginUrl = new URL('/password-protection', request.url)
+    const unlockUrl = new URL('/password-protection', request.url)
     const returnTo = `${request.nextUrl.pathname}${request.nextUrl.search}`
-    loginUrl.searchParams.set('returnTo', returnTo)
+    unlockUrl.searchParams.set('returnTo', returnTo)
 
-    const response = NextResponse.redirect(loginUrl)
+    const response = NextResponse.redirect(unlockUrl)
     response.headers.set('Cache-Control', 'no-store')
 
     return response

--- a/packages/core/src/utils/unlockResponse.ts
+++ b/packages/core/src/utils/unlockResponse.ts
@@ -1,17 +1,22 @@
-export interface LoginResponse {
+export interface UnlockResponse {
   success?: boolean
   redirectUrl?: string
   error?: string
 }
 
-export const isLoginResponse = (data: unknown): data is LoginResponse => {
+export const isUnlockResponse = (data: unknown): data is UnlockResponse => {
   if (typeof data !== 'object' || data === null || Array.isArray(data)) {
     return false
   }
 
   const payload = data as Record<string, unknown>
+  const hasUnlockResponseField =
+    payload.success !== undefined ||
+    payload.redirectUrl !== undefined ||
+    payload.error !== undefined
 
   return (
+    hasUnlockResponseField &&
     (payload.success === undefined || typeof payload.success === 'boolean') &&
     (payload.redirectUrl === undefined ||
       typeof payload.redirectUrl === 'string') &&

--- a/packages/core/test/server/password-protection-service.test.ts
+++ b/packages/core/test/server/password-protection-service.test.ts
@@ -2,9 +2,9 @@ import { decodeJwt, errors, importSPKI, jwtVerify } from 'jose'
 import { NextRequest } from 'next/server'
 
 import {
-  AuthenticationService,
+  PasswordProtectionService,
   resetPasswordProtectionPublicKeyCacheForTests,
-} from '../../src/server/authentication-service'
+} from '../../src/server/password-protection-service'
 
 function setNodeEnv(value: string | undefined): void {
   const env = process.env as Record<string, string | undefined>
@@ -62,7 +62,7 @@ function previewRequest(
   })
 }
 
-describe('AuthenticationService', () => {
+describe('PasswordProtectionService', () => {
   const originalNodeEnv = process.env.NODE_ENV
   const originalCustomDomains = process.env.CUSTOM_DOMAINS_PROTECTION_ENABLED
 
@@ -83,8 +83,10 @@ describe('AuthenticationService', () => {
   it('skips protection in development', async () => {
     setNodeEnv('development')
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(previewRequest('/p'))
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
+      previewRequest('/p')
+    )
 
     expect(response.status).toBe(200)
     expect(global.fetch).not.toHaveBeenCalled()
@@ -99,13 +101,13 @@ describe('AuthenticationService', () => {
       }),
     })
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
       previewRequest('/products')
     )
 
     expect(response.status).toBe(200)
-    expect(response.cookies.get('__fs_auth_token')?.value).toBe(
+    expect(response.cookies.get('__fs_password_protection')?.value).toBe(
       'neg-cache-token'
     )
     expect(global.fetch).toHaveBeenCalledWith(
@@ -118,7 +120,7 @@ describe('AuthenticationService', () => {
     )
   })
 
-  it('redirects to login when protected and host matches DEFAULT_DOMAINS scope', async () => {
+  it('redirects to unlock page when protected and host matches DEFAULT_DOMAINS scope', async () => {
     ;(global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -128,14 +130,14 @@ describe('AuthenticationService', () => {
       }),
     })
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
       previewRequest('/secret')
     )
 
     expect(response.status).toBe(307)
     const location = response.headers.get('location') ?? ''
-    expect(location).toContain('/fs-auth-login')
+    expect(location).toContain('/password-protection')
     expect(location).toContain('returnTo=%2Fsecret')
   })
 
@@ -148,13 +150,15 @@ describe('AuthenticationService', () => {
       }),
     })
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(previewRequest('/p'))
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
+      previewRequest('/p')
+    )
 
     expect(response.status).toBe(200)
   })
 
-  it('redirects to login when protected for ALL_DOMAINS on custom host', async () => {
+  it('redirects to unlock page when protected for ALL_DOMAINS on custom host', async () => {
     process.env.CUSTOM_DOMAINS_PROTECTION_ENABLED = 'true'
     ;(global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
@@ -164,8 +168,8 @@ describe('AuthenticationService', () => {
       }),
     })
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
       new NextRequest('https://shop.example.com/checkout', {
         headers: { host: 'shop.example.com' },
       })
@@ -190,10 +194,10 @@ describe('AuthenticationService', () => {
       protectedHeader: { alg: 'RS256' },
     } as unknown as Awaited<ReturnType<typeof jwtVerify>>)
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
       previewRequest('/account', {
-        headers: { cookie: '__fs_auth_token=valid' },
+        headers: { cookie: '__fs_password_protection=valid' },
       })
     )
 
@@ -220,12 +224,12 @@ describe('AuthenticationService', () => {
       protectedHeader: { alg: 'RS256' },
     } as unknown as Awaited<ReturnType<typeof jwtVerify>>)
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
       previewRequest('/p', {
         headers: {
           host: 'preview.vtex.app',
-          cookie: '__fs_auth_token=abc',
+          cookie: '__fs_password_protection=abc',
         },
       })
     )
@@ -254,11 +258,11 @@ describe('AuthenticationService', () => {
       }),
     })
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
       previewRequest('/x', {
         headers: {
-          cookie: '__fs_auth_token=bad',
+          cookie: '__fs_password_protection=bad',
         },
       })
     )
@@ -280,15 +284,17 @@ describe('AuthenticationService', () => {
       }),
     })
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
       previewRequest('/p', {
-        headers: { cookie: '__fs_auth_token=garbage' },
+        headers: { cookie: '__fs_password_protection=garbage' },
       })
     )
 
     expect(response.status).toBe(200)
-    expect(response.cookies.get('__fs_auth_token')?.value).toBe('after-bad-jwt')
+    expect(response.cookies.get('__fs_password_protection')?.value).toBe(
+      'after-bad-jwt'
+    )
     expect(jwtVerifyMock).toHaveBeenCalled()
     expect(global.fetch).toHaveBeenCalledTimes(2)
   })
@@ -316,18 +322,20 @@ describe('AuthenticationService', () => {
       }),
     })
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
       previewRequest('/p', {
-        headers: { cookie: '__fs_auth_token=old' },
+        headers: { cookie: '__fs_password_protection=old' },
       })
     )
 
     expect(response.status).toBe(200)
-    expect(response.cookies.get('__fs_auth_token')?.value).toBe('renewed-token')
+    expect(response.cookies.get('__fs_password_protection')?.value).toBe(
+      'renewed-token'
+    )
   })
 
-  it('redirects to login when JWT is expired and renew response is not ok', async () => {
+  it('redirects to unlock page when JWT is expired and renew response is not ok', async () => {
     ;(global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ publicKey: 'test-pem' }),
@@ -345,17 +353,17 @@ describe('AuthenticationService', () => {
       status: 502,
     })
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
       previewRequest('/p', {
-        headers: { cookie: '__fs_auth_token=expired' },
+        headers: { cookie: '__fs_password_protection=expired' },
       })
     )
 
     expect(response.status).toBe(307)
   })
 
-  it('redirects to login when JWT is expired and renew body is not valid', async () => {
+  it('redirects to unlock page when JWT is expired and renew body is not valid', async () => {
     ;(global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ publicKey: 'test-pem' }),
@@ -373,10 +381,10 @@ describe('AuthenticationService', () => {
       json: async () => ({ valid: false }),
     })
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
       previewRequest('/p', {
-        headers: { cookie: '__fs_auth_token=expired' },
+        headers: { cookie: '__fs_password_protection=expired' },
       })
     )
 
@@ -398,61 +406,65 @@ describe('AuthenticationService', () => {
     } as ReturnType<typeof decodeJwt>)
     ;(global.fetch as jest.Mock).mockRejectedValueOnce(new Error('renew down'))
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
       previewRequest('/p', {
-        headers: { cookie: '__fs_auth_token=old' },
+        headers: { cookie: '__fs_password_protection=old' },
       })
     )
 
     expect(response.status).toBe(200)
   })
 
-  it('fail-closes to login on default domain when status request fails', async () => {
+  it('fail-closes to unlock page on default domain when status request fails', async () => {
     ;(global.fetch as jest.Mock).mockRejectedValue(new Error('network'))
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(previewRequest('/p'))
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
+      previewRequest('/p')
+    )
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toContain('/fs-auth-login')
+    expect(response.headers.get('location')).toContain('/password-protection')
   })
 
-  it('fail-closes to login when status endpoint returns a non-ok HTTP status', async () => {
+  it('fail-closes to unlock page when status endpoint returns a non-ok HTTP status', async () => {
     ;(global.fetch as jest.Mock).mockResolvedValue({
       ok: false,
       status: 503,
     })
 
-    const service = new AuthenticationService()
-    const { response } = await service.authenticateRequest(previewRequest('/p'))
+    const service = new PasswordProtectionService()
+    const { response } = await service.checkStoreProtection(
+      previewRequest('/p')
+    )
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toContain('/fs-auth-login')
+    expect(response.headers.get('location')).toContain('/password-protection')
   })
 
-  it('fail-closes to login on custom domain when status request fails', async () => {
+  it('fail-closes to unlock page on custom domain when status request fails', async () => {
     process.env.CUSTOM_DOMAINS_PROTECTION_ENABLED = 'true'
     ;(global.fetch as jest.Mock).mockRejectedValue(new Error('network'))
 
-    const service = new AuthenticationService()
+    const service = new PasswordProtectionService()
     const request = new NextRequest('https://shop.example.com/page', {
       headers: { host: 'shop.example.com' },
     })
 
-    const { response } = await service.authenticateRequest(request)
+    const { response } = await service.checkStoreProtection(request)
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toContain('/fs-auth-login')
+    expect(response.headers.get('location')).toContain('/password-protection')
   })
 
   it('does not enforce protection on custom domain when env gate is off', async () => {
-    const service = new AuthenticationService()
+    const service = new PasswordProtectionService()
     const request = new NextRequest('https://shop.example.com/page', {
       headers: { host: 'shop.example.com' },
     })
 
-    const { response } = await service.authenticateRequest(request)
+    const { response } = await service.checkStoreProtection(request)
 
     expect(response.status).toBe(200)
     expect(global.fetch).not.toHaveBeenCalled()


### PR DESCRIPTION
[FAS-1151](https://vtex-dev.atlassian.net/browse/FAS-1151)

## Summary

- Ports vocabulary changes from v4 (f4ed1513a / #3276) to v3 to fix a cookie name inconsistency with an external application
- Renames `__fs_auth_token` → `__fs_password_protection` (the critical fix)
- Aligns all related file names, class/method names, URLs, and UI copy to the `unlock` domain

## Changes

| Old (v3) | New |
|---|---|
| `__fs_auth_token` (cookie) | `__fs_password_protection` |
| `AuthenticationService` | `PasswordProtectionService` |
| `authenticateRequest()` | `checkStoreProtection()` |
| `authentication-service.ts` | `password-protection-service.ts` |
| `loginResponse.ts` | `unlockResponse.ts` |
| `LoginResponse` / `isLoginResponse` | `UnlockResponse` / `isUnlockResponse` |
| `pages/api/fs/auth/login` | `pages/api/fs/password-protection/unlock` |
| `pages/fs-auth-login/` | `pages/password-protection/` |
| Button label: `Login` | `Unlock` |
| Input id: `fs-auth-password` | `password-protection-input` |

## Context

The vocabulary inconsistency between v3 and v4 was causing issues in another application reading the auth cookie by name. This PR brings v3 in sync with the v4 refactor that was already merged (#3276).

## Test plan

- [ ] Unit tests pass (`pnpm test` in `packages/core`)
- [ ] Middleware correctly redirects to `/password-protection` when store is protected
- [ ] Unlock page posts to `/api/fs/password-protection/unlock` and sets `__fs_password_protection` cookie on success
- [ ] External application consuming the cookie reads it correctly with the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Switched store access checks from authentication-based protection to password-protection-based validation.
  * Updated the session protection service, including cookie name and renewal behavior.
  * Updated the unlock flow terminology and payload validation to use an unlock-specific response.
  * Adjusted middleware redirect behavior and cookie propagation to match the new protection flow.
* **New Features**
  * Added the password-protection unlock page flow (Unlock submission + unlock API).
* **Tests**
  * Updated password-protection service tests to match new cookies, redirects, and fail-close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[FAS-1151]: https://vtex-dev.atlassian.net/browse/FAS-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ