### PR TITLE
ci: build diagnostics before api in the back-merge workflow

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -109,7 +109,9 @@ jobs:
           # core#generate shells out to the CLI binary, which must be compiled
           # first (see turbo.json: @faststore/core#generate → @faststore/cli#build).
           # api must be built before the CLI because generate-types imports
-          # GraphqlVtexSchema from @faststore/api at runtime.
+          # GraphqlVtexSchema from @faststore/api at runtime. api's built ESM
+          # imports @faststore/diagnostics, so that package must be built too.
+          pnpm --filter @faststore/diagnostics build
           pnpm --filter @faststore/api build
           pnpm --filter @faststore/api generate
           pnpm --filter @faststore/cli build


### PR DESCRIPTION
## What's the purpose of this pull request?

The automated [Back-merge main to dev](https://github.com/vtex/faststore/actions/runs/32167840116/job/95811531546) job failed after graduating 4.6.0. `core generate` shells out to the CLI, which loads compiled `@faststore/api`. Since #3389 that package imports `@faststore/diagnostics` at runtime, and the workflow never built `diagnostics`, so generate died with `MODULE_NOT_FOUND` on `dist/es/index.mjs`.

This run does not need to be re-executed — the 4.6.0 sync is already in #3456. The YAML change is for the next CD on `main` (`workflow_run` reads this file from `dev`, the default branch).

## How it works?

Build `@faststore/diagnostics` before `@faststore/api` in the regenerate step, matching the existing explicit chain (`api` → `cli` → `core generate`).

## How to test it?

- [ ] Confirm the added `pnpm --filter @faststore/diagnostics build` runs before `api` build in `.github/workflows/back-merge.yml`
- [ ] After merge, the next successful CD on `main` should open the back-merge PR instead of failing at codegen

## References

- Failed job: https://github.com/vtex/faststore/actions/runs/32167840116/job/95811531546
- Related: #3389, #3456

## Checklist

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification


Made with [Cursor](https://cursor.com)