### PR TITLE
fix(api): keep excludent productClusterIds as repeated path facets

### DIFF
--- a/packages/api/src/platforms/vtex/utils/intelligentSearchRequest.ts
+++ b/packages/api/src/platforms/vtex/utils/intelligentSearchRequest.ts
@@ -30,7 +30,6 @@ type SegmentParams = {
   utmiCampaign?: string
   campaigns?: string
   priceTables?: string
-  productClusterIds?: string
 }
 
 export type Sort =
@@ -117,8 +116,6 @@ const SHIPPING_FACET_KEYS = new Set([
   'pickupPointsHash',
 ])
 
-const QUERY_PARAM_FACET_KEYS = new Set(['productClusterIds'])
-
 const encodeSafeURI = (uri: string) => encodeURI(decodeURI(uri))
 
 const removeDiacriticsFromURL = (url: string) =>
@@ -160,11 +157,9 @@ export function parseSegmentCookie(
 
 function parseSegmentFacetsString(facetsStr: string): {
   shipping: Record<string, string>
-  queryParams: Record<string, string>
   extraFacets: IntelligentSearchFacet[]
 } {
   const shipping: Record<string, string> = {}
-  const queryParams: Record<string, string> = {}
   const extraFacets: IntelligentSearchFacet[] = []
 
   for (const pair of facetsStr.split(';')) {
@@ -179,14 +174,15 @@ function parseSegmentFacetsString(facetsStr: string): {
 
     if (SHIPPING_FACET_KEYS.has(key)) {
       shipping[key] = value
-    } else if (QUERY_PARAM_FACET_KEYS.has(key)) {
-      queryParams[key] = value
     } else {
+      // NOTE: productClusterIds (and any other repeated facet key, e.g. for
+      // excludent collections) must stay as path segments, not collapse into
+      // a single query param — IS expects productClusterIds/X/productClusterIds/not:Y/.
       extraFacets.push({ key, value })
     }
   }
 
-  return { shipping, queryParams, extraFacets }
+  return { shipping, extraFacets }
 }
 
 function extractSegmentData(segment: Record<string, unknown>): {
@@ -194,8 +190,7 @@ function extractSegmentData(segment: Record<string, unknown>): {
   extraFacets: IntelligentSearchFacet[]
 } {
   const facetsStr = typeof segment.facets === 'string' ? segment.facets : ''
-  const { shipping, queryParams, extraFacets } =
-    parseSegmentFacetsString(facetsStr)
+  const { shipping, extraFacets } = parseSegmentFacetsString(facetsStr)
 
   return {
     segmentParams: {
@@ -214,7 +209,6 @@ function extractSegmentData(segment: Record<string, unknown>): {
       campaigns:
         typeof segment.campaigns === 'string' ? segment.campaigns : undefined,
       priceTables: (segment.priceTables as string | undefined) ?? undefined,
-      productClusterIds: queryParams.productClusterIds,
     },
     extraFacets,
   }
@@ -239,7 +233,6 @@ function appendSegmentParams(
     ['utmiCampaign', segmentParams.utmiCampaign],
     ['campaigns', segmentParams.campaigns],
     ['priceTables', segmentParams.priceTables],
-    ['productClusterId', segmentParams.productClusterIds],
   ]
 
   for (const [key, value] of entries) {

--- a/packages/api/test/unit/platforms/vtex/utils/intelligentSearchRequest.test.ts
+++ b/packages/api/test/unit/platforms/vtex/utils/intelligentSearchRequest.test.ts
@@ -486,7 +486,7 @@ describe('buildIntelligentSearchRequest', () => {
         },
       })
 
-      expect(request.path).toBe('brand/nike/')
+      expect(request.path).toBe('brand/nike/productClusterIds/158/')
 
       expect(paramsToObject(request.params)).toEqual({
         from: '24',
@@ -496,11 +496,30 @@ describe('buildIntelligentSearchRequest', () => {
         regionId: 'v2.7DCB7CD533993562A2FC4EAFEC6B3DB4',
         country: 'USA',
         locale: 'en-US',
-        productClusterId: '158',
         hideUnavailableItems: 'false',
         showSponsored: 'true',
         allowRedirect: 'false',
       })
+    })
+
+    it('keeps both an inclusion and an exclusion productClusterIds facet as separate path segments', () => {
+      const request = buildIntelligentSearchRequest({
+        endpoint: 'product-search',
+        segment: {
+          facets: 'productClusterIds=80182;productClusterIds=not:80183',
+        },
+        defaults: { locale: 'en-US', salesChannel: 1 },
+        args: {
+          page: 0,
+          count: 12,
+          selectedFacets: [{ key: 'category-1', value: 'furniture' }],
+        },
+      })
+
+      expect(request.path).toBe(
+        'category-1/furniture/productClusterIds/80182/productClusterIds/not%3A80183/'
+      )
+      expect(paramsToObject(request.params).productClusterId).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix a FastStore Intelligent Search bug (found while triaging a report on the odpstage account, Slack thread) where an excludent collection filter silently does nothing: products from an excluded `productClusterIds` cluster keep showing up even though the session facets correctly ask to exclude them.

## How it works?

Since the IS v1 migration, `intelligentSearchRequest.ts` treated `productClusterIds` segment facets as a single query param, stored in a plain JS object keyed by `productClusterIds`. When the session sends **two** facets sharing that key — one inclusion (`productClusterIds=80182`) and one exclusion (`productClusterIds=not:80183`) — the second silently overwrites the first in the object, and the one value that survives is still sent in the wrong shape: a singular `productClusterId` query param, which Intelligent Search does not recognize.

IS actually expects each occurrence as a repeated **path** segment (confirmed with a manual request against the account's IS endpoint):
```
.../product_search/productClusterIds/80182/productClusterIds/not:80183
```

The fix removes the special single-value query-param handling for `productClusterIds` so it flows through the same `extraFacets`/path pipeline as any other repeated facet, producing the correct repeated path segments.

## How to test it?

- Unit tests added/updated in `packages/api/test/unit/platforms/vtex/utils/intelligentSearchRequest.test.ts`:
  - Updated the existing `productClusterIds` cookie test to assert the corrected path-based output.
  - Added a new test reproducing the reported scenario (simultaneous inclusion + exclusion facets), asserting both survive as separate path segments and that no `productClusterId` query param is emitted anymore.
- Ran the full `packages/api` unit suite locally: all tests passing.
- Reproduced locally against the affected account's real discovery config (with CMS tenant set to `vtex` defaults) to confirm this is a framework bug, not an account customization issue, before implementing the fix.

## References

Reported and investigated in an internal Slack thread (Search & Recommendation team) about the odpstage account's excludent collection filter not working on Intelligent Search.

## Checklist

- [x] PR title and commit messages follow the Conventional Commits specification
- [x] Added a label according to the PR goal
- [x] No `pnpm-lock.yaml` changes (no dependency changes)
- [x] PR description filled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected product-cluster filtering so inclusion and exclusion facets are preserved in the request path.
  * Prevented product-cluster filters from being incorrectly converted into query parameters.
  * Preserved repeated facet keys for more accurate search requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->