### PR TITLE
fix: propagate upstream error status and stop retrying 429 (v3)

### DIFF
--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -17,6 +17,21 @@ const DEFAULT_MAX_AGE = 5 * 60 // 5 minutes
 const DEFAULT_STALE_WHILE_REVALIDATE = 60 * 60 // 1 hour
 const ALLOWED_HOST_SUFFIXES = ['localhost', '.vtex.app', '.localhost']
 
+/**
+ * Recovers a FastStoreError from an execution error, whether it is the error
+ * itself or wrapped as the `originalError` of a masked GraphQLError.
+ */
+const recoverFastStoreError = (graphqlError: unknown) => {
+  if (isFastStoreError(graphqlError)) {
+    return graphqlError
+  }
+
+  const originalError = (graphqlError as { originalError?: unknown })
+    ?.originalError
+
+  return isFastStoreError(originalError) ? originalError : undefined
+}
+
 // Example: "Set-Cookie: key=value; Domain=example.com; Path=/"
 const MATCH_DOMAIN_REGEXP = /(?:^|;\s*)(?:domain=)([^;]+)/i
 
@@ -205,13 +220,53 @@ const handler: NextApiHandler = async (request, response) => {
       { headers: request.headers }
     )
 
-    const hasErrors = Array.isArray(errors)
+    const hasErrors = Array.isArray(errors) && errors.length > 0
 
     if (hasErrors) {
-      const error = errors.find(isFastStoreError)
-      console.error(error)
+      // After error masking, entries are GraphQLError instances whose
+      // `name` is "GraphQLError" — the original FastStoreError (carrying the
+      // upstream status) is nested in `originalError`. Recover it so the BFF
+      // propagates the real status instead of collapsing everything to 500.
+      const fastStoreError = errors.map(recoverFastStoreError).find(Boolean)
 
-      response.status(error?.extensions.status ?? 500).end()
+      console.error(
+        'Graphql execution returned with error: ',
+        errors.map((graphqlError) => {
+          const fsError = recoverFastStoreError(graphqlError)
+
+          return {
+            message: (graphqlError as { message?: string })?.message,
+            status: fsError?.extensions.status,
+            type: fsError?.extensions.type,
+          }
+        })
+      )
+
+      const status = fastStoreError?.extensions.status ?? 500
+
+      // No recoverable FastStoreError: keep the masked, body-less 500.
+      if (!fastStoreError) {
+        response.status(status).end()
+        return
+      }
+
+      // Only FastStoreError-derived details are exposed. `type`/`status` are a
+      // closed enum (safe everywhere); the free-text `message` may echo raw
+      // upstream text, so it is restricted to non-production responses. The
+      // full message is still available server-side via the log above.
+      const responseError = {
+        extensions: {
+          type: fastStoreError.extensions.type,
+          status: fastStoreError.extensions.status,
+        },
+        ...(process.env.NODE_ENV !== 'production'
+          ? { message: fastStoreError.message }
+          : {}),
+      }
+
+      response.status(status)
+      response.setHeader('content-type', 'application/json')
+      response.send(JSON.stringify({ errors: [responseError] }))
       return
     }
 

