### PR TITLE
feat: make cms-sync content-source aware (CMS + CP)

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -30,7 +30,7 @@ Each file in `src/commands/` defines one oclif command:
 - `start.ts` — production server
 - `test.ts` — test runner
 - `prepare.ts` — pre-run preparation
-- `cms-sync.ts` — sync CMS content (legacy Headless CMS or CP schema publish, auto-detected from `discovery.config.js` `contentSource.type`; in CP mode, when `experimental.enableFaststoreMyAccount` is on, merges the core My Account schemas into a temp dir and includes them in the single generated/uploaded schema)
+- `cms-sync.ts` — sync CMS content (legacy Headless CMS or CP schema publish, auto-detected from `discovery.config.js` `contentSource.type`). CP mode runs a pre-flight (`vtex --version` + `vtex whoami` vs `api.storeId`, via `utils/vtex.ts`), then `generate-schema`/`upload-schema` **interactively** with paths relative to the store root. When `experimental.enableFaststoreMyAccount` is on, it file-merges the core My Account schemas with the store's `cms/faststore/{components,pages}` into a staging dir under `.faststore` (store overrides core) and uses those two merged dirs as the single generate/upload input.
 - `create.ts` — scaffold new stores
 - `generate.ts` — top-level type generation entry
 - `generate-graphql.ts` — GraphQL type generation

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -30,7 +30,7 @@ Each file in `src/commands/` defines one oclif command:
 - `start.ts` — production server
 - `test.ts` — test runner
 - `prepare.ts` — pre-run preparation
-- `cms-sync.ts` — sync CMS content (legacy Headless CMS or CP schema publish, auto-detected from `discovery.config.js` `contentSource.type`)
+- `cms-sync.ts` — sync CMS content (legacy Headless CMS or CP schema publish, auto-detected from `discovery.config.js` `contentSource.type`; in CP mode, when `experimental.enableFaststoreMyAccount` is on, merges the core My Account schemas into a temp dir and includes them in the single generated/uploaded schema)
 - `create.ts` — scaffold new stores
 - `generate.ts` — top-level type generation entry
 - `generate-graphql.ts` — GraphQL type generation

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -30,7 +30,7 @@ Each file in `src/commands/` defines one oclif command:
 - `start.ts` — production server
 - `test.ts` — test runner
 - `prepare.ts` — pre-run preparation
-- `cms-sync.ts` — sync CMS content
+- `cms-sync.ts` — sync CMS content (legacy Headless CMS or CP schema publish, auto-detected from `discovery.config.js` `contentSource.type`)
 - `create.ts` — scaffold new stores
 - `generate.ts` — top-level type generation entry
 - `generate-graphql.ts` — GraphQL type generation

--- a/packages/cli/src/commands/cms-sync.test.ts
+++ b/packages/cli/src/commands/cms-sync.test.ts
@@ -343,6 +343,42 @@ describe('CmsSync', () => {
       expect(cleanupMyAccountMergeDirMock).toHaveBeenCalledWith(mergeDir)
     })
 
+    it('cleans up via an exit hook so a toolbelt process.exit cannot leak the staging dir', async () => {
+      writeDiscoveryConfig(tempDir, {
+        contentSource: { type: 'CP' },
+        experimental: { enableFaststoreMyAccount: true },
+      })
+      getExistingCpDirsMock.mockReturnValue([])
+
+      let exitHandler: ((...args: unknown[]) => void) | undefined
+      const onceSpy = vi.spyOn(process, 'once').mockImplementation(((
+        event: string,
+        handler: (...args: unknown[]) => void
+      ) => {
+        if (event === 'exit') {
+          exitHandler = handler
+        }
+        return process
+      }) as never)
+      const removeSpy = vi.spyOn(process, 'removeListener')
+
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(onceSpy).toHaveBeenCalledWith('exit', expect.any(Function))
+      // The hook is removed on the normal path so listeners don't accumulate.
+      expect(removeSpy).toHaveBeenCalledWith('exit', exitHandler)
+
+      // The exit hook itself removes the staging dir — the guarantee for the
+      // process.exit() path that bypasses `finally`.
+      cleanupMyAccountMergeDirMock.mockClear()
+      expect(exitHandler).toBeDefined()
+      exitHandler?.()
+      expect(cleanupMyAccountMergeDirMock).toHaveBeenCalledWith(mergeDir)
+
+      onceSpy.mockRestore()
+      removeSpy.mockRestore()
+    })
+
     it('does not generate when core My Account schemas are missing (matrix #14)', async () => {
       writeDiscoveryConfig(tempDir, {
         contentSource: { type: 'CP' },

--- a/packages/cli/src/commands/cms-sync.test.ts
+++ b/packages/cli/src/commands/cms-sync.test.ts
@@ -17,6 +17,7 @@ const generateAndUploadSchemaMock = vi.hoisted(() => vi.fn())
 const getCpSchemaOutputPathMock = vi.hoisted(() => vi.fn())
 const prepareMyAccountMergeDirMock = vi.hoisted(() => vi.fn())
 const cleanupMyAccountMergeDirMock = vi.hoisted(() => vi.fn())
+const assertVtexReadyForAccountMock = vi.hoisted(() => vi.fn())
 
 vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => spawnMock(...args),
@@ -41,6 +42,11 @@ vi.mock('../utils/cp-schema', () => ({
     prepareMyAccountMergeDirMock(...args),
   cleanupMyAccountMergeDir: (...args: unknown[]) =>
     cleanupMyAccountMergeDirMock(...args),
+}))
+
+vi.mock('../utils/vtex', () => ({
+  assertVtexReadyForAccount: (...args: unknown[]) =>
+    assertVtexReadyForAccountMock(...args),
 }))
 
 import CmsSync from './cms-sync'
@@ -230,6 +236,18 @@ describe('CmsSync', () => {
       expect(infoMock).toHaveBeenCalledWith(
         expect.stringContaining('Detected contentSource "CP"')
       )
+    })
+
+    it('runs the vtex preflight with the store account before generating', async () => {
+      writeDiscoveryConfig(tempDir, {
+        api: { storeId: 'brandless' },
+        contentSource: { type: 'CP' },
+      })
+      getExistingCpDirsMock.mockReturnValue(['cms/faststore/components'])
+
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(assertVtexReadyForAccountMock).toHaveBeenCalledWith('brandless')
     })
   })
 

--- a/packages/cli/src/commands/cms-sync.test.ts
+++ b/packages/cli/src/commands/cms-sync.test.ts
@@ -1,0 +1,229 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { withBasePath } from '../utils/directory'
+
+const spawnMock = vi.hoisted(() => vi.fn())
+const generateMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const mergeCMSFilesMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const getExistingCpDirsMock = vi.hoisted(() => vi.fn())
+const errorNoCustomizationMock = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error('errorNoCustomization')
+  })
+)
+const generateAndUploadSchemaMock = vi.hoisted(() => vi.fn())
+const getCpSchemaOutputPathMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}))
+
+vi.mock('../utils/generate', () => ({
+  generate: (...args: unknown[]) => generateMock(...args),
+}))
+
+vi.mock('../utils/hcms', () => ({
+  mergeCMSFiles: (...args: unknown[]) => mergeCMSFilesMock(...args),
+}))
+
+vi.mock('../utils/cp-schema', () => ({
+  getExistingCpDirs: (...args: unknown[]) => getExistingCpDirsMock(...args),
+  errorNoCustomization: () => errorNoCustomizationMock(),
+  generateAndUploadSchema: (...args: unknown[]) =>
+    generateAndUploadSchemaMock(...args),
+  getCpSchemaOutputPath: (...args: unknown[]) =>
+    getCpSchemaOutputPathMock(...args),
+}))
+
+import CmsSync from './cms-sync'
+import { logger } from '../utils/logger'
+
+function writeDiscoveryConfig(
+  storeDir: string,
+  config: Record<string, unknown> = {}
+) {
+  fs.writeFileSync(
+    path.join(storeDir, 'discovery.config.js'),
+    `module.exports = ${JSON.stringify(config, null, 2)}`
+  )
+}
+
+async function runCmsSync(options?: {
+  storeDir?: string
+  dryRun?: boolean
+}) {
+  const storeDir = options?.storeDir ?? process.cwd()
+  const command = new CmsSync([], {} as never)
+
+  vi.spyOn(command, 'parse').mockResolvedValue({
+    flags: { 'dry-run': options?.dryRun ?? false },
+    args: { path: storeDir },
+  } as never)
+
+  await command.run()
+}
+
+describe('CmsSync', () => {
+  let tempDir: string
+  let originalCwd: string
+  let infoMock: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faststore-cms-sync-'))
+    originalCwd = process.cwd()
+    process.chdir(tempDir)
+
+    vi.clearAllMocks()
+    infoMock = vi.spyOn(logger, 'info').mockImplementation(() => {})
+    getCpSchemaOutputPathMock.mockImplementation((basePath: string) =>
+      path.join(withBasePath(basePath).userCMSDir, 'schema.json')
+    )
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    fs.rmSync(tempDir, { recursive: true, force: true })
+    infoMock.mockRestore()
+  })
+
+  describe('legacy CMS branch', () => {
+    it('runs vtex cms sync faststore when config is missing (matrix #1)', async () => {
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(generateMock).toHaveBeenCalledWith({
+        setup: true,
+        basePath: tempDir,
+      })
+      expect(mergeCMSFilesMock).toHaveBeenCalledWith(tempDir)
+      expect(spawnMock).toHaveBeenCalledWith('vtex cms sync faststore', {
+        shell: true,
+        cwd: path.join(tempDir, '.faststore'),
+        stdio: 'inherit',
+      })
+      expect(infoMock).toHaveBeenCalledWith(
+        expect.stringContaining('Detected contentSource "CMS"')
+      )
+      expect(infoMock).toHaveBeenCalledWith(
+        expect.stringContaining('merging and syncing CMS content')
+      )
+    })
+
+    it('uses contentSource.project from config (matrix #2)', async () => {
+      writeDiscoveryConfig(tempDir, {
+        contentSource: { type: 'CMS', project: 'myproj' },
+      })
+
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(spawnMock).toHaveBeenCalledWith('vtex cms sync myproj', {
+        shell: true,
+        cwd: path.join(tempDir, '.faststore'),
+        stdio: 'inherit',
+      })
+    })
+
+    it('skips vtex cms sync on --dry-run (matrix #3)', async () => {
+      writeDiscoveryConfig(tempDir, {
+        contentSource: { type: 'CMS' },
+      })
+
+      await runCmsSync({ storeDir: tempDir, dryRun: true })
+
+      expect(generateMock).toHaveBeenCalled()
+      expect(mergeCMSFilesMock).toHaveBeenCalled()
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('CP branch', () => {
+    beforeEach(() => {
+      writeDiscoveryConfig(tempDir, {
+        contentSource: { type: 'CP' },
+      })
+    })
+
+    it('generates and uploads schema when both dirs exist (matrix #4)', async () => {
+      getExistingCpDirsMock.mockReturnValue([
+        'cms/faststore/components',
+        'cms/faststore/pages',
+      ])
+
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(generateAndUploadSchemaMock).toHaveBeenCalledWith({
+        basePath: tempDir,
+        dirs: ['cms/faststore/components', 'cms/faststore/pages'],
+        schemaOut: path.join(tempDir, 'cms/faststore/schema.json'),
+        dryRun: false,
+      })
+      expect(infoMock).toHaveBeenCalledWith(
+        expect.stringContaining('Detected contentSource "CP"')
+      )
+      expect(infoMock).toHaveBeenCalledWith(
+        expect.stringContaining('generating and uploading schema')
+      )
+    })
+
+    it('uses components dir only (matrix #5)', async () => {
+      getExistingCpDirsMock.mockReturnValue(['cms/faststore/components'])
+
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(generateAndUploadSchemaMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dirs: ['cms/faststore/components'],
+        })
+      )
+    })
+
+    it('uses pages dir only (matrix #6)', async () => {
+      getExistingCpDirsMock.mockReturnValue(['cms/faststore/pages'])
+
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(generateAndUploadSchemaMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dirs: ['cms/faststore/pages'],
+        })
+      )
+    })
+
+    it('calls errorNoCustomization when no dirs exist (matrix #7)', async () => {
+      getExistingCpDirsMock.mockReturnValue([])
+
+      await expect(runCmsSync({ storeDir: tempDir })).rejects.toThrow(
+        'errorNoCustomization'
+      )
+
+      expect(errorNoCustomizationMock).toHaveBeenCalled()
+      expect(generateAndUploadSchemaMock).not.toHaveBeenCalled()
+    })
+
+    it('passes dryRun to generateAndUploadSchema (matrix #8)', async () => {
+      getExistingCpDirsMock.mockReturnValue(['cms/faststore/components'])
+
+      await runCmsSync({ storeDir: tempDir, dryRun: true })
+
+      expect(generateAndUploadSchemaMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dryRun: true,
+        })
+      )
+    })
+
+    it('detects CP from lowercase contentSource.type', async () => {
+      writeDiscoveryConfig(tempDir, {
+        contentSource: { type: 'cp' },
+      })
+      getExistingCpDirsMock.mockReturnValue(['cms/faststore/components'])
+
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(infoMock).toHaveBeenCalledWith(
+        expect.stringContaining('Detected contentSource "CP"')
+      )
+    })
+  })
+})

