### PR TITLE
fix: forward contentSource.project as --storeId in cms-sync CP flow

### DIFF
--- a/packages/cli/src/commands/cms-sync.test.ts
+++ b/packages/cli/src/commands/cms-sync.test.ts
@@ -238,6 +238,21 @@ describe('CmsSync', () => {
       )
     })
 
+    it('forwards contentSource.project to generateAndUploadSchema', async () => {
+      writeDiscoveryConfig(tempDir, {
+        contentSource: { type: 'CP', project: 'lojabigolin-faststore' },
+      })
+      getExistingCpDirsMock.mockReturnValue(['cms/faststore/components'])
+
+      await runCmsSync({ storeDir: tempDir })
+
+      expect(generateAndUploadSchemaMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          project: 'lojabigolin-faststore',
+        })
+      )
+    })
+
     it('runs the vtex preflight with the store account before generating', async () => {
       writeDiscoveryConfig(tempDir, {
         api: { storeId: 'brandless' },

--- a/packages/cli/src/commands/cms-sync.test.ts
+++ b/packages/cli/src/commands/cms-sync.test.ts
@@ -49,8 +49,8 @@ vi.mock('../utils/vtex', () => ({
     assertVtexReadyForAccountMock(...args),
 }))
 
-import CmsSync from './cms-sync'
 import { logger } from '../utils/logger'
+import CmsSync from './cms-sync'
 
 function writeDiscoveryConfig(
   storeDir: string,
@@ -240,7 +240,7 @@ describe('CmsSync', () => {
 
     it('forwards contentSource.project to generateAndUploadSchema', async () => {
       writeDiscoveryConfig(tempDir, {
-        contentSource: { type: 'CP', project: 'lojabigolin-faststore' },
+        contentSource: { type: 'CP', project: 'storeframework-faststore' },
       })
       getExistingCpDirsMock.mockReturnValue(['cms/faststore/components'])
 
@@ -248,7 +248,7 @@ describe('CmsSync', () => {
 
       expect(generateAndUploadSchemaMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          project: 'lojabigolin-faststore',
+          project: 'storeframework-faststore',
         })
       )
     })

--- a/packages/cli/src/commands/cms-sync.ts
+++ b/packages/cli/src/commands/cms-sync.ts
@@ -164,6 +164,7 @@ export default class CmsSync extends Command {
         dirs,
         schemaOut,
         dryRun: dryRun ?? false,
+        project: storeConfig?.contentSource?.project,
       })
     } finally {
       if (cleanup) {

--- a/packages/cli/src/utils/cp-schema.test.ts
+++ b/packages/cli/src/utils/cp-schema.test.ts
@@ -102,7 +102,7 @@ describe('cp-schema', () => {
   })
 
   describe('generateAndUploadSchema', () => {
-    it('runs generate then upload synchronously without -l', () => {
+    it('runs generate then upload synchronously without -l, forwarding the project as --storeId', () => {
       const schemaOut = path.join(tempDir, 'cms', 'faststore', 'schema.json')
 
       generateAndUploadSchema({
@@ -110,6 +110,7 @@ describe('cp-schema', () => {
         dirs: ['cms/faststore/components', 'cms/faststore/pages'],
         schemaOut,
         dryRun: false,
+        project: 'my-store',
       })
 
       expect(runCommandSyncMock).toHaveBeenCalledTimes(2)
@@ -121,12 +122,27 @@ describe('cp-schema', () => {
         interactive: true,
       })
       expect(runCommandSyncMock.mock.calls[1][0]).toEqual({
-        cmd: `vtex content upload-schema ${schemaOut}`,
+        cmd: `vtex content upload-schema ${schemaOut} --storeId my-store`,
         cwd: tempDir,
         throws: 'error',
         errorMessage: 'Failed to upload CMS schema',
         interactive: true,
       })
+    })
+
+    it('falls back to the "faststore" storeId when no project is configured', () => {
+      const schemaOut = path.join(tempDir, 'cms', 'faststore', 'schema.json')
+
+      generateAndUploadSchema({
+        basePath: tempDir,
+        dirs: ['cms/faststore/components', 'cms/faststore/pages'],
+        schemaOut,
+        dryRun: false,
+      })
+
+      expect(runCommandSyncMock.mock.calls[1][0].cmd).toBe(
+        `vtex content upload-schema ${schemaOut} --storeId faststore`
+      )
     })
 
     it('skips upload on dry-run', () => {

--- a/packages/cli/src/utils/cp-schema.ts
+++ b/packages/cli/src/utils/cp-schema.ts
@@ -124,11 +124,21 @@ export function generateAndUploadSchema({
   dirs,
   schemaOut,
   dryRun,
+  project,
 }: {
   basePath: string
   dirs: string[]
   schemaOut: string
   dryRun: boolean
+  /**
+   * The store's `contentSource.project`, forwarded as `--storeId` to
+   * `vtex content upload-schema` so the published schema's `$id`
+   * (`${account}.${storeId}`) matches the project declared in
+   * `discovery.config.js`, mirroring the legacy CMS flow's use of `project`
+   * in `vtex cms sync ${project}`. Falls back to `'faststore'`, the same
+   * default already used there.
+   */
+  project?: string
 }): void {
   // Interactive: generate-schema prompts to confirm overriding base
   // definitions (no --yes flag), and upload-schema prompts for the schema
@@ -145,8 +155,10 @@ export function generateAndUploadSchema({
     return
   }
 
+  const storeId = project ?? 'faststore'
+
   runCommandSync({
-    cmd: `vtex content upload-schema ${schemaOut}`,
+    cmd: `vtex content upload-schema ${schemaOut} --storeId ${storeId}`,
     cwd: basePath,
     throws: 'error',
     errorMessage: 'Failed to upload CMS schema',


### PR DESCRIPTION
## Problem

In the CP (Content Platform) `cms-sync` flow, `contentSource.project` was read only for the account preflight check (`assertVtexReadyForAccount`) and never passed along to `vtex content upload-schema`. Without `--storeId`, the toolbelt falls back to an interactive prompt (default `faststore`), which can produce a schema `$id` that doesn't match the project declared in `discovery.config.js` — e.g. `account.faststore` instead of the expected `account.my-project`.

This mirrors a bug reported in Slack: a store configured with
```js
contentSource: {
  type: 'CP',
  project: 'storeframework-faststore',
}
```
ended up with `$id: storeframework. storeframework` instead of the expected `storeframework. storeframework-faststore`.

The legacy CMS flow (`runLegacySync`) already forwards `project` (with the same `'faststore'` fallback) to `vtex cms sync ${project}`, so the CP flow was inconsistent with it.

## Fix

- `packages/cli/src/utils/cp-schema.ts`: `generateAndUploadSchema` now accepts an optional `project` param and appends `--storeId ${project ?? 'faststore'}` to the `vtex content upload-schema` command.
- `packages/cli/src/commands/cms-sync.ts`: `runCpSync` forwards `storeConfig?.contentSource?.project` into `generateAndUploadSchema`.

Verified against the installed `@vtex/cli-plugin-content`'s `upload-schema.js`: the `storeId` flag is real (`-s`, hidden), and when both `account` and `storeId` are resolvable, `resolveAccountAndStoreId` skips the interactive prompt entirely and builds `$id` as `${account}.${storeId}` — exactly the expected behavior.

## Tests

- Updated `cp-schema.test.ts` to assert `--storeId <project>` is appended, and added a test for the `'faststore'` fallback when no project is configured.
- Added a test in `cms-sync.test.ts` confirming `contentSource.project` is forwarded end-to-end to `generateAndUploadSchema`.
- `pnpm vitest run` in `packages/cli`: 178/179 pass (the 1 failure is a pre-existing, unrelated timeout in `generate.test.ts`'s filesystem-copy test).
- `biome check` clean on changed files; no new `tsc` errors introduced.

## Scope

`packages/cli` only — no generated files, auth/CSP, or CI config touched.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- CMS schema uploads now use the configured content-source project as the store ID.
- When no project is configured, uploads continue using the default `faststore` store ID.
- Dry-run behavior remains unchanged, preserving existing preview workflows.

## Tests
- Added coverage for forwarding configured projects during CMS synchronization.
- Added verification that uploads use the default store ID when no project is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->