### PR TITLE
fix(core): avoid Yarn Classic Windows tar-extraction bug dropping src/pages/s.tsx

### DIFF
--- a/packages/cli/src/utils/generate.test.ts
+++ b/packages/cli/src/utils/generate.test.ts
@@ -307,9 +307,7 @@ describe('copyCoreFiles', () => {
     // (not a bare `src/pages/s.tsx`) because Yarn Classic 1.x silently drops
     // that specific tar entry when extracting on Windows — see
     // `enableSearchSSR` and the note on the `s/` folder.
-    expect(fs.existsSync(path.join(tmpDir, 'src/pages/s/index.tsx'))).toBe(
-      true
-    )
+    expect(fs.existsSync(path.join(tmpDir, 'src/pages/s/index.tsx'))).toBe(true)
     expect(fs.existsSync(path.join(tmpDir, 'src/pages/s.tsx'))).toBe(false)
     expect(tsConfig.include).not.toContain('test/**/*.ts')
     expect(tsConfig.include).not.toContain('test/**/*.tsx')

--- a/packages/cli/src/utils/generate.test.ts
+++ b/packages/cli/src/utils/generate.test.ts
@@ -303,6 +303,14 @@ describe('copyCoreFiles', () => {
 
     expect(fs.existsSync(path.join(tmpDir, 'src'))).toBe(true)
     expect(fs.existsSync(path.join(tmpDir, 'test'))).toBe(false)
+    // Regression guard: the search page lives at `src/pages/s/index.tsx`
+    // (not a bare `src/pages/s.tsx`) because Yarn Classic 1.x silently drops
+    // that specific tar entry when extracting on Windows — see
+    // `enableSearchSSR` and the note on the `s/` folder.
+    expect(fs.existsSync(path.join(tmpDir, 'src/pages/s/index.tsx'))).toBe(
+      true
+    )
+    expect(fs.existsSync(path.join(tmpDir, 'src/pages/s.tsx'))).toBe(false)
     expect(tsConfig.include).not.toContain('test/**/*.ts')
     expect(tsConfig.include).not.toContain('test/**/*.tsx')
     expect(tsConfig.exclude).toEqual(

--- a/packages/cli/src/utils/generate.ts
+++ b/packages/cli/src/utils/generate.ts
@@ -662,7 +662,7 @@ async function enableSearchSSR(basePath: string) {
   }
 
   const { tmpDir } = withBasePath(basePath)
-  const searchPagePath = path.join(tmpDir, 'src', 'pages', 's.tsx')
+  const searchPagePath = path.join(tmpDir, 'src', 'pages', 's', 'index.tsx')
   const searchPageData = String(readFileSync(searchPagePath))
 
   const searchPageWithSSR = searchPageData.replaceAll(

--- a/packages/core/src/pages/s/index.tsx
+++ b/packages/core/src/pages/s/index.tsx
@@ -1,3 +1,12 @@
+// This file intentionally lives at `s/index.tsx` instead of a bare `s.tsx`
+// (both compile to the same `/s` route). Yarn Classic 1.x silently drops the
+// `s.tsx` tar entry when extracting @faststore/core on Windows — every other
+// page in this folder survives, only that one file vanishes before `next
+// build` even starts type-checking. Windows' own `tar.exe` extracts the
+// identical tarball fine, so the bug is in Yarn's own extraction code, not
+// ours; nesting the file under a folder changes the tar-entry shape enough
+// to avoid it. Confirmed via the Windows CI job in @faststore/cli. Do not
+// rename this back to a bare `s.tsx`.
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'


### PR DESCRIPTION
## What

Moves `packages/core/src/pages/s.tsx` to `packages/core/src/pages/s/index.tsx` (same `/s` route, same content — Next.js treats a folder + `index.tsx` identically to a bare page file), and updates the one hardcoded reference to the old path in `@faststore/cli`'s `enableSearchSSR`.

## Why

Discovered while stabilizing the new Windows CI job in #3450: `Build starter` was failing deep inside Next.js's TypeScript check with a misleading error:

```
./src/components/templates/SearchPage/SearchPage.tsx:4:44
Type error: Cannot find module 'src/pages/s' or its corresponding type declarations.
```

Root-caused by turning the Windows CI runner itself into the repro environment (no local Windows machine available):

1. Confirmed `packages/core/src/pages/s.tsx` is a real, legitimate file (the `/s` search route) — not a truncated path.
2. Found `.faststore/src/pages/s.tsx` was **missing** from the generated storefront on Windows, while every sibling page file (`404.tsx`, `500.tsx`, `_app.tsx`, `index.tsx`, `login.tsx`, `pvt/`, etc.) copied fine.
3. Traced it one layer further back: the file is already missing from `node_modules/@faststore/core/src/pages/` right after `yarn install` — i.e. it never survives extraction of the `@faststore/core` tarball.
4. Isolated the extractor: extracting the **exact same tarball** with Windows' native `tar.exe` keeps the file; `yarn install` (Yarn Classic 1.22.19) drops it. Same runner, same archive, different outcome — the bug is in Yarn's own extraction implementation on Windows, not in our packing, copying, or TypeScript config.
5. Verified the fix empirically: renaming the file to `s/index.tsx` (identical route, different tar-entry shape) survives Yarn's extraction and the full Windows `Build starter` step passes end to end, including the `/s` route showing up correctly in the build output.

## Testing

- Added a regression assertion to the existing `copyCoreFiles` test in `packages/cli/src/utils/generate.test.ts` asserting `src/pages/s/index.tsx` exists and the old `src/pages/s.tsx` path does not.
- Verified against the real bug on a scratch branch: ran the Windows CI job (`CLI + starter (Windows)`) before and after this change — failing beforehand with the exact "Cannot find module" error, passing afterward with `/s` built successfully.
- Left an inline comment on the new file explaining why it must not be renamed back to a bare `s.tsx`.

## Scope note

This does not fix Yarn Classic's underlying bug (out of our control — it's upstream). It works around it for our own published package so Windows users on Yarn 1.x aren't affected.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search page generation so server-side rendering uses the correct page location.
  * Improved compatibility with Yarn Classic on Windows by preserving the nested search page structure.

* **Documentation**
  * Added documentation explaining the search page structure and its Windows compatibility considerations. 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->