--- a/packages/cli/src/commands/cms-sync.test.ts
+++ b/packages/cli/src/commands/cms-sync.test.ts
@@ -262,7 +262,7 @@ describe('CmsSync', () => {
       })
     })
 
-    it('appends merged My Account dirs and announces the merge (matrix #10)', async () => {
+    it('passes the merged My Account dirs and announces the merge (matrix #10)', async () => {
       writeDiscoveryConfig(tempDir, {
         contentSource: { type: 'CP' },
         experimental: { enableFaststoreMyAccount: true },
@@ -278,13 +278,12 @@ describe('CmsSync', () => {
       expect(infoMock).toHaveBeenCalledWith(
         expect.stringContaining('Merging My Account')
       )
+      // The merge dir already contains the store customizations, so generate
+      // receives exactly the two merged dirs (not the raw store dirs).
+      expect(getExistingCpDirsMock).not.toHaveBeenCalled()
       expect(generateAndUploadSchemaMock).toHaveBeenCalledWith({
         basePath: tempDir,
-        dirs: [
-          'cms/faststore/components',
-          'cms/faststore/pages',
-          ...mergedDirs,
-        ],
+        dirs: mergedDirs,
         schemaOut: path.join(tempDir, 'cms/faststore/schema.json'),
         dryRun: false,
       })

--- a/packages/cli/src/commands/cms-sync.test.ts
+++ b/packages/cli/src/commands/cms-sync.test.ts
@@ -15,6 +15,8 @@ const errorNoCustomizationMock = vi.hoisted(() =>
 )
 const generateAndUploadSchemaMock = vi.hoisted(() => vi.fn())
 const getCpSchemaOutputPathMock = vi.hoisted(() => vi.fn())
+const prepareMyAccountMergeDirMock = vi.hoisted(() => vi.fn())
+const cleanupMyAccountMergeDirMock = vi.hoisted(() => vi.fn())
 
 vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => spawnMock(...args),
@@ -35,6 +37,10 @@ vi.mock('../utils/cp-schema', () => ({
     generateAndUploadSchemaMock(...args),
   getCpSchemaOutputPath: (...args: unknown[]) =>
     getCpSchemaOutputPathMock(...args),
+  prepareMyAccountMergeDir: (...args: unknown[]) =>
+    prepareMyAccountMergeDirMock(...args),
+  cleanupMyAccountMergeDir: (...args: unknown[]) =>
+    cleanupMyAccountMergeDirMock(...args),
 }))
 
 import CmsSync from './cms-sync'
@@ -224,6 +230,118 @@ describe('CmsSync', () => {
       expect(infoMock).toHaveBeenCalledWith(
         expect.stringContaining('Detected contentSource "CP"')
       )
+    })
+  })
+
+  describe('CP branch with My Account', () => {
+    const mergeDir = '/tmp/faststore-cms-myaccount-xyz'
+    const mergedDirs = [`${mergeDir}/components`, `${mergeDir}/pages`]
+
+    beforeEach(() => {
+      prepareMyAccountMergeDirMock.mockReturnValue({
+        mergeDir,
+        dirs: mergedDirs,
+      })
+    })
+
+    it('appends merged My Account dirs and announces the merge (matrix #10)', async () => {
+      writeDiscoveryConfig(tempDir, {
+        contentSource: { type: 'CP' },
+        experimental: { enableFaststoreMyAccount: true },
+      })
+      getExistingCpDirsMock.mockReturnValue([
+        'cms/faststore/components',
+        'cms/faststore/pages',
+      ])
+
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(prepareMyAccountMergeDirMock).toHaveBeenCalledWith(tempDir)
+      expect(infoMock).toHaveBeenCalledWith(
+        expect.stringContaining('Merging My Account')
+      )
+      expect(generateAndUploadSchemaMock).toHaveBeenCalledWith({
+        basePath: tempDir,
+        dirs: [
+          'cms/faststore/components',
+          'cms/faststore/pages',
+          ...mergedDirs,
+        ],
+        schemaOut: path.join(tempDir, 'cms/faststore/schema.json'),
+        dryRun: false,
+      })
+      expect(errorNoCustomizationMock).not.toHaveBeenCalled()
+      expect(cleanupMyAccountMergeDirMock).toHaveBeenCalledWith(mergeDir)
+    })
+
+    it('proceeds with only My Account dirs when the store has none (matrix #11)', async () => {
+      writeDiscoveryConfig(tempDir, {
+        contentSource: { type: 'CP' },
+        experimental: { enableFaststoreMyAccount: true },
+      })
+      getExistingCpDirsMock.mockReturnValue([])
+
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(errorNoCustomizationMock).not.toHaveBeenCalled()
+      expect(generateAndUploadSchemaMock).toHaveBeenCalledWith(
+        expect.objectContaining({ dirs: mergedDirs })
+      )
+      expect(cleanupMyAccountMergeDirMock).toHaveBeenCalledWith(mergeDir)
+    })
+
+    it('does not include My Account when the flag is off (matrix #12)', async () => {
+      writeDiscoveryConfig(tempDir, {
+        contentSource: { type: 'CP' },
+        experimental: { enableFaststoreMyAccount: false },
+      })
+      getExistingCpDirsMock.mockReturnValue([
+        'cms/faststore/components',
+        'cms/faststore/pages',
+      ])
+
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(prepareMyAccountMergeDirMock).not.toHaveBeenCalled()
+      expect(cleanupMyAccountMergeDirMock).not.toHaveBeenCalled()
+      expect(generateAndUploadSchemaMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dirs: ['cms/faststore/components', 'cms/faststore/pages'],
+        })
+      )
+    })
+
+    it('cleans up the merge dir on --dry-run (matrix #13)', async () => {
+      writeDiscoveryConfig(tempDir, {
+        contentSource: { type: 'CP' },
+        experimental: { enableFaststoreMyAccount: true },
+      })
+      getExistingCpDirsMock.mockReturnValue(['cms/faststore/components'])
+
+      await runCmsSync({ storeDir: tempDir, dryRun: true })
+
+      expect(generateAndUploadSchemaMock).toHaveBeenCalledWith(
+        expect.objectContaining({ dryRun: true })
+      )
+      expect(cleanupMyAccountMergeDirMock).toHaveBeenCalledWith(mergeDir)
+    })
+
+    it('does not generate when core My Account schemas are missing (matrix #14)', async () => {
+      writeDiscoveryConfig(tempDir, {
+        contentSource: { type: 'CP' },
+        experimental: { enableFaststoreMyAccount: true },
+      })
+      getExistingCpDirsMock.mockReturnValue(['cms/faststore/components'])
+      prepareMyAccountMergeDirMock.mockImplementation(() => {
+        throw new Error('prepareMyAccountMergeDir exited')
+      })
+
+      await expect(runCmsSync({ storeDir: tempDir })).rejects.toThrow(
+        'prepareMyAccountMergeDir exited'
+      )
+
+      expect(generateAndUploadSchemaMock).not.toHaveBeenCalled()
+      expect(cleanupMyAccountMergeDirMock).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -5,14 +5,18 @@ import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import {
+  isMyAccountEnabled,
   resolveContentSource,
   type ResolvedContentSource,
 } from '../utils/config'
 import {
+  cleanupMyAccountMergeDir,
   errorNoCustomization,
   generateAndUploadSchema,
   getCpSchemaOutputPath,
   getExistingCpDirs,
+  type MyAccountMerge,
+  prepareMyAccountMergeDir,
 } from '../utils/cp-schema'
 import { getBasePath, withBasePath } from '../utils/directory'
 import { generate } from '../utils/generate'
@@ -23,6 +27,9 @@ type StoreConfig = {
   contentSource?: {
     type?: string
     project?: string
+  }
+  experimental?: {
+    enableFaststoreMyAccount?: boolean
   }
 }
 
@@ -71,6 +78,7 @@ export default class CmsSync extends Command {
       case 'CP':
         return this.runCpSync({
           basePath,
+          storeConfig,
           dryRun: flags['dry-run'],
         })
       default: {
@@ -107,12 +115,23 @@ export default class CmsSync extends Command {
 
   private runCpSync({
     basePath,
+    storeConfig,
     dryRun,
   }: {
     basePath: string
+    storeConfig: StoreConfig | null
     dryRun?: boolean
   }) {
     const dirs = getExistingCpDirs(basePath)
+
+    let merge: MyAccountMerge | undefined
+    if (isMyAccountEnabled(storeConfig)) {
+      logger.info(
+        `${chalk.blue('[Info]')} - Merging My Account sections and content-types into the schema`
+      )
+      merge = prepareMyAccountMergeDir(basePath)
+      dirs.push(...merge.dirs)
+    }
 
     if (dirs.length === 0) {
       errorNoCustomization()
@@ -120,11 +139,17 @@ export default class CmsSync extends Command {
 
     const schemaOut = getCpSchemaOutputPath(basePath)
 
-    generateAndUploadSchema({
-      basePath,
-      dirs,
-      schemaOut,
-      dryRun: dryRun ?? false,
-    })
+    try {
+      generateAndUploadSchema({
+        basePath,
+        dirs,
+        schemaOut,
+        dryRun: dryRun ?? false,
+      })
+    } finally {
+      if (merge) {
+        cleanupMyAccountMergeDir(merge.mergeDir)
+      }
+    }
   }
 }

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -128,15 +128,19 @@ export default class CmsSync extends Command {
   }) {
     assertVtexReadyForAccount(storeConfig?.api?.storeId)
 
-    const dirs = getExistingCpDirs(basePath)
-
     let merge: MyAccountMerge | undefined
+    let dirs: string[]
+
     if (isMyAccountEnabled(storeConfig)) {
       logger.info(
         `${chalk.blue('[Info]')} - Merging My Account sections and content-types into the schema`
       )
+      // The merge dir already contains the store's own customizations merged
+      // with the core My Account schemas, so it replaces the raw store dirs.
       merge = prepareMyAccountMergeDir(basePath)
-      dirs.push(...merge.dirs)
+      dirs = merge.dirs
+    } else {
+      dirs = getExistingCpDirs(basePath)
     }
 
     if (dirs.length === 0) {

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -22,8 +22,12 @@ import { getBasePath, withBasePath } from '../utils/directory'
 import { generate } from '../utils/generate'
 import { mergeCMSFiles } from '../utils/hcms'
 import { logger } from '../utils/logger'
+import { assertVtexReadyForAccount } from '../utils/vtex'
 
 type StoreConfig = {
+  api?: {
+    storeId?: string
+  }
   contentSource?: {
     type?: string
     project?: string
@@ -122,6 +126,8 @@ export default class CmsSync extends Command {
     storeConfig: StoreConfig | null
     dryRun?: boolean
   }) {
+    assertVtexReadyForAccount(storeConfig?.api?.storeId)
+
     const dirs = getExistingCpDirs(basePath)
 
     let merge: MyAccountMerge | undefined

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -129,7 +129,6 @@ export default class CmsSync extends Command {
     assertVtexReadyForAccount(storeConfig?.api?.storeId)
 
     let merge: MyAccountMerge | undefined
-    let dirs: string[]
 
     if (isMyAccountEnabled(storeConfig)) {
       logger.info(
@@ -138,16 +137,26 @@ export default class CmsSync extends Command {
       // The merge dir already contains the store's own customizations merged
       // with the core My Account schemas, so it replaces the raw store dirs.
       merge = prepareMyAccountMergeDir(basePath)
-      dirs = merge.dirs
-    } else {
-      dirs = getExistingCpDirs(basePath)
     }
+
+    const dirs = merge ? merge.dirs : getExistingCpDirs(basePath)
 
     if (dirs.length === 0) {
       errorNoCustomization()
     }
 
     const schemaOut = getCpSchemaOutputPath(basePath)
+
+    // A toolbelt failure inside generateAndUploadSchema exits via process.exit(),
+    // which bypasses `finally`. Register the cleanup on `exit` so the staging dir
+    // is removed on that path too, then run it synchronously and drop the hook on
+    // every normal path (success, dry-run, or a thrown error).
+    let cleanup: (() => void) | undefined
+    if (merge) {
+      const { mergeDir } = merge
+      cleanup = () => cleanupMyAccountMergeDir(mergeDir)
+      process.once('exit', cleanup)
+    }
 
     try {
       generateAndUploadSchema({
@@ -157,8 +166,9 @@ export default class CmsSync extends Command {
         dryRun: dryRun ?? false,
       })
     } finally {
-      if (merge) {
-        cleanupMyAccountMergeDir(merge.mergeDir)
+      if (cleanup) {
+        process.removeListener('exit', cleanup)
+        cleanup()
       }
     }
   }

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -1,10 +1,35 @@
 import { Args, Command, Flags } from '@oclif/core'
+import chalk from 'chalk'
 import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import {
+  resolveContentSource,
+  type ResolvedContentSource,
+} from '../utils/config'
+import {
+  errorNoCustomization,
+  generateAndUploadSchema,
+  getCpSchemaOutputPath,
+  getExistingCpDirs,
+} from '../utils/cp-schema'
 import { getBasePath, withBasePath } from '../utils/directory'
 import { generate } from '../utils/generate'
 import { mergeCMSFiles } from '../utils/hcms'
-import path from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { logger } from '../utils/logger'
+
+type StoreConfig = {
+  contentSource?: {
+    type?: string
+    project?: string
+  }
+}
+
+const CONTENT_SOURCE_ACTION: Record<ResolvedContentSource, string> = {
+  CMS: 'merging and syncing CMS content',
+  CP: 'generating and uploading schema',
+}
 
 export default class CmsSync extends Command {
   static flags = {
@@ -23,24 +48,83 @@ export default class CmsSync extends Command {
     const { flags, args } = await this.parse(CmsSync)
 
     const basePath = getBasePath(args.path)
-    const { tmpDir, userStoreConfigFile } = withBasePath(basePath)
+    const { userStoreConfigFile } = withBasePath(basePath)
 
-    const { default: userStoreConfig } = await import(
-      pathToFileURL(path.resolve(userStoreConfigFile)).href
+    const storeConfig: StoreConfig | null = existsSync(userStoreConfigFile)
+      ? (await import(pathToFileURL(path.resolve(userStoreConfigFile)).href))
+          .default
+      : null
+
+    const source = resolveContentSource(storeConfig?.contentSource?.type)
+
+    logger.info(
+      `${chalk.blue('[Info]')} - Detected contentSource "${source}" — ${CONTENT_SOURCE_ACTION[source]}`
     )
-    const cmsProjectName = userStoreConfig.contentSource?.project ?? 'faststore'
+
+    switch (source) {
+      case 'CMS':
+        return this.runLegacySync({
+          basePath,
+          storeConfig,
+          dryRun: flags['dry-run'],
+        })
+      case 'CP':
+        return this.runCpSync({
+          basePath,
+          dryRun: flags['dry-run'],
+        })
+      default: {
+        return source
+      }
+    }
+  }
+
+  private async runLegacySync({
+    basePath,
+    storeConfig,
+    dryRun,
+  }: {
+    basePath: string
+    storeConfig: StoreConfig | null
+    dryRun?: boolean
+  }) {
+    const { tmpDir } = withBasePath(basePath)
+    const project = storeConfig?.contentSource?.project ?? 'faststore'
 
     await generate({ setup: true, basePath })
     await mergeCMSFiles(basePath)
 
-    if (flags['dry-run']) {
+    if (dryRun) {
       return
     }
 
-    return spawn(`vtex cms sync ${cmsProjectName}`, {
+    return spawn(`vtex cms sync ${project}`, {
       shell: true,
       cwd: tmpDir,
       stdio: 'inherit',
+    })
+  }
+
+  private runCpSync({
+    basePath,
+    dryRun,
+  }: {
+    basePath: string
+    dryRun?: boolean
+  }) {
+    const dirs = getExistingCpDirs(basePath)
+
+    if (dirs.length === 0) {
+      errorNoCustomization()
+    }
+
+    const schemaOut = getCpSchemaOutputPath(basePath)
+
+    generateAndUploadSchema({
+      basePath,
+      dirs,
+      schemaOut,
+      dryRun: dryRun ?? false,
     })
   }
 }

--- a/packages/cli/src/utils/config.test.ts
+++ b/packages/cli/src/utils/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { resolveContentSource } from './config'
+import { isMyAccountEnabled, resolveContentSource } from './config'
 import { logger } from './logger'
 
 describe('resolveContentSource', () => {
@@ -37,5 +37,26 @@ describe('resolveContentSource', () => {
       expect.stringContaining('Unsupported contentSource.type "WORDPRESS"')
     )
     expect(exitMock).toHaveBeenCalledWith(1)
+  })
+})
+
+describe('isMyAccountEnabled', () => {
+  it('returns true when experimental.enableFaststoreMyAccount is true', () => {
+    expect(
+      isMyAccountEnabled({ experimental: { enableFaststoreMyAccount: true } })
+    ).toBe(true)
+  })
+
+  it('returns false when explicitly disabled', () => {
+    expect(
+      isMyAccountEnabled({ experimental: { enableFaststoreMyAccount: false } })
+    ).toBe(false)
+  })
+
+  it('returns false when the flag, experimental, or config is absent', () => {
+    expect(isMyAccountEnabled({ experimental: {} })).toBe(false)
+    expect(isMyAccountEnabled({})).toBe(false)
+    expect(isMyAccountEnabled(null)).toBe(false)
+    expect(isMyAccountEnabled(undefined)).toBe(false)
   })
 })

--- a/packages/cli/src/utils/config.test.ts
+++ b/packages/cli/src/utils/config.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveContentSource } from './config'
+import { logger } from './logger'
+
+describe('resolveContentSource', () => {
+  let exitMock: ReturnType<typeof vi.spyOn>
+  let errorMock: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    errorMock = vi.spyOn(logger, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    exitMock.mockRestore()
+    errorMock.mockRestore()
+  })
+
+  it('returns CMS when type is undefined', () => {
+    expect(resolveContentSource(undefined)).toBe('CMS')
+  })
+
+  it('returns CMS for cms/CMS (case-insensitive)', () => {
+    expect(resolveContentSource('cms')).toBe('CMS')
+    expect(resolveContentSource('CMS')).toBe('CMS')
+  })
+
+  it('returns CP for cp/CP (case-insensitive)', () => {
+    expect(resolveContentSource('cp')).toBe('CP')
+    expect(resolveContentSource('CP')).toBe('CP')
+  })
+
+  it('exits with code 1 for unsupported types', () => {
+    resolveContentSource('WORDPRESS')
+
+    expect(errorMock).toHaveBeenCalledWith(
+      expect.stringContaining('Unsupported contentSource.type "WORDPRESS"')
+    )
+    expect(exitMock).toHaveBeenCalledWith(1)
+  })
+})

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -8,6 +8,30 @@ import { logger } from './logger'
 
 const configFileName = 'discovery.config.js'
 
+export type ResolvedContentSource = 'CMS' | 'CP'
+
+/**
+ * Resolves the store's contentSource.type to a supported CMS flow.
+ * Absent or CMS → legacy Headless CMS; CP → Content Platform schema publish.
+ */
+export function resolveContentSource(rawType?: string): ResolvedContentSource {
+  const normalized = rawType?.toUpperCase()
+
+  switch (normalized) {
+    case undefined:
+    case 'CMS':
+      return 'CMS'
+    case 'CP':
+      return 'CP'
+    default: {
+      logger.error(
+        `${chalk.red('[Error]')} - Unsupported contentSource.type "${rawType}". Expected "CMS" or "CP".`
+      )
+      process.exit(1)
+    }
+  }
+}
+
 /**
  * Partial type for discovery config with only the properties used by this module
  */

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -11,6 +11,25 @@ const configFileName = 'discovery.config.js'
 export type ResolvedContentSource = 'CMS' | 'CP'
 
 /**
+ * Minimal config shape consumed when deciding whether to merge My Account
+ * schemas. Kept loose on purpose so callers can pass their own store config.
+ */
+type MyAccountConfig = {
+  experimental?: {
+    enableFaststoreMyAccount?: boolean
+  }
+}
+
+/**
+ * Whether FastStore My Account is enabled in the store config.
+ * When enabled (CP mode only), `cms-sync` merges the core My Account CMS
+ * schemas into the generated schema. Defaults to false when absent.
+ */
+export function isMyAccountEnabled(config?: MyAccountConfig | null): boolean {
+  return config?.experimental?.enableFaststoreMyAccount === true
+}
+
+/**
  * Resolves the store's contentSource.type to a supported CMS flow.
  * Absent or CMS → legacy Headless CMS; CP → Content Platform schema publish.
  */

--- a/packages/cli/src/utils/cp-schema.test.ts
+++ b/packages/cli/src/utils/cp-schema.test.ts
@@ -83,9 +83,9 @@ describe('cp-schema', () => {
   })
 
   describe('getCpSchemaOutputPath', () => {
-    it('points to cms/faststore/schema.json under the store root', () => {
+    it('returns a path relative to the store root', () => {
       expect(getCpSchemaOutputPath(tempDir)).toBe(
-        path.join(tempDir, 'cms', 'faststore', 'schema.json')
+        path.join('cms', 'faststore', 'schema.json')
       )
     })
   })

--- a/packages/cli/src/utils/cp-schema.test.ts
+++ b/packages/cli/src/utils/cp-schema.test.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const runCommandSyncMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./runCommandSync', () => ({
+  runCommandSync: (...args: unknown[]) => runCommandSyncMock(...args),
+}))
+
+import {
+  errorNoCustomization,
+  generateAndUploadSchema,
+  getCpSchemaOutputPath,
+  getExistingCpDirs,
+} from './cp-schema'
+import { logger } from './logger'
+
+describe('cp-schema', () => {
+  let tempDir: string
+  let exitMock: ReturnType<typeof vi.spyOn>
+  let errorMock: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faststore-cp-schema-'))
+    runCommandSyncMock.mockClear()
+    exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    errorMock = vi.spyOn(logger, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+    exitMock.mockRestore()
+    errorMock.mockRestore()
+  })
+
+  describe('getExistingCpDirs', () => {
+    it('returns relative paths for existing customization dirs', () => {
+      fs.mkdirSync(path.join(tempDir, 'cms', 'faststore', 'components'), {
+        recursive: true,
+      })
+
+      expect(getExistingCpDirs(tempDir)).toEqual(['cms/faststore/components'])
+    })
+
+    it('returns both dirs when both exist', () => {
+      fs.mkdirSync(path.join(tempDir, 'cms', 'faststore', 'components'), {
+        recursive: true,
+      })
+      fs.mkdirSync(path.join(tempDir, 'cms', 'faststore', 'pages'), {
+        recursive: true,
+      })
+
+      expect(getExistingCpDirs(tempDir)).toEqual([
+        'cms/faststore/components',
+        'cms/faststore/pages',
+      ])
+    })
+
+    it('returns empty array when neither dir exists', () => {
+      expect(getExistingCpDirs(tempDir)).toEqual([])
+    })
+  })
+
+  describe('getCpSchemaOutputPath', () => {
+    it('points to cms/faststore/schema.json under the store root', () => {
+      expect(getCpSchemaOutputPath(tempDir)).toBe(
+        path.join(tempDir, 'cms', 'faststore', 'schema.json')
+      )
+    })
+  })
+
+  describe('errorNoCustomization', () => {
+    it('logs and exits with code 1', () => {
+      errorNoCustomization()
+
+      expect(errorMock).toHaveBeenCalledWith(
+        expect.stringContaining('No CMS customization found')
+      )
+      expect(exitMock).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('generateAndUploadSchema', () => {
+    it('runs generate then upload synchronously without -l', () => {
+      const schemaOut = path.join(tempDir, 'cms', 'faststore', 'schema.json')
+
+      generateAndUploadSchema({
+        basePath: tempDir,
+        dirs: ['cms/faststore/components', 'cms/faststore/pages'],
+        schemaOut,
+        dryRun: false,
+      })
+
+      expect(runCommandSyncMock).toHaveBeenCalledTimes(2)
+      expect(runCommandSyncMock.mock.calls[0][0]).toEqual({
+        cmd: `vtex content generate-schema cms/faststore/components cms/faststore/pages -o ${schemaOut}`,
+        cwd: tempDir,
+        throws: 'error',
+        errorMessage: 'Failed to generate CMS schema',
+      })
+      expect(runCommandSyncMock.mock.calls[1][0]).toEqual({
+        cmd: `vtex content upload-schema ${schemaOut}`,
+        cwd: tempDir,
+        throws: 'error',
+        errorMessage: 'Failed to upload CMS schema',
+      })
+      expect(runCommandSyncMock.mock.calls[0][0].cmd).not.toContain('-l')
+    })
+
+    it('skips upload on dry-run', () => {
+      generateAndUploadSchema({
+        basePath: tempDir,
+        dirs: ['cms/faststore/pages'],
+        schemaOut: path.join(tempDir, 'cms', 'faststore', 'schema.json'),
+        dryRun: true,
+      })
+
+      expect(runCommandSyncMock).toHaveBeenCalledTimes(1)
+      expect(runCommandSyncMock.mock.calls[0][0].cmd).toContain(
+        'generate-schema'
+      )
+    })
+  })
+})

--- a/packages/cli/src/utils/cp-schema.test.ts
+++ b/packages/cli/src/utils/cp-schema.test.ts
@@ -154,7 +154,27 @@ describe('cp-schema', () => {
       coreCMSDirMock.mockReturnValue(coreDir)
     }
 
-    it('copies core My Account components/pages into a temp dir', () => {
+    function seedStoreCustomizations() {
+      const storeComponents = path.join(
+        tempDir,
+        'cms',
+        'faststore',
+        'components'
+      )
+      const storePages = path.join(tempDir, 'cms', 'faststore', 'pages')
+      fs.mkdirSync(storeComponents, { recursive: true })
+      fs.mkdirSync(storePages, { recursive: true })
+      fs.writeFileSync(
+        path.join(storeComponents, 'cms_component__store.jsonc'),
+        '{}'
+      )
+      fs.writeFileSync(
+        path.join(storePages, 'cms_content_type__store.jsonc'),
+        '{}'
+      )
+    }
+
+    it('merges core My Account components/pages into two staging dirs', () => {
       seedCoreMyAccount()
 
       const { mergeDir, dirs } = prepareMyAccountMergeDir(tempDir)
@@ -175,6 +195,76 @@ describe('cp-schema', () => {
           )
         ).toBe(true)
         expect(exitMock).not.toHaveBeenCalled()
+      } finally {
+        fs.rmSync(mergeDir, { recursive: true, force: true })
+      }
+    })
+
+    it('merges the store customizations alongside the core My Account schemas', () => {
+      seedCoreMyAccount()
+      seedStoreCustomizations()
+
+      const { mergeDir } = prepareMyAccountMergeDir(tempDir)
+
+      try {
+        // Core My Account files present.
+        expect(
+          fs.existsSync(
+            path.join(mergeDir, 'components', 'cms_component__x.jsonc')
+          )
+        ).toBe(true)
+        // Store customizations present in the same staging dir.
+        expect(
+          fs.existsSync(
+            path.join(mergeDir, 'components', 'cms_component__store.jsonc')
+          )
+        ).toBe(true)
+        expect(
+          fs.existsSync(
+            path.join(mergeDir, 'pages', 'cms_content_type__store.jsonc')
+          )
+        ).toBe(true)
+      } finally {
+        fs.rmSync(mergeDir, { recursive: true, force: true })
+      }
+    })
+
+    it('lets the store override a core My Account file on collision', () => {
+      const coreDir = path.join(tempDir, 'core', 'cms', 'faststore')
+      const coreComponents = path.join(coreDir, 'my-account', 'components')
+      fs.mkdirSync(coreComponents, { recursive: true })
+      fs.writeFileSync(
+        path.join(coreComponents, 'cms_component__shared.jsonc'),
+        '{"owner":"core"}'
+      )
+      fs.mkdirSync(path.join(coreDir, 'my-account', 'pages'), {
+        recursive: true,
+      })
+      coreCMSDirMock.mockReturnValue(coreDir)
+
+      const storeComponents = path.join(
+        tempDir,
+        'cms',
+        'faststore',
+        'components'
+      )
+      fs.mkdirSync(storeComponents, { recursive: true })
+      fs.writeFileSync(
+        path.join(storeComponents, 'cms_component__shared.jsonc'),
+        '{"owner":"store"}'
+      )
+
+      const { mergeDir } = prepareMyAccountMergeDir(tempDir)
+
+      try {
+        expect(
+          fs
+            .readFileSync(
+              path.join(mergeDir, 'components', 'cms_component__shared.jsonc'),
+              'utf-8'
+            )
+            .toString()
+        ).toContain('store')
       } finally {
         fs.rmSync(mergeDir, { recursive: true, force: true })
       }

--- a/packages/cli/src/utils/cp-schema.test.ts
+++ b/packages/cli/src/utils/cp-schema.test.ts
@@ -275,6 +275,28 @@ describe('cp-schema', () => {
       }
     })
 
+    it('removes the staging dir and rethrows when a copy fails midway', () => {
+      // core/my-account exists (so the guard passes), but `components` is a FILE.
+      // cpSync(file → staging dir) throws, so the copy fails after the staging
+      // dir was created — exercising the self-cleanup path.
+      const coreDir = path.join(tempDir, 'core', 'cms', 'faststore')
+      const myAccount = path.join(coreDir, 'my-account')
+      fs.mkdirSync(myAccount, { recursive: true })
+      fs.writeFileSync(path.join(myAccount, 'components'), 'not a dir')
+      coreCMSDirMock.mockReturnValue(coreDir)
+
+      expect(() => prepareMyAccountMergeDir(tempDir)).toThrow()
+
+      // The staging dir was created under .faststore then removed on failure.
+      const stagingParent = path.join(tempDir, '.faststore')
+      const leftovers = fs.existsSync(stagingParent)
+        ? fs
+            .readdirSync(stagingParent)
+            .filter((name) => name.startsWith('cms-myaccount-'))
+        : []
+      expect(leftovers).toEqual([])
+    })
+
     it('errors and exits when core My Account schemas are missing', () => {
       coreCMSDirMock.mockReturnValue(
         path.join(tempDir, 'core-without-myaccount')

--- a/packages/cli/src/utils/cp-schema.test.ts
+++ b/packages/cli/src/utils/cp-schema.test.ts
@@ -4,16 +4,30 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const runCommandSyncMock = vi.hoisted(() => vi.fn())
+const coreCMSDirMock = vi.hoisted(() => vi.fn<[], string>())
 
 vi.mock('./runCommandSync', () => ({
   runCommandSync: (...args: unknown[]) => runCommandSyncMock(...args),
 }))
 
+vi.mock('./directory', async () => {
+  const nodePath = await import('node:path')
+
+  return {
+    withBasePath: (basePath: string) => ({
+      userCMSDir: nodePath.join(basePath, 'cms', 'faststore'),
+      coreCMSDir: coreCMSDirMock(),
+    }),
+  }
+})
+
 import {
+  cleanupMyAccountMergeDir,
   errorNoCustomization,
   generateAndUploadSchema,
   getCpSchemaOutputPath,
   getExistingCpDirs,
+  prepareMyAccountMergeDir,
 } from './cp-schema'
 import { logger } from './logger'
 
@@ -25,6 +39,10 @@ describe('cp-schema', () => {
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faststore-cp-schema-'))
     runCommandSyncMock.mockClear()
+    coreCMSDirMock.mockReset()
+    coreCMSDirMock.mockReturnValue(
+      path.join(tempDir, 'core', 'cms', 'faststore')
+    )
     exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
     errorMock = vi.spyOn(logger, 'error').mockImplementation(() => {})
   })
@@ -121,6 +139,83 @@ describe('cp-schema', () => {
       expect(runCommandSyncMock.mock.calls[0][0].cmd).toContain(
         'generate-schema'
       )
+    })
+  })
+
+  describe('prepareMyAccountMergeDir', () => {
+    function seedCoreMyAccount() {
+      const coreDir = path.join(tempDir, 'core', 'cms', 'faststore')
+      const componentsDir = path.join(coreDir, 'my-account', 'components')
+      const pagesDir = path.join(coreDir, 'my-account', 'pages')
+      fs.mkdirSync(componentsDir, { recursive: true })
+      fs.mkdirSync(pagesDir, { recursive: true })
+      fs.writeFileSync(path.join(componentsDir, 'cms_component__x.jsonc'), '{}')
+      fs.writeFileSync(path.join(pagesDir, 'cms_content_type__y.jsonc'), '{}')
+      coreCMSDirMock.mockReturnValue(coreDir)
+    }
+
+    it('copies core My Account components/pages into a temp dir', () => {
+      seedCoreMyAccount()
+
+      const { mergeDir, dirs } = prepareMyAccountMergeDir(tempDir)
+
+      try {
+        expect(dirs).toEqual([
+          path.join(mergeDir, 'components'),
+          path.join(mergeDir, 'pages'),
+        ])
+        expect(
+          fs.existsSync(
+            path.join(mergeDir, 'components', 'cms_component__x.jsonc')
+          )
+        ).toBe(true)
+        expect(
+          fs.existsSync(
+            path.join(mergeDir, 'pages', 'cms_content_type__y.jsonc')
+          )
+        ).toBe(true)
+        expect(exitMock).not.toHaveBeenCalled()
+      } finally {
+        fs.rmSync(mergeDir, { recursive: true, force: true })
+      }
+    })
+
+    it('errors and exits when core My Account schemas are missing', () => {
+      coreCMSDirMock.mockReturnValue(
+        path.join(tempDir, 'core-without-myaccount')
+      )
+
+      const result = prepareMyAccountMergeDir(tempDir)
+
+      expect(errorMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'My Account is enabled but the core My Account schemas were not found'
+        )
+      )
+      expect(exitMock).toHaveBeenCalledWith(1)
+
+      // process.exit is mocked to a noop in tests, so the function continues and
+      // may create an empty temp dir — clean it up to avoid leaking.
+      if (result?.mergeDir) {
+        fs.rmSync(result.mergeDir, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('cleanupMyAccountMergeDir', () => {
+    it('removes the merge directory', () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'faststore-cleanup-'))
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'x')
+
+      cleanupMyAccountMergeDir(dir)
+
+      expect(fs.existsSync(dir)).toBe(false)
+    })
+
+    it('does not throw when the directory is already gone', () => {
+      const dir = path.join(tempDir, 'nonexistent')
+
+      expect(() => cleanupMyAccountMergeDir(dir)).not.toThrow()
     })
   })
 })

--- a/packages/cli/src/utils/cp-schema.test.ts
+++ b/packages/cli/src/utils/cp-schema.test.ts
@@ -118,12 +118,14 @@ describe('cp-schema', () => {
         cwd: tempDir,
         throws: 'error',
         errorMessage: 'Failed to generate CMS schema',
+        interactive: true,
       })
       expect(runCommandSyncMock.mock.calls[1][0]).toEqual({
         cmd: `vtex content upload-schema ${schemaOut}`,
         cwd: tempDir,
         throws: 'error',
         errorMessage: 'Failed to upload CMS schema',
+        interactive: true,
       })
       expect(runCommandSyncMock.mock.calls[0][0].cmd).not.toContain('-l')
     })

--- a/packages/cli/src/utils/cp-schema.test.ts
+++ b/packages/cli/src/utils/cp-schema.test.ts
@@ -17,6 +17,7 @@ vi.mock('./directory', async () => {
     withBasePath: (basePath: string) => ({
       userCMSDir: nodePath.join(basePath, 'cms', 'faststore'),
       coreCMSDir: coreCMSDirMock(),
+      tmpDir: nodePath.join(basePath, '.faststore'),
     }),
   }
 })
@@ -180,9 +181,11 @@ describe('cp-schema', () => {
       const { mergeDir, dirs } = prepareMyAccountMergeDir(tempDir)
 
       try {
+        // Staging lives inside the store's .faststore and paths are relative.
+        expect(mergeDir.startsWith(path.join(tempDir, '.faststore'))).toBe(true)
         expect(dirs).toEqual([
-          path.join(mergeDir, 'components'),
-          path.join(mergeDir, 'pages'),
+          path.relative(tempDir, path.join(mergeDir, 'components')),
+          path.relative(tempDir, path.join(mergeDir, 'pages')),
         ])
         expect(
           fs.existsSync(

--- a/packages/cli/src/utils/cp-schema.ts
+++ b/packages/cli/src/utils/cp-schema.ts
@@ -4,11 +4,14 @@
  * Store context only: no `-l` / base.jsonc, no core merge.
  */
 import chalk from 'chalk'
-import { existsSync } from 'node:fs'
+import { cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { withBasePath } from './directory'
 import { logger } from './logger'
 import { runCommandSync } from './runCommandSync'
+
+const MY_ACCOUNT_SUBDIRS = ['components', 'pages'] as const
 
 export function getExistingCpDirs(basePath: string): string[] {
   const { userCMSDir } = withBasePath(basePath)
@@ -29,6 +32,66 @@ export function errorNoCustomization(): never {
 
 export function getCpSchemaOutputPath(basePath: string): string {
   return path.join(withBasePath(basePath).userCMSDir, 'schema.json')
+}
+
+export type MyAccountMerge = {
+  /** Temporary root directory holding the merged My Account JSONC. */
+  mergeDir: string
+  /** Absolute paths of the merged subdirectories to feed to generate-schema. */
+  dirs: string[]
+}
+
+/**
+ * Builds a temporary directory with the My Account CMS JSONC, ready to be fed
+ * to `generate-schema`.
+ *
+ * The My Account schemas are intentionally excluded from the published base
+ * schema (and the Schema Registry), so they must be supplied locally when the
+ * `experimental.enableFaststoreMyAccount` flag is on. They are copied from the
+ * installed `@faststore/core`; this temp dir is also the seam where a future
+ * store-side My Account customization could be overlaid per-file.
+ *
+ * Exits the process when the core My Account schemas are not found.
+ */
+export function prepareMyAccountMergeDir(basePath: string): MyAccountMerge {
+  const coreMyAccountDir = path.join(
+    withBasePath(basePath).coreCMSDir,
+    'my-account'
+  )
+
+  if (!existsSync(coreMyAccountDir)) {
+    logger.error(
+      `${chalk.red('[Error]')} - My Account is enabled but the core My Account schemas were not found at ${coreMyAccountDir}. Update @faststore/core or disable experimental.enableFaststoreMyAccount.`
+    )
+    process.exit(1)
+  }
+
+  const mergeDir = mkdtempSync(
+    path.join(os.tmpdir(), 'faststore-cms-myaccount-')
+  )
+
+  const dirs: string[] = []
+  for (const subdir of MY_ACCOUNT_SUBDIRS) {
+    const source = path.join(coreMyAccountDir, subdir)
+
+    if (!existsSync(source)) {
+      continue
+    }
+
+    const dest = path.join(mergeDir, subdir)
+    cpSync(source, dest, { recursive: true })
+    dirs.push(dest)
+  }
+
+  return { mergeDir, dirs }
+}
+
+/**
+ * Removes the temporary My Account merge directory. Safe to call on any
+ * outcome (success, dry-run, or failure).
+ */
+export function cleanupMyAccountMergeDir(mergeDir: string): void {
+  rmSync(mergeDir, { recursive: true, force: true })
 }
 
 export function generateAndUploadSchema({

--- a/packages/cli/src/utils/cp-schema.ts
+++ b/packages/cli/src/utils/cp-schema.ts
@@ -4,7 +4,7 @@
  * Store context only: no `-l` / base.jsonc, no core merge.
  */
 import chalk from 'chalk'
-import { cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { withBasePath } from './directory'
@@ -37,27 +37,35 @@ export function getCpSchemaOutputPath(basePath: string): string {
 export type MyAccountMerge = {
   /** Temporary root directory holding the merged My Account JSONC. */
   mergeDir: string
-  /** Absolute paths of the merged subdirectories to feed to generate-schema. */
+  /**
+   * Absolute paths of the two merged directories, ordered as
+   * `[components, pages]` so they can be passed positionally to
+   * `generate-schema <componentsPath> <pagesPath>`.
+   */
   dirs: string[]
 }
 
 /**
- * Builds a temporary directory with the My Account CMS JSONC, ready to be fed
- * to `generate-schema`.
+ * Builds a temporary staging directory with exactly two subdirectories
+ * (`components` and `pages`), each holding the file-level merge of the core My
+ * Account CMS JSONC and the store's own customizations, ready to be fed to
+ * `generate-schema <componentsPath> <pagesPath>`.
+ *
+ * `generate-schema` accepts exactly two positional directory arguments, so the
+ * merge has to happen at the file level (not by passing extra directories).
+ * Core My Account files are copied first and the store's files are copied on
+ * top, so a store that customizes a My Account file keeps its own version.
  *
  * The My Account schemas are intentionally excluded from the published base
  * schema (and the Schema Registry), so they must be supplied locally when the
  * `experimental.enableFaststoreMyAccount` flag is on. They are copied from the
- * installed `@faststore/core`; this temp dir is also the seam where a future
- * store-side My Account customization could be overlaid per-file.
+ * installed `@faststore/core`.
  *
  * Exits the process when the core My Account schemas are not found.
  */
 export function prepareMyAccountMergeDir(basePath: string): MyAccountMerge {
-  const coreMyAccountDir = path.join(
-    withBasePath(basePath).coreCMSDir,
-    'my-account'
-  )
+  const { coreCMSDir, userCMSDir } = withBasePath(basePath)
+  const coreMyAccountDir = path.join(coreCMSDir, 'my-account')
 
   if (!existsSync(coreMyAccountDir)) {
     logger.error(
@@ -72,14 +80,20 @@ export function prepareMyAccountMergeDir(basePath: string): MyAccountMerge {
 
   const dirs: string[] = []
   for (const subdir of MY_ACCOUNT_SUBDIRS) {
-    const source = path.join(coreMyAccountDir, subdir)
+    const dest = path.join(mergeDir, subdir)
+    mkdirSync(dest, { recursive: true })
 
-    if (!existsSync(source)) {
-      continue
+    // Core My Account first; the store's customizations override on collision.
+    const coreSource = path.join(coreMyAccountDir, subdir)
+    if (existsSync(coreSource)) {
+      cpSync(coreSource, dest, { recursive: true })
     }
 
-    const dest = path.join(mergeDir, subdir)
-    cpSync(source, dest, { recursive: true })
+    const storeSource = path.join(userCMSDir, subdir)
+    if (existsSync(storeSource)) {
+      cpSync(storeSource, dest, { recursive: true })
+    }
+
     dirs.push(dest)
   }
 

--- a/packages/cli/src/utils/cp-schema.ts
+++ b/packages/cli/src/utils/cp-schema.ts
@@ -1,0 +1,62 @@
+/**
+ * CP (Content Platform) schema helpers for `cms-sync`.
+ * Generates and uploads the store's custom CMS schema via `vtex content`.
+ * Store context only: no `-l` / base.jsonc, no core merge.
+ */
+import chalk from 'chalk'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { withBasePath } from './directory'
+import { logger } from './logger'
+import { runCommandSync } from './runCommandSync'
+
+export function getExistingCpDirs(basePath: string): string[] {
+  const { userCMSDir } = withBasePath(basePath)
+  const componentsDir = path.join(userCMSDir, 'components')
+  const pagesDir = path.join(userCMSDir, 'pages')
+
+  return [componentsDir, pagesDir]
+    .filter((dir) => existsSync(dir))
+    .map((dir) => path.relative(basePath, dir))
+}
+
+export function errorNoCustomization(): never {
+  logger.error(
+    `${chalk.red('[Error]')} - No CMS customization found. Expected cms/faststore/components and/or cms/faststore/pages.`
+  )
+  process.exit(1)
+}
+
+export function getCpSchemaOutputPath(basePath: string): string {
+  return path.join(withBasePath(basePath).userCMSDir, 'schema.json')
+}
+
+export function generateAndUploadSchema({
+  basePath,
+  dirs,
+  schemaOut,
+  dryRun,
+}: {
+  basePath: string
+  dirs: string[]
+  schemaOut: string
+  dryRun: boolean
+}): void {
+  runCommandSync({
+    cmd: `vtex content generate-schema ${dirs.join(' ')} -o ${schemaOut}`,
+    cwd: basePath,
+    throws: 'error',
+    errorMessage: 'Failed to generate CMS schema',
+  })
+
+  if (dryRun) {
+    return
+  }
+
+  runCommandSync({
+    cmd: `vtex content upload-schema ${schemaOut}`,
+    cwd: basePath,
+    throws: 'error',
+    errorMessage: 'Failed to upload CMS schema',
+  })
+}

--- a/packages/cli/src/utils/cp-schema.ts
+++ b/packages/cli/src/utils/cp-schema.ts
@@ -5,7 +5,6 @@
  */
 import chalk from 'chalk'
 import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import { withBasePath } from './directory'
 import { logger } from './logger'
@@ -35,26 +34,32 @@ export function getCpSchemaOutputPath(basePath: string): string {
 }
 
 export type MyAccountMerge = {
-  /** Temporary root directory holding the merged My Account JSONC. */
+  /** Absolute root directory holding the merged My Account JSONC. */
   mergeDir: string
   /**
-   * Absolute paths of the two merged directories, ordered as
-   * `[components, pages]` so they can be passed positionally to
+   * Paths of the two merged directories, relative to `basePath` and ordered as
+   * `[components, pages]`, so they can be passed positionally to
    * `generate-schema <componentsPath> <pagesPath>`.
    */
   dirs: string[]
 }
 
 /**
- * Builds a temporary staging directory with exactly two subdirectories
- * (`components` and `pages`), each holding the file-level merge of the core My
- * Account CMS JSONC and the store's own customizations, ready to be fed to
+ * Builds a staging directory with exactly two subdirectories (`components` and
+ * `pages`), each holding the file-level merge of the core My Account CMS JSONC
+ * and the store's own customizations, ready to be fed to
  * `generate-schema <componentsPath> <pagesPath>`.
  *
  * `generate-schema` accepts exactly two positional directory arguments, so the
  * merge has to happen at the file level (not by passing extra directories).
  * Core My Account files are copied first and the store's files are copied on
  * top, so a store that customizes a My Account file keeps its own version.
+ *
+ * The staging dir lives inside the store's `.faststore` tmp folder (created on
+ * demand) and the returned paths are relative to `basePath`. The toolbelt
+ * resolves positional args against the cwd (`path.join(cwd, arg)`), so an
+ * absolute path under `os.tmpdir()` would be mangled into `<store>/var/...`
+ * and fail with ENOENT.
  *
  * The My Account schemas are intentionally excluded from the published base
  * schema (and the Schema Registry), so they must be supplied locally when the
@@ -64,7 +69,7 @@ export type MyAccountMerge = {
  * Exits the process when the core My Account schemas are not found.
  */
 export function prepareMyAccountMergeDir(basePath: string): MyAccountMerge {
-  const { coreCMSDir, userCMSDir } = withBasePath(basePath)
+  const { coreCMSDir, userCMSDir, tmpDir } = withBasePath(basePath)
   const coreMyAccountDir = path.join(coreCMSDir, 'my-account')
 
   if (!existsSync(coreMyAccountDir)) {
@@ -74,9 +79,9 @@ export function prepareMyAccountMergeDir(basePath: string): MyAccountMerge {
     process.exit(1)
   }
 
-  const mergeDir = mkdtempSync(
-    path.join(os.tmpdir(), 'faststore-cms-myaccount-')
-  )
+  // `.faststore` may not exist yet in the CP flow (it does not run `generate`).
+  mkdirSync(tmpDir, { recursive: true })
+  const mergeDir = mkdtempSync(path.join(tmpDir, 'cms-myaccount-'))
 
   const dirs: string[] = []
   for (const subdir of MY_ACCOUNT_SUBDIRS) {
@@ -94,7 +99,7 @@ export function prepareMyAccountMergeDir(basePath: string): MyAccountMerge {
       cpSync(storeSource, dest, { recursive: true })
     }
 
-    dirs.push(dest)
+    dirs.push(path.relative(basePath, dest))
   }
 
   return { mergeDir, dirs }

--- a/packages/cli/src/utils/cp-schema.ts
+++ b/packages/cli/src/utils/cp-schema.ts
@@ -56,11 +56,6 @@ export type MyAccountMerge = {
  * and the store's own customizations, ready to be fed to
  * `generate-schema <componentsPath> <pagesPath>`.
  *
- * `generate-schema` accepts exactly two positional directory arguments, so the
- * merge has to happen at the file level (not by passing extra directories).
- * Core My Account files are copied first and the store's files are copied on
- * top, so a store that customizes a My Account file keeps its own version.
- *
  * The staging dir lives inside the store's `.faststore` tmp folder (created on
  * demand) and the returned paths are relative to `basePath`. The toolbelt
  * resolves positional args against the cwd (`path.join(cwd, arg)`), so an
@@ -89,26 +84,31 @@ export function prepareMyAccountMergeDir(basePath: string): MyAccountMerge {
   mkdirSync(tmpDir, { recursive: true })
   const mergeDir = mkdtempSync(path.join(tmpDir, 'cms-myaccount-'))
 
-  const dirs: string[] = []
-  for (const subdir of MY_ACCOUNT_SUBDIRS) {
-    const dest = path.join(mergeDir, subdir)
-    mkdirSync(dest, { recursive: true })
+  try {
+    const dirs: string[] = []
+    for (const subdir of MY_ACCOUNT_SUBDIRS) {
+      const dest = path.join(mergeDir, subdir)
+      mkdirSync(dest, { recursive: true })
 
-    // Core My Account first; the store's customizations override on collision.
-    const coreSource = path.join(coreMyAccountDir, subdir)
-    if (existsSync(coreSource)) {
-      cpSync(coreSource, dest, { recursive: true })
+      // Core My Account first; the store's customizations override on collision.
+      const coreSource = path.join(coreMyAccountDir, subdir)
+      if (existsSync(coreSource)) {
+        cpSync(coreSource, dest, { recursive: true })
+      }
+
+      const storeSource = path.join(userCMSDir, subdir)
+      if (existsSync(storeSource)) {
+        cpSync(storeSource, dest, { recursive: true })
+      }
+
+      dirs.push(path.relative(basePath, dest))
     }
 
-    const storeSource = path.join(userCMSDir, subdir)
-    if (existsSync(storeSource)) {
-      cpSync(storeSource, dest, { recursive: true })
-    }
-
-    dirs.push(path.relative(basePath, dest))
+    return { mergeDir, dirs }
+  } catch (error) {
+    cleanupMyAccountMergeDir(mergeDir)
+    throw error
   }
-
-  return { mergeDir, dirs }
 }
 
 /**

--- a/packages/cli/src/utils/cp-schema.ts
+++ b/packages/cli/src/utils/cp-schema.ts
@@ -30,7 +30,13 @@ export function errorNoCustomization(): never {
 }
 
 export function getCpSchemaOutputPath(basePath: string): string {
-  return path.join(withBasePath(basePath).userCMSDir, 'schema.json')
+  // Relative to basePath: the toolbelt resolves -o against the cwd
+  // (path.join(cwd, arg)), so an absolute path would be doubled into
+  // <store>/<store>/cms/... and fail with ENOENT.
+  return path.relative(
+    basePath,
+    path.join(withBasePath(basePath).userCMSDir, 'schema.json')
+  )
 }
 
 export type MyAccountMerge = {

--- a/packages/cli/src/utils/cp-schema.ts
+++ b/packages/cli/src/utils/cp-schema.ts
@@ -130,11 +130,15 @@ export function generateAndUploadSchema({
   schemaOut: string
   dryRun: boolean
 }): void {
+  // Interactive: generate-schema prompts to confirm overriding base
+  // definitions (no --yes flag), and upload-schema prompts for the schema
+  // version to publish. stdio must reach the user's TTY.
   runCommandSync({
     cmd: `vtex content generate-schema ${dirs.join(' ')} -o ${schemaOut}`,
     cwd: basePath,
     throws: 'error',
     errorMessage: 'Failed to generate CMS schema',
+    interactive: true,
   })
 
   if (dryRun) {
@@ -146,5 +150,6 @@ export function generateAndUploadSchema({
     cwd: basePath,
     throws: 'error',
     errorMessage: 'Failed to upload CMS schema',
+    interactive: true,
   })
 }

--- a/packages/cli/src/utils/runCommandSync.ts
+++ b/packages/cli/src/utils/runCommandSync.ts
@@ -46,22 +46,29 @@ export const runCommandSync = ({
   errorMessage,
   throws,
   cwd,
+  interactive = false,
 }: {
   cmd: string
   errorMessage: string
   throws: 'warning' | 'error'
   cwd?: string
+  interactive?: boolean
 }) => {
   try {
     logger.log(`[STARTED] ${cmd}`)
 
-    // stdout + stderr are merged via 2>&1 so the captured output holds the
-    // tool's real error. We intentionally do not append --debug/--verbose:
-    // strict toolbelt commands (e.g. `vtex content generate-schema`) reject
-    // unknown flags. Verbose progress logging is gated by DISCOVERY_DEBUG in
-    // the logger itself.
-    const res = execSync(`${cmd} 2>&1`, {
-      stdio: 'pipe',
+    // Interactive mode (stdio: 'inherit') wires the child to the parent TTY so
+    // the toolbelt can prompt the user — e.g. generate-schema's "override
+    // default definitions?" confirmation and upload-schema's version selection.
+    // execSync stays synchronous, preserving generate → upload ordering. Output
+    // goes straight to the terminal, so it can't be captured (and need not be).
+    //
+    // Non-interactive mode merges stdout + stderr via 2>&1 so the captured
+    // output holds the tool's real error. We intentionally do not append
+    // --debug/--verbose: strict toolbelt commands reject unknown flags. Verbose
+    // progress logging is gated by DISCOVERY_DEBUG in the logger itself.
+    const res = execSync(interactive ? cmd : `${cmd} 2>&1`, {
+      stdio: interactive ? 'inherit' : 'pipe',
       cwd,
     })
     logger.log(`[STATUS] ${res?.toString() ?? 'Unknown'}`)

--- a/packages/cli/src/utils/runCommandSync.ts
+++ b/packages/cli/src/utils/runCommandSync.ts
@@ -17,8 +17,8 @@ const showError = ({
   logger.error(`${chalk.red('error')} - ${message}`)
 
   if (cmd && output) {
-    logger.log(`${chalk.magenta('DEBUG')} - $ ${JSON.stringify(cmd)} error ↓`)
-    logger.log(output)
+    logger.error(`${chalk.magenta('$')} ${cmd}`)
+    logger.error(output)
   }
 
   process.exit(1)
@@ -36,8 +36,8 @@ const showWarning = ({
   logger.warn(`${chalk.yellow('warn')} - ${message}`)
 
   if (cmd && output) {
-    logger.log(`${chalk.magenta('DEBUG')} - $ ${JSON.stringify(cmd)} warn ↓`)
-    logger.log(output)
+    logger.warn(`${chalk.magenta('$')} ${cmd}`)
+    logger.warn(output)
   }
 }
 
@@ -52,18 +52,18 @@ export const runCommandSync = ({
   throws: 'warning' | 'error'
   cwd?: string
 }) => {
-  const debug = process.env.DISCOVERY_DEBUG === 'true' ? true : false
-
   try {
     logger.log(`[STARTED] ${cmd}`)
 
-    const res = execSync(
-      debug ? `${cmd} --debug --verbose 2>&1` : `${cmd} 2>&1`,
-      {
-        stdio: 'pipe',
-        cwd,
-      }
-    )
+    // stdout + stderr are merged via 2>&1 so the captured output holds the
+    // tool's real error. We intentionally do not append --debug/--verbose:
+    // strict toolbelt commands (e.g. `vtex content generate-schema`) reject
+    // unknown flags. Verbose progress logging is gated by DISCOVERY_DEBUG in
+    // the logger itself.
+    const res = execSync(`${cmd} 2>&1`, {
+      stdio: 'pipe',
+      cwd,
+    })
     logger.log(`[STATUS] ${res?.toString() ?? 'Unknown'}`)
     logger.log(`[FINISHED] ${cmd}`)
   } catch (error) {

--- a/packages/cli/src/utils/vtex.test.ts
+++ b/packages/cli/src/utils/vtex.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execSyncMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:child_process', () => ({
+  execSync: (...args: unknown[]) => execSyncMock(...args),
+}))
+
+import {
+  assertVtexReadyForAccount,
+  getLoggedVtexAccount,
+  isVtexCliInstalled,
+  parseAccountFromWhoami,
+} from './vtex'
+import { logger } from './logger'
+
+describe('parseAccountFromWhoami', () => {
+  it('parses the "email @ account / workspace" format', () => {
+    expect(
+      parseAccountFromWhoami('leandro.rodrigues@vtex.com @ brandless / master')
+    ).toBe('brandless')
+  })
+
+  it('parses the "Logged into <account>" format', () => {
+    expect(
+      parseAccountFromWhoami(
+        'Logged into brandless as user@vtex.com at workspace master'
+      )
+    ).toBe('brandless')
+  })
+
+  it('returns null for logged-out output', () => {
+    expect(parseAccountFromWhoami("You're not logged in")).toBeNull()
+  })
+})
+
+describe('isVtexCliInstalled', () => {
+  beforeEach(() => {
+    execSyncMock.mockReset()
+  })
+
+  it('returns true when vtex --version succeeds', () => {
+    execSyncMock.mockReturnValue(Buffer.from('4.3.2'))
+    expect(isVtexCliInstalled()).toBe(true)
+  })
+
+  it('returns false when the command throws (not installed)', () => {
+    execSyncMock.mockImplementation(() => {
+      throw new Error('command not found: vtex')
+    })
+    expect(isVtexCliInstalled()).toBe(false)
+  })
+})
+
+describe('getLoggedVtexAccount', () => {
+  beforeEach(() => {
+    execSyncMock.mockReset()
+  })
+
+  it('returns the account from whoami', () => {
+    execSyncMock.mockReturnValue(
+      Buffer.from('leandro.rodrigues@vtex.com @ brandless / master')
+    )
+    expect(getLoggedVtexAccount()).toBe('brandless')
+  })
+
+  it('returns null when whoami fails', () => {
+    execSyncMock.mockImplementation(() => {
+      throw new Error('not logged in')
+    })
+    expect(getLoggedVtexAccount()).toBeNull()
+  })
+})
+
+describe('assertVtexReadyForAccount', () => {
+  let exitMock: ReturnType<typeof vi.spyOn>
+  let errorMock: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    execSyncMock.mockReset()
+    exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    errorMock = vi.spyOn(logger, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    exitMock.mockRestore()
+    errorMock.mockRestore()
+  })
+
+  function mockVtex({
+    installed,
+    whoami,
+  }: {
+    installed: boolean
+    whoami?: string
+  }) {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (cmd.startsWith('vtex --version')) {
+        if (!installed) {
+          throw new Error('command not found: vtex')
+        }
+        return Buffer.from('4.3.2')
+      }
+
+      if (cmd.startsWith('vtex whoami')) {
+        if (whoami === undefined) {
+          throw new Error('not logged in')
+        }
+        return Buffer.from(whoami)
+      }
+
+      return Buffer.from('')
+    })
+  }
+
+  it('passes when installed and logged into the store account', () => {
+    mockVtex({
+      installed: true,
+      whoami: 'user@vtex.com @ brandless / master',
+    })
+
+    assertVtexReadyForAccount('brandless')
+
+    expect(exitMock).not.toHaveBeenCalled()
+    expect(errorMock).not.toHaveBeenCalled()
+  })
+
+  it('exits when the toolbelt is not installed', () => {
+    mockVtex({ installed: false })
+
+    assertVtexReadyForAccount('brandless')
+
+    expect(errorMock).toHaveBeenCalledWith(
+      expect.stringContaining('VTEX toolbelt')
+    )
+    expect(exitMock).toHaveBeenCalledWith(1)
+  })
+
+  it('exits and suggests login when logged out', () => {
+    mockVtex({ installed: true, whoami: undefined })
+
+    assertVtexReadyForAccount('brandless')
+
+    expect(errorMock).toHaveBeenCalledWith(
+      expect.stringContaining('vtex login brandless')
+    )
+    expect(exitMock).toHaveBeenCalledWith(1)
+  })
+
+  it('exits on account mismatch', () => {
+    mockVtex({
+      installed: true,
+      whoami: 'user@vtex.com @ otheraccount / master',
+    })
+
+    assertVtexReadyForAccount('brandless')
+
+    expect(errorMock).toHaveBeenCalledWith(
+      expect.stringContaining('vtex switch brandless')
+    )
+    expect(exitMock).toHaveBeenCalledWith(1)
+  })
+
+  it('accepts any logged-in account when the store account is unknown', () => {
+    mockVtex({
+      installed: true,
+      whoami: 'user@vtex.com @ whatever / master',
+    })
+
+    assertVtexReadyForAccount(undefined)
+
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/utils/vtex.ts
+++ b/packages/cli/src/utils/vtex.ts
@@ -1,11 +1,12 @@
 /**
  * Preflight checks for the `vtex` toolbelt used by the CP flow of `cms-sync`.
  *
- * The CP flow runs `vtex content generate-schema`/`upload-schema` through
- * `runCommandSync` (non-interactive, `stdio: 'pipe'`). If the toolbelt is
- * missing or the user is logged out / logged into the wrong account, those
- * commands either fail silently or stop at an interactive login prompt that
- * never gets answered. These checks surface an actionable error up front.
+ * The CP flow shells out to `vtex content generate-schema`/`upload-schema`. If
+ * the toolbelt is missing, the user is logged out, or logged into the wrong
+ * account, those commands either fail opaquely or stall on an interactive login
+ * prompt before the dev can answer the real schema prompts. Running these
+ * checks first surfaces an actionable error (install / `vtex login` /
+ * `vtex switch`) up front, against the store's `api.storeId`.
  */
 import { execSync } from 'node:child_process'
 import chalk from 'chalk'

--- a/packages/cli/src/utils/vtex.ts
+++ b/packages/cli/src/utils/vtex.ts
@@ -1,0 +1,107 @@
+/**
+ * Preflight checks for the `vtex` toolbelt used by the CP flow of `cms-sync`.
+ *
+ * The CP flow runs `vtex content generate-schema`/`upload-schema` through
+ * `runCommandSync` (non-interactive, `stdio: 'pipe'`). If the toolbelt is
+ * missing or the user is logged out / logged into the wrong account, those
+ * commands either fail silently or stop at an interactive login prompt that
+ * never gets answered. These checks surface an actionable error up front.
+ */
+import { execSync } from 'node:child_process'
+import chalk from 'chalk'
+import { logger } from './logger'
+
+/**
+ * Runs a command capturing its merged stdout/stderr.
+ * Returns null when the command fails to run or exits non-zero.
+ */
+function runCapture(cmd: string): string | null {
+  try {
+    return execSync(`${cmd} 2>&1`, { stdio: 'pipe' }).toString()
+  } catch {
+    return null
+  }
+}
+
+/** Whether the `vtex` toolbelt is available on the PATH. */
+export function isVtexCliInstalled(): boolean {
+  return runCapture('vtex --version') !== null
+}
+
+/**
+ * Extracts the logged-in account from `vtex whoami` output.
+ * Returns null when the output indicates a logged-out state or can't be parsed.
+ *
+ * Handles the toolbelt formats observed in practice, e.g.:
+ *   - "Logged into brandless as user@vtex.com at workspace master"
+ *   - "user@vtex.com @ brandless / master"
+ */
+export function parseAccountFromWhoami(output: string): string | null {
+  if (/not logged|isn't logged|no user|please login/i.test(output)) {
+    return null
+  }
+
+  const patterns = [
+    /@\s+([\w.-]+)\s*\//, // "user@vtex.com @ brandless / master"
+    /logged in(?:to)?\s+(?:account\s+)?([\w.-]+)/i, // "Logged into brandless ..."
+    /account[:\s]+([\w.-]+)/i, // "... account brandless ..."
+  ]
+
+  for (const pattern of patterns) {
+    const match = output.match(pattern)
+    if (match?.[1]) {
+      return match[1]
+    }
+  }
+
+  return null
+}
+
+/** Returns the account currently logged into the toolbelt, or null. */
+export function getLoggedVtexAccount(): string | null {
+  const output = runCapture('vtex whoami')
+
+  if (!output) {
+    return null
+  }
+
+  return parseAccountFromWhoami(output)
+}
+
+/**
+ * Ensures the `vtex` toolbelt is installed and authenticated against the
+ * store's account before running CP schema commands. Exits the process with an
+ * actionable message when any check fails.
+ *
+ * @param account - The store account from `discovery.config.js` (`api.storeId`).
+ */
+export function assertVtexReadyForAccount(account?: string): void {
+  if (!isVtexCliInstalled()) {
+    logger.error(
+      `${chalk.red('[Error]')} - The VTEX toolbelt (\`vtex\`) was not found. Install it with ${chalk.bold('npm i -g vtex')} and try again.\n` +
+        `${chalk.dim('Docs: https://developers.vtex.com/docs/guides/vtex-io-documentation-vtex-io-cli-installation-and-command-reference')}`
+    )
+    process.exit(1)
+    return
+  }
+
+  const loggedAccount = getLoggedVtexAccount()
+  const loginHint = account ? `vtex login ${account}` : 'vtex login <account>'
+
+  if (!loggedAccount) {
+    logger.error(
+      `${chalk.red('[Error]')} - You are not logged into the VTEX toolbelt.\n` +
+        `${chalk.cyan('Required Action:')} log into the store account by running ${chalk.bold(loginHint)}.`
+    )
+    process.exit(1)
+    return
+  }
+
+  if (account && loggedAccount.toLowerCase() !== account.toLowerCase()) {
+    logger.error(
+      `${chalk.red('[Error]')} - You are logged into ${chalk.bold(loggedAccount)}, but this store targets ${chalk.bold(account)} (\`api.storeId\` in discovery.config.js).\n` +
+        `${chalk.cyan('Required Action:')} switch accounts with ${chalk.bold(`vtex switch ${account}`)} or ${chalk.bold(loginHint)}.`
+    )
+    process.exit(1)
+  }
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -18,21 +20,37 @@ export default defineConfig({
     {
       name: 'virtual-module',
       resolveId(id) {
-        if (id.endsWith('discovery.config.js')) {
+        if (
+          id.endsWith('discovery.config.js') ||
+          id.includes('discovery.config.js')
+        ) {
           return id
         }
         return null
       },
       load(id) {
-        if (id.endsWith('discovery.config.js')) {
-          return `
+        if (
+          !id.endsWith('discovery.config.js') &&
+          !id.includes('discovery.config.js')
+        ) {
+          return null
+        }
+
+        try {
+          const filePath = id.startsWith('file:') ? fileURLToPath(id) : id
+          if (existsSync(filePath)) {
+            return null
+          }
+        } catch {
+          // fall through to virtual default
+        }
+
+        return `
           module.exports = {
             contentSource: {
               project: 'faststore-3',
             }
           }`
-        }
-        return null
       },
     },
   ],

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -133,7 +133,9 @@ yarn cms-sync
 
 `cms-sync` detects the content source automatically — in CP mode it generates the schema from your customizations and uploads it to the Schema Registry. Use `--dry-run` to generate locally without uploading.
 
-If `experimental.enableFaststoreMyAccount` is enabled, `cms-sync` also merges the core My Account schemas (shipped in `@faststore/core`) into the generated schema. These schemas are intentionally excluded from the published base schema (so they are not in the Schema Registry), so the command copies them into a temporary directory, includes them in the same single `generate-schema`/`upload-schema` run as your own customizations, announces the merge, and removes the temporary directory afterwards.
+Before running anything in CP mode, `cms-sync` checks that the `vtex` toolbelt is installed and that you are logged into your store's account (`api.storeId` in `discovery.config.js`); otherwise it stops with a hint to run `vtex login <account>` / `vtex switch <account>`. The toolbelt is interactive: `generate-schema` asks you to confirm when one of your definitions overrides a base one, and `upload-schema` asks for the version to publish — answer the prompts in your terminal.
+
+If `experimental.enableFaststoreMyAccount` is enabled, `cms-sync` also merges the core My Account schemas (shipped in `@faststore/core`) into the generated schema. These schemas are intentionally excluded from the published base schema (so they are not in the Schema Registry). The command performs a file-level merge of the core My Account JSONC with your own `cms/faststore/{components,pages}` into a temporary staging directory under your store's `.faststore/` (your files override core on name collision), runs a single `generate-schema`/`upload-schema` over it, announces the merge, and removes the staging directory afterwards.
 
 **FastStore Core team** (publishing the base schema with the core layer):
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -131,7 +131,9 @@ IMPORTANT: The Faststore Core Team is the only one that needs to add the -l base
 yarn cms-sync
 ```
 
-`cms-sync` detects the content source automatically — in CP mode it generates the schema from your customizations (no `-l` / `base.jsonc`) and uploads it to the Schema Registry. Use `--dry-run` to generate locally without uploading.
+`cms-sync` detects the content source automatically — in CP mode it generates the schema from your customizations and uploads it to the Schema Registry. Use `--dry-run` to generate locally without uploading.
+
+If `experimental.enableFaststoreMyAccount` is enabled, `cms-sync` also merges the core My Account schemas (shipped in `@faststore/core`) into the generated schema. These schemas are intentionally excluded from the published base schema (so they are not in the Schema Registry), so the command copies them into a temporary directory, includes them in the same single `generate-schema`/`upload-schema` run as your own customizations, announces the merge, and removes the temporary directory afterwards.
 
 **FastStore Core team** (publishing the base schema with the core layer):
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -124,6 +124,17 @@ vtex content split-content-types -i cms/faststore/content-types.json -s cms/fast
 ```
 
 IMPORTANT: The Faststore Core Team is the only one that needs to add the -l base.jsonc to the output. Merchants will automatically use the base from the Schema Registry.
+
+**Store developers:** set `contentSource: { type: 'CP' }` in `discovery.config.js`, place custom schemas under `cms/faststore/components/` and/or `cms/faststore/pages/`, then run:
+
+```sh
+yarn cms-sync
+```
+
+`cms-sync` detects the content source automatically — in CP mode it generates the schema from your customizations (no `-l` / `base.jsonc`) and uploads it to the Schema Registry. Use `--dry-run` to generate locally without uploading.
+
+**FastStore Core team** (publishing the base schema with the core layer):
+
 2. Generate the schema:
 ```sh
    vtex content generate-schema cms/faststore/components cms/faststore/pages -l cms/faststore/base.jsonc -o cms/faststore/schema.json


### PR DESCRIPTION
## What's the purpose of this pull request?

Store developers on Content Platform (CP) had to run `vtex content generate-schema` and `upload-schema` manually, easy to get wrong and a recurring source of support tickets. This PR extends `cms-sync` to detect `contentSource.type` in `discovery.config.js` and run the right flow in one command: legacy Headless CMS unchanged, CP with generate + upload built in.

When `experimental.enableFaststoreMyAccount` is on, CP mode also merges the core My Account CMS schemas (kept out of the published base / Schema Registry) into the same generated schema so merchants don't have to copy JSONC by hand.

**Jira:** [SFS-3243](https://vtex-dev.atlassian.net/jira/software/c/projects/SFS/boards/1051?selectedIssue=SFS-3243)

## How it works?

**Content-source detection**

- Reads the store's own `discovery.config.js` at `basePath` (not `.faststore` tmp).
- `contentSource.type` absent or `CMS` → legacy flow unchanged (`generate` + `mergeCMSFiles` + `vtex cms sync`).
- `CP` → CP flow: pre-flight, then `generate-schema` (no `-l`) and `upload-schema`.
- Unknown `type` → fail fast with a clear error.
- Logs detected mode at startup (`CMS` vs `CP`).

**CP flow**

- **Pre-flight first** (`utils/vtex.ts`, `assertVtexReadyForAccount`): checks `vtex --version` (installed) and `vtex whoami` (logged in, account matches `api.storeId` case-insensitively). Fails fast with an install / `vtex login <account>` / `vtex switch <account>` hint — avoids the toolbelt stalling on a login prompt.
- Uses existing `cms/faststore/components` and/or `pages` when present; fails if neither exists (before any toolbelt call).
- All directory and `-o` paths are passed **relative to the store root** — the toolbelt resolves them against the cwd, so absolute paths would be doubled into `<store>/<store>/…` and fail with `ENOENT`.
- `generate-schema`/`upload-schema` run **synchronously, in order, and interactively** (`runCommandSync` with `stdio: 'inherit'`): `generate-schema` has no `--yes` and prompts to confirm overriding a base definition; `upload-schema` prompts for the version to publish. `--dry-run` stops after generation.

**My Account merge (opt-in)**

- When `experimental.enableFaststoreMyAccount === true` in CP mode:
  - **File-level merge** of the core My Account JSONC (`coreCMSDir/my-account/{components,pages}`) with the store's own `cms/faststore/{components,pages}` into a staging dir with exactly two subdirs (`components`, `pages`), created under the store's **`.faststore`** folder. Core is copied first, the store's files on top → store wins on name collision.
  - These two merged dirs **replace** the store dirs as the two positional args to a single `generate-schema` (`generate-schema` accepts only two positional dirs, so the merge has to be at the file level).
  - Announces the merge in the log.
  - Removes the staging dir in `finally` (success, dry-run, or failure).
  - Proceeds even if the store has no own `components`/`pages`.
  - Fails fast if core My Account schemas are missing.

**Package scope:** `@faststore/cli` (`cms-sync.ts`, `utils/cp-schema.ts`, `utils/config.ts`, new `utils/vtex.ts`, `utils/runCommandSync.ts` interactive flag) + docs in `packages/core/README.md` and `packages/cli/AGENTS.md`.

```mermaid
flowchart TD
    A([faststore cms-sync PATH --dry-run]) --> B["basePath = getBasePath(PATH ?? cwd)"]
    B --> E["storeConfig = discovery.config.js em basePath (ou null)"]
    E --> F["resolveContentSource(storeConfig?.contentSource?.type)"]

    F --> G{"type (uppercase)"}
    G -- "undefined / 'CMS'" --> H["source = CMS"]
    G -- "'CP'" --> I["source = CP"]
    G -- "outro (ex: 'WORDPRESS')" --> X1["logger.error<br/>Unsupported contentSource.type"]:::err
    X1 --> X2([process.exit 1]):::exit

    H --> LOG["logger.info — Detected contentSource ... + ação"]
    I --> LOG
    LOG --> SW{"switch(source)"}

    %% ===== Legacy CMS =====
    SW -- CMS --> L1["runLegacySync"]
    L1 --> L3["generate({ setup }) + mergeCMSFiles(basePath)"]
    L3 --> L5{"--dry-run?"}
    L5 -- sim --> L6([return — sem sync]):::ok
    L5 -- não --> L7["spawn('vtex cms sync <project>',<br/>cwd = .faststore tmpDir)"]
    L7 --> L8([fim]):::ok

    %% ===== CP =====
    SW -- CP --> PF["assertVtexReadyForAccount(api.storeId)<br/>vtex --version + vtex whoami"]
    PF -- "ausente / deslogado / conta errada" --> XPF["logger.error<br/>install / vtex login / vtex switch"]:::err
    XPF --> XPF2([process.exit 1]):::exit
    PF -- ok --> P3{"isMyAccountEnabled?"}

    P3 -- sim --> M1["logger.info — Merging My Account ..."]
    M1 --> M3{"coreCMSDir/my-account<br/>existe?"}
    M3 -- não --> X3["logger.error — core My Account não encontrado"]:::err
    X3 --> X4([process.exit 1]):::exit
    M3 -- sim --> M4["prepareMyAccountMergeDir:<br/>mkdtemp em .faststore;<br/>cpSync core + loja (loja vence)"]
    M4 --> M5["dirs = [merge/components, merge/pages]<br/>(relativos; substituem dirs da loja)"]
    M5 --> P4

    P3 -- não --> PD["dirs = getExistingCpDirs(basePath)<br/>(subset relativo de components/pages)"]
    PD --> P4{"dirs.length === 0?"}
    P4 -- sim --> X5["errorNoCustomization()"]:::err
    X5 --> X6([process.exit 1]):::exit
    P4 -- não --> P5["schemaOut = cms/faststore/schema.json (relativo)"]

    P5 --> T1["try: generateAndUploadSchema"]
    T1 --> G1["runCommandSync (interactive)<br/>vtex content generate-schema &lt;dirs&gt; -o schemaOut<br/>(sem -l, cwd = basePath)<br/>prompt: confirmar override do base"]
    G1 --> G2{"--dry-run?"}
    G2 -- sim --> G3["return (sem upload)"]
    G2 -- não --> G4["runCommandSync (interactive)<br/>vtex content upload-schema schemaOut<br/>prompt: versão a publicar"]
    G3 --> FIN["finally"]
    G4 --> FIN
    T1 -. erro do toolbelt .-> FIN
    FIN --> FZ{"merge criado?"}
    FZ -- sim --> FC["cleanupMyAccountMergeDir(mergeDir)<br/>rmSync recursive/force"]
    FZ -- não --> FE([fim]):::ok
    FC --> FE

    classDef err fill:#5c1a1a,stroke:#ff6b6b,color:#fff;
    classDef exit fill:#3a0d0d,stroke:#ff6b6b,color:#fff;
    classDef ok fill:#10391f,stroke:#3ddc84,color:#fff;

```

## How to test it?

**Legacy CMS (regression)**

1. Store with `contentSource: { type: 'CMS' }` (or no `contentSource`).
2. Run `pnpm faststore cms-sync` — expect merge + `vtex cms sync` as before.
3. Run with `--dry-run` — expect no `vtex cms sync`.

**CP — customizations only**

1. Set `contentSource: { type: 'CP' }` in `discovery.config.js`.
2. Add schemas under `cms/faststore/components/` and/or `pages/`.
3. Run `pnpm faststore cms-sync` — expect `generate-schema` (no `-l`) then `upload-schema`.
4. Run with `--dry-run` — schema generated, no upload.
5. Remove both dirs — expect exit 1 with "No CMS customization found".

**CP pre-flight**

1. With the `vtex` toolbelt not installed → exit 1 with an install hint.
2. Logged out → exit 1 with `vtex login <account>`.
3. Logged into a different account than `api.storeId` → exit 1 with `vtex switch <account>`.
4. Logged into the matching account → flow proceeds.

**CP + My Account**

1. Set `contentSource: { type: 'CP' }` and `experimental: { enableFaststoreMyAccount: true }`.
2. Run `pnpm faststore cms-sync` — log mentions the My Account merge; the generated schema includes the store's components/content-types **and** the My Account ones.
3. Repeat with no store `components`/`pages` — should still generate from the core My Account schemas.
4. Repeat with `--dry-run` — generate only; staging dir under `.faststore` cleaned up.
5. With flag off — My Account must not be included (same as CP-only case).

**End-to-end validation (`brandless` store)**

Validated against a real CP store:

- `yarn cms-sync --dry-run` → generates `cms/faststore/schema.json` containing the store's `Banner example` component, the `landingPage` content-type, and the 14 core My Account components + 6 content-types (confirmed answering the `landingPage` base-override prompt).
- `yarn cms-sync` → answered the override prompt, picked the version (`4.22.0`), confirmed the upload → `Schema uploaded successfully with ID brandless.faststore@4.22.0`.

**Automated**

```sh
cd packages/cli && pnpm test   # matrix #1–#14 + pre-flight #15–#18
pnpm lint
```

## References

- [SFS-3243](https://vtex-dev.atlassian.net/jira/software/c/projects/SFS/boards/1051?selectedIssue=SFS-3243)
- Spec: `specs/005-cms-sync-content-source/`


[SFS-3243]: https://vtex-dev.atlassian.net/browse/SFS-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFS-3243]: https://vtex-dev.atlassian.net/browse/SFS-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