--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -244,6 +244,11 @@ const handler: NextApiHandler = async (request, response) => {
 
       const status = fastStoreError?.extensions.status ?? 500
 
+      // Error responses are never cacheable: some upstream statuses (404,
+      // 410, ...) are heuristically cacheable by intermediaries per RFC 9111
+      // §4.2.2, which would let a CDN cache an error for this operation.
+      response.setHeader('cache-control', 'no-store')
+
       // No recoverable FastStoreError: keep the masked, body-less 500.
       if (!fastStoreError) {
         response.status(status).end()

--- a/packages/core/src/sdk/graphql/retryPolicy.ts
+++ b/packages/core/src/sdk/graphql/retryPolicy.ts
@@ -1,0 +1,47 @@
+const MAX_BACKOFF_EXPONENT = 8
+const TOO_MANY_REQUESTS = 429
+
+/** Mirrors SWR's `RevalidatorOptions`. */
+type RetryOptions = { retryCount: number; dedupe?: boolean }
+
+/** Mirrors the subset of SWR's resolved config that the retry policy reads. */
+type RetryConfig = { errorRetryCount?: number; errorRetryInterval: number }
+
+/**
+ * SWR retry policy: never retry an upstream rate limit, retry everything else
+ * exactly as SWR would.
+ *
+ * A 429 means an upstream is already shedding load, so retrying multiplies the
+ * traffic it is trying to reject. Providing `onErrorRetry` replaces SWR's
+ * default implementation entirely, so the fall-through branch mirrors
+ * swr@2.3.1's default (ceiling check plus jittered exponential backoff) to keep
+ * every other status behaving as it did before. Revisit on an SWR upgrade.
+ */
+export const onErrorRetry = (
+  error: unknown,
+  _key: string,
+  config: RetryConfig,
+  revalidate: (opts: RetryOptions) => void,
+  opts: RetryOptions
+) => {
+  if (
+    (error as { status?: number } | undefined)?.status === TOO_MANY_REQUESTS
+  ) {
+    return
+  }
+
+  const maxRetryCount = config.errorRetryCount
+  const { retryCount } = opts
+
+  const timeout =
+    ~~(
+      (Math.random() + 0.5) *
+      (1 << Math.min(retryCount, MAX_BACKOFF_EXPONENT))
+    ) * config.errorRetryInterval
+
+  if (maxRetryCount !== undefined && retryCount > maxRetryCount) {
+    return
+  }
+
+  setTimeout(revalidate, timeout, opts)
+}

--- a/packages/core/src/sdk/graphql/useQuery.ts
+++ b/packages/core/src/sdk/graphql/useQuery.ts
@@ -5,6 +5,7 @@ import { getClientCacheBustingValue } from 'src/utils/cookieCacheBusting'
 
 import type { Operation, RequestOptions } from './request'
 import { request } from './request'
+import { onErrorRetry } from './retryPolicy'
 
 export type QueryOptions = SWRConfiguration &
   RequestOptions & { doNotRun?: boolean }
@@ -34,6 +35,7 @@ export const DEFAULT_OPTIONS = {
   revalidateOnFocus: false,
   revalidateOnReconnect: false,
   shouldRetryOnError: true,
+  onErrorRetry,
 }
 
 export const useQuery = <Data, Variables = Record<string, unknown>>(

--- a/packages/core/test/pages/api/graphql.test.ts
+++ b/packages/core/test/pages/api/graphql.test.ts
@@ -173,4 +173,20 @@ describe('/api/graphql error status propagation', () => {
 
     expect(res.status).toHaveBeenCalledWith(404)
   })
+
+  it('treats an empty errors array as success instead of a 500', async () => {
+    mockedExecute.mockResolvedValue({
+      data: { product: { id: '1' } },
+      errors: [],
+      extensions: { cookies: new Map(), cacheControl: undefined },
+    } as never)
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).not.toHaveBeenCalled()
+    expect(res.send).toHaveBeenCalledWith(
+      JSON.stringify({ data: { product: { id: '1' } }, errors: [] })
+    )
+  })
 })

