### PR TITLE
fix: gate the Cards route and sidebar entry on org membership

### DIFF
--- a/packages/core/src/components/account/Layout/Layout.tsx
+++ b/packages/core/src/components/account/Layout/Layout.tsx
@@ -35,10 +35,11 @@ const Layout = ({
       })
     : menuRoutes
 
-  // Cards is never route-gated here: `useAdHocCard` only affects the
-  // Personal-tab rendering inside the page itself (spec
-  // my-account-cards-gating-plan), so it never joins
-  // ROUTES_ONLY_FOR_B2B_MEMBERS — the sidebar entry always stays visible.
+  // Cards is org-gated like Quotes: without a unit/contract association there
+  // is no card list to show (the Saved-cards service has no customer record
+  // for such a buyer), so the entry is hidden rather than leading to an empty
+  // page. `useAdHocCard` is a separate, finer gate that only affects the
+  // Personal-tab rendering inside the page itself — it never hides the entry.
   const routes = (
     isRepresentative
       ? menuItems

--- a/packages/core/src/pages/pvt/account/cards/index.tsx
+++ b/packages/core/src/pages/pvt/account/cards/index.tsx
@@ -131,6 +131,20 @@ const getServerSidePropsBase: GetServerSideProps<
     return { redirect }
   }
 
