### PR TITLE
fix: restore account, path, port arg order on cli dev command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,7 +84,7 @@ Versioning and publishing are managed at the monorepo root by Lerna. Do not publ
 * [`faststore cache-graphql [STORE]`](#faststore-cache-graphql-store)
 * [`faststore cms-sync [PATH]`](#faststore-cms-sync-path)
 * [`faststore create [PATH]`](#faststore-create-path)
-* [`faststore dev [PATH] [ACCOUNT] [PORT]`](#faststore-dev-path-account-port)
+* [`faststore dev [ACCOUNT] [PATH] [PORT]`](#faststore-dev-account-path-port)
 * [`faststore generate`](#faststore-generate)
 * [`faststore help [COMMAND]`](#faststore-help-command)
 * [`faststore prepare [PATH]`](#faststore-prepare-path)
@@ -151,15 +151,15 @@ EXAMPLES
   $ yarn faststore create discovery
 ```
 
-## `faststore dev [PATH] [ACCOUNT] [PORT]`
+## `faststore dev [ACCOUNT] [PATH] [PORT]`
 
 ```
 USAGE
-  $ faststore dev [PATH] [ACCOUNT] [PORT] [--watch-plugins]
+  $ faststore dev [ACCOUNT] [PATH] [PORT] [--watch-plugins]
 
 ARGUMENTS
-  [PATH]     The path where the FastStore being run is. Defaults to cwd.
   [ACCOUNT]  The account for which the Discovery is running. Currently noop.
+  [PATH]     The path where the FastStore being run is. Defaults to cwd.
   [PORT]     The port where FastStore should run. Defaults to 3000.
 
 FLAGS

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -126,15 +126,15 @@ function copyGenerated(from: string, to: string) {
 
 export default class Dev extends Command {
   static args = {
-    path: Args.string({
-      name: 'path',
-      description:
-        'The path where the FastStore being run is. Defaults to cwd.',
-    }),
     account: Args.string({
       name: 'account',
       description:
         'The account for which the Discovery is running. Currently noop.',
+    }),
+    path: Args.string({
+      name: 'path',
+      description:
+        'The path where the FastStore being run is. Defaults to cwd.',
     }),
     port: Args.string({
       name: 'port',


### PR DESCRIPTION
## What's the purpose of this pull request?

Restores the `account, path, port` positional argument order on the `faststore dev` command, matching `build` (`account, path`), `serve` (`account, path, port`) and the [FastStore Platform Spec](https://github.com/vtex/faststore-platform/blob/main/docs/specification.md).

The inversion was an unintended side effect of the oclif migration in #3111: `static args` went from an array to an object, and since positional order now follows key order, `path` ended up ahead of `account` — on `dev` only. `build` and `serve` were migrated in the same commit and kept the original order (introduced deliberately in #2491 to comply with the spec).

The impact is on the FastStore Platform CLI, which calls the module commands positionally:

```ts
// vtex/faststore-platform packages/cli/src/commands/dev.ts
return dev.run([account, path, port?.toString() ?? ''])
```

With the current v4 order, the account name lands in `args.path`, so `getBasePath()` resolves the base path to a directory named after the account. `build.run([account, path])` and `serve.run([account, path, port])` are unaffected because those commands kept the correct order.

## Is this a breaking change?

No known consumer depends on the current v4 order:

- **Stores:** a code search for `"faststore dev"` in `package.json` across GitHub returns 50+ stores, all using `"dev": "faststore dev"` with no positional arguments. Since all three args are optional, those are unaffected.
- **Programmatic callers:** searching for `loadedCli` across the `vtex` org returns only `vtex/faststore-platform`, which already uses the spec order for `dev`, `build` and `serve`.
- **This monorepo:** nothing invokes `faststore dev` with positional arguments. `@faststore/core`'s `dev` script is `next dev`, and the internal spawns inside `dev.ts` target `generate-types`, `cache-graphql` and `generate-i18n` with an explicit `basePath`.
- **CI/CD:** pipelines run `build` and `serve`, never `dev`.

Passing a path as the single positional (`faststore dev ./store`) never worked on v3 either, since `account` has always been the first argument there.

`account` remains a noop — `run()` only reads `args.path` and `args.port` — so this changes nothing beyond the positional mapping.

## How to test it?

Install the version generated by the codesandbox check in a monorepo store and run `fsp dev <account>`. The dev server should start at the module path declared in `faststore.json` instead of failing to resolve a directory named after the account.

For a single store, `yarn dev` (i.e. `faststore dev` with no arguments) should behave exactly as before.

## References

- Spec: https://github.com/vtex/faststore-platform/blob/main/docs/specification.md
- Order introduced in #2491
- Order accidentally inverted in #3111


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `faststore dev` command documentation to list `ACCOUNT` before `PATH`.
  * Revised the command usage, heading, index, and argument descriptions.

* **Bug Fixes**
  * Corrected positional argument ordering for the `faststore dev` command: `ACCOUNT`, `PATH`, then `PORT`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->