### PR TITLE
fix: prevent My Account 500s from empty session profile and missing CMS content

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -838,16 +838,37 @@ export const Query = {
       }
 
       const profile = sessionData.namespaces.profile ?? null
-      const contract = await commerce.masterData.getContractById({
-        contractId: profile?.id?.value ?? '',
-      })
+      const shopper = sessionData.namespaces.shopper ?? null
+      const authentication = sessionData.namespaces.authentication ?? null
 
-      const name = resolveActiveContractDisplayName(contract, profile)
+      const contractId =
+        resolveActiveContractIdFromSession(sessionData) || jwt?.customerId || ''
+
+      let contract = null
+      if (contractId) {
+        try {
+          contract = await commerce.masterData.getContractById({ contractId })
+        } catch (err) {
+          console.error(
+            `Error while getting contract data for contract ID (${contractId}).\n`
+          )
+        }
+      }
+
+      const shopperName =
+        `${(shopper?.firstName?.value ?? '').trim()} ${(shopper?.lastName?.value ?? '').trim()}`.trim()
+      const name =
+        resolveActiveContractDisplayName(contract, profile) || shopperName
 
       return {
         name: name || '',
-        email: profile?.email?.value || '',
-        id: profile?.id?.value || '',
+        email:
+          profile?.email?.value || authentication?.storeUserEmail?.value || '',
+        id:
+          profile?.id?.value ||
+          authentication?.customerId?.value ||
+          jwt?.customerId ||
+          '',
         // createdAt: '',
       }
     }

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -842,7 +842,9 @@ export const Query = {
       const authentication = sessionData.namespaces.authentication ?? null
 
       const contractId =
-        resolveActiveContractIdFromSession(sessionData) || jwt?.customerId || ''
+        resolveActiveContractIdFromSession(sessionData) ||
+        jwt?.customerId?.trim() ||
+        ''
 
       let contract = null
       if (contractId) {
@@ -867,7 +869,7 @@ export const Query = {
         id:
           profile?.id?.value ||
           authentication?.customerId?.value ||
-          jwt?.customerId ||
+          jwt?.customerId?.trim() ||
           '',
         // createdAt: '',
       }

--- a/packages/api/src/platforms/vtex/resolvers/query.ts
+++ b/packages/api/src/platforms/vtex/resolvers/query.ts
@@ -852,7 +852,8 @@ export const Query = {
           contract = await commerce.masterData.getContractById({ contractId })
         } catch (err) {
           console.error(
-            `Error while getting contract data for contract ID (${contractId}).\n`
+            `Error while getting contract data for contract ID (${contractId}).`,
+            err
           )
         }
       }

--- a/packages/api/test/unit/platforms/vtex/resolvers/query.test.ts
+++ b/packages/api/test/unit/platforms/vtex/resolvers/query.test.ts
@@ -686,4 +686,3 @@ describe('Query.accountProfile', () => {
     })
   })
 })
-

--- a/packages/api/test/unit/platforms/vtex/resolvers/query.test.ts
+++ b/packages/api/test/unit/platforms/vtex/resolvers/query.test.ts
@@ -566,3 +566,124 @@ describe('Query.product', () => {
     })
   })
 })
