### PR TITLE
feat: copy fonts and nested assets from public/ to build

### DIFF
--- a/packages/cli/src/utils/generate.test.ts
+++ b/packages/cli/src/utils/generate.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   PUBLIC_FILES_ALLOWED_EXTENSIONS,
   buildFaststorePackageJson,
+  copyPublicFiles,
   isPublicFileAllowed,
 } from './generate'
 
@@ -170,5 +174,53 @@ describe('isPublicFileAllowed', () => {
     for (const extension of PUBLIC_FILES_ALLOWED_EXTENSIONS) {
       expect(extension.startsWith('.')).toBe(true)
     }
+  })
+})
+
+describe('copyPublicFiles', () => {
+  let basePath: string
+
+  const publicDir = () => path.join(basePath, 'public')
+  const buildDir = () => path.join(basePath, '.faststore', 'public')
+
+  beforeEach(() => {
+    basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'faststore-public-'))
+    fs.mkdirSync(path.join(publicDir(), 'fonts'), { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(basePath, { recursive: true, force: true })
+  })
+
+  it('copies allowed files, including fonts in nested folders, and skips the rest', () => {
+    fs.writeFileSync(path.join(publicDir(), 'inter.woff2'), 'font')
+    fs.writeFileSync(path.join(publicDir(), 'readme.md'), 'nope')
+    fs.writeFileSync(path.join(publicDir(), 'fonts', 'bold.woff'), 'font')
+    fs.writeFileSync(path.join(publicDir(), 'fonts', 'notes.ts'), 'nope')
+
+    copyPublicFiles(basePath)
+
+    expect(fs.existsSync(path.join(buildDir(), 'inter.woff2'))).toBe(true)
+    expect(fs.existsSync(path.join(buildDir(), 'fonts', 'bold.woff'))).toBe(
+      true
+    )
+    expect(fs.existsSync(path.join(buildDir(), 'readme.md'))).toBe(false)
+    expect(fs.existsSync(path.join(buildDir(), 'fonts', 'notes.ts'))).toBe(
+      false
+    )
+  })
+
+  it('does not abort the whole copy when a single entry cannot be stat-ed', () => {
+    fs.writeFileSync(path.join(publicDir(), 'inter.woff2'), 'font')
+    // Dangling symlink: statSync (with dereference) throws for this entry.
+    fs.symlinkSync(
+      path.join(publicDir(), 'does-not-exist'),
+      path.join(publicDir(), 'broken.woff2')
+    )
+
+    expect(() => copyPublicFiles(basePath)).not.toThrow()
+
+    expect(fs.existsSync(path.join(buildDir(), 'inter.woff2'))).toBe(true)
+    expect(fs.existsSync(path.join(buildDir(), 'broken.woff2'))).toBe(false)
   })
 })

--- a/packages/cli/src/utils/generate.test.ts
+++ b/packages/cli/src/utils/generate.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildFaststorePackageJson } from './generate'
+import {
+  PUBLIC_FILES_ALLOWED_EXTENSIONS,
+  buildFaststorePackageJson,
+  isPublicFileAllowed,
+} from './generate'
 
 describe('buildFaststorePackageJson', () => {
   const coreManifest = {
@@ -118,5 +122,53 @@ describe('buildFaststorePackageJson', () => {
     const result = buildFaststorePackageJson(coreManifest)
 
     expect(result).not.toHaveProperty('volta')
+  })
+})
+
+describe('isPublicFileAllowed', () => {
+  it('always allows directories regardless of their name', () => {
+    expect(isPublicFileAllowed('/public', true)).toBe(true)
+    expect(isPublicFileAllowed('/public/fonts', true)).toBe(true)
+    expect(isPublicFileAllowed('/public/assets/images', true)).toBe(true)
+  })
+
+  it('copies self-hosted font files', () => {
+    expect(isPublicFileAllowed('/public/fonts/inter.woff', false)).toBe(true)
+    expect(isPublicFileAllowed('/public/fonts/inter.woff2', false)).toBe(true)
+    expect(isPublicFileAllowed('/public/fonts/inter.ttf', false)).toBe(true)
+    expect(isPublicFileAllowed('/public/fonts/inter.otf', false)).toBe(true)
+    expect(isPublicFileAllowed('/public/fonts/inter.eot', false)).toBe(true)
+  })
+
+  it('still copies the previously supported extensions', () => {
+    expect(isPublicFileAllowed('/public/manifest.json', false)).toBe(true)
+    expect(isPublicFileAllowed('/public/robots.txt', false)).toBe(true)
+    expect(isPublicFileAllowed('/public/sitemap.xml', false)).toBe(true)
+    expect(isPublicFileAllowed('/public/favicon.ico', false)).toBe(true)
+    expect(isPublicFileAllowed('/public/logo.svg', false)).toBe(true)
+  })
+
+  it('matches the extension case-insensitively', () => {
+    expect(isPublicFileAllowed('/public/fonts/Inter.WOFF2', false)).toBe(true)
+    expect(isPublicFileAllowed('/public/LOGO.SVG', false)).toBe(true)
+  })
+
+  it('rejects files whose extension is not allowed', () => {
+    expect(isPublicFileAllowed('/public/script.ts', false)).toBe(false)
+    expect(isPublicFileAllowed('/public/styles.css', false)).toBe(false)
+    expect(isPublicFileAllowed('/public/notes.md', false)).toBe(false)
+  })
+
+  it('does not match extensions as a substring of the file name', () => {
+    // Regression: the old filter used `endsWith`, so `basico` matched `ico`.
+    expect(isPublicFileAllowed('/public/basico', false)).toBe(false)
+    expect(isPublicFileAllowed('/public/data.myjson', false)).toBe(false)
+    expect(isPublicFileAllowed('/public/nested/public', false)).toBe(false)
+  })
+
+  it('exposes the allowed extensions as dot-prefixed values', () => {
+    for (const extension of PUBLIC_FILES_ALLOWED_EXTENSIONS) {
+      expect(extension.startsWith('.')).toBe(true)
+    }
   })
 })

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -227,7 +227,7 @@ export function isPublicFileAllowed(
   )
 }
 
