### PR TITLE
ci: build CLI before core generate in back-merge

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -106,8 +106,13 @@ jobs:
         if: steps.prep.outputs.skip == 'false'
         run: |
           pnpm i
+          # core#generate shells out to the CLI binary, which must be compiled
+          # first (see turbo.json: @faststore/core#generate → @faststore/cli#build).
+          # api must be built before the CLI because generate-types imports
+          # GraphqlVtexSchema from @faststore/api at runtime.
           pnpm --filter @faststore/api build
           pnpm --filter @faststore/api generate
+          pnpm --filter @faststore/cli build
           pnpm --filter @faststore/core generate
           git add -A
 


### PR DESCRIPTION
## What's the purpose of this pull request?

The automated back-merge after a `main` release/hotfix was firing but failing before opening the sync PR to `dev`. After the `4.5.1` hotfix (#3437), [run 31502187816](https://github.com/vtex/faststore/actions/runs/31502187816) died on `pnpm --filter @faststore/core generate` with `MODULE_NOT_FOUND` for `packages/cli/dist/index.js`.

## How it works?

`@faststore/core#generate` shells out to the CLI (`node ../cli/bin/run generate-types`), which requires a built `packages/cli/dist`. That dependency is already encoded in `turbo.json` (`@faststore/core#generate` → `@faststore/cli#build`), but `back-merge.yml` skipped the CLI build.

This PR adds `pnpm --filter @faststore/cli build` after the API build/generate and before the core generate step.

## How to test it?

- [ ] Merge this PR to `dev` (default branch — `workflow_run` always uses the workflow file from there)
- [ ] Re-run the failed back-merge: https://github.com/vtex/faststore/actions/runs/31502187816
- [ ] Confirm it opens `chore: update dev with main (v4.5.1)` (or equivalent) targeting `dev`

### Starters Deploy Preview

N/A — CI workflow only.

## References

- Failed back-merge after hotfix: https://github.com/vtex/faststore/actions/runs/31502187816
- Related hotfix: https://github.com/vtex/faststore/pull/3437
- Same failure pattern on graduate 4.5.0: https://github.com/vtex/faststore/actions/runs/30858525928

## Checklist

**PR Title and Commit Messages**

- [x] PR title and commit messages follow Conventional Commits (`ci`)

**PR Description**

- [ ] Added a label according to the PR goal

**Dependencies**

- [x] N/A — no package changes

**Documentation**

- [x] PR description

Made with [Cursor](https://cursor.com)