### PR TITLE
fix: make PDP product JSON-LD Schema.org compliant

### DIFF
--- a/packages/api/src/platforms/vtex/resolvers/product.ts
+++ b/packages/api/src/platforms/vtex/resolvers/product.ts
@@ -16,6 +16,7 @@ import {
   attributeToPropertyValue,
   VALUE_REFERENCES,
 } from '../utils/propertyValue'
+import { normalizeReleaseDate } from '../utils/releaseDate'
 import { slugify } from '../utils/slugify'
 import type { Query } from './query'
 
@@ -298,7 +299,8 @@ export const StoreProduct: Record<string, GraphqlResolver<Root>> & {
     skuSpecifications ?? [],
   specificationGroups: ({ isVariantOf: { specificationGroups } }) =>
     specificationGroups,
-  releaseDate: ({ isVariantOf: { releaseDate } }) => releaseDate ?? '',
+  releaseDate: ({ isVariantOf: { releaseDate } }) =>
+    normalizeReleaseDate(releaseDate),
   advertisement: ({ isVariantOf: { advertisement } }) => advertisement,
   deliveryPromiseBadges: ({ isVariantOf: { deliveryPromisesBadges } }) =>
     deliveryPromisesBadges,

--- a/packages/api/src/platforms/vtex/utils/releaseDate.ts
+++ b/packages/api/src/platforms/vtex/utils/releaseDate.ts
@@ -15,9 +15,17 @@ const MILLISECONDS_THRESHOLD = 1e11
 
 const isAllDigits = (value: string) => /^\d+$/.test(value)
 
+// An ISO date-time with no timezone designator. `new Date()` reads these as
+// host-local time (date-only forms are already read as UTC), which would make
+// the emitted calendar day depend on the build machine's zone.
+const ISO_DATE_TIME_WITHOUT_ZONE =
+  /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/
+
 const toDate = (value: string): Date => {
   if (!isAllDigits(value)) {
-    return new Date(value)
+    return new Date(
+      ISO_DATE_TIME_WITHOUT_ZONE.test(value) ? `${value}Z` : value
+    )
   }
 
   const epoch = Number(value)
@@ -36,7 +44,8 @@ const toDate = (value: string): Date => {
  * on any machine. An input carrying a timezone offset is converted first, which
  * means `2026-03-23T21:00:00-05:00` normalizes to `2026-03-24`. That is
  * deliberate: preserving the source calendar day would make the output depend on
- * the offset embedded in each record.
+ * the offset embedded in each record. An input with no timezone designator is
+ * read as UTC rather than as host-local time, for the same reason.
  */
 export const normalizeReleaseDate = (
   value: string | number | null | undefined

--- a/packages/api/src/platforms/vtex/utils/releaseDate.ts
+++ b/packages/api/src/platforms/vtex/utils/releaseDate.ts
@@ -1,0 +1,61 @@
+/**
+ * `StoreProduct.releaseDate` is documented in the schema as ISO 8601, but
+ * Intelligent Search delivers whatever the account has stored — epoch
+ * milliseconds for some, an ISO string for others. Normalizing here keeps the
+ * resolver honest about the contract it advertises.
+ */
+
+// Epoch values are disambiguated by magnitude, not digit count: anything at or
+// above this is milliseconds (>= 1973-03-03), anything below is seconds. A
+// millisecond value under the threshold is read as seconds — accepted, since no
+// real catalog carries a release date that early, and a digit-count heuristic
+// leaves a strictly larger hole (9-digit seconds and 12-digit milliseconds both
+// fall through to the string parser, which reads them as a year).
+const MILLISECONDS_THRESHOLD = 1e11
+
+const isAllDigits = (value: string) => /^\d+$/.test(value)
+
+const toDate = (value: string): Date => {
+  if (!isAllDigits(value)) {
+    return new Date(value)
+  }
+
+  const epoch = Number(value)
+
+  return new Date(epoch >= MILLISECONDS_THRESHOLD ? epoch : epoch * 1000)
+}
+
+/**
+ * Normalizes a release date to an ISO 8601 calendar date (`YYYY-MM-DD`).
+ *
+ * Accepts epoch milliseconds, epoch seconds, and date strings. Returns an empty
+ * string when the input is absent or unparseable — never throws, and never
+ * returns `"Invalid Date"`.
+ *
+ * The calendar day is always taken in UTC, so a build produces the same markup
+ * on any machine. An input carrying a timezone offset is converted first, which
+ * means `2026-03-23T21:00:00-05:00` normalizes to `2026-03-24`. That is
+ * deliberate: preserving the source calendar day would make the output depend on
+ * the offset embedded in each record.
+ */
+export const normalizeReleaseDate = (
+  value: string | number | null | undefined
+): string => {
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  const raw = String(value).trim()
+
+  if (raw === '') {
+    return ''
+  }
+
+  const date = toDate(raw)
+
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  return date.toISOString().slice(0, 10)
+}

--- a/packages/api/test/unit/platforms/vtex/resolvers/product.test.ts
+++ b/packages/api/test/unit/platforms/vtex/resolvers/product.test.ts
@@ -406,6 +406,18 @@ describe('StoreProduct', () => {
       expect(resolve('2026-03-23T21:00:00-05:00')).toBe('2026-03-24')
     })
 
+    // `new Date(...)` reads an ISO date-time with no timezone designator as
+    // host-local, so without explicit handling this value resolves to the day
+    // before in any zone ahead of UTC. The build machine must not change the
+    // markup.
+    it('reads an ISO date-time with no timezone as UTC, not host-local', () => {
+      expect(resolve('2026-03-23T00:30:00')).toBe('2026-03-23')
+    })
+
+    it('reads an end-of-day ISO date-time with no timezone as UTC', () => {
+      expect(resolve('2026-03-23T23:30:00')).toBe('2026-03-23')
+    })
+
     it.each([
       ['an empty string', ''],
       ['whitespace', '   '],

--- a/packages/api/test/unit/platforms/vtex/resolvers/product.test.ts
+++ b/packages/api/test/unit/platforms/vtex/resolvers/product.test.ts
@@ -367,4 +367,57 @@ describe('StoreProduct', () => {
       expect(getLocalizedProduct).not.toHaveBeenCalled()
     })
   })
+
+  describe('releaseDate', () => {
+    const resolve = (releaseDate: unknown) =>
+      (StoreProduct.releaseDate as any)({ isVariantOf: { releaseDate } })
+
+    it('converts epoch milliseconds to an ISO calendar date', () => {
+      expect(resolve('1774224000000')).toBe('2026-03-23')
+    })
+
+    it('converts epoch seconds to the same date as its millisecond form', () => {
+      expect(resolve('1774224000')).toBe(resolve('1774224000000'))
+    })
+
+    it('reads a value at the millisecond threshold as milliseconds', () => {
+      expect(resolve('100000000000')).toBe('1973-03-03')
+    })
+
+    it('reads a value just below the threshold as seconds', () => {
+      expect(resolve('99999999999')).toBe('5138-11-16')
+    })
+
+    it('accepts a numeric epoch, not only its string form', () => {
+      expect(resolve(1774224000000)).toBe('2026-03-23')
+    })
+
+    it('passes an ISO date through unchanged', () => {
+      expect(resolve('2026-03-23')).toBe('2026-03-23')
+    })
+
+    it('truncates an ISO datetime to its calendar date', () => {
+      expect(resolve('2026-03-23T14:30:00Z')).toBe('2026-03-23')
+    })
+
+    // UTC is deliberate: preserving the source calendar day would make the
+    // output depend on the offset embedded in each record.
+    it('resolves an offset that crosses midnight to the UTC day', () => {
+      expect(resolve('2026-03-23T21:00:00-05:00')).toBe('2026-03-24')
+    })
+
+    it.each([
+      ['an empty string', ''],
+      ['whitespace', '   '],
+      ['an unparseable value', 'not-a-date'],
+      ['null', null],
+      ['undefined', undefined],
+    ])('returns an empty string for %s', (_label, input) => {
+      expect(resolve(input)).toBe('')
+    })
+
+    it('never returns "Invalid Date"', () => {
+      expect(resolve('garbage')).not.toContain('Invalid')
+    })
+  })
 })

--- a/packages/core/src/pages/[slug]/p.tsx
+++ b/packages/core/src/pages/[slug]/p.tsx
@@ -28,6 +28,7 @@ import { useSession } from 'src/sdk/session'
 import { execute } from 'src/server'
 import { getComponentKey } from 'src/utils/cms'
 import { getChannelForLocale } from 'src/utils/localization/bindingPaths'
+import { toProductJsonLdOffer } from 'src/utils/productJsonLd'
 
 import storeConfig from 'discovery.config'
 import {
@@ -328,11 +329,13 @@ function Page({
         description={description}
         brand={product.brand.name}
         sku={product.sku}
-        gtin={product.gtin}
-        mpn={product.mpn}
-        releaseDate={product.releaseDate}
+        // Spread conditionally so an unregistered identifier is omitted rather
+        // than published as "": next-seo passes these through untouched.
+        {...(product.gtin && { gtin: product.gtin })}
+        {...(product.mpn && { mpn: product.mpn })}
+        {...(product.releaseDate && { releaseDate: product.releaseDate })}
         images={product.image.map((img) => img.url)} // Somehow, Google does not understand this valid Schema.org schema, so we need to do conversions
-        offers={offers}
+        {...(offers && { offers })}
         {...(itemListElements.length !== 0 && {
           category: itemListElements[0].name,
         })}
@@ -508,19 +511,10 @@ export const getStaticProps: GetStaticProps<
 
   const meta = { title, description, canonical }
 
-  let offer = {}
-
-  if (data.product.offers.offers.length > 0) {
-    const { listPrice, ...offerData } = data.product.offers.offers[0]
-
-    offer = offerData
-  }
-
-  const offers = {
-    ...offer,
+  const offers = toProductJsonLdOffer(data.product.offers.offers[0], {
     priceCurrency: data.product.offers.priceCurrency,
     url: canonical,
-  }
+  })
 
   const globalSectionsResult = injectGlobalSections({
     globalSections,

--- a/packages/core/src/utils/productJsonLd.ts
+++ b/packages/core/src/utils/productJsonLd.ts
@@ -60,5 +60,12 @@ export const toProductJsonLdOffer = (
     }
   }
 
+  // `price` resolves to null outside the search and order-form roots. Dropping
+  // the key alone would leave a priceless Offer — the same invalid markup the
+  // no-offer case above avoids, so it gets the same treatment.
+  if (isEmpty(offer.price)) {
+    return undefined
+  }
+
   return offer
 }

--- a/packages/core/src/utils/productJsonLd.ts
+++ b/packages/core/src/utils/productJsonLd.ts
@@ -1,0 +1,64 @@
+import type { ServerProductQueryQuery } from '@generated/graphql'
+
+type ServerOffers = ServerProductQueryQuery['product']['offers']
+type ServerOffer = ServerOffers['offers'][number]
+
+/**
+ * Schema.org properties the PDP JSON-LD is allowed to publish on an Offer.
+ *
+ * This is an allowlist on purpose. The PDP's server query and
+ * `ProductDetailsFragment_product` both select `offers.offers`, and GraphQL
+ * merges the two selection sets — so the offer object reaching this module
+ * carries UI-only fields (`priceWithTaxes`, `listPrice`, `listPriceWithTaxes`,
+ * `quantity`, `priceToken`) that have no meaning to Schema.org consumers.
+ * Excluding them by name would mean tracking a fragment this module does not
+ * own, which is exactly how they leaked into public markup in the first place.
+ */
+const SCHEMA_ORG_OFFER_FIELDS = [
+  'availability',
+  'itemCondition',
+  'price',
+  'priceValidUntil',
+] as const satisfies ReadonlyArray<keyof ServerOffer>
+
+// Emptiness, not falsiness: `price` is numeric and `0` is a real price, so a
+// falsy check would strip it and leave an Offer with no price at all.
+const isEmpty = (value: unknown) =>
+  value === null || value === undefined || value === ''
+
+type ObjectLevelFields = {
+  priceCurrency: ServerOffers['priceCurrency']
+  url: string
+}
+
+/**
+ * Builds the `offers` object for the PDP's `ProductJsonLd`, or `undefined` when
+ * the product has no offer to describe.
+ *
+ * `undefined` matters: an `Offer` carrying only a currency and a URL is invalid
+ * Schema.org, so omitting the property entirely beats emitting a priceless one.
+ * Every key is dropped when its value is empty — `priceValidUntil` and
+ * `availability` are both nullable upstream.
+ */
+export const toProductJsonLdOffer = (
+  serverOffer: ServerOffer | undefined,
+  { priceCurrency, url }: ObjectLevelFields
+) => {
+  if (!serverOffer) {
+    return undefined
+  }
+
+  const offer: Record<string, unknown> = { priceCurrency, url }
+
+  for (const field of SCHEMA_ORG_OFFER_FIELDS) {
+    offer[field] = serverOffer[field]
+  }
+
+  for (const [key, value] of Object.entries(offer)) {
+    if (isEmpty(value)) {
+      delete offer[key]
+    }
+  }
+
+  return offer
+}

--- a/packages/core/test/utils/productJsonLd.test.ts
+++ b/packages/core/test/utils/productJsonLd.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import { toProductJsonLdOffer } from '../../src/utils/productJsonLd'
+
+const OBJECT_LEVEL = { priceCurrency: 'USD', url: 'https://store.example/p' }
+
+// Mirrors what actually reaches getStaticProps: the PDP query's Schema.org
+// fields merged with the UI-only fields ProductDetailsFragment_product selects
+// on the same `offers.offers` field.
+const makeServerOffer = (overrides: Record<string, unknown> = {}) =>
+  ({
+    availability: 'https://schema.org/InStock',
+    itemCondition: 'https://schema.org/NewCondition',
+    price: 12.5,
+    priceValidUntil: '2027-08-24T19:48:25Z',
+    // UI-only fields that must never reach the markup
+    listPrice: 20,
+    listPriceWithTaxes: 22,
+    priceWithTaxes: 13.75,
+    quantity: 10000,
+    priceToken: 'a-short-lived-pricing-token',
+    seller: { identifier: '1' },
+    ...overrides,
+  }) as any
+
+describe('toProductJsonLdOffer', () => {
+  it('emits exactly the allowed Schema.org keys', () => {
+    const offer = toProductJsonLdOffer(makeServerOffer(), OBJECT_LEVEL)
+
+    expect(Object.keys(offer!).sort()).toEqual([
+      'availability',
+      'itemCondition',
+      'price',
+      'priceCurrency',
+      'priceValidUntil',
+      'url',
+    ])
+  })
+
+  it.each([
+    'listPrice',
+    'listPriceWithTaxes',
+    'priceWithTaxes',
+    'quantity',
+    'priceToken',
+    'seller',
+  ])('does not leak %s into the markup', (field) => {
+    const offer = toProductJsonLdOffer(makeServerOffer(), OBJECT_LEVEL)
+
+    expect(offer).not.toHaveProperty(field)
+  })
+
+  // The regression guarantee: the mapper picks by allowlist, so a field added
+  // to any fragment selecting offers.offers cannot reach public markup.
+  it('ignores a field a future fragment might add', () => {
+    const offer = toProductJsonLdOffer(
+      makeServerOffer({ someFutureInternalField: 'leaked' }),
+      OBJECT_LEVEL
+    )
+
+    expect(offer).not.toHaveProperty('someFutureInternalField')
+  })
+
+  it('carries the allowed values through unchanged', () => {
+    const offer = toProductJsonLdOffer(makeServerOffer(), OBJECT_LEVEL)
+
+    expect(offer).toEqual({
+      availability: 'https://schema.org/InStock',
+      itemCondition: 'https://schema.org/NewCondition',
+      price: 12.5,
+      priceValidUntil: '2027-08-24T19:48:25Z',
+      priceCurrency: 'USD',
+      url: 'https://store.example/p',
+    })
+  })
+
+  it.each([
+    ['priceValidUntil', ''],
+    ['priceValidUntil', null],
+    ['availability', null],
+  ])('drops %s when it resolves to %p', (field, value) => {
+    const offer = toProductJsonLdOffer(
+      makeServerOffer({ [field]: value }),
+      OBJECT_LEVEL
+    )
+
+    expect(offer).not.toHaveProperty(field)
+    expect(offer).toHaveProperty('price')
+  })
+
+  // Emptiness, not falsiness — a free item still has a price.
+  it('keeps a price of 0', () => {
+    const offer = toProductJsonLdOffer(
+      makeServerOffer({ price: 0 }),
+      OBJECT_LEVEL
+    )
+
+    expect(offer).toHaveProperty('price', 0)
+  })
+
+  it('drops an empty priceCurrency', () => {
+    const offer = toProductJsonLdOffer(makeServerOffer(), {
+      ...OBJECT_LEVEL,
+      priceCurrency: '',
+    })
+
+    expect(offer).not.toHaveProperty('priceCurrency')
+  })
+
+  // An Offer with only a currency and a URL is invalid Schema.org, so the
+  // property is omitted entirely rather than emitted priceless.
+  it('returns undefined when the product has no offer', () => {
+    expect(toProductJsonLdOffer(undefined, OBJECT_LEVEL)).toBeUndefined()
+  })
+})

--- a/packages/core/test/utils/productJsonLd.test.ts
+++ b/packages/core/test/utils/productJsonLd.test.ts
@@ -111,4 +111,16 @@ describe('toProductJsonLdOffer', () => {
   it('returns undefined when the product has no offer', () => {
     expect(toProductJsonLdOffer(undefined, OBJECT_LEVEL)).toBeUndefined()
   })
+
+  // StoreOffer.price resolves to null outside the search and order-form roots.
+  // Dropping the key alone would leave a priceless Offer, which is exactly the
+  // invalid markup the no-offer case avoids.
+  it.each([
+    ['null', null],
+    ['an empty string', ''],
+  ])('returns undefined when the price is %s', (_label, price) => {
+    expect(
+      toProductJsonLdOffer(makeServerOffer({ price }), OBJECT_LEVEL)
+    ).toBeUndefined()
+  })
 })

--- a/packages/core/test/utils/productJsonLdRendering.test.tsx
+++ b/packages/core/test/utils/productJsonLdRendering.test.tsx
@@ -1,0 +1,74 @@
+import { ProductJsonLd } from 'next-seo'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { toProductJsonLdOffer } from '../../src/utils/productJsonLd'
+
+/**
+ * Pins the next-seo behaviour the PDP's JSON-LD depends on.
+ *
+ * `p.tsx` omits `mpn`, `gtin` and `releaseDate` by conditional spread rather
+ * than passing empty strings, and drops `seller` from the offer allowlist. Both
+ * choices only work because of how next-seo builds the script — it forwards
+ * unknown props untouched (so `""` would be published) and turns any truthy
+ * `seller` into an `Organization`, even when it has no name. A next-seo upgrade
+ * that changed either would silently reintroduce the defects from ticket
+ * #1449246, so the behaviour is asserted here instead of assumed.
+ */
+
+// `useAppDir` renders the script directly; without it next-seo emits through
+// next/head, which produces no markup outside a Next document.
+const renderJsonLd = (props: Record<string, unknown>) => {
+  const html = renderToStaticMarkup(
+    <ProductJsonLd useAppDir productName="Product" images={[]} {...props} />
+  )
+
+  return JSON.parse(html.replace(/^[\s\S]*?>([\s\S]*)<\/script>[\s\S]*$/, '$1'))
+}
+
+describe('next-seo ProductJsonLd contract', () => {
+  it('publishes an empty string when a prop is passed empty', () => {
+    expect(renderJsonLd({ mpn: '' })).toHaveProperty('mpn', '')
+  })
+
+  it('omits the key when the prop is absent — what the conditional spread relies on', () => {
+    expect(renderJsonLd({})).not.toHaveProperty('mpn')
+  })
+
+  it('emits a nameless Organization for a seller that has no name', () => {
+    const jsonLd = renderJsonLd({
+      offers: { price: 1, seller: { identifier: '1' } },
+    })
+
+    expect(jsonLd.offers.seller).toEqual({ '@type': 'Organization' })
+  })
+
+  it('leaves the mapper output intact, adding only @type', () => {
+    const offers = toProductJsonLdOffer(
+      {
+        availability: 'https://schema.org/InStock',
+        itemCondition: 'https://schema.org/NewCondition',
+        price: 0.2,
+        priceValidUntil: '2027-08-24T19:48:25Z',
+        priceWithTaxes: 0.2,
+        listPrice: 0.2,
+        listPriceWithTaxes: 0.2,
+        quantity: 10000,
+        priceToken: 'a-short-lived-pricing-token',
+        seller: { identifier: '1' },
+      } as any,
+      { priceCurrency: 'USD', url: 'https://store.example/p' }
+    )
+
+    const jsonLd = renderJsonLd({ offers })
+
+    expect(jsonLd.offers).toEqual({
+      '@type': 'Offer',
+      availability: 'https://schema.org/InStock',
+      itemCondition: 'https://schema.org/NewCondition',
+      price: 0.2,
+      priceCurrency: 'USD',
+      priceValidUntil: '2027-08-24T19:48:25Z',
+      url: 'https://store.example/p',
+    })
+  })
+})


### PR DESCRIPTION
[Jira task](https://vtex-dev.atlassian.net/browse/SO-666)

## What

Fixes the four defects reported in [SO-666](https://vtex-dev.atlassian.net/browse/SO-666) / ticket [#1449246](https://vtexhelp.zendesk.com/agent/tickets/1449246) (Stanley Black & Decker) in the `application/ld+json` block emitted on the PDP.

| # | Defect | Fix |
|---|---|---|
| 1 | `"mpn":""` / `"gtin":""` for products with no catalog value | Spread conditionally in `p.tsx` — the key is omitted, not emitted empty |
| 2 | `"releaseDate":"1774224000000"` (epoch ms) | Normalized to ISO 8601 in the resolver that documents that contract |
| 3 | `offers` leaking `priceWithTaxes`, `listPriceWithTaxes`, `quantity`, `priceToken` | Blacklist replaced by an allowlist |
| 4 | `"seller":{"@type":"Organization"}` with no name | Falls out of the allowlist |

## Why defect 3 recurred silently

The PDP's inline query and `ProductDetailsFragment_product` both select `offers.offers`. GraphQL merges the two selection sets, so `data.product.offers.offers[0]` arrives carrying the union — including UI-only fields the JSON-LD never asked for. The old code used a blacklist:

```ts
const { listPrice, ...offerData } = data.product.offers.offers[0]
```

That has to enumerate fields owned by a fragment the JSON-LD does not control, which is exactly how four fields leaked in unnoticed. It is now an allowlist in `packages/core/src/utils/productJsonLd.ts`, so a field added to any fragment cannot reach the JSON-LD.

To be precise about the scope of that guarantee: it covers the `application/ld+json` block, not the whole HTML response. The same fields — `priceToken` included — remain in Next's `__NEXT_DATA__` hydration payload, because the PDP needs them client-side (price display, quantity selector, add-to-cart). That is by design and unchanged by this PR; see the out-of-scope note below.

## Verified output

Rendered through next-seo with the reported ticket data:

```json
{"@context":"https://schema.org","@type":"Product","sku":"1101","gtin":"SC13-0702A-FTKALG","releaseDate":"2026-03-23","brand":{"@type":"Brand","name":"Lista"},"offers":{"priceCurrency":"USD","url":"…","availability":"https://schema.org/InStock","itemCondition":"https://schema.org/NewCondition","price":0.2,"priceValidUntil":"2027-08-24T19:48:25Z","@type":"Offer"},"name":"LISTA XPRESS"}
```

## Notes for review

- **Behavior change**: stores reading `StoreProduct.releaseDate` directly now get ISO 8601 instead of the raw upstream value. This moves the field onto the contract its own schema already documented (`product.graphql:70-72`).
- **Behavior change**: an offerless product now omits `offers` entirely rather than emitting an `Offer` carrying only a currency and URL, which is invalid Schema.org.
- **Emptiness, not falsiness**: the allowlist filter drops `null`/`undefined`/`""` but keeps `price: 0`, which is a real price. Covered by a test.
- **Epoch disambiguation** is by magnitude (`>= 1e11` → milliseconds), not digit count. A digit-count heuristic leaves a larger hole: 9-digit seconds and 12-digit milliseconds both fall through to the string parser, which reads them as a year.
- **No backport.** `priceToken` is selected only on `dev`/`main` — `0.x` through `3.x` have zero occurrences, so it never reaches their JSON-LD. Those majors do still carry defects 1–3 and would need per-branch verification, since their fragment field sets differ.

## Out of scope, investigated

- **`priceToken` in `__NEXT_DATA__`.** Removing it from the JSON-LD does not remove it from the page. It is still in the hydration payload of the same HTML response, and always was — the buy button reads it client-side. Decoded on a live PDP it carries `accountName`, `id`, `price`, `salesChannel` and `seller`, with a 1800s validity window. Pre-existing and out of scope here, but worth stating explicitly so "the token leak is fixed" is not read more broadly than it should be. Whether a 30-minute token behind statically generated, cached pages is worth acting on has not been assessed.
- **`gtin` populated with a non-GTIN value.** The payload's `SC13-0702A-FTKALG` is a manufacturer reference: `product.ts:253` falls back to `referenceId[0]?.Value` when there is no EAN, and Google rejects the field for values that aren't 8/12/13/14 digits. Not covered by this PR — the fallback predates it and may exist for a compatibility reason worth understanding first.
- **`&quot;` in `name`/`description`.** Two causes, neither the JSON-LD builder: `description` goes through `sanitize-html` in `enhanceSku.ts:10`, which escapes for an HTML context the value never reaches; `name` is unsanitized, so its entity comes from the catalog record.

## Testing

- `packages/api`: 263 unit tests passing, 13 new for the normalizer (epoch ms/s, both sides of the `1e11` threshold, ISO, ISO with an offset crossing midnight, empty, garbage, null/undefined).
- `packages/core`: 19 new tests — 15 on the allowlist mapper, 4 pinning the next-seo behavior the fix depends on so an upgrade can't silently reintroduce the defects.

Still to do before undrafting: render the reported SKU in a starter store via `ci/codesandbox` and validate against the Google Rich Results Test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SO-666]: https://vtex-dev.atlassian.net/browse/SO-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Product release dates are now consistently formatted as UTC dates across supported input formats.
  * Invalid or missing release dates no longer produce misleading values such as “Invalid Date.”
  * Product structured data now omits unavailable optional fields instead of emitting empty values.
  * Offer data is filtered to include only valid Schema.org properties while preserving legitimate zero prices.

* **Tests**
  * Expanded coverage for release-date formatting, structured product data, and offer serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