--- a/packages/core/test/pages/api/graphql.test.ts
+++ b/packages/core/test/pages/api/graphql.test.ts
@@ -1,0 +1,176 @@
+import {
+  BadRequestError,
+  FastStoreError,
+  ForbiddenError,
+  NotFoundError,
+  UnauthorizedError,
+} from '@faststore/api'
+import { GraphQLError } from 'graphql'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import handler from '../../../src/pages/api/graphql'
+import { execute } from '../../../src/server'
+
+jest.mock('../../../src/server', () => ({
+  execute: jest.fn(),
+}))
+
+const mockedExecute = jest.mocked(execute)
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV
+
+const setNodeEnv = (value: string | undefined) => {
+  ;(process.env as Record<string, string | undefined>).NODE_ENV = value
+}
+
+const createResponse = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    end: jest.fn().mockReturnThis(),
+  }
+
+  return res as unknown as NextApiResponse & typeof res
+}
+
+const createRequest = (operationName = 'ClientShippingSimulationQuery') =>
+  ({
+    method: 'GET',
+    headers: { host: 'localhost:3000' },
+    query: {
+      operationName,
+      operationHash: 'hash',
+      variables: '{}',
+    },
+  }) as unknown as NextApiRequest
+
+const mockExecuteWithErrors = (errors: unknown[]) => {
+  mockedExecute.mockResolvedValue({
+    data: null,
+    errors,
+    extensions: { cookies: new Map(), cacheControl: undefined },
+  } as never)
+}
+
+// Reproduces what `useMaskedErrors` produces: a GraphQLError whose
+// `originalError` is the FastStoreError thrown by a resolver/`fetchAPI`.
+// graphql@15 exposes `originalError` as the 6th positional constructor arg.
+const maskedError = (original: FastStoreError) =>
+  new GraphQLError(
+    original.message,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    original
+  )
+
+describe('/api/graphql error status propagation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    setNodeEnv(ORIGINAL_NODE_ENV)
+  })
+
+  it('propagates the upstream 400 from a wrapped BadRequestError instead of 500', async () => {
+    mockExecuteWithErrors([
+      maskedError(new BadRequestError('O campo CEP (88) é inválido')),
+    ])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.end).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['UnauthorizedError', () => new UnauthorizedError('nope'), 401],
+    ['ForbiddenError', () => new ForbiddenError('nope'), 403],
+    ['NotFoundError', () => new NotFoundError('nope'), 404],
+  ])('propagates %s status', async (_name, makeError, expectedStatus) => {
+    mockExecuteWithErrors([maskedError(makeError())])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(expectedStatus)
+  })
+
+  it('propagates an unmapped upstream status (UnknownError 429)', async () => {
+    mockExecuteWithErrors([
+      maskedError(
+        new FastStoreError({ status: 429, type: 'UnknownError' }, 'slow down')
+      ),
+    ])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(429)
+  })
+
+  it('recovers status when the error itself is a FastStoreError (not wrapped)', async () => {
+    mockExecuteWithErrors([new BadRequestError('bad input')])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+  })
+
+  it('falls back to a body-less 500 for non-FastStore errors', async () => {
+    mockExecuteWithErrors([new GraphQLError('Sorry, something went wrong.')])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.end).toHaveBeenCalled()
+    expect(res.send).not.toHaveBeenCalled()
+  })
+
+  it('exposes type, status and message in the body outside production', async () => {
+    setNodeEnv('development')
+    mockExecuteWithErrors([maskedError(new BadRequestError('invalid CEP'))])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    const body = JSON.parse((res.send as jest.Mock).mock.calls[0][0])
+    expect(body.errors[0]).toEqual({
+      extensions: { type: 'BadRequestError', status: 400 },
+      message: 'invalid CEP',
+    })
+  })
+
+  it('omits the free-text message from the body in production', async () => {
+    setNodeEnv('production')
+    mockExecuteWithErrors([maskedError(new BadRequestError('invalid CEP'))])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    const body = JSON.parse((res.send as jest.Mock).mock.calls[0][0])
+    expect(body.errors[0]).toEqual({
+      extensions: { type: 'BadRequestError', status: 400 },
+    })
+    expect(body.errors[0].message).toBeUndefined()
+  })
+
+  it('uses the first recoverable FastStoreError when several errors exist', async () => {
+    mockExecuteWithErrors([
+      new GraphQLError('plain error'),
+      maskedError(new NotFoundError('missing')),
+      maskedError(new BadRequestError('bad')),
+    ])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.status).toHaveBeenCalledWith(404)
+  })
+})

