### PR TITLE
chore(core): align tsconfig moduleResolution with bundler

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "declaration": false,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "resolveJsonModule": true,


### PR DESCRIPTION
## What's the purpose of this pull request?

On v4.6.0, Next.js rewrites the generated `.faststore/tsconfig.json` on every `dev`/`build` and logs `We detected TypeScript in your project and reconfigured your tsconfig.json file`.

`@faststore/cli` copies `packages/core/tsconfig.json` almost verbatim into each store's `.faststore/tsconfig.json`, and that file still had `"moduleResolution": "node"`. Next 16 (`next/dist/lib/typescript/writeConfigurationDefaults.js`) treats `moduleResolution` as a **required** option: for TypeScript >= 5 with `module: esnext` it only accepts `bundler | node16 | nodenext`, so `"node"` is rewritten to `"bundler"` before Next runs its own type-check — every time, in every store.

## How it works?

One-line change: `packages/core/tsconfig.json` `moduleResolution` goes from `"node"` to `"bundler"`, matching the root `tsconfig.json` and every other package in the monorepo (`api`, `sdk`, `ui`, `components`, `diagnostics`).

This is not a behaviour change for stores: Next already forces `"bundler"` on the file it type-checks with, so `next build` has been running under bundler resolution all along. The change only (a) removes the drift between the committed config and what Next actually uses, so the "reconfigured your tsconfig.json" message stops appearing, and (b) makes editor / standalone `tsc` diagnostics match the real build.

## How to test it?

- `cd packages/core && pnpm exec tsc --noEmit -p tsconfig.json` with and without `--moduleResolution node`: the outputs are byte-identical (same 122 pre-existing errors, all under `test/**`, zero under `src/`).
- `pnpm lint` and `cd packages/cli && pnpm test` (173 tests, including the `.faststore` tsconfig copy tests) pass.
- In a store using this build: run `yarn dev` / `yarn build` and confirm the `reconfigured your tsconfig.json` message is gone and `.faststore/tsconfig.json` is left untouched by Next. Verified in a Yarn 1 workspaces monorepo: the generated `.faststore/tsconfig.json` already carries `"moduleResolution": "bundler"` and Next no longer reports a reconfiguration.

### Starters Deploy Preview

Pending CodeSandbox build for this PR.

## References

- Next.js source: `next/dist/lib/typescript/writeConfigurationDefaults.js` (`moduleResolution` is in the required set; `preferBundlerResolution` = TS >= 5.0 && module not commonjs/amd)
- Companion PRs (independent): #3474, #3476, #3477

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module resolution settings to improve compatibility with modern bundling workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
