### PR TITLE
feat: render images in RichText via a custom Lexical image node

### DIFF
--- a/packages/core/src/components/ui/RichText/RichText.tsx
+++ b/packages/core/src/components/ui/RichText/RichText.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lexical'
 import { RichText as UIRichText } from '@faststore/ui'
 import { isContentPlatformSource } from 'src/server/content/utils'
+import { RichTextImageNode } from './RichTextImageNode'
 
 export interface RichTextProps {
   /**
@@ -124,6 +125,7 @@ function lexicalToHtml(content: string) {
       ListItemNode,
       CodeNode,
       HorizontalRuleNode,
+      RichTextImageNode,
     ],
     onError: (error) => {
       throw error

--- a/packages/core/src/components/ui/RichText/RichTextImageNode.ts
+++ b/packages/core/src/components/ui/RichText/RichTextImageNode.ts
@@ -35,9 +35,11 @@ function resolveAlignment(alignment: unknown): ImageAlignment {
 }
 
 function resolveWidthPercent(widthPercent: unknown): number {
-  return typeof widthPercent === 'number' && widthPercent > 0
-    ? widthPercent
-    : DEFAULT_WIDTH_PERCENT
+  if (typeof widthPercent !== 'number' || widthPercent <= 0) {
+    return DEFAULT_WIDTH_PERCENT
+  }
+
+  return Math.min(widthPercent, DEFAULT_WIDTH_PERCENT)
 }
 
 function withVtexResizeParams(src: string, widthPercent: number): string {
@@ -78,8 +80,8 @@ export class RichTextImageNode extends DecoratorNode<null> {
     super(key)
     this.__src = src
     this.__altText = altText
-    this.__alignment = alignment
-    this.__widthPercent = widthPercent
+    this.__alignment = resolveAlignment(alignment)
+    this.__widthPercent = resolveWidthPercent(widthPercent)
   }
 
   static getType(): string {
@@ -106,8 +108,8 @@ export class RichTextImageNode extends DecoratorNode<null> {
     return new RichTextImageNode(
       typeof serializedNode.src === 'string' ? serializedNode.src : '',
       typeof serializedNode.altText === 'string' ? serializedNode.altText : '',
-      resolveAlignment(serializedNode.alignment),
-      resolveWidthPercent(serializedNode.widthPercent)
+      serializedNode.alignment,
+      serializedNode.widthPercent
     )
   }
 

--- a/packages/core/src/components/ui/RichText/RichTextImageNode.ts
+++ b/packages/core/src/components/ui/RichText/RichTextImageNode.ts
@@ -1,0 +1,164 @@
+import {
+  DecoratorNode,
+  type DOMExportOutput,
+  type EditorConfig,
+  type LexicalEditor,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread,
+} from 'lexical'
+
+export type ImageAlignment = 'left' | 'center' | 'right'
+
+export type SerializedRichTextImageNode = Spread<
+  {
+    type: 'image'
+    version: 1
+    src: string
+    altText: string
+    alignment: ImageAlignment
+    widthPercent: number
+  },
+  SerializedLexicalNode
+>
+
+const VALID_ALIGNMENTS: ImageAlignment[] = ['left', 'center', 'right']
+const DEFAULT_ALIGNMENT: ImageAlignment = 'left'
+const DEFAULT_WIDTH_PERCENT = 100
+const RICH_TEXT_CONTENT_MAX_WIDTH = 720
+const DEFAULT_IMAGE_QUALITY = 8
+
+function resolveAlignment(alignment: unknown): ImageAlignment {
+  return VALID_ALIGNMENTS.includes(alignment as ImageAlignment)
+    ? (alignment as ImageAlignment)
+    : DEFAULT_ALIGNMENT
+}
+
+function resolveWidthPercent(widthPercent: unknown): number {
+  return typeof widthPercent === 'number' && widthPercent > 0
+    ? widthPercent
+    : DEFAULT_WIDTH_PERCENT
+}
+
+function withVtexResizeParams(src: string, widthPercent: number): string {
+  if (!src.includes('vtexassets') || !src.includes('/assets')) {
+    return src
+  }
+
+  try {
+    const url = new URL(src)
+    const targetWidth = Math.max(
+      1,
+      Math.round((RICH_TEXT_CONTENT_MAX_WIDTH * widthPercent) / 100)
+    )
+
+    url.searchParams.set('width', targetWidth.toString())
+    url.searchParams.set('aspect', 'true')
+    url.searchParams.set('quality', DEFAULT_IMAGE_QUALITY.toString())
+
+    return url.toString()
+  } catch {
+    return src
+  }
+}
+
+export class RichTextImageNode extends DecoratorNode<null> {
+  __src: string
+  __altText: string
+  __alignment: ImageAlignment
+  __widthPercent: number
+
+  constructor(
+    src: string,
+    altText: string,
+    alignment: ImageAlignment = DEFAULT_ALIGNMENT,
+    widthPercent: number = DEFAULT_WIDTH_PERCENT,
+    key?: NodeKey
+  ) {
+    super(key)
+    this.__src = src
+    this.__altText = altText
+    this.__alignment = alignment
+    this.__widthPercent = widthPercent
+  }
+
+  static getType(): string {
+    return 'image'
+  }
+
+  static clone(node: RichTextImageNode): RichTextImageNode {
+    return new RichTextImageNode(
+      node.__src,
+      node.__altText,
+      node.__alignment,
+      node.__widthPercent,
+      node.__key
+    )
+  }
+
+  static importDOM(): null {
+    return null
+  }
+
+  static importJSON(
+    serializedNode: SerializedRichTextImageNode
+  ): RichTextImageNode {
+    return new RichTextImageNode(
+      typeof serializedNode.src === 'string' ? serializedNode.src : '',
+      typeof serializedNode.altText === 'string' ? serializedNode.altText : '',
+      resolveAlignment(serializedNode.alignment),
+      resolveWidthPercent(serializedNode.widthPercent)
+    )
+  }
+
+  exportJSON(): SerializedRichTextImageNode {
+    return {
+      type: 'image',
+      version: 1,
+      src: this.__src,
+      altText: this.__altText,
+      alignment: this.__alignment,
+      widthPercent: this.__widthPercent,
+    }
+  }
+
+  isInline(): boolean {
+    return false
+  }
+
+  createDOM(_config: EditorConfig, _editor: LexicalEditor): HTMLElement {
+    return document.createElement('div')
+  }
+
+  updateDOM(): boolean {
+    return false
+  }
+
+  decorate(): null {
+    return null
+  }
+
+  exportDOM(_editor: LexicalEditor): DOMExportOutput {
+    if (!this.__src) {
+      return { element: null }
+    }
+
+    const wrapper = document.createElement('div')
+    wrapper.setAttribute('data-fs-rich-text-image-wrapper', '')
+    wrapper.setAttribute('data-fs-rich-text-image-alignment', this.__alignment)
+
+    const img = document.createElement('img')
+    img.setAttribute('data-fs-rich-text-image', '')
+    img.setAttribute(
+      'src',
+      withVtexResizeParams(this.__src, this.__widthPercent)
+    )
+    img.setAttribute('alt', this.__altText)
+    img.setAttribute('loading', 'lazy')
+    img.setAttribute('style', `width: ${this.__widthPercent}%`)
+
+    wrapper.append(img)
+
+    return { element: wrapper }
+  }
+}

--- a/packages/core/src/components/ui/RichText/RichTextImageNode.ts
+++ b/packages/core/src/components/ui/RichText/RichTextImageNode.ts
@@ -22,14 +22,14 @@ export type SerializedRichTextImageNode = Spread<
   SerializedLexicalNode
 >
 
-const VALID_ALIGNMENTS: ImageAlignment[] = ['left', 'center', 'right']
+const VALID_ALIGNMENTS = new Set<ImageAlignment>(['left', 'center', 'right'])
 const DEFAULT_ALIGNMENT: ImageAlignment = 'left'
 const DEFAULT_WIDTH_PERCENT = 100
 const RICH_TEXT_CONTENT_MAX_WIDTH = 720
 const DEFAULT_IMAGE_QUALITY = 8
 
 function resolveAlignment(alignment: unknown): ImageAlignment {
-  return VALID_ALIGNMENTS.includes(alignment as ImageAlignment)
+  return VALID_ALIGNMENTS.has(alignment as ImageAlignment)
     ? (alignment as ImageAlignment)
     : DEFAULT_ALIGNMENT
 }
@@ -146,18 +146,15 @@ export class RichTextImageNode extends DecoratorNode<null> {
     }
 
     const wrapper = document.createElement('div')
-    wrapper.setAttribute('data-fs-rich-text-image-wrapper', '')
-    wrapper.setAttribute('data-fs-rich-text-image-alignment', this.__alignment)
+    wrapper.dataset.fsRichTextImageWrapper = ''
+    wrapper.dataset.fsRichTextImageAlignment = this.__alignment
 
     const img = document.createElement('img')
-    img.setAttribute('data-fs-rich-text-image', '')
-    img.setAttribute(
-      'src',
-      withVtexResizeParams(this.__src, this.__widthPercent)
-    )
-    img.setAttribute('alt', this.__altText)
+    img.dataset.fsRichTextImage = ''
+    img.src = withVtexResizeParams(this.__src, this.__widthPercent)
+    img.alt = this.__altText
     img.setAttribute('loading', 'lazy')
-    img.setAttribute('style', `width: ${this.__widthPercent}%`)
+    img.style.width = `${this.__widthPercent}%`
 
     wrapper.append(img)
 

--- a/packages/core/test/components/ui/RichText/RichText.browser.test.tsx
+++ b/packages/core/test/components/ui/RichText/RichText.browser.test.tsx
@@ -5,10 +5,10 @@
 import { render } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const isContentPlatformSourceMock = vi.fn(() => true)
+const isContentPlatformSourceMock = vi.hoisted(() => vi.fn(() => true))
 
 vi.mock('src/server/content/utils', () => ({
-  isContentPlatformSource: () => isContentPlatformSourceMock(),
+  isContentPlatformSource: isContentPlatformSourceMock,
 }))
 
 import { RichText } from '../../../../src/components/ui/RichText/RichText'

--- a/packages/core/test/components/ui/RichText/RichText.test.tsx
+++ b/packages/core/test/components/ui/RichText/RichText.test.tsx
@@ -1,0 +1,321 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const isContentPlatformSourceMock = vi.fn(() => true)
+
+vi.mock('src/server/content/utils', () => ({
+  isContentPlatformSource: () => isContentPlatformSourceMock(),
+}))
+
+import { RichText } from '../../../../src/components/ui/RichText/RichText'
+
+function textNode(text: string) {
+  return {
+    detail: 0,
+    format: 0,
+    mode: 'normal',
+    style: '',
+    text,
+    type: 'text',
+    version: 1,
+  }
+}
+
+function paragraphNode(children: unknown[]) {
+  return {
+    children,
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    type: 'paragraph',
+    version: 1,
+  }
+}
+
+function headingNode(text: string, tag = 'h2') {
+  return {
+    children: [textNode(text)],
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    type: 'heading',
+    version: 1,
+    tag,
+  }
+}
+
+function linkNode(url: string, text: string) {
+  return {
+    children: [textNode(text)],
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    type: 'link',
+    version: 1,
+    rel: null,
+    target: null,
+    title: null,
+    url,
+  }
+}
+
+function listNode(itemText: string) {
+  return {
+    children: [
+      {
+        children: [textNode(itemText)],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        type: 'listitem',
+        version: 1,
+        value: 1,
+      },
+    ],
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    type: 'list',
+    version: 1,
+    listType: 'bullet',
+    start: 1,
+    tag: 'ul',
+  }
+}
+
+function imageNode(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'image',
+    version: 1,
+    src: 'https://storeaccount.vtexassets.com/assets/vtex.file-manager-graphql/images/abc123.png',
+    altText: 'A nice picture',
+    alignment: 'center',
+    widthPercent: 60,
+    ...overrides,
+  }
+}
+
+function lexicalContent(children: unknown[]) {
+  return JSON.stringify({
+    root: {
+      children,
+      direction: 'ltr',
+      format: '',
+      indent: 0,
+      type: 'root',
+      version: 1,
+    },
+  })
+}
+
+function draftJsContent(text: string) {
+  return JSON.stringify({
+    blocks: [
+      {
+        key: '1',
+        text,
+        type: 'unstyled',
+        depth: 0,
+        inlineStyleRanges: [],
+        entityRanges: [],
+        data: {},
+      },
+    ],
+    entityMap: {},
+  })
+}
+
+describe('RichText', () => {
+  beforeEach(() => {
+    isContentPlatformSourceMock.mockReturnValue(true)
+  })
+
+  it('renders an image node with the correct src, alt, alignment and width', () => {
+    const { container } = render(
+      <RichText content={lexicalContent([imageNode()])} />
+    )
+
+    const wrapper = container.querySelector('[data-fs-rich-text-image-wrapper]')
+    const img = container.querySelector<HTMLImageElement>(
+      '[data-fs-rich-text-image]'
+    )
+
+    expect(wrapper?.getAttribute('data-fs-rich-text-image-alignment')).toBe(
+      'center'
+    )
+    expect(img?.getAttribute('alt')).toBe('A nice picture')
+    expect(img?.getAttribute('loading')).toBe('lazy')
+    expect(img?.getAttribute('style')).toBe('width: 60%;')
+
+    const src = img?.getAttribute('src') ?? ''
+    expect(src).toContain('width=432')
+    expect(src).toContain('aspect=true')
+    expect(src).toContain('quality=8')
+  })
+
+  it('renders images together with text, headings, links and lists in document order', () => {
+    const { container } = render(
+      <RichText
+        content={lexicalContent([
+          headingNode('Title'),
+          paragraphNode([
+            textNode('See '),
+            linkNode('https://example.com', 'this link'),
+          ]),
+          listNode('An item'),
+          imageNode(),
+        ])}
+      />
+    )
+
+    const html = container.innerHTML
+
+    expect(container.querySelector('h2')?.textContent).toBe('Title')
+    expect(
+      container.querySelector('a[href="https://example.com"]')
+    ).toBeTruthy()
+    expect(
+      container.querySelector('[data-fs-rich-text-list="true"]')
+    ).toBeTruthy()
+    expect(container.querySelector('[data-fs-rich-text-image]')).toBeTruthy()
+
+    const headingIndex = html.indexOf('<h2')
+    const linkIndex = html.indexOf('href="https://example.com"')
+    const listIndex = html.indexOf('data-fs-rich-text-list')
+    const imageIndex = html.indexOf('data-fs-rich-text-image-wrapper')
+
+    expect(headingIndex).toBeLessThan(linkIndex)
+    expect(linkIndex).toBeLessThan(listIndex)
+    expect(listIndex).toBeLessThan(imageIndex)
+  })
+
+  it('drops an image node with a missing src without breaking the rest of the content', () => {
+    const { container } = render(
+      <RichText
+        content={lexicalContent([
+          paragraphNode([textNode('Before')]),
+          imageNode({ src: '' }),
+          paragraphNode([textNode('After')]),
+        ])}
+      />
+    )
+
+    expect(container.querySelector('[data-fs-rich-text-image]')).toBeNull()
+    expect(
+      container.querySelector('[data-fs-rich-text-image-wrapper]')
+    ).toBeNull()
+    expect(container.textContent).toContain('Before')
+    expect(container.textContent).toContain('After')
+  })
+
+  it('does not throw and skips an image node with an unsupported/unexpected shape', () => {
+    expect(() =>
+      render(
+        <RichText
+          content={lexicalContent([
+            paragraphNode([textNode('Still here')]),
+            {
+              type: 'image',
+              version: 2,
+              imageUrl: 'https://storeaccount.vtexassets.com/assets/x.png',
+            },
+          ])}
+        />
+      )
+    ).not.toThrow()
+
+    const { container } = render(
+      <RichText
+        content={lexicalContent([
+          paragraphNode([textNode('Still here')]),
+          {
+            type: 'image',
+            version: 2,
+            imageUrl: 'https://storeaccount.vtexassets.com/assets/x.png',
+          },
+        ])}
+      />
+    )
+
+    expect(container.querySelector('[data-fs-rich-text-image]')).toBeNull()
+    expect(container.textContent).toContain('Still here')
+  })
+
+  it('renders multiple images, defaulting alignment/width when omitted and passing through non-VTEX URLs unmodified', () => {
+    const { container } = render(
+      <RichText
+        content={lexicalContent([
+          imageNode({ alignment: 'right', widthPercent: 30 }),
+          imageNode({
+            src: 'https://storeaccount.vtexassets.com/assets/vtex.file-manager-graphql/images/no-layout.png',
+            alignment: undefined,
+            widthPercent: undefined,
+          }),
+          imageNode({
+            src: 'https://cdn.example.com/external.png',
+            alignment: 'center',
+            widthPercent: 80,
+          }),
+        ])}
+      />
+    )
+
+    const wrappers = container.querySelectorAll(
+      '[data-fs-rich-text-image-wrapper]'
+    )
+    expect(wrappers).toHaveLength(3)
+
+    expect(wrappers[0].getAttribute('data-fs-rich-text-image-alignment')).toBe(
+      'right'
+    )
+
+    expect(wrappers[1].getAttribute('data-fs-rich-text-image-alignment')).toBe(
+      'left'
+    )
+    expect(
+      wrappers[1]
+        .querySelector('[data-fs-rich-text-image]')
+        ?.getAttribute('style')
+    ).toBe('width: 100%;')
+
+    const externalImg = wrappers[2].querySelector('[data-fs-rich-text-image]')
+    expect(externalImg?.getAttribute('src')).toBe(
+      'https://cdn.example.com/external.png'
+    )
+  })
+
+  it('clamps widthPercent to 100 so the image never overflows its container', () => {
+    const { container } = render(
+      <RichText content={lexicalContent([imageNode({ widthPercent: 150 })])} />
+    )
+
+    const img = container.querySelector('[data-fs-rich-text-image]')
+    expect(img?.getAttribute('style')).toBe('width: 100%;')
+  })
+
+  it('keeps rendering existing hCMS Draft.js content unaffected', () => {
+    isContentPlatformSourceMock.mockReturnValue(false)
+
+    const { container } = render(
+      <RichText content={draftJsContent('Hello legacy content')} />
+    )
+
+    expect(container.textContent).toContain('Hello legacy content')
+    expect(container.querySelector('[data-fs-rich-text-image]')).toBeNull()
+  })
+
+  it('keeps rendering existing Lexical content without images unaffected', () => {
+    const { container } = render(
+      <RichText
+        content={lexicalContent([paragraphNode([textNode('No images here')])])}
+      />
+    )
+
+    expect(container.textContent).toContain('No images here')
+    expect(container.querySelector('[data-fs-rich-text-image]')).toBeNull()
+  })
+})

--- a/packages/ui/src/components/atoms/RichText/styles.scss
+++ b/packages/ui/src/components/atoms/RichText/styles.scss
@@ -1,4 +1,26 @@
 [data-fs-rich-text] {
+  [data-fs-rich-text-image-wrapper] {
+    display: flex;
+    margin: var(--fs-spacing-2) 0;
+
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+
+    &[data-fs-rich-text-image-alignment="left"] {
+      justify-content: flex-start;
+    }
+
+    &[data-fs-rich-text-image-alignment="center"] {
+      justify-content: center;
+    }
+
+    &[data-fs-rich-text-image-alignment="right"] {
+      justify-content: flex-end;
+    }
+  }
+
   [data-fs-rich-text-list="true"] {
     padding: 0;
     margin: 0;


### PR DESCRIPTION
## What's the purpose of this pull request?

This pull request introduces support for custom image nodes in the rich text editor, allowing images with alignment and width options to be rendered and styled consistently. The main changes include the implementation of a new `RichTextImageNode` for image handling, its integration into the editor pipeline, and corresponding styling updates.

**Rich Text Image Node Implementation and Integration:**

* Added the new `RichTextImageNode` class to `RichTextImageNode.ts`, supporting image source, alt text, alignment (`left`, `center`, `right`), and width percentage, with logic for exporting to and importing from JSON and DOM, and automatic image resizing for VTEX assets.
* Registered `RichTextImageNode` in the `lexicalToHtml` function, enabling the rich text editor to recognize and handle image nodes.
* Imported `RichTextImageNode` into `RichText.tsx` to ensure it is available for use in the editor.

**Styling Enhancements:**

* Updated `styles.scss` to add styles for `[data-fs-rich-text-image-wrapper]`, ensuring images are displayed with correct alignment and responsive sizing according to their alignment and width settings.

## How it works?

An image inserted via Content Platform's RichTextWidget gets serialized as a Lexical image node (src, altText, alignment, widthPercent) inside the rich text field's content. RichText's headless Lexical editor didn't recognize that node type, so images were dropped or broke parsing.

Added RichTextImageNode, registered in lexicalToHtml(), to close that gap: it parses the node (sanitizing alignment/widthPercent, capping width at 100%) and renders it to `<div data-fs-rich-text-image-wrapper>` + `<img data-fs-rich-text-image loading="lazy">`. VTEX file-manager URLs get resized via query params (same convention as faststoreLoader). A missing/invalid src makes the node skip itself instead of breaking the block. Styling was added to @faststore/ui's RichText/styles.scss.

(Check this [PR](https://github.com/vtex/content-platform/pull/1396) to get more context)

## How to test it?

This should be tested using Content Platform as content source. It can be tested using the Newsletter component. Simply set up a store that uses the code from this PR on CP and create a new entry with the Newsletter component. The preview feature can then be used to test the rendering of the Newsletter rich text.

## Checklist

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `ci` and `test`

**PR Description**

- [x] Added a label according to the PR goal - `breaking change`, `bug`, `contributing`, `performance`, `documentation`..

**Dependencies**

- [x] Committed the `pnpm-lock.yaml` file when there were changes to the packages

**Documentation**

- [x] PR description
- [ ] For documentation changes, ping `@Mariana-Caetano` to review and update (Or submit a doc request)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for displaying images within rich-text content.
  - Images now support left, center, and right alignment.
  - Image widths are responsive and constrained to valid values.
  - Images include descriptive alternative text and optimized loading behavior.
  - Rich-text content preserves image placement alongside text and supports external image URLs.

- **Bug Fixes**
  - Improved handling of missing or malformed image data without disrupting rich-text rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->