### PR TITLE
fix: sync IS locale with URL and selectedFacets on navigation

### DIFF
--- a/packages/api/src/platforms/vtex/clients/search/index.ts
+++ b/packages/api/src/platforms/vtex/clients/search/index.ts
@@ -81,7 +81,9 @@ function getRegionIdFromContext(ctx: GraphqlContext): string | undefined {
 function getSegmentLocale(ctx: GraphqlContext): string {
   const segment = parseSegmentCookie(ctx.headers?.cookie)
 
-  return (segment.cultureInfo as string | undefined) ?? ctx.storage.locale
+  // Prefer ctx.storage.locale (set from trusted selectedFacets) over the
+  // vtex_segment cookie, which can lag on hard locale-switch navigation.
+  return ctx.storage.locale || (segment.cultureInfo as string | undefined) || ''
 }
 
 export const IntelligentSearch = (

--- a/packages/api/test/unit/platforms/vtex/clients/search.test.ts
+++ b/packages/api/test/unit/platforms/vtex/clients/search.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { IntelligentSearch } from '../../../../../src/platforms/vtex/clients/search'
+import type { GraphqlContext } from '../../../../../src/platforms/vtex'
+
+const searchOptions = {
+  platform: 'vtex',
+  account: 'storeframework',
+  environment: 'vtexcommercestable',
+  hideUnavailableItems: false,
+  simulationBehavior: 'default' as const,
+  showSponsored: false,
+} as Options
+
+const fetchAPIMocked = vi.fn()
+
+beforeEach(() => {
+  fetchAPIMocked.mockClear()
+})
+
+vi.mock('../../../../../src/platforms/vtex/clients/fetch.ts', () => ({
+  fetchAPI: async (info: RequestInfo, init?: RequestInit) =>
+    fetchAPIMocked(info, init),
+}))
+
+function makeCtx(overrides: {
+  storageLocale?: string
+  cookie?: string
+}): GraphqlContext {
+  return {
+    id: 'test',
+    clients: {} as GraphqlContext['clients'],
+    loaders: {} as GraphqlContext['loaders'],
+    storage: {
+      channel: { salesChannel: '1', regionId: '', seller: '' },
+      locale: overrides.storageLocale ?? '',
+      flags: {} as GraphqlContext['storage']['flags'],
+      cookies: new Map(),
+    },
+    headers: {
+      cookie: overrides.cookie ?? '',
+      host: 'localhost',
+    },
+    account: 'storeframework',
+    OTEL: {},
+  } as unknown as GraphqlContext
+}
+
+/** Parses the `locale` query param from the URL the mock was called with. */
+function capturedLocale(): string | null {
+  const [url] = fetchAPIMocked.mock.calls[0]
+  return new URL(url).searchParams.get('locale')
+}
+
+describe('IntelligentSearch — getSegmentLocale priority', () => {
+  it('prefers ctx.storage.locale over vtex_segment cookie cultureInfo', async () => {
+    // Simulate stale vtex_segment cookie from previous locale (en-US) while the
+    // server-side ctx.storage.locale is already updated to it-IT.
+    const enUSSegment = Buffer.from(
+      JSON.stringify({ cultureInfo: 'en-US' })
+    ).toString('base64')
+
+    fetchAPIMocked.mockResolvedValueOnce({ products: { edges: [] } })
+
+    const ctx = makeCtx({
+      storageLocale: 'it-IT',
+      cookie: `vtex_segment=${enUSSegment}`,
+    })
+
+    const is = IntelligentSearch(searchOptions, ctx)
+    await is.products({ page: 0, count: 1 })
+
+    expect(capturedLocale()).toBe('it-IT')
+  })
+
+  it('falls back to vtex_segment cultureInfo when ctx.storage.locale is empty', async () => {
+    // base64 JSON: { "cultureInfo": "pt-BR" }
+    const ptBRSegment = Buffer.from(
+      JSON.stringify({ cultureInfo: 'pt-BR' })
+    ).toString('base64')
+
+    fetchAPIMocked.mockResolvedValueOnce({ products: { edges: [] } })
+
+    const ctx = makeCtx({
+      storageLocale: '',
+      cookie: `vtex_segment=${ptBRSegment}`,
+    })
+
+    const is = IntelligentSearch(searchOptions, ctx)
+    await is.products({ page: 0, count: 1 })
+
+    expect(capturedLocale()).toBe('pt-BR')
+  })
+
+  it('omits the locale param when both ctx.storage.locale and cookie are absent', async () => {
+    // buildIntelligentSearchRequest skips params with empty/falsy values, so
+    // URLSearchParams.get('locale') returns null rather than ''.
+    fetchAPIMocked.mockResolvedValueOnce({ products: { edges: [] } })
+
+    const ctx = makeCtx({ storageLocale: '', cookie: '' })
+
+    const is = IntelligentSearch(searchOptions, ctx)
+    await is.products({ page: 0, count: 1 })
+
+    expect(capturedLocale()).toBeNull()
+  })
+})

--- a/packages/core/src/sdk/product/useLocalizedVariables.ts
+++ b/packages/core/src/sdk/product/useLocalizedVariables.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react'
 
 import type { ClientManyProductsQueryQueryVariables } from '@generated/graphql'
+import { useRouter } from 'next/router'
 
+import storeConfig from 'discovery.config'
 import { ITEMS_PER_SECTION } from 'src/constants'
 import { useSession } from 'src/sdk/session'
 import { toArray } from 'src/utils/utilities'
@@ -14,7 +16,18 @@ export const useLocalizedVariables = ({
   selectedFacets,
   sponsoredCount,
 }: Partial<ClientManyProductsQueryQueryVariables>) => {
-  const { channel, locale } = useSession()
+  const { channel, locale: sessionLocale } = useSession()
+  const router = useRouter()
+
+  // Prefer router.locale over session.locale: Next.js i18n exposes the locale
+  // prefix as router.locale (always current), while session.locale can lag on
+  // navigation.
+  const locale = useMemo(() => {
+    if (storeConfig.localization?.enabled) {
+      return router.locale ?? sessionLocale
+    }
+    return sessionLocale
+  }, [router.locale, sessionLocale])
 
   return useMemo(() => {
     return {


### PR DESCRIPTION
## Summary

- **`@faststore/core`**: when `localization.enabled`, derive the locale facet for client-side IS queries from `router.locale` (via `getSettings`) instead of `session.locale`, which can lag after a hard locale switch or back/forward navigation.
- **`@faststore/api`**: prefer `ctx.storage.locale` (set from trusted `selectedFacets`) over `vtex_segment` cookie `cultureInfo` when building Intelligent Search requests — the cookie can remain stale while the URL and facets already reflect the new locale.

These two changes work together: core sends the correct locale in the GraphQL request; API ensures IS does not override it with a stale segment cookie.

## Context

Introduced while working on localized PLP pages (#3401). The bug also affects stores with localization enabled on `dev` today (locale-prefixed PLPs, search, shelves) even without localized collection slug resolution.

Does **not** include PLP-specific work (`by-linkid`, `StoreCollection.otherLocales`, etc.) — that remains in #3401.

## Test plan

- [ ] `cd packages/api && pnpm vitest run test/unit/platforms/vtex/clients/search.test.ts`
- [ ] With `localization.enabled: true`, open a locale-prefixed PLP (e.g. `/pt-BR/apparel`)
- [ ] Switch locale via LocalizationSelector → product grid shows correct translated names immediately
- [ ] Browser back/forward on a localized PLP → product slugs/names stay correct
- [ ] With `localization.enabled: false`, verify no behavior change on PLP/search pages


PR: https://vtex-dev.atlassian.net/jira/software/c/projects/SFS/boards/1051?selectedIssue=SFS-3242
Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Localized stores now derive the active locale from the current page URL, enabling immediate updates to language-aware selections during navigation.

* **Bug Fixes**
  * Search requests now prioritize the current stored locale over stale cookie data, with a safe fallback when locale is unavailable.
  * Search requests omit the locale parameter when no locale can be determined, preventing invalid locale values.
  
* **Tests**
  * Added unit coverage to verify locale query parameter behavior across precedence and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->