### PR TITLE
fix: normalize outputFileTracingRoot to forward slashes on Windows

### DIFF
--- a/packages/cli/src/utils/generate.test.ts
+++ b/packages/cli/src/utils/generate.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   PUBLIC_FILES_ALLOWED_EXTENSIONS,
   buildFaststorePackageJson,
@@ -9,6 +9,7 @@ import {
   copyPublicFiles,
   isPublicFileAllowed,
   relativeNextBin,
+  updateNextConfig,
 } from './generate'
 
 describe('buildFaststorePackageJson', () => {
@@ -311,6 +312,42 @@ describe('copyCoreFiles', () => {
         '**/__tests__/**',
       ])
     )
+  })
+})
+
+describe('updateNextConfig', () => {
+  let basePath: string
+
+  beforeEach(() => {
+    basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'faststore-next-config-'))
+    fs.mkdirSync(path.join(basePath, '.faststore'), { recursive: true })
+    fs.writeFileSync(
+      path.join(basePath, '.faststore', 'next.config.js'),
+      "module.exports = {\n  outputFileTracingRoot: '/placeholder',\n}\n"
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(basePath, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('normalizes a Windows cwd to forward slashes so the written config stays valid JS', () => {
+    vi.spyOn(process, 'cwd').mockReturnValue(
+      'C:\\Users\\dev\\starter\\.faststore'
+    )
+
+    updateNextConfig(basePath)
+
+    const nextConfigData = fs.readFileSync(
+      path.join(basePath, '.faststore', 'next.config.js'),
+      'utf8'
+    )
+
+    expect(nextConfigData).toContain(
+      "outputFileTracingRoot: 'C:/Users/dev/starter/.faststore',"
+    )
+    expect(nextConfigData).not.toContain('\\')
   })
 })
 

--- a/packages/cli/src/utils/generate.test.ts
+++ b/packages/cli/src/utils/generate.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import vm from 'node:vm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   PUBLIC_FILES_ALLOWED_EXTENSIONS,
@@ -318,6 +319,22 @@ describe('copyCoreFiles', () => {
 describe('updateNextConfig', () => {
   let basePath: string
 
+  /**
+   * Actually parses the generated next.config.js as JS, the same way
+   * Next.js loads it via require(). A malformed string literal (e.g. an
+   * unescaped apostrophe, or a raw backslash treated as an escape
+   * sequence) throws here instead of just failing a string comparison.
+   */
+  function loadNextConfig(code: string) {
+    const context: { module: { exports: Record<string, unknown> } } = {
+      module: { exports: {} },
+    }
+
+    vm.runInNewContext(code, context)
+
+    return context.module.exports
+  }
+
   beforeEach(() => {
     basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'faststore-next-config-'))
     fs.mkdirSync(path.join(basePath, '.faststore'), { recursive: true })
@@ -344,10 +361,29 @@ describe('updateNextConfig', () => {
       'utf8'
     )
 
-    expect(nextConfigData).toContain(
-      "outputFileTracingRoot: 'C:/Users/dev/starter/.faststore',"
-    )
     expect(nextConfigData).not.toContain('\\')
+    expect(loadNextConfig(nextConfigData).outputFileTracingRoot).toBe(
+      'C:/Users/dev/starter/.faststore'
+    )
+  })
+
+  it('escapes an apostrophe in the cwd so the generated config stays valid JS', () => {
+    // A Windows username like O'Brien would otherwise terminate the
+    // hand-wrapped single-quoted string literal early.
+    vi.spyOn(process, 'cwd').mockReturnValue(
+      "C:\\Users\\O'Brien\\starter\\.faststore"
+    )
+
+    updateNextConfig(basePath)
+
+    const nextConfigData = fs.readFileSync(
+      path.join(basePath, '.faststore', 'next.config.js'),
+      'utf8'
+    )
+
+    expect(loadNextConfig(nextConfigData).outputFileTracingRoot).toBe(
+      "C:/Users/O'Brien/starter/.faststore"
+    )
   })
 })
 

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -566,9 +566,14 @@ export function updateNextConfig(basePath: string) {
   // literal is read as an escape sequence (e.g. `\f` becomes a form feed),
   // corrupting the path. Forward slashes are valid on Windows too, and
   // match the same normalization already applied to nextBin below.
+  // JSON.stringify (rather than wrapping in a template literal by hand)
+  // also escapes quotes, so a path containing an apostrophe (e.g. a
+  // Windows username like `C:\Users\O'Brien\...`) doesn't terminate the
+  // string literal early and produce invalid JS.
+  const normalizedCwd = process.cwd().replaceAll('\\', '/')
   nextConfigData = nextConfigData.replace(
     /outputFileTracingRoot\:\s+(.*),/,
-    `outputFileTracingRoot: '${process.cwd().replaceAll('\\', '/')}',`
+    `outputFileTracingRoot: ${JSON.stringify(normalizedCwd)},`
   )
 
   writeFileSync(nextConfigPath, nextConfigData)

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -555,15 +555,20 @@ async function checkDependencies(basePath: string, packagesToCheck: string[]) {
   })
 }
 
-function updateNextConfig(basePath: string) {
+export function updateNextConfig(basePath: string) {
   const { tmpDir } = withBasePath(basePath)
 
   const nextConfigPath = path.join(tmpDir, 'next.config.js')
 
   let nextConfigData = String(readFileSync(nextConfigPath))
+  // process.cwd() returns backslashes on Windows; next.config.js is later
+  // parsed as JS source, where an unescaped backslash inside a string
+  // literal is read as an escape sequence (e.g. `\f` becomes a form feed),
+  // corrupting the path. Forward slashes are valid on Windows too, and
+  // match the same normalization already applied to nextBin below.
   nextConfigData = nextConfigData.replace(
     /outputFileTracingRoot\:\s+(.*),/,
-    `outputFileTracingRoot: '${process.cwd()}',`
+    `outputFileTracingRoot: '${process.cwd().replaceAll('\\', '/')}',`
   )
 
   writeFileSync(nextConfigPath, nextConfigData)


### PR DESCRIPTION
Closes #3483

## Why

`process.cwd()` returns backslashes on Windows. `updateNextConfig` interpolated it raw into `next.config.js`, a file later parsed as JS source via `require()`. Inside a single-quoted string literal, backslashes are not inert:

- `\f` is a real JS escape sequence (form feed)
- unrecognized escapes like `\a`, `\.`, `\s` silently drop the backslash and keep the following character

So the written path got corrupted the moment Next.js parsed the file — which is why it then warned `outputFileTracingRoot should be absolute` and fell back to resolving the corrupted value relative to `cwd`, producing a doubled, mangled path:

```
⚠ outputFileTracingRoot should be absolute, using: D:\a\faststore\faststore\starter\.faststore\a^Laststore^Laststorestarter
```

(`^L` is the form-feed control character from `\f` — direct evidence of the escape-sequence corruption.)

Found via the first `windows-latest` run of #3450, the first PR to ever run this suite on Windows. See #3483 for the full root-cause writeup.

## Fix

```diff
-    `outputFileTracingRoot: '${process.cwd()}',`
+    `outputFileTracingRoot: '${process.cwd().replaceAll('\\', '/')}',`
```

Node and Next.js both accept forward slashes on Windows. This is the same normalization already applied to `nextBin` in this same file (`packages/cli/src/utils/generate.ts`), which had the identical bug fixed earlier in #3450.

## Tests

Added a unit test for `updateNextConfig` that mocks `process.cwd()` to return a Windows-style path and asserts the written config contains no backslashes. Exported `updateNextConfig` (previously module-private) to make it directly testable, following the pattern already used for `copyCoreFiles` and `relativeNextBin` in the same file.

```
cd packages/cli && pnpm vitest run src/utils/generate.test.ts
```

184/184 tests pass in the package.

## Scope

This does not touch the CI workflow in #3450 — that PR stays as-is and is expected to still fail at `Build starter` for other reasons until this lands and a few more Windows-only issues are found and fixed the same way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue affecting Windows environments where generated configuration paths could contain invalid backslashes.
  * Generated configuration now consistently uses forward-slash paths for improved compatibility.
  * Fixed generated configuration for working-directory paths containing apostrophes or other quotation marks, ensuring the configuration remains valid JavaScript.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->