+  // Cards requires a unit/contract association, mirroring the sidebar gate in
+  // account/Layout (ROUTES_ONLY_FOR_B2B_MEMBERS). This resolves O1: the
+  // combinations without an association used to render a lone, inert Personal
+  // tab over a list the Saved-cards service answers 500 for. Gated ahead of
+  // the query so those buyers never trigger that call.
+  if (!hasOrgAssociation) {
+    return {
+      redirect: {
+        destination: '/pvt/account/404',
+        permanent: false,
+      },
+    }
+  }
+
   const [
     globalSectionsPromise,
     globalSectionsHeaderPromise,

--- a/packages/core/src/sdk/account/getMyAccountRoutes.ts
+++ b/packages/core/src/sdk/account/getMyAccountRoutes.ts
@@ -37,7 +37,7 @@ export const SECURITY_ROUTE = '/pvt/account/security'
 export const CARDS_ROUTE = '/pvt/account/cards'
 export const QUOTES_ROUTE = '/pvt/account/quotes'
 
-export const ROUTES_ONLY_FOR_B2B_MEMBERS = [QUOTES_ROUTE]
+export const ROUTES_ONLY_FOR_B2B_MEMBERS = [QUOTES_ROUTE, CARDS_ROUTE]
 
 const ROUTE_LABEL_KEYS: Record<string, keyof AccountNavigationLabels> = {
   [PROFILE_ROUTE]: 'profileLabel',

--- a/packages/core/test/components/account/Layout.test.tsx
+++ b/packages/core/test/components/account/Layout.test.tsx
@@ -39,6 +39,23 @@ describe('Layout', () => {
     expect(screen.getByText('Quotes')).toBeTruthy()
   })
 
+  it('hides the Cards route when the user is not an org member', () => {
+    mockUseSession.mockReturnValue({ b2b: null })
+
+    render(<Layout accountName="Jane Doe">content</Layout>)
+
+    expect(screen.queryByText('Cards')).toBeNull()
+    expect(screen.getByText('Profile')).toBeTruthy()
+  })
+
+  it('shows the Cards route when the user belongs to an org unit', () => {
+    mockUseSession.mockReturnValue({ b2b: { unitId: 'unit-1' } })
+
+    render(<Layout accountName="Jane Doe">content</Layout>)
+
+    expect(screen.getByText('Cards')).toBeTruthy()
+  })
+
   it('hides User Details when not a representative, regardless of org membership', () => {
     mockUseSession.mockReturnValue({ b2b: { unitId: 'unit-1' } })
 

--- a/packages/core/test/pages/pvt/account/cards/index.test.ts
+++ b/packages/core/test/pages/pvt/account/cards/index.test.ts
@@ -85,9 +85,24 @@ describe('Cards page getServerSideProps', () => {
     expect(mockExecute).not.toHaveBeenCalled()
   })
 
-  it('redirects to /pvt/account/403 when the query fails with 401/403', async () => {
+  it('redirects to /pvt/account/404 when the buyer has no org association, before querying', async () => {
     mockGetB2BSessionClaims.mockReturnValueOnce({
       hasOrgAssociation: false,
+      hasCustomerId: false,
+    })
+
+    const result: any = await getServerSideProps(makeContext())
+
+    expect(result.redirect.destination).toBe('/pvt/account/404')
+    // Gated ahead of the Saved-cards call: a buyer who cannot reach the page
+    // must not cost a round trip to a service that answers 500 for shoppers
+    // with no customer record.
+    expect(mockExecute).not.toHaveBeenCalled()
+  })
+
+  it('redirects to /pvt/account/403 when the query fails with 401/403', async () => {
+    mockGetB2BSessionClaims.mockReturnValueOnce({
+      hasOrgAssociation: true,
       hasCustomerId: false,
     })
     mockExecute.mockResolvedValueOnce({
@@ -102,7 +117,7 @@ describe('Cards page getServerSideProps', () => {
 
   it('renders the error state (no redirect) when the query fails with a non-auth status', async () => {
     mockGetB2BSessionClaims.mockReturnValueOnce({
-      hasOrgAssociation: false,
+      hasOrgAssociation: true,
       hasCustomerId: false,
     })
     mockExecute.mockResolvedValueOnce({
@@ -135,7 +150,7 @@ describe('Cards page getServerSideProps', () => {
     expect(result.props).not.toHaveProperty('hasAdHocCardAccess')
   })
 
-  it('never gates the route: canViewPersonalCards is false but no redirect happens', async () => {
+  it('does not gate the route on useAdHocCard: canViewPersonalCards is false but an org member still gets the page', async () => {
     mockGetB2BSessionClaims.mockReturnValueOnce({
       hasOrgAssociation: true,
       hasCustomerId: false,
@@ -165,21 +180,10 @@ describe('Cards page getServerSideProps', () => {
     expect(result.props.accountPageData.sharedCards).toEqual([CARD_SHARED])
   })
 
-  it('keeps personal cards in the payload when there is no org association, even though canViewPersonalCards is false (FR-7: B2C buyers are never subject to this check)', async () => {
-    mockGetB2BSessionClaims.mockReturnValueOnce({
-      hasOrgAssociation: false,
-      hasCustomerId: false,
-    })
-    mockSuccessfulExecute({ hasAdHocCardAccess: false })
-
-    const result: any = await getServerSideProps(makeContext())
-
-    // Without hasOrgAssociation, the component still renders the Personal
-    // tab (the "kept as-is" O1 combination) — stripping the data here would
-    // silently regress a buyer this gate was never meant to touch, even
-    // though canViewPersonalCards itself is false.
-    expect(result.props.accountPageData.personalCards).toEqual([CARD_PERSONAL])
-  })
+  // The previous FR-7 case ("keeps personal cards in the payload when there is
+  // no org association") is gone by design: O1 was resolved by gating the
+  // route on org membership, so that combination now 404s and never reaches a
+  // payload at all. See the no-org-association gate test above.
 
   it('defaults hasAdHocCardAccess to allowed when the query field is missing', async () => {
     mockGetB2BSessionClaims.mockReturnValueOnce({

--- a/packages/core/test/sdk/account/getMyAccountRoutes.test.ts
+++ b/packages/core/test/sdk/account/getMyAccountRoutes.test.ts
@@ -125,6 +125,10 @@ describe('getMyAccountRoutes', () => {
   it('marks Quotes as a B2B-only route', () => {
     expect(ROUTES_ONLY_FOR_B2B_MEMBERS).toContain(QUOTES_ROUTE)
   })
+
+  it('marks Cards as a B2B-only route', () => {
+    expect(ROUTES_ONLY_FOR_B2B_MEMBERS).toContain(CARDS_ROUTE)
+  })
 })
 
 describe('getExtraMyAccountRoutes', () => {


### PR DESCRIPTION
## What's the purpose of this pull request?

Resolves **O1**, the open question left in #3443: what the Cards page should render for the combinations *without* a Unit/Contract association. Those combinations were deliberately left "exactly as the component already behaved, pending product confirmation".

Testing the released `4.7.0-dev.0` against a plain B2C shopper surfaced what that behaviour actually is, and it is not good:

- The sidebar advertises **Cards** to every shopper, including ones with no card capability at all.
- The page renders a **lone, inert "Personal" tab** — a single `role="tab"` button with nothing to switch to. The component already avoids this on the other side (`sharedOnly` returns a plain label, no tab chrome), so it was asymmetric.
- Underneath that tab, `listCreditCards` answers **500**: the Saved-cards service has no customer record for a buyer with no association. The buyer gets "We couldn't load your cards" on a page they were never able to use.

## How it works?

Cards is now org-gated the same way Quotes already is.

**Sidebar** — `CARDS_ROUTE` joins `ROUTES_ONLY_FOR_B2B_MEMBERS`. Both consumers (`account/Layout` and `OrganizationDrawerBody`) already filter that list by `isOrgMember`, so no new wiring.

**Route** — `getServerSideProps` redirects to `/pvt/account/404` when `hasOrgAssociation` is false. The gate sits **ahead of the query** so a buyer who cannot reach the page never costs a round trip to the service that 500s for them.

The comment in `Layout.tsx` that asserted the opposite ("the sidebar entry always stays visible") was rewritten.

`useAdHocCard` is untouched and remains the finer, separate gate over Personal-tab rendering only. It still never hides the entry.

### Note for reviewers: two follow-ups I did not fold in

- **Divergence with Quotes.** Quotes redirects non-members to `/pvt/account/403` (`quotes/index.tsx:201`); this uses `/pvt/account/404` — the gate #3443 originally removed. Two behaviours now exist for the same condition. Worth aligning, in whichever direction.
- **Now-dead branches.** With the route gated, `hasOrgAssociation` always arrives `true` in `MyAccountListCards`, so its `{hasOrgAssociation && ...}` guards and the `sharedOnly` path are always-true. Left in place as defensive code rather than widening this PR.

## How to test it?

- Sign in as a shopper **without** a Unit/Contract association:
  - **Cards** must be absent from the My Account sidebar and from the Organization drawer.
  - Hitting `/pvt/account/cards` directly must land on `/pvt/account/404`.
  - No request should reach the Saved-cards service.
- Sign in as a buyer **with** an association: Cards behaves exactly as it did in #3443, including the `useAdHocCard` Personal-tab gating.

## References

- Follows up #3443 (released in `4.7.0-dev.0`), which tracked this as O1.

**Authorization-change approval**: #3443 deliberately removed the route-level gate; this reinstates it on a different condition (org membership rather than `useAdHocCard`). Per `AGENTS.md`, that change was walked through and approved by Arthur Andrade before being built.

## Checklist

**PR Title and Commit Messages**

- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification

**PR Description**

- [ ] Added a label according to the PR goal

**Dependencies**

- [x] No package changes, so no `pnpm-lock.yaml` change

**Documentation**

- [x] PR description

## Tests

Full `@faststore/core` suite: **687 passing**. (`test/server/index.test.ts` and `test/server/rootSpan.test.ts` fail to load with `Cannot find package 'cross-inspect'` — verified pre-existing on `dev`, unrelated to this change.)

Added:
- `getMyAccountRoutes.test.ts` — Cards is marked B2B-only.
- `Layout.test.tsx` — entry hidden without an org unit, shown with one.
- `cards/index.test.ts` — no-association redirects to `/pvt/account/404` and `execute` is never called.

Changed, and worth a look during review:
- Two tests used `hasOrgAssociation: false` as an incidental scenario; moved to `true` so they keep exercising what they were written for instead of hitting the new gate.
- `keeps personal cards in the payload when there is no org association (FR-7...)` was **removed** — it asserted precisely the behaviour this PR reverses, and its scenario can no longer occur. A comment marks the spot.
- `never gates the route` renamed to `does not gate the route on useAdHocCard`, which is still true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted the Cards area to eligible business accounts with an organization association.
  * Users without an organization association are now redirected to the 404 page instead of seeing card-related content.
  * Clarified that personal card availability is controlled separately within the Cards page.
* **Tests**
  * Added coverage for route visibility and 404 behavior for ineligible accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->