+
+describe('Query.accountProfile', () => {
+  const accountProfile = (Query as any).accountProfile
+
+  const makeRepCtx = ({
+    customerId = 'contract-1',
+  }: { customerId?: string }) => {
+    const getContractById = vi.fn()
+    const getUserById = vi.fn()
+    const sessionMock = vi.fn()
+
+    const jwtPayload = Buffer.from(
+      JSON.stringify({ userId: 'user-1', isRepresentative: true, customerId })
+    ).toString('base64url')
+    const token = `header.${jwtPayload}.signature`
+
+    const ctx = {
+      account: 'b2bfaststoredev',
+      headers: { cookie: `VtexIdclientAutCookie_b2bfaststoredev=${token}` },
+      clients: {
+        commerce: {
+          session: sessionMock,
+          masterData: { getContractById },
+          licenseManager: { getUserById },
+        },
+      },
+    } as any
+
+    return { ctx, getContractById, getUserById, sessionMock }
+  }
+
+  it('does not throw when the representative session is all-null and resolves the contract via jwt.customerId', async () => {
+    const { ctx, getContractById, sessionMock } = makeRepCtx({
+      customerId: 'contract-1',
+    })
+    sessionMock.mockResolvedValue({
+      namespaces: { profile: null, authentication: null, shopper: null },
+    })
+    getContractById.mockResolvedValue({
+      corporateName: 'BENAROYA RESEARCH COUPA',
+    })
+
+    const result = await accountProfile(null, null, ctx)
+
+    expect(getContractById).toHaveBeenCalledWith({ contractId: 'contract-1' })
+    expect(result).toEqual({
+      name: 'BENAROYA RESEARCH COUPA',
+      email: '',
+      id: 'contract-1',
+    })
+  })
+
+  it('does not throw and skips the CL lookup when no contract id is available anywhere', async () => {
+    const { ctx, getContractById, sessionMock } = makeRepCtx({ customerId: '' })
+    sessionMock.mockResolvedValue({
+      namespaces: {
+        profile: null,
+        authentication: null,
+        shopper: {
+          firstName: { value: 'Joao' },
+          lastName: { value: 'Caetano' },
+        },
+      },
+    })
+
+    const result = await accountProfile(null, null, ctx)
+
+    expect(getContractById).not.toHaveBeenCalled()
+    expect(result).toEqual({ name: 'Joao Caetano', email: '', id: '' })
+  })
+
+  it('does not fail the field when getContractById throws', async () => {
+    const { ctx, getContractById, sessionMock } = makeRepCtx({
+      customerId: 'contract-1',
+    })
+    sessionMock.mockResolvedValue({
+      namespaces: {
+        profile: null,
+        authentication: { storeUserEmail: { value: 'rep@acme.com' } },
+        shopper: {
+          firstName: { value: 'Joao' },
+          lastName: { value: 'Caetano' },
+        },
+      },
+    })
+    getContractById.mockRejectedValue(new Error('CL unavailable'))
+
+    const result = await accountProfile(null, null, ctx)
+
+    expect(getContractById).toHaveBeenCalledWith({ contractId: 'contract-1' })
+    expect(result).toEqual({
+      name: 'Joao Caetano',
+      email: 'rep@acme.com',
+      id: 'contract-1',
+    })
+  })
+
+  it('uses the populated profile namespace when available', async () => {
+    const { ctx, getContractById, sessionMock } = makeRepCtx({
+      customerId: 'contract-1',
+    })
+    sessionMock.mockResolvedValue({
+      namespaces: {
+        profile: { id: { value: 'contract-1' }, email: { value: 'x@y.com' } },
+        authentication: null,
+        shopper: null,
+      },
+    })
+    getContractById.mockResolvedValue({ corporateName: 'Corp X' })
+
+    const result = await accountProfile(null, null, ctx)
+
+    expect(getContractById).toHaveBeenCalledWith({ contractId: 'contract-1' })
+    expect(result).toEqual({
+      name: 'Corp X',
+      email: 'x@y.com',
+      id: 'contract-1',
+    })
+  })
+})
+

--- a/packages/core/src/experimental/myAccountServerSideProps.ts
+++ b/packages/core/src/experimental/myAccountServerSideProps.ts
@@ -114,7 +114,7 @@ const getServerSidePropsBase: GetServerSideProps<
   return {
     props: {
       globalSections: globalSectionsResult,
-      accountName: account.data.accountProfile.name,
+      accountName: account.data?.accountProfile?.name ?? '',
       isRepresentative,
     },
   }

--- a/packages/core/src/pages/pvt/account/404.tsx
+++ b/packages/core/src/pages/pvt/account/404.tsx
@@ -147,9 +147,9 @@ const getServerSidePropsBase: GetServerSideProps<
 
   return {
     props: {
-      page,
+      page: page ?? ({ sections: [] } as unknown as PageContentType),
       globalSections: globalSectionsResult,
-      accountName: account.data.accountProfile.name,
+      accountName: account.data?.accountProfile?.name ?? '',
     },
   }
 }

