### PR TITLE
chore: pin npm@11 on 3.x CD for Node 20 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.VTEX_GITHUB_BOT_TOKEN }}
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -42,7 +42,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        # Pin to npm 11.x: it already supports OIDC Trusted Publishing (since
+        # 11.5.1) and stays compatible with Node 20. npm@latest (12.x)
+        # requires Node ^22.22.2 || ^24.15.0 || >=26.0.0.
+        run: npm install -g npm@11
 
       - name: Configure CI Git User
         run: |


### PR DESCRIPTION
## What's the purpose of this pull request?

Unblock CD on `3.x`. After #3468 merged, [the publish run](https://github.com/vtex/faststore/actions/runs/33195201831) failed at **Upgrade npm for OIDC support**: `npm@latest` now resolves to `npm@12.0.2`, which requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`. The `3.x` runner is still Node 20, so nothing was published — `v3-latest` remains **3.100.3**.

Same pin already landed on `main`/`dev` (`chore(release): pin npm version to 11.x for OIDC support compatibility`). This is the backport.

## How it works?

- Pin the OIDC upgrade step to `npm@11` (Trusted Publishing since 11.5.1, still runs on Node 20).
- Set `fetch-depth: 0` so the next CD run can see tag `v3.100.3` and the already-merged `fix:` from #3468, and publish **3.100.4**.

## How to test it?

- Merge this PR into `3.x`.
- Confirm CD gets past **Upgrade npm for OIDC support**.
- Confirm all `@faststore/*` packages publish under dist-tag `v3-latest` as **3.100.4** (includes the redirect matcher fix from #3468).

### Starters Deploy Preview

N/A — workflow-only change.

## References

- Failed CD: https://github.com/vtex/faststore/actions/runs/33195201831
- Feature that did not publish: #3468
- Equivalent pin on `main`/`dev`: `78ad5aecb`

## Checklist

**PR Title and Commit Messages**

- [x] PR title and commit messages follow Conventional Commits (`ci`)

**PR Description**

- [ ] Added a label according to the PR goal

**Dependencies**

- [x] No lockfile changes

**Documentation**

- [x] PR description

Made with [Cursor](https://cursor.com)