--- a/packages/core/test/pages/api/graphql.test.ts
+++ b/packages/core/test/pages/api/graphql.test.ts
@@ -174,6 +174,15 @@ describe('/api/graphql error status propagation', () => {
     expect(res.status).toHaveBeenCalledWith(404)
   })
 
+  it('sets cache-control: no-store on error responses so a bare 404/410 is not cached by intermediaries', async () => {
+    mockExecuteWithErrors([maskedError(new NotFoundError('missing'))])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.setHeader).toHaveBeenCalledWith('cache-control', 'no-store')
+  })
+
   it('treats an empty errors array as success instead of a 500', async () => {
     mockedExecute.mockResolvedValue({
       data: { product: { id: '1' } },

--- a/packages/core/test/sdk/graphql/retryPolicy.test.ts
+++ b/packages/core/test/sdk/graphql/retryPolicy.test.ts
@@ -1,0 +1,127 @@
+import { onErrorRetry } from '../../../src/sdk/graphql/retryPolicy'
+
+const ERROR_RETRY_INTERVAL = 5000
+
+const createConfig = (overrides: Record<string, unknown> = {}) =>
+  ({
+    errorRetryCount: 3,
+    errorRetryInterval: ERROR_RETRY_INTERVAL,
+    ...overrides,
+  }) as never
+
+// The client throws the object built by `baseRequest` in `request.ts`, which
+// carries the HTTP status — not an Error instance.
+const clientError = (status?: number) =>
+  ({ status, message: 'upstream failure' }) as never
+
+const runRetry = ({
+  error,
+  retryCount = 0,
+  config = createConfig(),
+}: {
+  error: unknown
+  retryCount?: number
+  config?: never
+}) => {
+  const revalidate = jest.fn()
+
+  onErrorRetry(error as never, 'a-key', config, revalidate, {
+    retryCount,
+    dedupe: false,
+  })
+
+  jest.runAllTimers()
+
+  return revalidate
+}
+
+describe('useQuery retry policy', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    // Pins SWR's jitter so the backoff assertions are deterministic.
+    jest.spyOn(Math, 'random').mockReturnValue(0.5)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it('never retries an upstream rate limit (429)', () => {
+    expect(runRetry({ error: clientError(429) })).not.toHaveBeenCalled()
+  })
+
+  it('does not retry a 429 even on the first attempt of a fresh key', () => {
+    const revalidate = runRetry({ error: clientError(429), retryCount: 0 })
+
+    expect(revalidate).not.toHaveBeenCalled()
+  })
+
+  it.each([400, 401, 403, 404, 409, 422, 500, 502, 503])(
+    'still retries status %i',
+    (status) => {
+      expect(runRetry({ error: clientError(status) })).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('still retries an error carrying no status (e.g. network failure)', () => {
+    expect(runRetry({ error: clientError(undefined) })).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries while at the errorRetryCount ceiling', () => {
+    expect(
+      runRetry({ error: clientError(500), retryCount: 3 })
+    ).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops retrying once errorRetryCount is exceeded', () => {
+    expect(
+      runRetry({ error: clientError(500), retryCount: 4 })
+    ).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [0, 1 * ERROR_RETRY_INTERVAL],
+    [2, 4 * ERROR_RETRY_INTERVAL],
+    [3, 8 * ERROR_RETRY_INTERVAL],
+  ])(
+    'mirrors SWR exponential backoff for retryCount %i',
+    (retryCount, expectedTimeout) => {
+      const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout')
+      const revalidate = jest.fn()
+
+      onErrorRetry(
+        clientError(500),
+        'a-key',
+        createConfig({ errorRetryCount: 10 }),
+        revalidate,
+        { retryCount, dedupe: false }
+      )
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(
+        revalidate,
+        expectedTimeout,
+        expect.objectContaining({ retryCount })
+      )
+    }
+  )
+
+  it('caps the backoff exponent at 8, as SWR does', () => {
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout')
+    const revalidate = jest.fn()
+
+    onErrorRetry(
+      clientError(500),
+      'a-key',
+      createConfig({ errorRetryCount: 100 }),
+      revalidate,
+      { retryCount: 12, dedupe: false }
+    )
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(
+      revalidate,
+      256 * ERROR_RETRY_INTERVAL,
+      expect.objectContaining({ retryCount: 12 })
+    )
+  })
+})

--- a/packages/core/test/sdk/graphql/retryPolicy.test.ts
+++ b/packages/core/test/sdk/graphql/retryPolicy.test.ts
@@ -43,8 +43,10 @@ describe('useQuery retry policy', () => {
   })
 
   afterEach(() => {
-    jest.useRealTimers()
+    // Restore mocks before reinstating real timers, so the `setTimeout` spy
+    // is not put back onto `globalThis` while timers are still faked.
     jest.restoreAllMocks()
+    jest.useRealTimers()
   })
 
   it('never retries an upstream rate limit (429)', () => {


### PR DESCRIPTION
## What's the purpose of this pull request?

Two related fixes to how **v3** reports and reacts to upstream failures. They are bundled because they only work together (see *Why one PR*).

Automated crawlers periodically hit a store's public routes and trip the *"Increased 5XX error rate by account and cluster"* alert, remediated so far only by manual, per-incident IP blocks that never converge (the offender rotates IPs). Investigation showed the "5xx" is largely an **artifact**:

1. A low-volume bot (~20 req/s) trips VTEX **per-account upstream rate limits**, which answer `429`.
2. The v3 BFF **mislabels that `429` as `500`**, which is what fires the 5xx alert.

This PR fixes (2), and adds a client-side guard so a `429` is never retried once retries are actually live (see *Status* below — that guard does nothing observable today on `3.x`). Nothing here blocks or throttles legitimate crawlers.

### Why one PR

The status fix and the retry guard are reviewed together because the retry guard needs the status fix to ever see a `429` client-side (today the BFF's `500` masks it) — but see *Status*, the retry guard is not currently reachable at all, for an independent reason.

## Status: the retry guard is inert on `3.x` today

Corrected after review from [lariciamota on this PR](https://github.com/vtex/faststore/pull/3420#issuecomment) and the identical finding on the `dev` sibling, [#3453](https://github.com/vtex/faststore/pull/3453) (verified independently on both branches):

`useQuery`'s fetcher never lets a rejection reach SWR:

```ts
// packages/core/src/sdk/graphql/useQuery.ts
fetcher: () => new Promise((resolve) => {
  setTimeout(async () => { resolve(await request(...)) }) // a rejection is dropped here
})
```

If `request()` rejects, the `await` throws inside the `async` callback, `resolve` is never called, and the outer promise stays pending forever. SWR never sees an error, so `onErrorRetry`, `errorRetryCount: 3` and `shouldRetryOnError: true` on `DEFAULT_OPTIONS` have never taken effect for `useQuery` — on either branch, and since the commit that created `@faststore/core`.

What follows from that, specifically for `3.x`:

- **The "storefront retries 3×, tripling the load" premise does not hold.** Product-query traffic goes through `useQuery`, and that path cannot retry today. The originally-cited amplification has other causes — chiefly the per-page-view fanout of `ValidateSession`/`ValidateCartMutation`, which call `request()` directly with no SWR involved and no retry loop, and are outside what this policy (even once live) can reach.
- **This half of the PR changes no observable behavior right now.**
- **It's still worth landing here.** It's correct (mirrors `swr@2.3.1`'s default exactly, tests pin both branches), and landing it now means it's already in place *before* the `useQuery` fetcher bug is fixed elsewhere — so there's no window where retries go live for `429` without the guard.

The status-propagation half (part 1) does **not** depend on this and stands on its own: it fixes real 5xx mislabeling and log/consumer visibility regardless of whether client retries are active.

## How it works?

### 1. Propagate the upstream error status (backport of [#3379](https://github.com/vtex/faststore/pull/3379))

The GraphQL BFF (`/api/graphql` handler in `@faststore/core`) collapsed **every** error into HTTP `500`, even when the upstream VTEX error was a client error (`400/401/403/404/429/...`). For example, an invalid `postalCode` in the shipping simulation makes VTEX Checkout return `400`, but the storefront received `500`, hiding the real cause from consumers and server logs.

**Root cause:** after `useMaskedErrors`, the `errors` array holds `GraphQLError` instances (`name === 'GraphQLError'`). The handler used `errors.find(isFastStoreError)`, which checks `name === 'FastStoreError'` and therefore never matched — the real `FastStoreError` (carrying `extensions.status`) is nested in `originalError`. So the status always fell back to `500`.

Changes in `packages/core/src/pages/api/graphql.ts`:

- Added `recoverFastStoreError` to unwrap the `FastStoreError` whether it is the error itself or nested in the `originalError` of a masked `GraphQLError`.
- `hasErrors` now also checks `errors.length > 0`. Without this, an empty `errors` array fell into the error branch, found nothing recoverable, and answered `500` — another spurious 5xx.
- The handler responds with the recovered `extensions.status` (still `?? 500` as the safe default).
- For a recovered `FastStoreError`, the JSON body exposes `extensions.type` and `extensions.status` always; the free-text `message` is included **only when `NODE_ENV !== 'production'`** (and always logged server-side).
- Non-`FastStoreError`s keep the masked, body-less `500` (error masking unchanged).
- The error branch now sets `cache-control: no-store`. A bare `404`/`410` (previously always a `500`) is heuristically cacheable by intermediaries per RFC 9111 §4.2.2; without this an error for a given `/api/graphql?operationName=...` could get cached at a CDN. *(Added per review.)*

`fetchAPI` already preserved the upstream status (its `default` branch throws `FastStoreError({ status, type: 'UnknownError' })`), so **no change to `@faststore/api`** was needed — the status was being produced correctly and discarded downstream.

> **v3 adaptation notes.** The handler code is a 1:1 port of #3379, with two deliberate deviations. (a) The original test targets the `dev`/v4 toolchain (Vitest + graphql 16); on `3.x` core uses **Jest** and **graphql 15**, so the test was adapted: `vi` → `jest`, `vi.stubEnv` → manual `NODE_ENV` handling, and the masked-error helper uses graphql 15's positional `originalError` constructor argument. (b) v4's version of this block also calls `OTELLogger`, which does not exist anywhere in `3.x`; here the structured payload goes to `console.error` only, rather than adding that dependency to a maintenance branch.

### 2. Never retry an upstream `429` (pre-emptive guard, see *Status*)

`DEFAULT_OPTIONS` in `packages/core/src/sdk/graphql/useQuery.ts` sets `errorRetryCount: 3` and `shouldRetryOnError: true`. Retrying a `429` would multiply exactly the traffic the upstream is trying to reject, whenever those retries do run — so the guard is added now rather than left for whoever fixes the fetcher bug to remember.

- The policy lives in a new `packages/core/src/sdk/graphql/retryPolicy.ts` and is wired in as `DEFAULT_OPTIONS.onErrorRetry`. It is a separate module so it can be unit-tested without pulling the session/SDK graph in through `useQuery`.
- No plumbing was needed to see the status client-side: `baseRequest` in `request.ts` already builds `{ status, message }` from `response.status` and `request` throws it. Note it is a **plain object, not an `Error`**, hence the `error?.status` read.
- **Important for review:** providing `onErrorRetry` **replaces SWR's default implementation entirely** — it does not compose. So the fall-through branch mirrors `swr@2.3.1`'s default (the `errorRetryCount` ceiling plus the jittered exponential backoff, capped at `1 << 8`) to keep every other status retrying exactly as it does today. The tests pin both branches, and `Math.random` is stubbed so the backoff assertions are exact. This is the one spot to revisit on an SWR upgrade.
- Narrowing to `429` is deliberate: it is the only status the bot induces, and touching other 4xx risks regressing flows that may rely on a retry. The `401`/refresh-token recovery is a separate explicit path in the session SDK, not SWR-retry-driven, so it is unaffected.

## Behavior changes (for the changelog)

- The BFF now returns accurate upstream statuses (`429`/`400`/`404`/...) instead of a blanket `500`. Intended, from #3379. Consumers treating "any non-200" as failure are unaffected; consumers branching specifically on `500` will now see the real code.
- BFF error responses now set `cache-control: no-store`.
- An empty `errors` array is treated as success instead of `500`.
- A `429` is no longer retried by the client, but this has **no observable effect today** — see *Status*. Once the unrelated `useQuery` fetcher bug is fixed, all other statuses will retry exactly as before; only `429` changes.
- No schema or public-API signature changes.

As a side effect, once bot-induced `429`s stop being reported as `500`, they drop out of the `5xx` metric and the existing alert self-corrects — no suppression rules to maintain. This holds regardless of the retry guard's status.

## How to test it?

Unit tests (30 assertions across the two halves):

```sh
cd packages/core
pnpm test -- test/pages/api/graphql.test.ts        # 12 passing
pnpm test -- test/sdk/graphql/retryPolicy.test.ts  # 18 passing
```

The handler tests were also confirmed to **fail** against `3.x` without this change (9 of 11), so they are pinning real behavior rather than the implementation.

Manually, against a store:

- Trigger a shipping simulation with an invalid `postalCode` (e.g. `555`) → `/api/graphql` should return `400` (was `500`).
- Confirm a genuine upstream `500` still returns `500`.
- In a non-production build, confirm the JSON error body carries `extensions.type`, `extensions.status` and `message`; in production the `message` is omitted.
- The `429`-no-retry behavior is exercised directly in `retryPolicy.test.ts`; it is not currently observable end-to-end (see *Status*).

## Follow-ups (not in this PR)

- **The `useQuery` fetcher bug.** The dropped rejection is a real bug independent of `429`: today any query error leaves the component loading forever, with no error state. Needs its own PR and review: two consumers use `suspense: true`, where a rejecting fetcher throws to the global `ErrorBoundary`, which does a hard `window.location.href = '/500'` — itself a fresh page load firing more uncacheable mutations. Fixing this is also what makes the `429` guard in this PR load-bearing for the first time.
- **The validation fanout.** `ValidateSession`/`ValidateCartMutation` fire once per page load, unconditionally, including with an empty cart, and are the dominant source of bot-induced traffic per SO-631 (not reachable by any SWR-level retry policy since they bypass SWR entirely). An empty-cart gate would remove most of it, taking care to preserve the sales-channel sync `validateCart` also performs.
- The "elevated `429` rate across multiple client IPs" signal and the detect → stopgap → recommend runbook are Grafana/process work, meaningful once the fetcher bug is fixed and the guard becomes live.
- Honoring `Retry-After` (instead of just skipping the retry) would need the header captured in `fetchAPI`, carried on the error, set on the BFF response and honored in SWR — a cross-package change, deliberately out of scope.

## References

- Original v4 PR: [#3379](https://github.com/vtex/faststore/pull/3379)
- v4 sibling for the retry guard: [#3453](https://github.com/vtex/faststore/pull/3453) (same "inert today" finding, same resolution)
- [Jira Task SFS-2997](https://vtex-dev.atlassian.net/browse/SFS-2997)
- [Jira SO-631](https://vtex-dev.atlassian.net/browse/SO-631) — "Avaliar FS para lidar com comportamentos de crawlers/bots em rotas públicas"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL error responses with accurate HTTP status and error type details.
  * Preserved secure production responses while providing additional diagnostic messages in non-production environments.
  * Prevented automatic retries for rate-limit errors.
  * Added controlled retries with exponential backoff for other GraphQL failures.
  * Disabled caching for GraphQL error responses.

* **Tests**
  * Added coverage for error handling, status propagation, retry limits, rate limiting, and backoff behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