--- a/packages/core/src/pages/pvt/account/404.tsx
+++ b/packages/core/src/pages/pvt/account/404.tsx
@@ -147,7 +147,7 @@ const getServerSidePropsBase: GetServerSideProps<
 
   return {
     props: {
-      page: page ?? ({ sections: [] } as unknown as PageContentType),
+      page: page ?? ({ sections: [], settings: {} } as PageContentType),
       globalSections: globalSectionsResult,
       accountName: account.data?.accountProfile?.name ?? '',
     },

--- a/packages/core/src/server/cms/fetchMyAccountPageContent.ts
+++ b/packages/core/src/server/cms/fetchMyAccountPageContent.ts
@@ -16,22 +16,23 @@ export async function fetchMyAccountPageContent(
   context: FetchMyAccountPageContentContext,
   pagePath: string
 ) {
-  const pageContent = await contentService
-    .getSingleContent<PageContentType>({
-      contentType,
-      previewData: context.previewData,
-      locale: context.locale,
-    })
-    .catch((err) => {
-      console.warn('[MyAccount CMS fallback]', {
+  const pageContent =
+    (await contentService
+      .getSingleContent<PageContentType>({
         contentType,
+        previewData: context.previewData,
         locale: context.locale,
-        fallbackReason: err instanceof Error ? err.message : String(err),
-        page: pagePath,
       })
+      .catch((err) => {
+        console.warn('[MyAccount CMS fallback]', {
+          contentType,
+          locale: context.locale,
+          fallbackReason: err instanceof Error ? err.message : String(err),
+          page: pagePath,
+        })
 
-      return { sections: [], settings: {} } as PageContentType
-    })
+        return { sections: [], settings: {} } as PageContentType
+      })) ?? ({ sections: [], settings: {} } as PageContentType)
 
   const sections = withDefaultMyAccountSections(
     contentType,


### PR DESCRIPTION
## What's the purpose of this pull request?

My Account routes (`pvt/account/*`, `pvt/organization-account/*`) can return HTTP 500 store-wide. Two independent triggers cause it: (1) a representative session whose VTEX `profile` namespace comes back empty, making `accountProfile` call `getContractById('')` and throw a 400; (2) a My Account content type without a published CMS document, which resolves to `undefined` and is dereferenced. The `/pvt/account/404` fallback runs the same queries, so it also 500s and there is no graceful degradation.

## How it works?

- `@faststore/api` `accountProfile`: aligns with `validateSession` — resolves the contract id via `resolveActiveContractIdFromSession` with a `jwt.customerId` fallback, only calls `getContractById` when an id exists, and wraps it in `try/catch`. Name/email/id fall back to the `shopper`/`authentication` namespaces and the JWT.
- `@faststore/core` My Account SSR: defaults CMS content to empty sections when no document is published, and stops dereferencing `account.data.accountProfile.name` / `page` without guarding `null`/`undefined` (including the `/404` fallback page).

## How to test it?

- Sign in to a B2B storefront as a **representative** user and navigate to any My Account page (e.g. `/pvt/account/profile`); it should render instead of 500, even when the session `profile` namespace is empty.
- Unpublish a My Account content type (e.g. `myAccountProfile`) in the CMS and open the page; it should render default sections instead of 500.
- `cd packages/api && pnpm test:unit` (new `accountProfile` cases covering empty/all-null sessions).

### Starters Deploy Preview
N/A

## References

- Slack thread: https://vtex.slack.com/archives/C08QH7W3C2Y/p1784313602904399
- [jira task](https://vtex-dev.atlassian.net/jira/software/c/projects/SFS/boards/1051?selectedIssue=SFS-3293)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved representative account profile resolution by deriving name/email/id from VTEX session data when profile fields are missing, and making contract lookup conditional and more fault-tolerant.
  * Hardened My Account server-side props and the account 404 page, plus CMS page content loading, with safe fallbacks when data is missing.
* **Tests**
  * Added unit coverage for representative account profile resolution, including missing contract IDs, lookup failures, and session profile precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->