### PR TITLE
feat: CMS-driven custom My Account pages

### DIFF
--- a/packages/cli/src/utils/__fixtures__/myAccount/navigation-collision.ts
+++ b/packages/cli/src/utils/__fixtures__/myAccount/navigation-collision.ts
@@ -1,4 +1,4 @@
-import { getMyAccountRoutes } from 'src/sdk/account/getMyAccountRoutes'
+import { getMyAccountRoutes } from '@faststore/core'
 
 export default getMyAccountRoutes({
   routes: [

--- a/packages/cli/src/utils/__fixtures__/myAccount/navigation-collision.ts
+++ b/packages/cli/src/utils/__fixtures__/myAccount/navigation-collision.ts
@@ -1,0 +1,16 @@
+import { getMyAccountRoutes } from 'src/sdk/account/getMyAccountRoutes'
+
+export default getMyAccountRoutes({
+  routes: [
+    {
+      route: '/pvt/account/profile',
+      title: 'Profile Override',
+      contentType: 'myAccountProfileCustom',
+    },
+    {
+      route: '/shop/not-account',
+      title: 'Outside',
+      contentType: 'myAccountOutside',
+    },
+  ],
+})

--- a/packages/cli/src/utils/__fixtures__/myAccount/navigation-collision.ts
+++ b/packages/cli/src/utils/__fixtures__/myAccount/navigation-collision.ts
@@ -12,5 +12,10 @@ export default getMyAccountRoutes({
       title: 'Outside',
       contentType: 'myAccountOutside',
     },
+    {
+      route: '/pvt/accounting/dashboard',
+      title: 'Prefix Lookalike',
+      contentType: 'myAccountLookalike',
+    },
   ],
 })

--- a/packages/cli/src/utils/__fixtures__/myAccount/navigation-legacy-only.ts
+++ b/packages/cli/src/utils/__fixtures__/myAccount/navigation-legacy-only.ts
@@ -1,4 +1,4 @@
-import { getMyAccountRoutes } from 'src/sdk/account/getMyAccountRoutes'
+import { getMyAccountRoutes } from '@faststore/core'
 
 export default getMyAccountRoutes({
   routes: [

--- a/packages/cli/src/utils/__fixtures__/myAccount/navigation-legacy-only.ts
+++ b/packages/cli/src/utils/__fixtures__/myAccount/navigation-legacy-only.ts
@@ -1,0 +1,10 @@
+import { getMyAccountRoutes } from 'src/sdk/account/getMyAccountRoutes'
+
+export default getMyAccountRoutes({
+  routes: [
+    {
+      route: '/pvt/account/legacy',
+      title: 'Legacy',
+    },
+  ],
+})

--- a/packages/cli/src/utils/__fixtures__/myAccount/navigation-with-cms.ts
+++ b/packages/cli/src/utils/__fixtures__/myAccount/navigation-with-cms.ts
@@ -1,4 +1,4 @@
-import { getMyAccountRoutes } from 'src/sdk/account/getMyAccountRoutes'
+import { getMyAccountRoutes } from '@faststore/core'
 
 export default getMyAccountRoutes({
   routes: [

--- a/packages/cli/src/utils/__fixtures__/myAccount/navigation-with-cms.ts
+++ b/packages/cli/src/utils/__fixtures__/myAccount/navigation-with-cms.ts
@@ -1,0 +1,15 @@
+import { getMyAccountRoutes } from 'src/sdk/account/getMyAccountRoutes'
+
+export default getMyAccountRoutes({
+  routes: [
+    {
+      route: '/pvt/account/wishlist',
+      title: 'Wishlist',
+      contentType: 'myAccountWishlist',
+    },
+    {
+      route: '/pvt/account/page-static',
+      title: 'Static Page',
+    },
+  ],
+})

--- a/packages/cli/src/utils/createNextjsPages.test.ts
+++ b/packages/cli/src/utils/createNextjsPages.test.ts
@@ -1,0 +1,202 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./directory', async () => {
+  const nodePath = await import('node:path')
+
+  return {
+    withBasePath: (basePath: string) => ({
+      tmpDir: nodePath.join(basePath, '.faststore'),
+    }),
+  }
+})
+
+import { createNextJsPages } from './createNextjsPages'
+
+const fixturesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '__fixtures__/myAccount'
+)
+
+describe('createNextJsPages', () => {
+  let tempDir: string
+  let tmpFaststore: string
+  let corePagesDir: string
+  let customizationPagesDir: string
+  let navigationDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faststore-create-pages-'))
+    tmpFaststore = path.join(tempDir, '.faststore')
+    corePagesDir = path.join(tmpFaststore, 'src', 'pages')
+    customizationPagesDir = path.join(
+      tmpFaststore,
+      'src',
+      'customizations',
+      'src',
+      'pages'
+    )
+    navigationDir = path.join(
+      tmpFaststore,
+      'src',
+      'customizations',
+      'src',
+      'myAccount'
+    )
+
+    fs.mkdirSync(corePagesDir, { recursive: true })
+    fs.mkdirSync(customizationPagesDir, { recursive: true })
+    fs.mkdirSync(navigationDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function seedNavigation(fixtureName: string) {
+    fs.copyFileSync(
+      path.join(fixturesDir, fixtureName),
+      path.join(navigationDir, 'navigation.ts')
+    )
+  }
+
+  it('generates a Mode A CMS page when contentType is set and no .tsx exists', () => {
+    seedNavigation('navigation-with-cms.ts')
+
+    createNextJsPages(tempDir)
+
+    const generated = path.join(corePagesDir, 'pvt', 'account', 'wishlist.tsx')
+    expect(fs.existsSync(generated)).toBe(true)
+    const content = fs.readFileSync(generated, 'utf8')
+    expect(content).toContain(
+      "myAccountCmsServerSideProps('myAccountWishlist', '/pvt/account/wishlist')"
+    )
+    expect(content).not.toContain('DynamicPage')
+  })
+
+  it('generates a Mode B CMS page when contentType and a .tsx body exist', () => {
+    seedNavigation('navigation-with-cms.ts')
+
+    const bodyDir = path.join(customizationPagesDir, 'pvt', 'account')
+    fs.mkdirSync(bodyDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(bodyDir, 'wishlist.tsx'),
+      'export default function Wishlist() { return null }\n'
+    )
+
+    createNextJsPages(tempDir)
+
+    const generated = path.join(corePagesDir, 'pvt', 'account', 'wishlist.tsx')
+    const content = fs.readFileSync(generated, 'utf8')
+    expect(content).toContain(
+      "import DynamicPage from 'src/customizations/src/pages/pvt/account/wishlist'"
+    )
+    expect(content).toContain('<DynamicPage />')
+  })
+
+  it('keeps the legacy template for pages without contentType', () => {
+    seedNavigation('navigation-legacy-only.ts')
+
+    const bodyDir = path.join(customizationPagesDir, 'pvt', 'account')
+    fs.mkdirSync(bodyDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(bodyDir, 'legacy.tsx'),
+      'export default function Legacy() { return null }\n'
+    )
+
+    createNextJsPages(tempDir)
+
+    const generated = path.join(corePagesDir, 'pvt', 'account', 'legacy.tsx')
+    expect(fs.existsSync(generated)).toBe(true)
+    const content = fs.readFileSync(generated, 'utf8')
+    expect(content).toContain('myAccountServerSideProps')
+    expect(content).toContain('DynamicPage')
+    expect(content).not.toContain('myAccountCmsServerSideProps')
+  })
+
+  it('skips CMS generation when the route collides with a native page', () => {
+    seedNavigation('navigation-collision.ts')
+
+    const nativeDir = path.join(corePagesDir, 'pvt', 'account')
+    fs.mkdirSync(nativeDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(nativeDir, 'profile.tsx'),
+      '// native profile\nexport default function Profile() { return null }\n'
+    )
+
+    createNextJsPages(tempDir)
+
+    const content = fs.readFileSync(path.join(nativeDir, 'profile.tsx'), 'utf8')
+    expect(content).toContain('// native profile')
+    expect(content).not.toContain('myAccountCmsServerSideProps')
+  })
+
+  it('does not generate CMS pages outside /pvt/account', () => {
+    seedNavigation('navigation-collision.ts')
+
+    createNextJsPages(tempDir)
+
+    expect(
+      fs.existsSync(path.join(corePagesDir, 'shop', 'not-account.tsx'))
+    ).toBe(false)
+  })
+
+  it('wires before/after extensions for hybrid CMS pages', () => {
+    seedNavigation('navigation-with-cms.ts')
+
+    const bodyDir = path.join(customizationPagesDir, 'pvt', 'account')
+    fs.mkdirSync(bodyDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(bodyDir, 'wishlist.tsx'),
+      'export default function Wishlist() { return null }\n'
+    )
+
+    const extensionsDir = path.join(
+      tmpFaststore,
+      'src',
+      'customizations',
+      'src',
+      'myAccount',
+      'extensions',
+      'wishlist'
+    )
+    fs.mkdirSync(extensionsDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(extensionsDir, 'before.tsx'),
+      'export default function Before() { return null }\n'
+    )
+    fs.writeFileSync(
+      path.join(extensionsDir, 'after.tsx'),
+      'export default function After() { return null }\n'
+    )
+
+    createNextJsPages(tempDir)
+
+    const content = fs.readFileSync(
+      path.join(corePagesDir, 'pvt', 'account', 'wishlist.tsx'),
+      'utf8'
+    )
+    expect(content).toContain(
+      "import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/wishlist/before'"
+    )
+    expect(content).toContain(
+      "import { default as AfterSection } from 'src/customizations/src/myAccount/extensions/wishlist/after'"
+    )
+  })
+
+  it('throws when a customization page is outside the allowed prefix', () => {
+    seedNavigation('navigation-legacy-only.ts')
+
+    const badDir = path.join(customizationPagesDir, 'shop')
+    fs.mkdirSync(badDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(badDir, 'home.tsx'),
+      'export default function Home() { return null }\n'
+    )
+
+    expect(() => createNextJsPages(tempDir)).toThrow(/Only these prefix pages/)
+  })
+})

--- a/packages/cli/src/utils/createNextjsPages.test.ts
+++ b/packages/cli/src/utils/createNextjsPages.test.ts
@@ -144,6 +144,18 @@ describe('createNextJsPages', () => {
     ).toBe(false)
   })
 
+  it('does not generate CMS pages for routes that only look like the allowed prefix', () => {
+    seedNavigation('navigation-collision.ts')
+
+    createNextJsPages(tempDir)
+
+    expect(
+      fs.existsSync(
+        path.join(corePagesDir, 'pvt', 'accounting', 'dashboard.tsx')
+      )
+    ).toBe(false)
+  })
+
   it('wires before/after extensions for hybrid CMS pages', () => {
     seedNavigation('navigation-with-cms.ts')
 

--- a/packages/cli/src/utils/createNextjsPages.ts
+++ b/packages/cli/src/utils/createNextjsPages.ts
@@ -1,21 +1,33 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+import chalk from 'chalk'
+
 import { withBasePath } from './directory'
+import { logger } from './logger'
+import {
+  type MyAccountCmsRoute,
+  readMyAccountCmsRoutes,
+} from './readMyAccountCmsRoutes'
+import { myAccountCmsPageTemplate } from './templates/myAccountCmsPage'
 import { myAccountPageTemplate } from './templates/myAccountPage'
 
 const ALLOWED_PREFIX_PAGES = ['/pvt/account']
+const ACCOUNT_ROUTE_PREFIX = '/pvt/account'
 
 type CreateExternalPagesArgs = {
   customizationPagesDir: string
   corePagesDir: string
   baseCustomizationPagesDir: string
+  /** Routes that already have a CMS generated page (keyed by normalized route). */
+  cmsHandledRoutes: Set<string>
 }
 
 const createExternalPages = ({
   customizationPagesDir,
   corePagesDir,
   baseCustomizationPagesDir,
+  cmsHandledRoutes,
 }: CreateExternalPagesArgs) => {
   fs.readdirSync(customizationPagesDir).forEach((file) => {
     const filePath = path.join(customizationPagesDir, file)
@@ -28,6 +40,7 @@ const createExternalPages = ({
         customizationPagesDir: filePath,
         corePagesDir: destinationPath,
         baseCustomizationPagesDir,
+        cmsHandledRoutes,
       })
     }
 
@@ -43,7 +56,18 @@ const createExternalPages = ({
       )
 
     if (isReactFile && isDestinationAvailable) {
-      const externalPagePath = `src/customizations/src/pages${filePath.replace(baseCustomizationPagesDir, '').replace('.tsx', '')}`
+      const relativePagePath = filePath
+        .replace(baseCustomizationPagesDir, '')
+        .replace(/\\/g, '/')
+        .replace(/\.tsx$/, '')
+      const normalizedRoute = normalizeAccountRoute(relativePagePath)
+
+      // Already generated as a CMS/hybrid page — skip legacy wrap.
+      if (cmsHandledRoutes.has(normalizedRoute)) {
+        return
+      }
+
+      const externalPagePath = `src/customizations/src/pages${relativePagePath}`
       const content = myAccountPageTemplate(externalPagePath)
       fs.writeFileSync(destinationPath, content)
     }
@@ -54,6 +78,142 @@ function isAllowedPrefixPage(file: string) {
   return ALLOWED_PREFIX_PAGES.some((prefix) => file.startsWith(prefix))
 }
 
+function normalizeAccountRoute(routeOrRelativePath: string): string {
+  const withSlash = routeOrRelativePath.startsWith('/')
+    ? routeOrRelativePath
+    : `/${routeOrRelativePath}`
+  const withPvt = withSlash.startsWith('/pvt') ? withSlash : `/pvt${withSlash}`
+  return withPvt.replace(/\/index$/, '') || withPvt
+}
+
+function routeToPageFilePath(corePagesDir: string, route: string): string {
+  const relative = route.replace(/^\//, '') // pvt/account/wishlist
+  return path.join(corePagesDir, `${relative}.tsx`)
+}
+
+function routeToCustomizationPagePath(
+  customizationPagesDir: string,
+  route: string
+): string | null {
+  // /pvt/account/wishlist → pvt/account/wishlist.tsx under customization pages
+  const relative = route.replace(/^\//, '')
+  if (!relative) return null
+
+  const asFile = path.join(customizationPagesDir, `${relative}.tsx`)
+  if (fs.existsSync(asFile)) return asFile
+
+  const asIndex = path.join(customizationPagesDir, relative, 'index.tsx')
+  if (fs.existsSync(asIndex)) return asIndex
+
+  return null
+}
+
+function routeToExtensionImportBase(route: string): string {
+  // /pvt/account/wishlist → wishlist ; /pvt/account/orders/foo → orders/foo
+  return route.replace(ACCOUNT_ROUTE_PREFIX, '').replace(/^\//, '')
+}
+
+function resolveExtensionPaths(
+  tmpDir: string,
+  route: string
+): { beforePath?: string; afterPath?: string } {
+  const relative = routeToExtensionImportBase(route)
+  if (!relative) return {}
+
+  const extensionsDir = path.join(
+    tmpDir,
+    'src/customizations/src/myAccount/extensions',
+    relative
+  )
+
+  const beforeFile = path.join(extensionsDir, 'before.tsx')
+  const afterFile = path.join(extensionsDir, 'after.tsx')
+
+  const importBase = `src/customizations/src/myAccount/extensions/${relative}`
+
+  return {
+    ...(fs.existsSync(beforeFile)
+      ? { beforePath: `${importBase}/before` }
+      : {}),
+    ...(fs.existsSync(afterFile) ? { afterPath: `${importBase}/after` } : {}),
+  }
+}
+
+function destinationExists(destinationPath: string): boolean {
+  if (fs.existsSync(destinationPath)) return true
+
+  const asIndex = path.join(destinationPath.replace(/\.tsx$/, ''), 'index.tsx')
+  return fs.existsSync(asIndex)
+}
+
+function generateCmsPages({
+  routes,
+  corePagesDir,
+  customizationPagesDir,
+  tmpDir,
+}: {
+  routes: MyAccountCmsRoute[]
+  corePagesDir: string
+  customizationPagesDir: string
+  tmpDir: string
+}): Set<string> {
+  const handled = new Set<string>()
+
+  for (const { route, contentType } of routes) {
+    const normalizedRoute = normalizeAccountRoute(route)
+
+    if (!isAllowedPrefixPage(normalizedRoute)) {
+      logger.warn(
+        `${chalk.yellow('warning')} - Skipping CMS route ${normalizedRoute}: only ${ALLOWED_PREFIX_PAGES.join(', ')} prefixes are allowed`
+      )
+      continue
+    }
+
+    const destinationPath = routeToPageFilePath(corePagesDir, normalizedRoute)
+
+    if (destinationExists(destinationPath)) {
+      logger.warn(
+        `${chalk.yellow('warning')} - Skipping CMS route ${normalizedRoute}: native page takes precedence`
+      )
+      continue
+    }
+
+    const customizationTsx = fs.existsSync(customizationPagesDir)
+      ? routeToCustomizationPagePath(customizationPagesDir, normalizedRoute)
+      : null
+
+    const pagePath = customizationTsx
+      ? `src/customizations/src/pages${customizationTsx
+          .replace(customizationPagesDir, '')
+          .replace(/\\/g, '/')
+          .replace(/\.tsx$/, '')}`
+      : undefined
+
+    const { beforePath, afterPath } = resolveExtensionPaths(
+      tmpDir,
+      normalizedRoute
+    )
+
+    const content = myAccountCmsPageTemplate({
+      contentType,
+      routePath: normalizedRoute,
+      pagePath,
+      beforePath,
+      afterPath,
+    })
+
+    fs.mkdirSync(path.dirname(destinationPath), { recursive: true })
+    fs.writeFileSync(destinationPath, content)
+    handled.add(normalizedRoute)
+
+    logger.log(
+      `${chalk.green('success')} - Generated CMS My Account page for ${normalizedRoute} (${contentType}${pagePath ? ', hybrid' : ''})`
+    )
+  }
+
+  return handled
+}
+
 export function createNextJsPages(basePath: string) {
   const { tmpDir } = withBasePath(basePath)
 
@@ -62,24 +222,38 @@ export function createNextJsPages(basePath: string) {
     tmpDir,
     'src/customizations/src/pages'
   )
+  const navigationFilePath = path.join(
+    tmpDir,
+    'src/customizations/src/myAccount/navigation.ts'
+  )
+
+  const cmsRoutes = readMyAccountCmsRoutes(navigationFilePath)
+  const cmsHandledRoutes = generateCmsPages({
+    routes: cmsRoutes,
+    corePagesDir,
+    customizationPagesDir,
+    tmpDir,
+  })
 
   if (!fs.existsSync(customizationPagesDir)) {
-    // If the customization pages directory doesn't exist, we don't need to create any pages
-    // and we can return early.
+    // No customization pages — Mode A CMS pages (if any) were still generated above.
     return
   }
 
   const allPagesAreAllowed = ({
-    basePath,
+    basePath: pagesBase,
     dirPath,
   }: { basePath: string; dirPath: string }): boolean => {
     const items = fs.readdirSync(dirPath, { withFileTypes: true })
+
+    // Empty pages dir is fine (Mode A only).
+    if (items.length === 0) return true
 
     return items.every((item) => {
       const itemPath = path.join(dirPath, item.name)
 
       if (item.isDirectory()) {
-        return allPagesAreAllowed({ basePath, dirPath: itemPath })
+        return allPagesAreAllowed({ basePath: pagesBase, dirPath: itemPath })
       }
 
       if (!item.isFile()) {
@@ -92,7 +266,7 @@ export function createNextJsPages(basePath: string) {
       }
 
       // For Next.js page files, check if they match allowed prefixes
-      const relativePath = path.relative(basePath, itemPath)
+      const relativePath = path.relative(pagesBase, itemPath)
       const normalizedPath =
         '/' + relativePath.replace(/\\/g, '/').replace(/\.(js|jsx|ts|tsx)$/, '')
 
@@ -115,5 +289,6 @@ export function createNextJsPages(basePath: string) {
     customizationPagesDir,
     corePagesDir,
     baseCustomizationPagesDir: customizationPagesDir,
+    cmsHandledRoutes,
   })
 }

--- a/packages/cli/src/utils/createNextjsPages.ts
+++ b/packages/cli/src/utils/createNextjsPages.ts
@@ -75,7 +75,11 @@ const createExternalPages = ({
 }
 
 function isAllowedPrefixPage(file: string) {
-  return ALLOWED_PREFIX_PAGES.some((prefix) => file.startsWith(prefix))
+  // Match on route-segment boundaries so `/pvt/accounting` is not treated as
+  // a `/pvt/account` descendant.
+  return ALLOWED_PREFIX_PAGES.some(
+    (prefix) => file === prefix || file.startsWith(`${prefix}/`)
+  )
 }
 
 function normalizeAccountRoute(routeOrRelativePath: string): string {

--- a/packages/cli/src/utils/createNextjsPages.ts
+++ b/packages/cli/src/utils/createNextjsPages.ts
@@ -58,7 +58,7 @@ const createExternalPages = ({
     if (isReactFile && isDestinationAvailable) {
       const relativePagePath = filePath
         .replace(baseCustomizationPagesDir, '')
-        .replace(/\\/g, '/')
+        .replaceAll(/\\/g, '/')
         .replace(/\.tsx$/, '')
       const normalizedRoute = normalizeAccountRoute(relativePagePath)
 
@@ -185,7 +185,7 @@ function generateCmsPages({
     const pagePath = customizationTsx
       ? `src/customizations/src/pages${customizationTsx
           .replace(customizationPagesDir, '')
-          .replace(/\\/g, '/')
+          .replaceAll(/\\/g, '/')
           .replace(/\.tsx$/, '')}`
       : undefined
 

--- a/packages/cli/src/utils/readMyAccountCmsRoutes.test.ts
+++ b/packages/cli/src/utils/readMyAccountCmsRoutes.test.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { readMyAccountCmsRoutes } from './readMyAccountCmsRoutes'
+
+const fixturesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '__fixtures__/myAccount'
+)
+
+describe('readMyAccountCmsRoutes', () => {
+  it('extracts routes that declare a contentType', () => {
+    const routes = readMyAccountCmsRoutes(
+      path.join(fixturesDir, 'navigation-with-cms.ts')
+    )
+
+    expect(routes).toEqual([
+      {
+        route: '/pvt/account/wishlist',
+        title: 'Wishlist',
+        contentType: 'myAccountWishlist',
+      },
+    ])
+  })
+
+  it('returns an empty list when no route declares contentType', () => {
+    const routes = readMyAccountCmsRoutes(
+      path.join(fixturesDir, 'navigation-legacy-only.ts')
+    )
+
+    expect(routes).toEqual([])
+  })
+
+  it('returns an empty list when the file does not exist', () => {
+    expect(readMyAccountCmsRoutes('/tmp/does-not-exist-navigation.ts')).toEqual(
+      []
+    )
+  })
+
+  it('returns empty and does not throw for unparseable input', () => {
+    const tmp = path.join(os.tmpdir(), `nav-dynamic-${Date.now()}.ts`)
+    fs.writeFileSync(
+      tmp,
+      `const routes = buildRoutes()\nexport default getMyAccountRoutes({ routes })\n`
+    )
+
+    try {
+      expect(readMyAccountCmsRoutes(tmp)).toEqual([])
+    } finally {
+      fs.unlinkSync(tmp)
+    }
+  })
+})
+
+afterEach(() => {
+  // no-op placeholder for symmetry with other suites
+})

--- a/packages/cli/src/utils/readMyAccountCmsRoutes.ts
+++ b/packages/cli/src/utils/readMyAccountCmsRoutes.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs'
+
+import { logger } from './logger'
+
+export type MyAccountCmsRoute = {
+  route: string
+  title: string
+  contentType: string
+}
+
+/**
+ * Extracts a property value from a static object-literal fragment when the
+ * value is a plain string literal (single or double quotes).
+ */
+function readStringProp(
+  objectLiteral: string,
+  propName: string
+): string | undefined {
+  const pattern = new RegExp(
+    `${propName}\\s*:\\s*(['"\`])((?:\\\\.|(?!\\1).)*)\\1`,
+    'm'
+  )
+  const match = objectLiteral.match(pattern)
+  return match?.[2]
+}
+
+/**
+ * Locates the `routes: [ ... ]` array passed to `getMyAccountRoutes({...})`
+ * and returns each top-level object-literal that declares a `contentType`.
+ *
+ * Supports the documented static-literal authoring pattern only. Dynamic /
+ * computed route entries are skipped with a warning (they still work as
+ * legacy code-only pages when a `.tsx` exists).
+ */
+export function readMyAccountCmsRoutes(
+  navigationFilePath: string
+): MyAccountCmsRoute[] {
+  if (!fs.existsSync(navigationFilePath)) {
+    return []
+  }
+
+  let sourceText: string
+  try {
+    sourceText = fs.readFileSync(navigationFilePath, 'utf8')
+  } catch {
+    logger.warn(
+      `[my-account-cms] Could not read navigation file at ${navigationFilePath}`
+    )
+    return []
+  }
+
+  // Strip line comments to avoid false matches inside comments.
+  const withoutLineComments = sourceText.replace(/^\s*\/\/.*$/gm, '')
+
+  const routesMatch = withoutLineComments.match(
+    /getMyAccountRoutes\s*\(\s*\{[\s\S]*?routes\s*:\s*\[([\s\S]*?)\]/
+  )
+
+  if (!routesMatch) {
+    logger.warn(
+      `[my-account-cms] Could not statically parse routes in ${navigationFilePath}; skipping CMS page generation`
+    )
+    return []
+  }
+
+  const routesBody = routesMatch[1]
+  const objectLiterals = routesBody.match(/\{[^{}]*\}/g) ?? []
+
+  const routes: MyAccountCmsRoute[] = []
+
+  for (const literal of objectLiterals) {
+    const contentType = readStringProp(literal, 'contentType')
+    if (!contentType) {
+      continue
+    }
+
+    const route = readStringProp(literal, 'route')
+    const title = readStringProp(literal, 'title')
+
+    if (!route || !title) {
+      logger.warn(
+        `[my-account-cms] Skipping CMS route entry missing route/title in ${navigationFilePath}`
+      )
+      continue
+    }
+
+    routes.push({ route, title, contentType })
+  }
+
+  return routes
+}

--- a/packages/cli/src/utils/readMyAccountCmsRoutes.ts
+++ b/packages/cli/src/utils/readMyAccountCmsRoutes.ts
@@ -20,7 +20,7 @@ function readStringProp(
     `${propName}\\s*:\\s*(['"\`])((?:\\\\.|(?!\\1).)*)\\1`,
     'm'
   )
-  const match = objectLiteral.match(pattern)
+  const match = pattern.exec(objectLiteral)
   return match?.[2]
 }
 
@@ -50,11 +50,12 @@ export function readMyAccountCmsRoutes(
   }
 
   // Strip line comments to avoid false matches inside comments.
-  const withoutLineComments = sourceText.replace(/^\s*\/\/.*$/gm, '')
+  const withoutLineComments = sourceText.replaceAll(/^\s*\/\/.*$/gm, '')
 
-  const routesMatch = withoutLineComments.match(
-    /getMyAccountRoutes\s*\(\s*\{[\s\S]*?routes\s*:\s*\[([\s\S]*?)\]/
-  )
+  const routesMatch =
+    /getMyAccountRoutes\s*\(\s*\{[\s\S]*?routes\s*:\s*\[([\s\S]*?)\]/.exec(
+      withoutLineComments
+    )
 
   if (!routesMatch) {
     logger.warn(

--- a/packages/cli/src/utils/templates/myAccountCmsPage.test.ts
+++ b/packages/cli/src/utils/templates/myAccountCmsPage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { myAccountCmsPageTemplate } from './myAccountCmsPage'
+
+describe('myAccountCmsPageTemplate', () => {
+  it('emits Mode A output without DynamicPage', () => {
+    const output = myAccountCmsPageTemplate({
+      contentType: 'myAccountWishlist',
+      routePath: '/pvt/account/wishlist',
+    })
+
+    expect(output).toContain(
+      "myAccountCmsServerSideProps('myAccountWishlist', '/pvt/account/wishlist')"
+    )
+    expect(output).toContain('RenderSectionsBase')
+    expect(output).toContain('ACCOUNT_COMPONENTS')
+    expect(output).not.toContain('DynamicPage')
+    expect(output).not.toContain('BeforeSection')
+    expect(output).not.toContain('AfterSection')
+  })
+
+  it('emits Mode B output with DynamicPage', () => {
+    const output = myAccountCmsPageTemplate({
+      contentType: 'myAccountWishlist',
+      routePath: '/pvt/account/wishlist',
+      pagePath: 'src/customizations/src/pages/pvt/account/wishlist',
+    })
+
+    expect(output).toContain(
+      "import DynamicPage from 'src/customizations/src/pages/pvt/account/wishlist'"
+    )
+    expect(output).toContain('<DynamicPage />')
+    expect(output).toContain('RenderSectionsBase')
+  })
+
+  it('wires before/after extensions when provided', () => {
+    const output = myAccountCmsPageTemplate({
+      contentType: 'myAccountWishlist',
+      routePath: '/pvt/account/wishlist',
+      pagePath: 'src/customizations/src/pages/pvt/account/wishlist',
+      beforePath: 'src/customizations/src/myAccount/extensions/wishlist/before',
+      afterPath: 'src/customizations/src/myAccount/extensions/wishlist/after',
+    })
+
+    expect(output).toContain(
+      "import { default as BeforeSection } from 'src/customizations/src/myAccount/extensions/wishlist/before'"
+    )
+    expect(output).toContain(
+      "import { default as AfterSection } from 'src/customizations/src/myAccount/extensions/wishlist/after'"
+    )
+    expect(output).toContain('<BeforeSection />')
+    expect(output).toContain('<AfterSection />')
+
+    const beforeIdx = output.indexOf('<BeforeSection />')
+    const sectionsIdx = output.indexOf('<RenderSectionsBase')
+    const dynamicIdx = output.indexOf('<DynamicPage />')
+    const afterIdx = output.indexOf('<AfterSection />')
+
+    expect(beforeIdx).toBeLessThan(sectionsIdx)
+    expect(sectionsIdx).toBeLessThan(dynamicIdx)
+    expect(dynamicIdx).toBeLessThan(afterIdx)
+  })
+})

--- a/packages/cli/src/utils/templates/myAccountCmsPage.ts
+++ b/packages/cli/src/utils/templates/myAccountCmsPage.ts
@@ -1,0 +1,66 @@
+type MyAccountCmsPageTemplateArgs = {
+  contentType: string
+  routePath: string
+  pagePath?: string
+  beforePath?: string
+  afterPath?: string
+}
+
+/**
+ * Template for CMS-driven custom My Account pages
+ */
+export const myAccountCmsPageTemplate = ({
+  contentType,
+  routePath,
+  pagePath,
+  beforePath,
+  afterPath,
+}: MyAccountCmsPageTemplateArgs) => `
+  import RenderSections, { RenderSectionsBase } from 'src/components/cms/RenderSections'
+  import ACCOUNT_COMPONENTS from 'src/components/cms/account/Components'
+  import { Layout } from 'src/components/account'
+  import {
+    myAccountCmsServerSideProps,
+    type MyAccountCmsPageProps,
+  } from 'src/experimental/myAccountCmsServerSideProps'
+  import PageProvider from 'src/sdk/overrides/PageProvider'
+  ${pagePath ? `import DynamicPage from '${pagePath}'` : ''}
+  ${beforePath ? `import { default as BeforeSection } from '${beforePath}'` : ''}
+  ${afterPath ? `import { default as AfterSection } from '${afterPath}'` : ''}
+
+  export const getServerSideProps = myAccountCmsServerSideProps('${contentType}', '${routePath}')
+
+  export default function Page({
+    globalSections: globalSectionsProp,
+    pageSections,
+    navigationLabels,
+    accountName,
+    isRepresentative,
+  }: MyAccountCmsPageProps) {
+    const { sections: globalSections, settings: globalSettings } =
+      globalSectionsProp ?? {}
+
+    return (
+      <PageProvider context={{ globalSettings, navigationLabels }}>
+        <RenderSections
+          globalSections={globalSections}
+          components={ACCOUNT_COMPONENTS}
+        >
+          <Layout
+            accountName={accountName}
+            isRepresentative={isRepresentative}
+            navigationLabels={navigationLabels}
+          >
+            ${beforePath ? '<BeforeSection />' : ''}
+            <RenderSectionsBase
+              sections={pageSections}
+              components={ACCOUNT_COMPONENTS}
+            />
+            ${pagePath ? '<DynamicPage />' : ''}
+            ${afterPath ? '<AfterSection />' : ''}
+          </Layout>
+        </RenderSections>
+      </PageProvider>
+    )
+  }
+`

--- a/packages/core/src/experimental/myAccountCmsServerSideProps.ts
+++ b/packages/core/src/experimental/myAccountCmsServerSideProps.ts
@@ -1,0 +1,149 @@
+import { gql } from '@generated/gql'
+import type {
+  ServerAccountPageQueryQuery,
+  ServerAccountPageQueryQueryVariables,
+} from '@generated/graphql'
+import type { Locator } from '@vtex/client-cms'
+import type { GetServerSideProps } from 'next'
+
+import {
+  type GlobalSectionsData,
+  getGlobalSectionsData,
+} from 'src/components/cms/GlobalSections'
+import { getIsRepresentative } from 'src/sdk/account/getIsRepresentative'
+import type { AccountNavigationLabels } from 'src/sdk/account/getMyAccountRoutes'
+import { validateUser } from 'src/sdk/account/validateUser'
+import { execute } from 'src/server'
+import { fetchMyAccountPageContent } from 'src/server/cms/fetchMyAccountPageContent'
+import { injectGlobalSections } from 'src/server/cms/global'
+import { extractAccountNavigationData } from 'src/server/cms/myAccountDefaultSections'
+import { localizeRedirectDestination } from 'src/utils/localization/localizeRedirectDestination'
+import { withLocaleValidationSSR } from 'src/utils/localization/withLocaleValidation'
+import { getMyAccountRedirect } from 'src/utils/myAccountRedirect'
+import storeConfig from '../../discovery.config'
+import type { MyAccountProps } from './myAccountServerSideProps'
+
+export type MyAccountCmsPageProps = MyAccountProps & {
+  pageSections: Array<{
+    name: string
+    data: Record<string, unknown>
+    $componentKey?: string
+  }>
+  navigationLabels: AccountNavigationLabels
+}
+
+const query = gql(`
+  query ServerAccountPageQuery {
+    accountProfile {
+      name
+    }
+  }
+`)
+
+/**
+ * Reusable SSR factory for CMS-driven custom My Account pages.
+ * Keeps the same auth/redirect guards as `myAccountServerSideProps`.
+ */
+export function myAccountCmsServerSideProps(
+  contentType: string,
+  pagePath: string
+): GetServerSideProps<MyAccountCmsPageProps, Record<string, string>, Locator> {
+  const handler: GetServerSideProps<
+    MyAccountCmsPageProps,
+    Record<string, string>,
+    Locator
+  > = async (context) => {
+    const contentContext = {
+      previewData: context.previewData,
+      locale: context.locale,
+    }
+
+    const validationResult = await validateUser(context)
+
+    if (!validationResult.isValid && !validationResult.needsRefresh) {
+      return {
+        redirect: {
+          destination: localizeRedirectDestination('/login', context),
+          permanent: false,
+        },
+      }
+    }
+
+    if (!validationResult.isValid && validationResult.needsRefresh) {
+      const currentPath = context.req.url || '/pvt/account'
+      return {
+        redirect: {
+          destination: localizeRedirectDestination(
+            `/pvt/account/403?from=${encodeURIComponent(currentPath)}`,
+            context
+          ),
+          permanent: false,
+        },
+      }
+    }
+
+    const { isFaststoreMyAccountEnabled, redirect } = getMyAccountRedirect({
+      query: context.query,
+    })
+
+    if (!isFaststoreMyAccountEnabled) {
+      return { redirect }
+    }
+
+    const isRepresentative = getIsRepresentative({
+      headers: context.req.headers as Record<string, string>,
+      account: storeConfig.api.storeId,
+    })
+
+    const [
+      globalSectionsPromise,
+      globalSectionsHeaderPromise,
+      globalSectionsFooterPromise,
+    ] = getGlobalSectionsData(contentContext)
+
+    const [
+      pageContent,
+      account,
+      globalSections,
+      globalSectionsHeader,
+      globalSectionsFooter,
+    ] = await Promise.all([
+      fetchMyAccountPageContent(contentType, contentContext, pagePath),
+      execute<
+        ServerAccountPageQueryQueryVariables,
+        ServerAccountPageQueryQuery
+      >(
+        {
+          variables: {},
+          operation: query,
+        },
+        { headers: { ...context.req.headers } }
+      ),
+      globalSectionsPromise,
+      globalSectionsHeaderPromise,
+      globalSectionsFooterPromise,
+    ])
+
+    const { pageSections, navigationData } = extractAccountNavigationData(
+      pageContent.sections
+    )
+
+    const globalSectionsResult = injectGlobalSections({
+      globalSections,
+      globalSectionsHeader,
+      globalSectionsFooter,
+    })
+
+    return {
+      props: {
+        globalSections: globalSectionsResult as GlobalSectionsData,
+        accountName: account.data?.accountProfile?.name ?? '',
+        isRepresentative,
+        pageSections,
+        navigationLabels: navigationData as AccountNavigationLabels,
+      },
+    }
+  }
+
+  return withLocaleValidationSSR(handler)
+}

--- a/packages/core/src/experimental/myAccountCmsServerSideProps.ts
+++ b/packages/core/src/experimental/myAccountCmsServerSideProps.ts
@@ -6,10 +6,7 @@ import type {
 import type { Locator } from '@vtex/client-cms'
 import type { GetServerSideProps } from 'next'
 
-import {
-  type GlobalSectionsData,
-  getGlobalSectionsData,
-} from 'src/components/cms/GlobalSections'
+import { getGlobalSectionsData } from 'src/components/cms/GlobalSections'
 import { getIsRepresentative } from 'src/sdk/account/getIsRepresentative'
 import type { AccountNavigationLabels } from 'src/sdk/account/getMyAccountRoutes'
 import { validateUser } from 'src/sdk/account/validateUser'
@@ -136,7 +133,7 @@ export function myAccountCmsServerSideProps(
 
     return {
       props: {
-        globalSections: globalSectionsResult as GlobalSectionsData,
+        globalSections: globalSectionsResult,
         accountName: account.data?.accountProfile?.name ?? '',
         isRepresentative,
         pageSections,

--- a/packages/core/src/sdk/account/getMyAccountRoutes.ts
+++ b/packages/core/src/sdk/account/getMyAccountRoutes.ts
@@ -3,6 +3,12 @@ export interface Route {
   title: string
   /* Accessible path within My Account */
   route: string
+  /**
+   * When set, the page body renders from this CMS content-type.
+   * Presence of this field is the single opt-in for a CMS-driven page.
+   * Pure CMS vs hybrid is derived by the CLI from whether a code body exists.
+   */
+  contentType?: string
 }
 
 export type AccountNavigationLabels = Partial<{

--- a/packages/core/src/server/cms/myAccountDefaultSections.ts
+++ b/packages/core/src/server/cms/myAccountDefaultSections.ts
@@ -1,4 +1,4 @@
-export type MyAccountContentType =
+export type NativeMyAccountContentType =
   | 'myAccountProfile'
   | 'myAccountOrders'
   | 'myAccountOrderDetails'
@@ -6,13 +6,16 @@ export type MyAccountContentType =
   | 'myAccountSecurity'
   | 'myAccountUnauthorized'
 
+/** Store content-types are opaque strings; native literals keep autocompletion. */
+export type MyAccountContentType = NativeMyAccountContentType | (string & {})
+
 export type DefaultMyAccountSection = {
   name: string
   $componentKey: string
   data: Record<string, unknown>
 }
 
-const DEFAULT_SECTION_KEYS: Record<MyAccountContentType, string[]> = {
+const DEFAULT_SECTION_KEYS: Record<NativeMyAccountContentType, string[]> = {
   myAccountProfile: ['AccountNavigation', 'AccountProfile'],
   myAccountOrders: ['AccountNavigation', 'AccountOrdersList'],
   myAccountOrderDetails: [
@@ -34,7 +37,9 @@ const DEFAULT_SECTION_KEYS: Record<MyAccountContentType, string[]> = {
 export function getDefaultMyAccountSections(
   contentType: MyAccountContentType
 ): DefaultMyAccountSection[] {
-  return (DEFAULT_SECTION_KEYS[contentType] ?? []).map((key) => ({
+  return (
+    DEFAULT_SECTION_KEYS[contentType as NativeMyAccountContentType] ?? []
+  ).map((key) => ({
     name: key,
     $componentKey: key,
     data: {},

--- a/packages/core/src/utils/myAccountRedirect.tsx
+++ b/packages/core/src/utils/myAccountRedirect.tsx
@@ -1,6 +1,16 @@
 import storeConfig from 'discovery.config'
 import type { ParsedUrlQuery } from 'node:querystring'
 
+type MyAccountRedirect = { destination: string; permanent: boolean }
+
+/**
+ * Discriminated union so callers that guard on `isFaststoreMyAccountEnabled`
+ * get a non-nullable `redirect`.
+ */
+export type MyAccountRedirectResult =
+  | { isFaststoreMyAccountEnabled: false; redirect: MyAccountRedirect }
+  | { isFaststoreMyAccountEnabled: true; redirect: null }
+
 /**
  * Check if the Faststore My Account feature flag is enabled.
  * If not, redirect to the legacy My Account URL with the query parameters.
@@ -8,10 +18,9 @@ import type { ParsedUrlQuery } from 'node:querystring'
  * @param {ParsedUrlQuery} query - The query parameters from the request.
  * @returns {Object} - An object containing the feature flag status and redirect information.
  */
-export function getMyAccountRedirect({ query }: { query: ParsedUrlQuery }): {
-  isFaststoreMyAccountEnabled: boolean
-  redirect: { destination: string; permanent: boolean } | null
-} {
+export function getMyAccountRedirect({
+  query,
+}: { query: ParsedUrlQuery }): MyAccountRedirectResult {
   const isFaststoreMyAccountEnabled =
     storeConfig.experimental?.enableFaststoreMyAccount
 
@@ -29,8 +38,8 @@ export function getMyAccountRedirect({ query }: { query: ParsedUrlQuery }): {
       permanent: false,
     }
 
-    return { isFaststoreMyAccountEnabled, redirect }
+    return { isFaststoreMyAccountEnabled: false, redirect }
   }
 
-  return { isFaststoreMyAccountEnabled, redirect: null }
+  return { isFaststoreMyAccountEnabled: true, redirect: null }
 }

--- a/packages/core/test/experimental/myAccountCmsServerSideProps.test.ts
+++ b/packages/core/test/experimental/myAccountCmsServerSideProps.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockValidateUser = vi.fn()
+const mockGetMyAccountRedirect = vi.fn()
+const mockGetIsRepresentative = vi.fn()
+const mockFetchMyAccountPageContent = vi.fn()
+const mockGetGlobalSectionsData = vi.fn()
+const mockExecute = vi.fn()
+const mockInjectGlobalSections = vi.fn()
+const mockLocalizeRedirectDestination = vi.fn(
+  (destination: string) => destination
+)
+
+vi.mock('src/sdk/account/validateUser', () => ({
+  validateUser: (...args: unknown[]) => mockValidateUser(...args),
+}))
+
+vi.mock('src/utils/myAccountRedirect', () => ({
+  getMyAccountRedirect: (...args: unknown[]) =>
+    mockGetMyAccountRedirect(...args),
+}))
+
+vi.mock('src/sdk/account/getIsRepresentative', () => ({
+  getIsRepresentative: (...args: unknown[]) => mockGetIsRepresentative(...args),
+}))
+
+vi.mock('src/server/cms/fetchMyAccountPageContent', () => ({
+  fetchMyAccountPageContent: (...args: unknown[]) =>
+    mockFetchMyAccountPageContent(...args),
+}))
+
+vi.mock('src/components/cms/GlobalSections', () => ({
+  getGlobalSectionsData: (...args: unknown[]) =>
+    mockGetGlobalSectionsData(...args),
+}))
+
+vi.mock('src/server', () => ({
+  execute: (...args: unknown[]) => mockExecute(...args),
+}))
+
+vi.mock('src/server/cms/global', () => ({
+  injectGlobalSections: (...args: unknown[]) =>
+    mockInjectGlobalSections(...args),
+}))
+
+vi.mock('src/utils/localization/localizeRedirectDestination', () => ({
+  localizeRedirectDestination: (...args: unknown[]) =>
+    mockLocalizeRedirectDestination(...(args as [string])),
+}))
+
+vi.mock('src/utils/localization/withLocaleValidation', () => ({
+  withLocaleValidationSSR: <T>(fn: T) => fn,
+}))
+
+vi.mock('../../../discovery.config', () => ({
+  default: { api: { storeId: 'teststore' } },
+}))
+
+vi.mock('@generated/gql', () => ({
+  gql: (source: string) => source,
+}))
+
+import { myAccountCmsServerSideProps } from '../../../src/experimental/myAccountCmsServerSideProps'
+
+function buildContext(overrides: Record<string, unknown> = {}) {
+  return {
+    previewData: undefined,
+    locale: 'en-US',
+    query: {},
+    req: {
+      url: '/pvt/account/wishlist',
+      headers: {},
+    },
+    ...overrides,
+  } as never
+}
+
+describe('myAccountCmsServerSideProps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetIsRepresentative.mockReturnValue(false)
+    mockGetGlobalSectionsData.mockReturnValue([
+      Promise.resolve({ sections: [], settings: {} }),
+      Promise.resolve({ sections: [] }),
+      Promise.resolve({ sections: [] }),
+    ])
+    mockInjectGlobalSections.mockReturnValue({
+      sections: [{ name: 'Children', data: {} }],
+      settings: {},
+    })
+    mockExecute.mockResolvedValue({
+      data: { accountProfile: { name: 'Ada' } },
+      errors: undefined,
+    })
+  })
+
+  it('redirects to login when the user is invalid and does not need refresh', async () => {
+    mockValidateUser.mockResolvedValue({
+      isValid: false,
+      needsRefresh: false,
+    })
+
+    const result = await myAccountCmsServerSideProps(
+      'myAccountWishlist',
+      '/pvt/account/wishlist'
+    )(buildContext())
+
+    expect(result).toEqual({
+      redirect: { destination: '/login', permanent: false },
+    })
+  })
+
+  it('redirects to 403 when the user is invalid and needs refresh', async () => {
+    mockValidateUser.mockResolvedValue({
+      isValid: false,
+      needsRefresh: true,
+    })
+
+    const result = await myAccountCmsServerSideProps(
+      'myAccountWishlist',
+      '/pvt/account/wishlist'
+    )(buildContext())
+
+    expect(result).toEqual({
+      redirect: {
+        destination: `/pvt/account/403?from=${encodeURIComponent('/pvt/account/wishlist')}`,
+        permanent: false,
+      },
+    })
+  })
+
+  it('returns the My Account disabled redirect', async () => {
+    mockValidateUser.mockResolvedValue({ isValid: true })
+    mockGetMyAccountRedirect.mockReturnValue({
+      isFaststoreMyAccountEnabled: false,
+      redirect: { destination: '/login', permanent: false },
+    })
+
+    const result = await myAccountCmsServerSideProps(
+      'myAccountWishlist',
+      '/pvt/account/wishlist'
+    )(buildContext())
+
+    expect(result).toEqual({
+      redirect: { destination: '/login', permanent: false },
+    })
+  })
+
+  it('returns pageSections, navigationLabels and accountName on success', async () => {
+    mockValidateUser.mockResolvedValue({ isValid: true })
+    mockGetMyAccountRedirect.mockReturnValue({
+      isFaststoreMyAccountEnabled: true,
+      redirect: { destination: '/login', permanent: false },
+    })
+    mockFetchMyAccountPageContent.mockResolvedValue({
+      sections: [
+        {
+          name: 'AccountNavigation',
+          $componentKey: 'AccountNavigation',
+          data: { profileLabel: 'Profile' },
+        },
+        {
+          name: 'HelloAccount',
+          $componentKey: 'HelloAccount',
+          data: { label: 'Hi' },
+        },
+      ],
+      settings: {},
+    })
+
+    const result = await myAccountCmsServerSideProps(
+      'myAccountWishlist',
+      '/pvt/account/wishlist'
+    )(buildContext())
+
+    expect(result).toMatchObject({
+      props: {
+        accountName: 'Ada',
+        isRepresentative: false,
+        navigationLabels: { profileLabel: 'Profile' },
+        pageSections: [
+          {
+            name: 'HelloAccount',
+            $componentKey: 'HelloAccount',
+            data: { label: 'Hi' },
+          },
+        ],
+      },
+    })
+    expect(mockFetchMyAccountPageContent).toHaveBeenCalledWith(
+      'myAccountWishlist',
+      { previewData: undefined, locale: 'en-US' },
+      '/pvt/account/wishlist'
+    )
+  })
+
+  it('returns empty pageSections when the content-type is unpublished', async () => {
+    mockValidateUser.mockResolvedValue({ isValid: true })
+    mockGetMyAccountRedirect.mockReturnValue({
+      isFaststoreMyAccountEnabled: true,
+      redirect: { destination: '/login', permanent: false },
+    })
+    mockFetchMyAccountPageContent.mockResolvedValue({
+      sections: [],
+      settings: {},
+    })
+
+    const result = await myAccountCmsServerSideProps(
+      'myAccountWishlist',
+      '/pvt/account/wishlist'
+    )(buildContext())
+
+    expect(result).toMatchObject({
+      props: {
+        pageSections: [],
+        navigationLabels: {},
+        accountName: 'Ada',
+      },
+    })
+  })
+})

--- a/packages/core/test/sdk/account/getMyAccountRoutes.test.ts
+++ b/packages/core/test/sdk/account/getMyAccountRoutes.test.ts
@@ -73,6 +73,45 @@ describe('getMyAccountRoutes', () => {
     expect(result.find((r) => r.route === QUOTES_ROUTE)?.title).toBe('Quotes')
   })
 
+  it('preserves contentType through getMyAccountRoutes', () => {
+    const result = getMyAccountRoutes({
+      routes: [
+        {
+          title: 'Wishlist',
+          route: '/pvt/account/wishlist',
+          contentType: 'myAccountWishlist',
+        },
+      ],
+    })
+
+    const wishlist = result.find((r) => r.route === '/pvt/account/wishlist')
+    expect(wishlist?.contentType).toBe('myAccountWishlist')
+    expect(wishlist?.title).toBe('Wishlist')
+  })
+
+  it('keeps custom-route titles when CMS labels override native routes (FR-011)', () => {
+    const result = getMyAccountRoutes({
+      routes: [
+        {
+          title: 'Wishlist',
+          route: '/pvt/account/wishlist',
+          contentType: 'myAccountWishlist',
+        },
+      ],
+      labels: { profileLabel: 'Meu Perfil', ordersLabel: 'Meus Pedidos' },
+    })
+
+    expect(result.find((r) => r.route === PROFILE_ROUTE)?.title).toBe(
+      'Meu Perfil'
+    )
+    expect(result.find((r) => r.route === ORDERS_ROUTE)?.title).toBe(
+      'Meus Pedidos'
+    )
+    expect(result.find((r) => r.route === '/pvt/account/wishlist')?.title).toBe(
+      'Wishlist'
+    )
+  })
+
   it('marks Quotes as a B2B-only route', () => {
     expect(ROUTES_ONLY_FOR_B2B_MEMBERS).toContain(QUOTES_ROUTE)
   })

--- a/packages/core/test/server/cms/myAccountDefaultSections.test.ts
+++ b/packages/core/test/server/cms/myAccountDefaultSections.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getDefaultMyAccountSections,
+  withDefaultMyAccountSections,
+} from '../../../src/server/cms/myAccountDefaultSections'
+
+describe('getDefaultMyAccountSections', () => {
+  it('returns the native section list for myAccountProfile', () => {
+    expect(getDefaultMyAccountSections('myAccountProfile')).toEqual([
+      {
+        name: 'AccountNavigation',
+        $componentKey: 'AccountNavigation',
+        data: {},
+      },
+      { name: 'AccountProfile', $componentKey: 'AccountProfile', data: {} },
+    ])
+  })
+
+  it('returns an empty list for store (unknown) content-types', () => {
+    expect(getDefaultMyAccountSections('myAccountWishlist')).toEqual([])
+  })
+})
+
+describe('withDefaultMyAccountSections', () => {
+  it('returns published sections when present', () => {
+    const sections = [
+      {
+        name: 'HelloAccount',
+        $componentKey: 'HelloAccount',
+        data: { label: 'Hi' },
+      },
+    ]
+
+    expect(withDefaultMyAccountSections('myAccountWishlist', sections)).toEqual(
+      sections
+    )
+  })
+
+  it('falls back to defaults for native types when sections are empty', () => {
+    expect(withDefaultMyAccountSections('myAccountSecurity', [])).toEqual(
+      getDefaultMyAccountSections('myAccountSecurity')
+    )
+  })
+
+  it('falls back to [] for store types when sections are empty', () => {
+    expect(withDefaultMyAccountSections('myAccountWishlist', null)).toEqual([])
+  })
+})


### PR DESCRIPTION
## What's the purpose of this pull request?

After the My Account CMS migration, **new** account pages created by a store were still code-only — merchants could not author/edit them in CMS Admin. This PR closes that gap ([SFS-3250](https://vtex-dev.atlassian.net/jira/software/c/projects/SFS/boards/1051?selectedIssue=SFS-3250)): stores can declare a My Account route bound to a CMS content-type and render it SSR like native pages.

## How it works?

- Opt-in: optional `contentType` on `Route` in `navigation.ts` (no separate `source` flag).
- **Mode A:** `contentType` + no `.tsx` → body 100% from CMS (CLI generates the page).
- **Mode B:** `contentType` + `.tsx` → CMS sections + code body (+ optional before/after).
- No `contentType` → legacy code-only wrap (unchanged).
- **core:** widened `MyAccountContentType`; new `myAccountCmsServerSideProps` (same auth as native pages).
- **cli:** parses `navigation.ts`, generates pages via `myAccountCmsPageTemplate`; skips native collisions and routes outside `/pvt/account`.

## How to test it?

- Unit tests in `@faststore/core` and `@faststore/cli` (CMS SSR, routes, page generation).
- In a store (e.g. b2bfaststoredev): add `contentType` on a route, add content-type under `cms/faststore/pages/`, `cms-sync`, publish sections in Admin, open the route logged in.
- Regression: routes without `contentType` and existing before/after still work.
- See also: `specs/007-myaccount-cms-custom-pages/quickstart.md`.


## References

- [SFS-3250](https://vtex-dev.atlassian.net/jira/software/c/projects/SFS/boards/1051?selectedIssue=SFS-3250)
- Spec/RFC: `specs/007-myaccount-cms-custom-pages/`



[SFS-3250]: https://vtex-dev.atlassian.net/browse/SFS-3250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFS-3250]: https://vtex-dev.atlassian.net/browse/SFS-3250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CMS-driven “My Account” page generation for routes under `/pvt/account` using an optional content type.
  * Supports hybrid pages with customization code and optional before/after sections.
  * Supports custom CMS content types and preserves existing native pages.
  * Added routing safeguards to prevent invalid or conflicting page generation.

* **Tests**
  * Expanded coverage for CMS route parsing, page generation, templates, redirects, and server-side data loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->