-function copyPublicFiles(basePath: string) {
+export function copyPublicFiles(basePath: string) {
   const { userDir, tmpDir } = withBasePath(basePath)
 
   try {
@@ -235,7 +235,15 @@ function copyPublicFiles(basePath: string) {
       copySync(`${userDir}/public`, `${tmpDir}/public`, {
         dereference: true,
         overwrite: true,
-        filter: (src) => isPublicFileAllowed(src, statSync(src).isDirectory()),
+        filter: (src) => {
+          try {
+            return isPublicFileAllowed(src, statSync(src).isDirectory())
+          } catch {
+            // Skip entries we can't stat (dangling symlinks, permission
+            // errors) so a single bad file never aborts the whole public/ copy.
+            return false
+          }
+        },
       })
       logger.log(`${chalk.green('success')} - Public files copied`)
     }

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -20,6 +20,7 @@ const {
   readFileSync,
   readdirSync,
   removeSync,
+  statSync,
   writeFileSync,
   writeJsonSync,
 } = fsExtra
@@ -192,20 +193,49 @@ function copyCoreFiles(basePath: string) {
   }
 }
 
+// File extensions allowed to be copied from the store's `public/` folder into
+// the build. Fonts are included so stores can self-host them (GDPR / CWV)
+// instead of relying on external CDNs.
+export const PUBLIC_FILES_ALLOWED_EXTENSIONS = [
+  '.json',
+  '.txt',
+  '.xml',
+  '.ico',
+  '.svg',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+  '.eot',
+]
+
+/**
+ * Decides whether an entry from the store's `public/` folder should be copied
+ * to the build. Directories always pass so nested assets can be reached, and
+ * files are matched by their real extension (not a substring of the path).
+ */
+export function isPublicFileAllowed(
+  src: string,
+  isDirectory: boolean
+): boolean {
+  if (isDirectory) {
+    return true
+  }
+
+  return PUBLIC_FILES_ALLOWED_EXTENSIONS.includes(
+    path.extname(src).toLowerCase()
+  )
+}
+
 function copyPublicFiles(basePath: string) {
   const { userDir, tmpDir } = withBasePath(basePath)
 
-  const allowList = ['json', 'txt', 'xml', 'ico', 'public', 'svg']
   try {
     if (existsSync(`${userDir}/public`)) {
       copySync(`${userDir}/public`, `${tmpDir}/public`, {
         dereference: true,
         overwrite: true,
-        filter: (src) => {
-          const allow = allowList.some((ext) => src.endsWith(ext))
-
-          return allow
-        },
+        filter: (src) => isPublicFileAllowed(src, statSync(src).isDirectory()),
       })
       logger.log(`${chalk.green('success')} - Public files copied`)
     }


### PR DESCRIPTION
## What's the purpose of this pull request?

Stores couldn't self-host fonts: `.woff`/`.woff2` files placed in `public/` were dropped during `@faststore/cli`'s generate step and returned 404 in production. This blocks GDPR-sensitive (EU) stores and hurts Core Web Vitals, forcing merchants to inline fonts as base64.

## How it works?

`copyPublicFiles` in `packages/cli/src/utils/generate.ts` used a fragile filter that matched extensions as a substring (`endsWith`) and cut whole subdirectories. It now:

- Always allows directories, so nested assets (e.g. `public/fonts/`) are traversed instead of being skipped.
- Matches the **real** file extension via `path.extname().toLowerCase()`, fixing false matches (e.g. `basico` matching `ico`).
- Expands the allowlist with font formats: `.woff`, `.woff2`, `.ttf`, `.otf`, `.eot`.

The decision logic was extracted into a pure, exported `isPublicFileAllowed(src, isDirectory)` and covered by unit tests.

## How to test it?

- Add a font under `public/fonts/` (e.g. `public/fonts/inter.woff2`) in a store.
- Run the generate step and confirm the file is copied to `.faststore/public/fonts/`.
- Confirm the font resolves (no 404) in the built store.
- Unit tests: `pnpm turbo run test --filter=@faststore/cli`.

## References

- Jira: [SO-640](https://vtex-dev.atlassian.net/browse/SO-640)
- Related issue: #3332



[SO-640]: https://vtex-dev.atlassian.net/browse/SO-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build copying for the public assets directory using an explicit, case-insensitive extension allowlist (including self-hosted font files).
  * Prevented unsupported or misleading filenames/extensions from being copied.
  * Ensured directories are always included, and the copy process skips entries that can’t be inspected instead of failing.

* **Tests**
  * Expanded coverage for public asset filtering and copying behavior, including nested font assets and scenarios like dangling/unstat’able entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->