### PR TITLE
feat(api): export `validateUserAuthentication` and `getAuthCookie`

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,6 +9,8 @@ export {
 } from './directives/cacheControl'
 export { GraphqlVtexContextFactory, GraphqlVtexSchema } from './platforms/vtex'
 export { typeDefs } from './platforms/vtex/typeDefs'
+export { validateUserAuthentication } from './platforms/vtex/utils/auth'
+export { getAuthCookie } from './platforms/vtex/utils/cookies'
 
 export * from './platforms/errors'
 export type { GraphqlContext, GraphqlResolver } from './platforms/vtex'

--- a/packages/api/test/unit/publicExports.test.ts
+++ b/packages/api/test/unit/publicExports.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  ForbiddenError,
+  UnauthorizedError,
+  getAuthCookie,
+  validateUserAuthentication,
+} from '../../src'
+import type { GraphqlContext } from '../../src'
+
+/**
+ * Regression tests for the runtime public entrypoint of `@faststore/api`.
+ *
+ * `validateUserAuthentication` and `getAuthCookie` are the helpers an API
+ * extension needs to answer "is this request authenticated?" and "which token
+ * do I forward to VTEX?". They used to be internal to
+ * `platforms/vtex/utils/*`, so every store reimplemented them — and the
+ * hand-written copies of `getAuthCookie` in particular tended to
+ * `split('=')[1]`, truncating any token that contains `=`.
+ *
+ * These tests pin them to the entrypoint so the exports are not dropped by a
+ * later refactor of the module layout.
+ */
+
+const contextWithAuthStatus = (authStatus: string | undefined) =>
+  ({
+    clients: {
+      commerce: { vtexid: { validate: vi.fn(async () => ({ authStatus })) } },
+    },
+  }) as unknown as GraphqlContext
+
+const contextThatRejects = (error: unknown) =>
+  ({
+    clients: {
+      commerce: {
+        vtexid: {
+          validate: vi.fn(async () => {
+            throw error
+          }),
+        },
+      },
+    },
+  }) as unknown as GraphqlContext
+
+describe('@faststore/api public runtime exports', () => {
+  it('exports the auth helpers used by API extensions', () => {
+    expect(typeof validateUserAuthentication).toBe('function')
+    expect(typeof getAuthCookie).toBe('function')
+  })
+
+  describe('getAuthCookie', () => {
+    it('reads the account auth cookie from a cookie header', () => {
+      const cookies =
+        'VtexIdclientAutCookie_other=nope; VtexIdclientAutCookie_storeframework=token'
+
+      expect(getAuthCookie(cookies, 'storeframework')).toBe('token')
+    })
+
+    it('keeps `=` inside the token value', () => {
+      const cookies = 'VtexIdclientAutCookie_storeframework=header.payload=='
+
+      expect(getAuthCookie(cookies, 'storeframework')).toBe('header.payload==')
+    })
+
+    it('keeps the last value when the cookie key is duplicated', () => {
+      const cookies =
+        'VtexIdclientAutCookie_storeframework=stale; VtexIdclientAutCookie_storeframework=fresh'
+
+      expect(getAuthCookie(cookies, 'storeframework')).toBe('fresh')
+    })
+
+    it('returns an empty string when the account has no auth cookie', () => {
+      expect(getAuthCookie('someOtherCookie=value', 'storeframework')).toBe('')
+      expect(getAuthCookie('', 'storeframework')).toBe('')
+    })
+  })
+
+  describe('validateUserAuthentication', () => {
+    it('resolves for a successful validation', async () => {
+      await expect(
+        validateUserAuthentication(contextWithAuthStatus('Success'))
+      ).resolves.toBeUndefined()
+    })
+
+    it('throws UnauthorizedError when the session is not authenticated', async () => {
+      await expect(
+        validateUserAuthentication(contextWithAuthStatus('Unauthorized'))
+      ).rejects.toBeInstanceOf(UnauthorizedError)
+    })
+
+    it('maps a 403 from VtexId to ForbiddenError', async () => {
+      await expect(
+        validateUserAuthentication(
+          contextThatRejects({ extensions: { status: 403 } })
+        )
+      ).rejects.toBeInstanceOf(ForbiddenError)
+    })
+  })
+})


### PR DESCRIPTION
## What's the purpose of this pull request?

`@faststore/api` maintains two helpers that stores writing API extensions need, but does not export them:

| Helper | What it does |
| --- | --- |
| `validateUserAuthentication(ctx)` | Calls `commerce.vtexid.validate()` and throws `UnauthorizedError` / `ForbiddenError` based on the result |
| `getAuthCookie(cookies, account)` | Normalizes the cookie string and returns `VtexIdclientAutCookie_{account}` |

Because neither `utils/auth` nor `utils/cookies` is re-exported from `packages/api/src/index.ts`, a custom resolver under `src/graphql/vtex/resolvers` cannot import either one — so every project rewrites them, and the copies drift. `getAuthCookie` is the sharp edge: the shipped version normalizes duplicated cookie keys to the last value and parses the cookie properly, while a hand-written `split('=')[1]` truncates any token containing `=` and fails as a `401` that is tedious to trace back.

Closes #3480.

## How it works?

Two lines added to the package entrypoint:

```ts
export { validateUserAuthentication } from './platforms/vtex/utils/auth'
export { getAuthCookie } from './platforms/vtex/utils/cookies'
```

Additive only — no existing export or behavior changes. `GraphqlContext`, the argument type of `validateUserAuthentication`, is already public (#3474), so the helper is usable with full typing from a store resolver:

```ts
import { getAuthCookie, validateUserAuthentication } from '@faststore/api'
import type { GraphqlContext } from '@faststore/api'

export const myResolver = async (_: unknown, __: unknown, ctx: GraphqlContext) => {
  await validateUserAuthentication(ctx)
  const token = getAuthCookie(ctx.headers.cookie ?? '', ctx.account)
  // forward `token` to a VTEX API
}
```

`test/unit/publicExports.test.ts` pins the two exports to the entrypoint so a later refactor of the module layout cannot silently drop them, and covers the behavior that motivated the request: `getAuthCookie` keeps `=` inside the token, keeps the last value for a duplicated cookie key, and returns `''` when the account has no auth cookie; `validateUserAuthentication` resolves on success, throws `UnauthorizedError` on a failed validation and `ForbiddenError` on a 403 from VtexId.

## How to test it?

- `cd packages/api && pnpm test:unit` — 23 files / 292 tests pass, including the 8 new ones.
- Typecheck: `pnpm tsc --noEmit -p packages/api/tsconfig.json` is clean.
- In a store, import both helpers from `@faststore/api` inside a custom resolver and confirm they resolve and type-check.

### Starters Deploy Preview

Not applicable — no runtime or rendering change.

## References

- Issue #3480
- PR #3474 — exported `GraphqlContext` / `Resolver`, the typing half of the same gap
- [Extending API schemas](https://developers.vtex.com/docs/guides/faststore/api-extensions-extending-api-schema)

## Checklist

- [x] PR title and commit messages follow Conventional Commits
- [x] PR description
- [ ] Dependencies — no package changes, no lockfile update needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publicly exposes authentication validation and authentication-cookie utilities through the API package.
* **Tests**
  * Added coverage for cookie extraction, duplicate and missing cookies, authentication outcomes, and forbidden-access error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->