### PR TITLE
fix(core): set cache-control: no-store on GraphQL error responses

### DIFF
--- a/packages/core/src/pages/api/graphql.ts
+++ b/packages/core/src/pages/api/graphql.ts
@@ -246,6 +246,11 @@ const handler: NextApiHandler = async (request, response) => {
 
       const status = fastStoreError?.extensions.status ?? 500
 
+      // Error responses are never cacheable: some upstream statuses (404,
+      // 410, ...) are heuristically cacheable by intermediaries per RFC 9111
+      // §4.2.2, which would let a CDN cache an error for this operation.
+      response.setHeader('cache-control', 'no-store')
+
       // No recoverable FastStoreError: keep the masked, body-less 500.
       if (!fastStoreError) {
         response.status(status).end()

--- a/packages/core/test/pages/api/graphql.test.ts
+++ b/packages/core/test/pages/api/graphql.test.ts
@@ -168,6 +168,15 @@ describe('/api/graphql error status propagation', () => {
 
     expect(res.status).toHaveBeenCalledWith(404)
   })
+
+  it('sets cache-control: no-store on error responses so a bare 404/410 is not cached by intermediaries', async () => {
+    mockExecuteWithErrors([maskedError(new NotFoundError('missing'))])
+
+    const res = createResponse()
+    await handler(createRequest(), res)
+
+    expect(res.setHeader).toHaveBeenCalledWith('cache-control', 'no-store')
+  })
 })
 
 describe('/api/graphql request handling', () => {


### PR DESCRIPTION
## What

Sets `cache-control: no-store` on the `/api/graphql` error branch.

## Why

This is live in v4 today, and it is a consequence of #3379 rather than a pre-existing bug.

Before #3379 every error answered `500`, which no intermediary caches heuristically. Since it shipped, a recovered `FastStoreError` answers with its **real** upstream status — so a `NotFoundError` now leaves the BFF as a bare `404`. Under [RFC 9111 §4.2.2](https://www.rfc-editor.org/rfc/rfc9111#section-4.2.2) a response with no explicit freshness information may be cached heuristically, and `404` is on the list of heuristically cacheable statuses. A CDN could therefore cache an error against a `/api/graphql?operationName=...` URL and serve it to other users.

The error branch has never set `cache-control`. It sets `content-type` and returns, so it never reaches the `cache-control` block further down the handler — every existing occurrence in the file is on the success path.

## How

One `setHeader` call in the error branch, before the masked-`500` early return so it covers both the recovered and unrecovered paths.

## Tests

One case in the existing suite asserting `cache-control: no-store` on an error response. Verified it fails without the fix and passes with it. Full file passes (18 tests), `biome` clean.

## Notes

- Found by @lariciamota reviewing #3453.
- Same fix as `3a453b2` on `3.x`, already carried by #3420 — identical footprint (+5 source, +9 test), so the two branches stay aligned.
- Independent of #3453 and #3420; it can merge in any order relative to them.
- No API surface or schema change. Success-path caching is untouched.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - GraphQL API error responses are no longer cached by intermediary systems, helping ensure clients receive current error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->